### PR TITLE
OpenCL interoperability test fixes

### DIFF
--- a/util/test_base_opencl.cpp
+++ b/util/test_base_opencl.cpp
@@ -94,6 +94,19 @@ bool test_base_opencl::setup(logger &log) {
   return true;
 }
 
+bool test_base_opencl::online_compiler_supported(cl_device_id clDeviceId,
+                                                 logger &log) {
+  cl_uint available;
+  cl_int error = clGetDeviceInfo(clDeviceId, CL_DEVICE_COMPILER_AVAILABLE,
+                                 sizeof(available), &available, NULL);
+  if (!CHECK_CL_SUCCESS(log, error)) return false;
+  if (available == 0) {
+    return false;
+  }
+
+  return true;
+}
+
 bool test_base_opencl::create_compiled_program(const std::string &source,
                                                cl_program &out_program,
                                                logger &log) {

--- a/util/test_base_opencl.h
+++ b/util/test_base_opencl.h
@@ -75,6 +75,8 @@ class test_base_opencl : public sycl_cts::util::test_base {
    */
   cl_command_queue get_cl_command_queue() { return m_cl_command_queue; }
 
+  bool online_compiler_supported(cl_device_id clDeviceId, logger &log);
+
   /** create and compile an OpenCL program
    */
   bool create_compiled_program(const std::string &source,


### PR DESCRIPTION
The changes to this test are all related to optional features: online
compilation, image, sampler.

 - Test cases using unsupported optional features are skipped.
 - Code using sampler::get() has been removed as it's not defined by the
   specification.
 - Remove test case checking handler::set_arg method with stream
   parameter.