### PR TITLE
Fix undefined behavior in h_item test

### DIFF
--- a/tests/h_item/h_item_api.cpp
+++ b/tests/h_item/h_item_api.cpp
@@ -121,21 +121,21 @@ class TEST_NAME : public util::test_base {
         testQueue.submit([&](cl::sycl::handler& cgh) {
           cgh.parallel_for_work_group(
               kernelGroupRange, kernelPhysicalLocalRange,
-              h_item_api_kernel_single<numDims, 1>{kernelLogicalLocalRange});
+              h_item_api_kernel_single<numDims, 0>{kernelLogicalLocalRange});
         });
       }
       if (numDims >= 2) {
         testQueue.submit([&](cl::sycl::handler& cgh) {
           cgh.parallel_for_work_group(
               kernelGroupRange, kernelPhysicalLocalRange,
-              h_item_api_kernel_single<numDims, 2>{kernelLogicalLocalRange});
+              h_item_api_kernel_single<numDims, 1>{kernelLogicalLocalRange});
         });
       }
       if (numDims >= 3) {
         testQueue.submit([&](cl::sycl::handler& cgh) {
           cgh.parallel_for_work_group(
               kernelGroupRange, kernelPhysicalLocalRange,
-              h_item_api_kernel_single<numDims, 3>{kernelLogicalLocalRange});
+              h_item_api_kernel_single<numDims, 2>{kernelLogicalLocalRange});
         });
       }
 


### PR DESCRIPTION
Class template `h_item_api_kernel_single` has two template parameters
number of dimensions and the current dimension index. Setting the
current index equal to the number of dimensions is undefined behavior.
Current index must be less than number of dimensions.