### PR TITLE
Changed sub buffer construction parameters

### DIFF
--- a/tests/buffer/buffer_api.cpp
+++ b/tests/buffer/buffer_api.cpp
@@ -250,7 +250,9 @@ void test_buffer(util::logger& log, cl::sycl::range<dims>& r,
     /* check is_sub_buffer() */
     {
       cl::sycl::buffer<T, dims> buf(r);
-      cl::sycl::buffer<T, dims> buf_sub(buf, i, r);
+      cl::sycl::range<dims> sub_r = r;
+      sub_r[0] = r[0] - i[0];
+      cl::sycl::buffer<T, dims> buf_sub(buf, i, sub_r);
       auto isSubBuffer = buf_sub.is_sub_buffer();
       check_return_type<bool>(log, isSubBuffer, "is_sub_buffer()");
     }
@@ -323,8 +325,8 @@ class TEST_NAME : public util::test_base {
     cl::sycl::range<3> range3d(size, size, size);
 
     cl::sycl::id<1> id1d(2);
-    cl::sycl::id<2> id2d(2, 2);
-    cl::sycl::id<3> id3d(2, 2, 2);
+    cl::sycl::id<2> id2d(2, 0);
+    cl::sycl::id<3> id3d(2, 0, 0);
 
     test_buffer<T, size, 1>(log, range1d, id1d);
     test_buffer<T, size * size, 2>(log, range2d, id2d);

--- a/tests/buffer/buffer_constructors.cpp
+++ b/tests/buffer/buffer_constructors.cpp
@@ -66,7 +66,9 @@ class buffer_ctors {
     /* Check subBuffer (buffer, id, range) constructor*/
     {
       cl::sycl::buffer<T, dims> buf(r);
-      cl::sycl::buffer<T, dims> buf_sub(buf, i, r);
+      cl::sycl::range<dims> sub_r = r;
+      sub_r[0] = r[0] - i[0];
+      cl::sycl::buffer<T, dims> buf_sub(buf, i, sub_r);
       if (!buf_sub.is_sub_buffer()) {
         FAIL(log, "buffer was not identified as a sub-buffer. (is_sub_buffer)");
       }
@@ -392,8 +394,8 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
     cl::sycl::range<3> range3d(size, size, size);
 
     cl::sycl::id<1> id1d(2);
-    cl::sycl::id<2> id2d(2, 2);
-    cl::sycl::id<3> id3d(2, 2, 2);
+    cl::sycl::id<2> id2d(2, 0);
+    cl::sycl::id<3> id3d(2, 0, 0);
 
     buffer_ctors<T, size, 1> buf1d;
     buffer_ctors<T, size * size, 2> buf2d;


### PR DESCRIPTION
According to the SYCL specification clarifications from
https://github.com/KhronosGroup/SYCL-Docs/pull/39, while constructing
sub buffer the offset and range specified by baseIndex and subRange
which passed to `buffer(buffer)` constructor together must represent a
contiguous region of the original SYCL buffer. Besides, the sum of
`baseIndex` and `subRange` in any dimension must not exceed the parent
buffer (`b`) size (`bufferRange`) in that dimension.

This patch changes an offset for sub buffer so it forms a contiguous region,
and calculates sub buffer range based on given offset and parent buffer range.

Patch by Ivan Karachun.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>