### PR TITLE
Make image accessor feature checks conditional

### DIFF
--- a/tests/accessor/accessor_api_image.cpp
+++ b/tests/accessor/accessor_api_image.cpp
@@ -38,19 +38,26 @@ class TEST_NAME : public util::test_base {
     try {
       auto queue = util::get_cts_object::queue();
 
-      /** check image accessor api for cl_int4
-       */
-      check_image_accessor_api_type<cl::sycl::cl_int4>(log, queue);
+      try {
+        /** check image accessor api for cl_int4
+         */
+        check_image_accessor_api_type<cl::sycl::cl_int4>(log, queue);
 
-      /** check image accessor api for cl_uint4
-       */
-      check_image_accessor_api_type<cl::sycl::cl_uint4>(log, queue);
+        /** check image accessor api for cl_uint4
+         */
+        check_image_accessor_api_type<cl::sycl::cl_uint4>(log, queue);
 
-      /** check image accessor api for cl_float4
-       */
-      check_image_accessor_api_type<cl::sycl::cl_float4>(log, queue);
-
-      queue.wait_and_throw();
+        /** check image accessor api for cl_float4
+         */
+        check_image_accessor_api_type<cl::sycl::cl_float4>(log, queue);
+      } catch (const cl::sycl::feature_not_supported &e) {
+        if (!queue.get_device()
+                .get_info<cl::sycl::info::device::image_support>()) {
+          log.note("device does not support images -- skipping check");
+        } else {
+          throw;
+        }
+      }
     } catch (const cl::sycl::exception &e) {
       log_exception(log, e);
       cl::sycl::string_class errorMsg =

--- a/tests/accessor/accessor_api_image.cpp
+++ b/tests/accessor/accessor_api_image.cpp
@@ -37,27 +37,25 @@ class TEST_NAME : public util::test_base {
   void run(util::logger &log) override {
     try {
       auto queue = util::get_cts_object::queue();
-
-      try {
-        /** check image accessor api for cl_int4
-         */
-        check_image_accessor_api_type<cl::sycl::cl_int4>(log, queue);
-
-        /** check image accessor api for cl_uint4
-         */
-        check_image_accessor_api_type<cl::sycl::cl_uint4>(log, queue);
-
-        /** check image accessor api for cl_float4
-         */
-        check_image_accessor_api_type<cl::sycl::cl_float4>(log, queue);
-      } catch (const cl::sycl::feature_not_supported &e) {
-        if (!queue.get_device()
-                .get_info<cl::sycl::info::device::image_support>()) {
-          log.note("device does not support images -- skipping check");
-        } else {
-          throw;
-        }
+      if (!queue.get_device()
+               .get_info<cl::sycl::info::device::image_support>()) {
+        log.note("Device does not support images -- skipping check");
+        return;
       }
+
+      /** check image accessor api for cl_int4
+       */
+      check_image_accessor_api_type<cl::sycl::cl_int4>(log, queue);
+
+      /** check image accessor api for cl_uint4
+       */
+      check_image_accessor_api_type<cl::sycl::cl_uint4>(log, queue);
+
+      /** check image accessor api for cl_float4
+       */
+      check_image_accessor_api_type<cl::sycl::cl_float4>(log, queue);
+
+      queue.wait_and_throw();
     } catch (const cl::sycl::exception &e) {
       log_exception(log, e);
       cl::sycl::string_class errorMsg =

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -549,7 +549,6 @@ class check_image_accessor_api_reads {
       check_command_group_reads(queue, range, imgCoordsSyntax,
                                 imgCoordsSamplerSyntax, errorBuffer,
                                 acc_type_tag::get<target>());
-      queue.wait_and_throw();
     }
 
     if (errors[0] != 0) {
@@ -664,7 +663,6 @@ class check_image_accessor_api_writes {
 
       check_command_group_writes(queue, range, imgCoordsSyntax,
                                  acc_type_tag::get<target>());
-      queue.wait_and_throw();
     }
 
     const auto storageData = convert_image_bytes_to_data<T>(dataCoordsSyntax);

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -549,6 +549,7 @@ class check_image_accessor_api_reads {
       check_command_group_reads(queue, range, imgCoordsSyntax,
                                 imgCoordsSamplerSyntax, errorBuffer,
                                 acc_type_tag::get<target>());
+      queue.wait_and_throw();
     }
 
     if (errors[0] != 0) {
@@ -663,6 +664,7 @@ class check_image_accessor_api_writes {
 
       check_command_group_writes(queue, range, imgCoordsSyntax,
                                  acc_type_tag::get<target>());
+      queue.wait_and_throw();
     }
 
     const auto storageData = convert_image_bytes_to_data<T>(dataCoordsSyntax);

--- a/tests/accessor/accessor_constructors_image.cpp
+++ b/tests/accessor/accessor_constructors_image.cpp
@@ -39,19 +39,28 @@ class TEST_NAME : public util::test_base {
     try {
       auto queue = util::get_cts_object::queue();
 
-      /** check accessor constructors for cl_int4
-       */
-      check_all_dims<cl::sycl::cl_int4>(log, queue);
+      try {
+        /** check accessor constructors for cl_int4
+         */
+        check_all_dims<cl::sycl::cl_int4>(log, queue);
 
-      /** check accessor constructors for cl_uint4
-       */
-      check_all_dims<cl::sycl::cl_uint4>(log, queue);
+        /** check accessor constructors for cl_uint4
+         */
+        check_all_dims<cl::sycl::cl_uint4>(log, queue);
 
-      /** check accessor constructors for cl_float4
-       */
-      check_all_dims<cl::sycl::cl_float4>(log, queue);
+        /** check accessor constructors for cl_float4
+         */
+        check_all_dims<cl::sycl::cl_float4>(log, queue);
 
-      queue.wait_and_throw();
+        queue.wait_and_throw();
+      } catch (const cl::sycl::feature_not_supported &fnse) {
+        if (!queue.get_device()
+                  .get_info<cl::sycl::info::device::image_support>()) {
+          log.note("device does not support images -- skipping check");
+        } else {
+          throw;
+        }
+      }
     } catch (const cl::sycl::exception &e) {
       log_exception(log, e);
       cl::sycl::string_class errorMsg =

--- a/tests/accessor/accessor_constructors_image.cpp
+++ b/tests/accessor/accessor_constructors_image.cpp
@@ -38,29 +38,25 @@ class TEST_NAME : public util::test_base {
   void run(util::logger &log) override {
     try {
       auto queue = util::get_cts_object::queue();
-
-      try {
-        /** check accessor constructors for cl_int4
-         */
-        check_all_dims<cl::sycl::cl_int4>(log, queue);
-
-        /** check accessor constructors for cl_uint4
-         */
-        check_all_dims<cl::sycl::cl_uint4>(log, queue);
-
-        /** check accessor constructors for cl_float4
-         */
-        check_all_dims<cl::sycl::cl_float4>(log, queue);
-
-        queue.wait_and_throw();
-      } catch (const cl::sycl::feature_not_supported &fnse) {
-        if (!queue.get_device()
-                  .get_info<cl::sycl::info::device::image_support>()) {
-          log.note("device does not support images -- skipping check");
-        } else {
-          throw;
-        }
+      if (!queue.get_device()
+               .get_info<cl::sycl::info::device::image_support>()) {
+        log.note("Device does not support images -- skipping check");
+        return;
       }
+
+      /** check accessor constructors for cl_int4
+       */
+      check_all_dims<cl::sycl::cl_int4>(log, queue);
+
+      /** check accessor constructors for cl_uint4
+       */
+      check_all_dims<cl::sycl::cl_uint4>(log, queue);
+
+      /** check accessor constructors for cl_float4
+       */
+      check_all_dims<cl::sycl::cl_float4>(log, queue);
+
+      queue.wait_and_throw();
     } catch (const cl::sycl::exception &e) {
       log_exception(log, e);
       cl::sycl::string_class errorMsg =


### PR DESCRIPTION
Images is optional feature, so conformance tests must skip the test
if feature is not supported.

Add image support check to accessor_constructors_image test.