### PR TITLE
Enable opencl_interop on implementations w/o online compilation support

### DIFF
--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -149,7 +149,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
       /** check program (context, cl_program) constructor
        */
       {
-        cl_program clProgram = nullptr;
+        cl_program clProgram{};
         if (online_compiler_supported(ctsDevice.get(), log)) {
           if (!create_built_program(kernelSource, ctsContext.get(),
                                     ctsDevice.get(), clProgram, log)) {
@@ -181,7 +181,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
       /** check kernel (cl_kernel, const context&) constructor
        */
       {
-        cl_program clProgram = nullptr;
+        cl_program clProgram{};
         if (online_compiler_supported(ctsDevice.get(), log)) {
           if (!create_built_program(kernelSource, ctsContext.get(),
                                     ctsDevice.get(), clProgram, log)) {
@@ -199,7 +199,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
           }
         }
 
-        cl_kernel clKernel = nullptr;
+        cl_kernel clKernel{};
         if (!create_kernel(clProgram, "opencl_interop_constructors_kernel",
                            clKernel, log)) {
           FAIL(log, "create_kernel failed");

--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -47,6 +47,8 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
               input[get_global_id(0)] = get_global_id(0);
             }
             )";
+      cl::sycl::string_class programBinaryFile =
+          "opencl_interop_constructors.bin";
       /** check platform (cl_platform_id) constructor
        */
       {
@@ -147,54 +149,70 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
       /** check program (context, cl_program) constructor
        */
       {
+        cl_program clProgram = nullptr;
         if (online_compiler_supported(ctsDevice.get(), log)) {
-          cl_program clProgram = nullptr;
           if (!create_built_program(kernelSource, ctsContext.get(),
                                     ctsDevice.get(), clProgram, log)) {
             FAIL(log, "create_built_program failed");
           }
-
-          cl::sycl::program program(ctsContext, clProgram);
-
-          cl_program interopProgram = program.get();
-          if (interopProgram != clProgram) {
-            FAIL(log, "program was not constructed correctly");
-          }
-          if (!CHECK_CL_SUCCESS(log, clReleaseProgram(interopProgram))) {
-            FAIL(log, "failed to release OpenCL program");
-          }
         } else {
-          log.note("online compiler not available -- skipping check");
+          if (!create_program_with_binary(programBinaryFile, ctsContext.get(),
+                                          ctsDevice.get(), clProgram, log)) {
+            cl::sycl::string_class errorMsg =
+                "create_program_with_binary failed.";
+            errorMsg +=
+                " Since online compile is not supported, expecting to find " +
+                programBinaryFile + " in same path as the executable binary";
+            FAIL(log, errorMsg.c_str());
+          }
+        }
+
+        cl::sycl::program program(ctsContext, clProgram);
+
+        cl_program interopProgram = program.get();
+        if (interopProgram != clProgram) {
+          FAIL(log, "program was not constructed correctly");
+        }
+        if (!CHECK_CL_SUCCESS(log, clReleaseProgram(interopProgram))) {
+          FAIL(log, "failed to release OpenCL program");
         }
       }
 
       /** check kernel (cl_kernel, const context&) constructor
        */
       {
+        cl_program clProgram = nullptr;
         if (online_compiler_supported(ctsDevice.get(), log)) {
-          cl_program clProgram = nullptr;
           if (!create_built_program(kernelSource, ctsContext.get(),
                                     ctsDevice.get(), clProgram, log)) {
             FAIL(log, "create_built_program failed");
           }
-
-          cl_kernel clKernel = nullptr;
-          if (!create_kernel(clProgram, "opencl_interop_constructors_kernel",
-                             clKernel, log)) {
-            FAIL(log, "create_kernel failed");
-          }
-
-          cl::sycl::kernel kernel(clKernel, ctsContext);
-
-          cl_kernel interopKernel = kernel.get();
-          if (interopKernel != clKernel) {
-            FAIL(log, "kernel was not constructed correctly");
-          }
-          if (!CHECK_CL_SUCCESS(log, clReleaseKernel(interopKernel))) {
-            FAIL(log, "failed to release OpenCL kernel");
-          }
         } else {
-          log.note("online compiler not available -- skipping check");
+          if (!create_program_with_binary(programBinaryFile, ctsContext.get(),
+                                          ctsDevice.get(), clProgram, log)) {
+            cl::sycl::string_class errorMsg =
+                "create_program_with_binary failed.";
+            errorMsg +=
+                " Since online compile is not supported, expecting to find " +
+                programBinaryFile + " in same path as the executable binary";
+            FAIL(log, errorMsg.c_str());
+          }
+        }
+
+        cl_kernel clKernel = nullptr;
+        if (!create_kernel(clProgram, "opencl_interop_constructors_kernel",
+                           clKernel, log)) {
+          FAIL(log, "create_kernel failed");
+        }
+
+        cl::sycl::kernel kernel(clKernel, ctsContext);
+
+        cl_kernel interopKernel = kernel.get();
+        if (interopKernel != clKernel) {
+          FAIL(log, "kernel was not constructed correctly");
+        }
+        if (!CHECK_CL_SUCCESS(log, clReleaseKernel(interopKernel))) {
+          FAIL(log, "failed to release OpenCL kernel");
         }
       }
 
@@ -322,7 +340,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
       }
 
       /** check sampler (cl_sampler, const context&) constructor
-      */
+       */
       {
         auto queue = util::get_cts_object::queue(ctsSelector);
         if (!queue.get_device()

--- a/tests/opencl_interop/opencl_interop_get.cpp
+++ b/tests/opencl_interop/opencl_interop_get.cpp
@@ -112,8 +112,8 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
        */
       {
         if (!util::get_cts_object::queue(ctsSelector)
-                   .get_device()
-                   .get_info<cl::sycl::info::device::is_compiler_available>()) {
+                 .get_device()
+                 .get_info<cl::sycl::info::device::is_compiler_available>()) {
           log.note("online compiler not available -- skipping check");
         } else {
           auto program =
@@ -147,25 +147,35 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
                                       ctsDevice.get(), clProgram, log)) {
               FAIL(log, "create_built_program failed");
             }
-
-            cl_kernel clKernel = nullptr;
-            if (!create_kernel(clProgram, "opencl_interop_get_kernel", clKernel,
-                               log)) {
-              FAIL(log, "create_kernel failed");
-            }
-
-            cl::sycl::kernel kernel(clKernel, ctsContext);
-
-            auto interopKernel = kernel.get();
-            check_return_type<cl_kernel>(log, interopKernel,
-                                         "cl::sycl::kernel::get()");
-
-            if (interopKernel == nullptr) {
-              FAIL(log,
-                   "cl::sycl::kernel::get() did not return a valid cl_kernel");
-            }
           } else {
-            log.note("online compiler not available -- skipping check");
+            cl::sycl::string_class programBinaryFile = "opencl_interop_get.bin";
+
+            if (!create_program_with_binary(programBinaryFile, ctsContext.get(),
+                                            ctsDevice.get(), clProgram, log)) {
+              cl::sycl::string_class errorMsg =
+                  "create_program_with_binary failed.";
+              errorMsg +=
+                  " Since online compile is not supported, expecting to find " +
+                  programBinaryFile + " in same path as the executable binary";
+              FAIL(log, errorMsg.c_str());
+            }
+          }
+
+          cl_kernel clKernel = nullptr;
+          if (!create_kernel(clProgram, "opencl_interop_get_kernel", clKernel,
+                             log)) {
+            FAIL(log, "create_kernel failed");
+          }
+
+          cl::sycl::kernel kernel(clKernel, ctsContext);
+
+          auto interopKernel = kernel.get();
+          check_return_type<cl_kernel>(log, interopKernel,
+                                       "cl::sycl::kernel::get()");
+
+          if (interopKernel == nullptr) {
+            FAIL(log,
+                 "cl::sycl::kernel::get() did not return a valid cl_kernel");
           }
         }
       }

--- a/tests/opencl_interop/opencl_interop_get.cpp
+++ b/tests/opencl_interop/opencl_interop_get.cpp
@@ -137,7 +137,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
        */
       {
         if (!ctsContext.is_host()) {
-          cl_program clProgram = nullptr;
+          cl_program clProgram{};
           if (online_compiler_supported(ctsDevice.get(), log)) {
             cl::sycl::string_class kernelSource = R"(
             __kernel void opencl_interop_get_kernel() {}
@@ -161,7 +161,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
             }
           }
 
-          cl_kernel clKernel = nullptr;
+          cl_kernel clKernel{};
           if (!create_kernel(clProgram, "opencl_interop_get_kernel", clKernel,
                              log)) {
             FAIL(log, "create_kernel failed");

--- a/tests/opencl_interop/opencl_interop_kernel.cpp
+++ b/tests/opencl_interop/opencl_interop_kernel.cpp
@@ -79,6 +79,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
         cl::sycl::buffer<int, 1> buffer(bufferData,
                                         cl::sycl::range<1>(bufferSize));
 
+        cl_program clProgram = nullptr;
         if (online_compiler_supported(device.get(), log)) {
           cl::sycl::string_class kernelSource = R"(
             struct simple_struct {
@@ -93,74 +94,84 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
             {}
             )";
 
-          cl_program clProgram = nullptr;
           if (!create_built_program(kernelSource, context.get(), device.get(),
                                     clProgram, log)) {
             FAIL(log, "create_built_program failed");
           }
-
-          cl_kernel clKernel = nullptr;
-          if (!create_kernel(clProgram, "opencl_interop_kernel_kernel",
-                             clKernel, log)) {
-            FAIL(log, "create_kernel failed");
-          }
-
-          cl::sycl::kernel kernel(clKernel, context);
-
-          /** test single_task(kernel)
-           */
-          queue.submit([&](cl::sycl::handler &handler) {
-            auto bufferAccessor =
-                buffer.get_access<cl::sycl::access::mode::read_write,
-                                  cl::sycl::access::target::global_buffer>(
-                    handler);
-
-            simple_struct simpleStruct{19, 13.37f};
-
-            /** check the set_arg() methods
-             */
-
-            // set_args(int, buffer)
-            handler.set_arg(0, bufferAccessor);
-            // set_args(int, float)
-            handler.set_arg(1, 15.0f);
-            // set_args(int, int)
-            handler.set_arg(2, 17);
-            // set_args(int, simple_struct)
-            handler.set_arg(3, simpleStruct);
-
-            handler.single_task(kernel);
-          });
-
-          /** test parallel_for(const nd range<dimensions>&, kernel)
-           */
-          queue.submit([&](cl::sycl::handler &handler) {
-            auto bufferAccessor =
-                buffer.get_access<cl::sycl::access::mode::read_write,
-                                  cl::sycl::access::target::global_buffer>(
-                    handler);
-
-            simple_struct simpleStruct{19, 13.37f};
-
-            /** check the set_args() method
-             */
-            handler.set_args(bufferAccessor, 15.0f, 17, simpleStruct);
-
-            cl::sycl::range<1> myRange(1024);
-            handler.parallel_for(myRange, kernel);
-          });
-
-          queue.wait_and_throw();
         } else {
-          log.note("online compiler not available -- skipping check");
+          cl::sycl::string_class programBinaryFile =
+              "opencl_interop_kernel.bin";
+
+          if (!create_program_with_binary(programBinaryFile, context.get(),
+                                          device.get(), clProgram, log)) {
+            cl::sycl::string_class errorMsg =
+                "create_program_with_binary failed.";
+            errorMsg +=
+                " Since online compile is not supported, expecting to find " +
+                programBinaryFile + " in same path as the executable binary";
+            FAIL(log, errorMsg.c_str());
+          }
         }
+
+        cl_kernel clKernel = nullptr;
+        if (!create_kernel(clProgram, "opencl_interop_kernel_kernel", clKernel,
+                           log)) {
+          FAIL(log, "create_kernel failed");
+        }
+
+        cl::sycl::kernel kernel(clKernel, context);
+
+        /** test single_task(kernel)
+         */
+        queue.submit([&](cl::sycl::handler &handler) {
+          auto bufferAccessor =
+              buffer.get_access<cl::sycl::access::mode::read_write,
+                                cl::sycl::access::target::global_buffer>(
+                  handler);
+
+          simple_struct simpleStruct{19, 13.37f};
+
+          /** check the set_arg() methods
+           */
+
+          // set_args(int, buffer)
+          handler.set_arg(0, bufferAccessor);
+          // set_args(int, float)
+          handler.set_arg(1, 15.0f);
+          // set_args(int, int)
+          handler.set_arg(2, 17);
+          // set_args(int, simple_struct)
+          handler.set_arg(3, simpleStruct);
+
+          handler.single_task(kernel);
+        });
+
+        /** test parallel_for(const nd range<dimensions>&, kernel)
+         */
+        queue.submit([&](cl::sycl::handler &handler) {
+          auto bufferAccessor =
+              buffer.get_access<cl::sycl::access::mode::read_write,
+                                cl::sycl::access::target::global_buffer>(
+                  handler);
+
+          simple_struct simpleStruct{19, 13.37f};
+
+          /** check the set_args() method
+           */
+          handler.set_args(bufferAccessor, 15.0f, 17, simpleStruct);
+
+          cl::sycl::range<1> myRange(1024);
+          handler.parallel_for(myRange, kernel);
+        });
+
+        queue.wait_and_throw();
       }
 
       {
         if (!util::get_cts_object::queue(ctsSelector)
-                   .get_device()
-                   .get_info<cl::sycl::info::device::image_support>()) {
-            log.note("Device does not support images");
+                 .get_device()
+                 .get_info<cl::sycl::info::device::image_support>()) {
+          log.note("Device does not support images");
         } else {
           static constexpr size_t imageSideSize = 32;
           static constexpr size_t imgAccElemSize = 4;  // rgba
@@ -177,6 +188,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
               cl::sycl::image_channel_type::fp32,
               cl::sycl::range<2>(imageSideSize, imageSideSize));
 
+          cl_program clProgram = nullptr;
           if (online_compiler_supported(device.get(), log)) {
             cl::sycl::string_class kernelSource = R"(
               struct simple_struct {
@@ -189,69 +201,79 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
               {}
               )";
 
-            cl_program clProgram = nullptr;
             if (!create_built_program(kernelSource, context.get(), device.get(),
                                       clProgram, log)) {
               FAIL(log, "create_built_program failed");
             }
-
-	    cl_kernel clKernel = nullptr;
-            if (!create_kernel(clProgram, "opencl_interop_image_kernel_kernel",
-                               clKernel, log)) {
-              FAIL(log, "create_kernel failed");
-            }
-
-            cl::sycl::kernel kernel(clKernel, context);
-
-            /** test single_task(kernel)
-             */
-            queue.submit([&](cl::sycl::handler &handler) {
-              auto imageAccessor =
-                  image
-                      .get_access<cl::sycl::float4, cl::sycl::access::mode::read>(
-                          handler);
-
-              cl::sycl::sampler sampler(
-                  cl::sycl::coordinate_normalization_mode::unnormalized,
-                  cl::sycl::addressing_mode::none,
-                  cl::sycl::filtering_mode::nearest);
-
-              /** check the set_arg() methods
-               */
-
-              // set_args(int, image)
-              handler.set_arg(0, imageAccessor);
-              // set_args(int, sampler)
-              handler.set_arg(1, sampler);
-
-              handler.single_task(kernel);
-            });
-
-            /** test parallel_for(const nd range<dimensions>&, kernel)
-             */
-            queue.submit([&](cl::sycl::handler &handler) {
-              auto imageAccessor =
-                  image
-                      .get_access<cl::sycl::float4, cl::sycl::access::mode::read>(
-                          handler);
-
-              cl::sycl::sampler sampler(
-                  cl::sycl::coordinate_normalization_mode::unnormalized,
-                  cl::sycl::addressing_mode::none,
-                  cl::sycl::filtering_mode::nearest);
-
-              /** check the set_args() method
-               */
-              handler.set_args(imageAccessor, sampler);
-
-              cl::sycl::range<1> myRange(1024);
-              handler.parallel_for(myRange, kernel);
-            });
-
-            queue.wait_and_throw();
           } else {
-            log.note("online compiler not available -- skipping check");
+            cl::sycl::string_class programBinaryFile =
+                "opencl_interop_image_kernel.bin";
+
+            if (!create_program_with_binary(programBinaryFile, context.get(),
+                                            device.get(), clProgram, log)) {
+              cl::sycl::string_class errorMsg =
+                  "create_program_with_binary failed.";
+              errorMsg +=
+                  " Since online compile is not supported, expecting to find " +
+                  programBinaryFile + " in same path as the executable binary";
+              FAIL(log, errorMsg.c_str());
+            }
           }
+
+          cl_kernel clKernel = nullptr;
+          if (!create_kernel(clProgram, "opencl_interop_image_kernel_kernel",
+                             clKernel, log)) {
+            FAIL(log, "create_kernel failed");
+          }
+
+          cl::sycl::kernel kernel(clKernel, context);
+
+          /** test single_task(kernel)
+           */
+          queue.submit([&](cl::sycl::handler &handler) {
+            auto imageAccessor =
+                image
+                    .get_access<cl::sycl::float4, cl::sycl::access::mode::read>(
+                        handler);
+
+            cl::sycl::sampler sampler(
+                cl::sycl::coordinate_normalization_mode::unnormalized,
+                cl::sycl::addressing_mode::none,
+                cl::sycl::filtering_mode::nearest);
+
+            /** check the set_arg() methods
+             */
+
+            // set_args(int, image)
+            handler.set_arg(0, imageAccessor);
+            // set_args(int, sampler)
+            handler.set_arg(1, sampler);
+
+            handler.single_task(kernel);
+          });
+
+          /** test parallel_for(const nd range<dimensions>&, kernel)
+           */
+          queue.submit([&](cl::sycl::handler &handler) {
+            auto imageAccessor =
+                image
+                    .get_access<cl::sycl::float4, cl::sycl::access::mode::read>(
+                        handler);
+
+            cl::sycl::sampler sampler(
+                cl::sycl::coordinate_normalization_mode::unnormalized,
+                cl::sycl::addressing_mode::none,
+                cl::sycl::filtering_mode::nearest);
+
+            /** check the set_args() method
+             */
+            handler.set_args(imageAccessor, sampler);
+
+            cl::sycl::range<1> myRange(1024);
+            handler.parallel_for(myRange, kernel);
+          });
+
+          queue.wait_and_throw();
         }
       }
 

--- a/tests/opencl_interop/opencl_interop_kernel.cpp
+++ b/tests/opencl_interop/opencl_interop_kernel.cpp
@@ -79,7 +79,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
         cl::sycl::buffer<int, 1> buffer(bufferData,
                                         cl::sycl::range<1>(bufferSize));
 
-        cl_program clProgram = nullptr;
+        cl_program clProgram{};
         if (online_compiler_supported(device.get(), log)) {
           cl::sycl::string_class kernelSource = R"(
             struct simple_struct {
@@ -113,7 +113,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
           }
         }
 
-        cl_kernel clKernel = nullptr;
+        cl_kernel clKernel{};
         if (!create_kernel(clProgram, "opencl_interop_kernel_kernel", clKernel,
                            log)) {
           FAIL(log, "create_kernel failed");
@@ -188,7 +188,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
               cl::sycl::image_channel_type::fp32,
               cl::sycl::range<2>(imageSideSize, imageSideSize));
 
-          cl_program clProgram = nullptr;
+          cl_program clProgram{};
           if (online_compiler_supported(device.get(), log)) {
             cl::sycl::string_class kernelSource = R"(
               struct simple_struct {
@@ -220,7 +220,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
             }
           }
 
-          cl_kernel clKernel = nullptr;
+          cl_kernel clKernel{};
           if (!create_kernel(clProgram, "opencl_interop_image_kernel_kernel",
                              clKernel, log)) {
             FAIL(log, "create_kernel failed");

--- a/util/test_base_opencl.h
+++ b/util/test_base_opencl.h
@@ -75,6 +75,8 @@ class test_base_opencl : public sycl_cts::util::test_base {
    */
   cl_command_queue get_cl_command_queue() { return m_cl_command_queue; }
 
+  bool get_exec_dir(char *path, size_t max_path_len);
+
   bool online_compiler_supported(cl_device_id clDeviceId, logger &log);
 
   /** create and compile an OpenCL program
@@ -92,6 +94,14 @@ class test_base_opencl : public sycl_cts::util::test_base {
   bool create_built_program(const std::string &source, cl_context clContext,
                             cl_device_id clDeviceId, cl_program &outProgram,
                             logger &log);
+
+  /** create an OpenCL program with binary
+   */
+  bool create_program_with_binary(const std::string &filename,
+                                  cl_program &outProgram, logger &log);
+  bool create_program_with_binary(const std::string &filename,
+                                  cl_context clContext, cl_device_id clDeviceId,
+                                  cl_program &outProgram, logger &log);
 
   /** create an OpenCL kernel
    */


### PR DESCRIPTION
Test devices that do not support online compile using binaries in same
directory as executable