### PR TITLE
Add initial support for hipSYCL

### DIFF
--- a/cmake/AddSYCLExecutable.cmake
+++ b/cmake/AddSYCLExecutable.cmake
@@ -3,11 +3,11 @@ if (NOT SYCL_IMPLEMENTATION)
   set (SYCL_IMPLEMENTATION ComputeCpp)
 endif()
 
-set (KNOWN_SYCL_IMPLEMENTATIONS "Intel_SYCL;ComputeCpp")
+set (KNOWN_SYCL_IMPLEMENTATIONS "Intel_SYCL;ComputeCpp;hipSYCL")
 if (NOT ${SYCL_IMPLEMENTATION} IN_LIST KNOWN_SYCL_IMPLEMENTATIONS)
     message(FATAL_ERROR
         "The SYCL CTS requires specifying a SYCL implementation with "
-        "-DSYCL_IMPLEMENTATION=[Intel_SYCL,ComputeCpp]")
+        "-DSYCL_IMPLEMENTATION=[Intel_SYCL,ComputeCpp,hipSYCL]")
 endif()
 
 find_package(${SYCL_IMPLEMENTATION} REQUIRED)

--- a/cmake/FindhipSYCL.cmake
+++ b/cmake/FindhipSYCL.cmake
@@ -1,0 +1,37 @@
+find_program(SYCLCC_EXECUTABLE syclcc-clang
+    PATH_SUFFIXES bin)
+
+if(NOT SYCLCC_EXECUTABLE)
+  message(SEND_ERROR "Could not find hipSYCL syclcc-clang compiler")
+endif()
+
+set(CMAKE_C_COMPILER    ${SYCLCC_EXECUTABLE})
+set(CMAKE_CXX_COMPILER  ${SYCLCC_EXECUTABLE})
+set(CMAKE_CXX_STANDARD 14)
+
+add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
+# add_sycl_executable_implementation function
+# Builds a SYCL program, compiling multiple SYCL test case source files into a
+# test executable, invoking a single-source/device compiler
+# Parameters are:
+#   - NAME             Name of the test executable
+#   - OBJECT_LIBRARY   Name of the object library of all the compiled test cases
+#   - TESTS            List of SYCL test case source files to be built into the
+# test executable
+function(add_sycl_executable_implementation)
+    cmake_parse_arguments(args "" "NAME;OBJECT_LIBRARY" "TESTS" ${ARGN})
+    set(exe_name            ${args_NAME})
+    set(object_lib_name     ${args_OBJECT_LIBRARY})
+    set(test_cases_list     ${args_TESTS})
+
+    add_library(${object_lib_name} OBJECT ${test_cases_list})
+    add_executable(${exe_name} $<TARGET_OBJECTS:${object_lib_name}>)
+
+    set_target_properties(${object_lib_name} PROPERTIES
+        INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${exe_name},INCLUDE_DIRECTORIES>
+        COMPILE_DEFINITIONS $<TARGET_PROPERTY:${exe_name},COMPILE_DEFINITIONS>
+        COMPILE_OPTIONS     $<TARGET_PROPERTY:${exe_name},COMPILE_OPTIONS>
+        COMPILE_FEATURES    $<TARGET_PROPERTY:${exe_name},COMPILE_FEATURES>
+        POSITION_INDEPENDENT_CODE ON)
+
+endfunction()


### PR DESCRIPTION
This extends the cmake infrastructure to allow for compilation with hipSYCL. Other implementations are not affected. Also note that compilation at the moment still fails (mostly due to OpenCL stuff) and is still work in progress.

Signed-off-by: Aksel Alpay <aksel.alpay@uni-heidelberg.de>