### PR TITLE
Allow additional flags to be passed to Intel SYCL

### DIFF
--- a/cmake/FindIntel_SYCL.cmake
+++ b/cmake/FindIntel_SYCL.cmake
@@ -6,11 +6,20 @@ find_program(INTEL_SYCL_CXX_EXECUTABLE clang++ HINTS ${INTEL_SYCL_ROOT}
 set(CMAKE_C_COMPILER    ${INTEL_SYCL_C_EXECUTABLE})
 set(CMAKE_CXX_COMPILER  ${INTEL_SYCL_CXX_EXECUTABLE})
 
+if(NOT DEFINED INTEL_SYCL_TRIPLE)
+   set(INTEL_SYCL_TRIPLE spir64-unknown-linux-sycldevice)
+endif()
+message("Intel SYCL: compiling SYCL to ${INTEL_SYCL_TRIPLE}")
+
+if(DEFINED INTEL_SYCL_FLAGS)
+    message("Intel SYCL: compiling SYCL using `${INTEL_SYCL_FLAGS}`")
+endif()
+
 add_library(INTEL_SYCL::Runtime INTERFACE IMPORTED GLOBAL)
 set_target_properties(INTEL_SYCL::Runtime PROPERTIES
     INTERFACE_LINK_LIBRARIES    OpenCL::OpenCL
-    INTERFACE_COMPILE_OPTIONS   -fsycl
-    INTERFACE_LINK_OPTIONS      -fsycl)
+    INTERFACE_COMPILE_OPTIONS   "-fsycl;-fsycl-targets=${INTEL_SYCL_TRIPLE};${INTEL_SYCL_FLAGS}"
+    INTERFACE_LINK_OPTIONS      "-fsycl;-fsycl-targets=${INTEL_SYCL_TRIPLE};${INTEL_SYCL_FLAGS}")
 
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 set_target_properties(SYCL::SYCL PROPERTIES

--- a/tests/common/cts_selector.h
+++ b/tests/common/cts_selector.h
@@ -98,7 +98,7 @@ class cts_selector : public cl::sycl::device_selector {
     }
 
     cl::sycl::string_class vendor =
-        dev.get_platform().get_info<cl::sycl::info::platform::name>();
+        dev.get_platform().get_info<cl::sycl::info::platform::vendor>();
     cl::sycl::info::device_type type =
         dev.get_info<cl::sycl::info::device::device_type>();
 


### PR DESCRIPTION
This patch allows new options for Intel SYCL to be passed to the SYCL CTS.

A minor fix is included that will resolve #13. The correct vendor information is now used within the device selector.