### PR TITLE
Fix out of bounds access in async_work_group_copy tests

### DIFF
--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -13,10 +13,10 @@
 namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 
-static const size_t GROUP_RANGE_1D = 2;
-static const size_t GROUP_RANGE_2D = 4;
-static const size_t GROUP_RANGE_3D = 8;
-static const size_t BUFFER_SIZE = 128;
+static constexpr size_t GROUP_RANGE_1D = 2;
+static constexpr size_t GROUP_RANGE_2D = 4;
+static constexpr size_t GROUP_RANGE_3D = 8;
+static constexpr size_t BUFFER_SIZE = 128;
 
 class group_async_work_group_copy_1d;
 class group_async_work_group_copy_2d;
@@ -60,8 +60,8 @@ class TEST_NAME : public util::test_base {
                 my_group.async_work_group_copy(ptrGlobal, ptrLocal,
                                                BUFFER_SIZE);
 
-                const size_t stride = 2;
-                const size_t numElements = BUFFER_SIZE / stride;
+                constexpr size_t stride = 2;
+                constexpr size_t numElements = BUFFER_SIZE / stride;
                 my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                                stride);
                 my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
@@ -90,8 +90,8 @@ class TEST_NAME : public util::test_base {
                 my_group.async_work_group_copy(ptrGlobal, ptrLocal,
                                                BUFFER_SIZE);
 
-                const size_t stride = 2;
-                const size_t numElements = BUFFER_SIZE / stride;
+                constexpr size_t stride = 2;
+                constexpr size_t numElements = BUFFER_SIZE / stride;
                 my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                                stride);
                 my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
@@ -121,8 +121,8 @@ class TEST_NAME : public util::test_base {
                 my_group.async_work_group_copy(ptrGlobal, ptrLocal,
                                                BUFFER_SIZE);
 
-                const size_t stride = 2;
-                const size_t numElements = BUFFER_SIZE / stride;
+                constexpr size_t stride = 2;
+                constexpr size_t numElements = BUFFER_SIZE / stride;
                 my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                                stride);
                 my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,

--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -61,9 +61,10 @@ class TEST_NAME : public util::test_base {
                                                BUFFER_SIZE);
 
                 const size_t stride = 2;
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE,
+                const size_t numElements = BUFFER_SIZE / stride;
+                my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                                stride);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE,
+                my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
                                                stride);
               });
         });
@@ -90,9 +91,10 @@ class TEST_NAME : public util::test_base {
                                                BUFFER_SIZE);
 
                 const size_t stride = 2;
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE,
+                const size_t numElements = BUFFER_SIZE / stride;
+                my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                                stride);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE,
+                my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
                                                stride);
               });
         });
@@ -120,9 +122,10 @@ class TEST_NAME : public util::test_base {
                                                BUFFER_SIZE);
 
                 const size_t stride = 2;
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE,
+                const size_t numElements = BUFFER_SIZE / stride;
+                my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                                stride);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE,
+                my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
                                                stride);
               });
         });

--- a/tests/nd_item/nd_item_async_work_group_copy.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy.cpp
@@ -13,10 +13,10 @@
 namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 
-static const size_t RANGE_SIZE_1D = 2;
-static const size_t RANGE_SIZE_2D = 4;
-static const size_t RANGE_SIZE_3D = 8;
-static const size_t BUFFER_SIZE = 128;
+static constexpr size_t RANGE_SIZE_1D = 2;
+static constexpr size_t RANGE_SIZE_2D = 4;
+static constexpr size_t RANGE_SIZE_3D = 8;
+static constexpr size_t BUFFER_SIZE = 128;
 
 class nd_item_async_work_group_copy_1d;
 class nd_item_async_work_group_copy_2d;
@@ -59,8 +59,8 @@ class TEST_NAME : public util::test_base {
                 ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE);
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
 
-                const size_t stride = 2;
-                const size_t numElements = BUFFER_SIZE / stride;
+                constexpr size_t stride = 2;
+                constexpr size_t numElements = BUFFER_SIZE / stride;
                 ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                              stride);
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
@@ -89,8 +89,8 @@ class TEST_NAME : public util::test_base {
                 ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE);
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
 
-                const size_t stride = 2;
-                const size_t numElements = BUFFER_SIZE / stride;
+                constexpr size_t stride = 2;
+                constexpr size_t numElements = BUFFER_SIZE / stride;
                 ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                              stride);
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
@@ -120,8 +120,8 @@ class TEST_NAME : public util::test_base {
                 ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE);
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
 
-                const size_t stride = 2;
-                const size_t numElements = BUFFER_SIZE / stride;
+                constexpr size_t stride = 2;
+                constexpr size_t numElements = BUFFER_SIZE / stride;
                 ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                              stride);
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,

--- a/tests/nd_item/nd_item_async_work_group_copy.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy.cpp
@@ -60,9 +60,10 @@ class TEST_NAME : public util::test_base {
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
 
                 const size_t stride = 2;
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE,
+                const size_t numElements = BUFFER_SIZE / stride;
+                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                              stride);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE,
+                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
                                              stride);
               });
         });
@@ -89,9 +90,10 @@ class TEST_NAME : public util::test_base {
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
 
                 const size_t stride = 2;
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE,
+                const size_t numElements = BUFFER_SIZE / stride;
+                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                              stride);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE,
+                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
                                              stride);
               });
         });
@@ -119,9 +121,10 @@ class TEST_NAME : public util::test_base {
                 ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
 
                 const size_t stride = 2;
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE,
+                const size_t numElements = BUFFER_SIZE / stride;
+                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
                                              stride);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE,
+                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
                                              stride);
               });
         });


### PR DESCRIPTION
async_work_group_copy test cases using strides copy the same number of elements as buffer holds, but buffer allocations do not take "strides" into consideration, which leads to out-of-bounds accesses.