### PR TITLE
Make backing buffer large enough to avoid buffer overrun

### DIFF
--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -242,7 +242,8 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
           log.note("Device does not support images");
         } else {
           constexpr size_t imageSideSize = 16;
-          constexpr auto size = imageSideSize * imageSideSize;
+          /* Size is *4 because image data is 4 channels (RGBA) */
+          constexpr auto size = imageSideSize * imageSideSize * 4;
           float data[size] = {0.0f};
 
           const auto clContext = queue.get_context().get();


### PR DESCRIPTION
Appears to be a copy/paste error from the earlier buffer test, when moving to multi-channel image testing.