### PR TITLE
Re-order unaligned writes and checks.

### DIFF
--- a/tests/accessor/accessor_api_common_buffer_local.h
+++ b/tests/accessor/accessor_api_common_buffer_local.h
@@ -295,16 +295,16 @@ class buffer_accessor_api_rw {
     */
     m_accIdSyntax[idx] = expectedWrite;
 
-    /** check size_t write syntax
-    */
-    multidim_subscript_write<T>(m_accMultiDimSyntax, idx, expectedWrite);
-
     /** validate id write syntax
     */
     elem = m_accIdSyntax[idx];
     if (!check_elems_equal(elem, expectedWrite)) {
       m_errorAccessor[2] = 1;
     }
+
+    /** check size_t write syntax
+    */
+    multidim_subscript_write<T>(m_accMultiDimSyntax, idx, expectedWrite);
 
     /** validate size_t write syntax
     */


### PR DESCRIPTION
According to the comments, test is supposed to do two checks in the following order: write using `id`, check the results, write using `size_t`, check the results.
Current order is write using `id`, write using `size_t`, check the results, check the results.