### PR TITLE
Move interoperability test cases to the opencl_interop test

### DIFF
--- a/tests/buffer/buffer_constructors.cpp
+++ b/tests/buffer/buffer_constructors.cpp
@@ -7,7 +7,6 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../../util/test_base_opencl.h"
 
 #define TEST_NAME buffer_constructors
 
@@ -25,7 +24,7 @@ class buffer_ctors {
   void operator()(cl::sycl::range<dims> &r, cl::sycl::id<dims> &i,
                   const cl::sycl::property_list &propList,
                   fail_proxy_alias fail_proxy,
-                  sycl_cts::util::test_base_opencl &helper, util::logger &log) {
+                  sycl_cts::util::test_base &helper, util::logger &log) {
     /* Check range constructor */
     {
       cl::sycl::buffer<T, dims> buf(r, propList);
@@ -163,91 +162,6 @@ class buffer_ctors {
                                                          buf_alloc);
     }
 
-    /* Check interop constructor */
-    if (dims == 1) {
-      // calculate element count, size and range for the interop buffer
-      cl::sycl::range<1> interopRange{r[0]};
-      size_t count = r[0];
-      size_t interopSize = count * sizeof(T);
-
-      // construct the SYCL buffer
-      cl_mem opencl_buffer;
-      if (!helper.create_buffer(opencl_buffer, interopSize, log)) {
-        FAIL(log,
-             "opencl buffer was not constructed properly. (interop), failed to "
-             "create OpenCL buffer");
-      }
-      cl::sycl::buffer<T, 1> buf(opencl_buffer,
-                                    cl::sycl::context(helper.get_cl_context()));
-
-      // check the buffer
-      if (buf.is_sub_buffer()) {
-        FAIL(log,
-             "opencl buffer was not interop constructed properly. "
-             "(is_sub_buffer) ");
-      }
-      if (buf.get_size() != interopSize) {
-        FAIL(log,
-             "opencl buffer was not interop constructed properly. (get_size) ");
-      }
-      if (buf.get_range() != interopRange) {
-        FAIL(
-            log,
-            "opencl buffer was not interop constructed properly. (get_range) ");
-      }
-      if (buf.get_count() != count) {
-        FAIL(
-            log,
-            "opencl buffer was not interop constructed properly. (get_count) ");
-      }
-    }
-
-    /* Check interop constructor with event*/
-    if (dims == 1) {
-      // create an event to wait for
-      cl::sycl::queue q;
-      cl::sycl::event e = q.submit([](cl::sycl::handler &cgh) {
-        cgh.single_task<BufferInteropNoEvent<T, size, dims>>(
-            []() {});  // do not do anything here, we only need the event
-      });
-
-      // calculate element count, size and range for the interop buffer
-      cl::sycl::range<1> interopRange{r[0]};
-      size_t count = r[0];
-      size_t interopSize = count * sizeof(T);
-
-      // construct the SYCL buffer
-      cl_mem opencl_buffer;
-      if (!helper.create_buffer(opencl_buffer, interopSize, log)) {
-        FAIL(log,
-             "opencl buffer was not constructed properly. (interop), failed to "
-             "create OpenCL buffer");
-      }
-      cl::sycl::buffer<T, 1> buf(
-          opencl_buffer, cl::sycl::context(helper.get_cl_context()), e);
-
-      // check the buffer
-      if (buf.is_sub_buffer()) {
-        FAIL(log,
-             "opencl buffer was not interop constructed properly. "
-             "(is_sub_buffer) ");
-      }
-      if (buf.get_size() != interopSize) {
-        FAIL(log,
-             "opencl buffer was not interop constructed properly. (get_size) ");
-      }
-      if (buf.get_range() != interopRange) {
-        FAIL(
-            log,
-            "opencl buffer was not interop constructed properly. (get_range) ");
-      }
-      if (buf.get_count() != count) {
-        FAIL(
-            log,
-            "opencl buffer was not interop constructed properly. (get_count) ");
-      }
-    }
-
     /* Check copy constructor */
     {
       cl::sycl::buffer<T, dims> bufA(r);
@@ -378,7 +292,7 @@ class buffer_ctors {
 /**
  * test cl::sycl::buffer initialization
  */
-class TEST_NAME : public sycl_cts::util::test_base_opencl {
+class TEST_NAME : public sycl_cts::util::test_base {
  public:
   /** return information about this test
    */

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -19,9 +19,7 @@
 #include "../../util/proxy.h"
 #include "macros.h"
 
-#include "../../util/opencl_helper.h"
 #include "../../util/test_base.h"
-#include "../../util/test_base_opencl.h"
 #include "../../util/math_vector.h"
 
 #include <string>

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -20,9 +20,7 @@
 #include "../../util/proxy.h"
 #include "macros.h"
 
-#include "../../util/opencl_helper.h"
 #include "../../util/test_base.h"
-#include "../../util/test_base_opencl.h"
 #include "../../util/math_vector.h"
 
 #include <string>

--- a/tests/image/image_api.cpp
+++ b/tests/image/image_api.cpp
@@ -365,7 +365,7 @@ class image_ctors {
 /**
  * test cl::sycl::image initialization
  */
-class TEST_NAME : public util::test_base_opencl {
+class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
    */

--- a/tests/kernel/kernel_api.cpp
+++ b/tests/kernel/kernel_api.cpp
@@ -19,7 +19,7 @@ using namespace sycl_cts;
 
 /** test cl::sycl::kernel
  */
-class TEST_NAME : public sycl_cts::util::test_base_opencl {
+class TEST_NAME : public sycl_cts::util::test_base {
  public:
   /** return information about this test
    */
@@ -41,11 +41,6 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
       ctsQueue.submit(
           [&](cl::sycl::handler &h) { h.single_task(kernel_name_api{}); });
       ctsQueue.wait_and_throw();
-
-      if (!isHostCtx) {
-        // Check get()
-        cl_kernel krnl = k.get();
-      }
 
       // Check is_host()
       bool isHost = k.is_host();

--- a/tests/kernel/kernel_constructors.cpp
+++ b/tests/kernel/kernel_constructors.cpp
@@ -24,7 +24,7 @@ using namespace sycl_cts;
 
 /** test cl::sycl::kernel
  */
-class TEST_NAME : public sycl_cts::util::test_base_opencl {
+class TEST_NAME : public sycl_cts::util::test_base {
  public:
   /** return information about this test
    */

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -17,7 +17,7 @@ class kernel0;
 
 /** tests the info for cl::sycl::kernel
  */
-class TEST_NAME : public sycl_cts::util::test_base_opencl {
+class TEST_NAME : public sycl_cts::util::test_base {
  public:
   /** return information about this test
    */

--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -7,6 +7,8 @@
 *******************************************************************************/
 
 #include "../common/common.h"
+#include "../../util/opencl_helper.h"
+#include "../../util/test_base_opencl.h"
 
 #define TEST_NAME opencl_interop_constructors
 
@@ -198,6 +200,66 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
         }
       }
 
+      /** check buffer (cl_mem, contex) constructor
+       */
+      {
+        const size_t size = 32;
+        int data[size] = {0};
+        cl_int error = CL_SUCCESS;
+
+        auto queue = util::get_cts_object::queue(ctsSelector);
+
+        cl_mem clBuffer = clCreateBuffer(
+            queue.get_context().get(), CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+            size * sizeof(int), data, &error);
+        if (!CHECK_CL_SUCCESS(log, error)) {
+          FAIL(log, "create buffer failed");
+        }
+
+        cl::sycl::buffer<int, 1> buffer(clBuffer, queue.get_context());
+
+        // calculate element count, size and range for the interop buffer
+        cl::sycl::range<1> interopRange{size};
+        size_t interopSize = size * sizeof(int);
+
+
+        // check the buffer
+        if (buffer.is_sub_buffer()) {
+          FAIL(log,
+               "opencl buffer was not interop constructed properly. "
+               "(is_sub_buffer) ");
+        }
+        if (buffer.get_size() != interopSize) {
+          FAIL(log,
+               "opencl buffer was not interop constructed properly. (get_size) ");
+        }
+        if (buffer.get_range() != interopRange) {
+          FAIL(
+              log,
+              "opencl buffer was not interop constructed properly. (get_range) ");
+        }
+        if (buffer.get_count() != size) {
+          FAIL(
+              log,
+              "opencl buffer was not interop constructed properly. (get_count) ");
+        }
+
+        queue.submit([&](cl::sycl::handler &handler) {
+          auto accessor =
+              buffer.get_access<cl::sycl::access::mode::read_write,
+                                cl::sycl::access::target::global_buffer>(
+                  handler);
+          handler.single_task<class buffer_interop_constructor_kernel_no_event>([]() {});
+        });
+
+        error = clReleaseMemObject(clBuffer);
+        if (!CHECK_CL_SUCCESS(log, error)) {
+          FAIL(log, "failed to release OpenCL buffer");
+        }
+
+        queue.wait_and_throw();
+      }
+
       /** check buffer (cl_mem, context, event) constructor
        */
       {
@@ -206,7 +268,12 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
         cl_int error = CL_SUCCESS;
 
         auto queue = util::get_cts_object::queue(ctsSelector);
-        cl::sycl::event event;
+
+        // create an event to wait for
+        cl::sycl::event event = queue.submit([](cl::sycl::handler &cgh) {
+          cgh.single_task<class buffer_interop_event>(
+              []() {});  // do not do anything here, we only need the event
+        });
 
         cl_mem clBuffer = clCreateBuffer(
             queue.get_context().get(), CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
@@ -217,12 +284,38 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
 
         cl::sycl::buffer<int, 1> buffer(clBuffer, queue.get_context(), event);
 
+        // calculate element count, size and range for the interop buffer
+        cl::sycl::range<1> interopRange{size};
+        size_t interopSize = size * sizeof(int);
+
+
+        // check the buffer
+        if (buffer.is_sub_buffer()) {
+          FAIL(log,
+               "opencl buffer was not interop constructed properly. "
+               "(is_sub_buffer) ");
+        }
+        if (buffer.get_size() != interopSize) {
+          FAIL(log,
+               "opencl buffer was not interop constructed properly. (get_size) ");
+        }
+        if (buffer.get_range() != interopRange) {
+          FAIL(
+              log,
+              "opencl buffer was not interop constructed properly. (get_range) ");
+        }
+        if (buffer.get_count() != size) {
+          FAIL(
+              log,
+              "opencl buffer was not interop constructed properly. (get_count) ");
+        }
+
         queue.submit([&](cl::sycl::handler &handler) {
           auto accessor =
               buffer.get_access<cl::sycl::access::mode::read_write,
                                 cl::sycl::access::target::global_buffer>(
                   handler);
-          handler.single_task<class buffer_interop_constructor_kernel>([]() {});
+          handler.single_task<class buffer_interop_constructor_kernel_with_event>([]() {});
         });
 
         error = clReleaseMemObject(clBuffer);

--- a/tests/opencl_interop/opencl_interop_get.cpp
+++ b/tests/opencl_interop/opencl_interop_get.cpp
@@ -7,6 +7,8 @@
 *******************************************************************************/
 
 #include "../common/common.h"
+#include "../../util/opencl_helper.h"
+#include "../../util/test_base_opencl.h"
 
 #define TEST_NAME opencl_interop_get
 

--- a/tests/program/program_constructors.cpp
+++ b/tests/program/program_constructors.cpp
@@ -36,7 +36,7 @@ using namespace sycl_cts;
 
 /** tests the constructors for cl::sycl::platform
  */
-class TEST_NAME : public sycl_cts::util::test_base_opencl {
+class TEST_NAME : public sycl_cts::util::test_base {
  public:
   /** return information about this test
    */

--- a/tests/program/program_info.cpp
+++ b/tests/program/program_info.cpp
@@ -15,7 +15,7 @@ using namespace sycl_cts;
 
 /** tests the info for cl::sycl::program
  */
-class TEST_NAME : public sycl_cts::util::test_base_opencl {
+class TEST_NAME : public sycl_cts::util::test_base {
  public:
   /** return information about this test
    */


### PR DESCRIPTION
SYCL CTS has a separate test checking interoperability with OpenCL.
There are some cases when this functionality is tested in other tests.
There are also cases of unnecessary inheritance from interoperability
utility class. Patch fixes described problems.

Patch by Artur Gainullin <artur.gainullin@intel.com>