### PR TITLE
Enhance handler copy test cases

### DIFF
--- a/tests/handler/handler_copy.cpp
+++ b/tests/handler/handler_copy.cpp
@@ -16,17 +16,14 @@ using namespace sycl_cts;
 using mode_t = cl::sycl::access::mode;
 using target_t = cl::sycl::access::target;
 
-struct simple_struct {
-  simple_struct(int va = 0, float vb = 0) : a(va), b(vb) {}
-  int a;
-  float b;
-};
-
 /**
  * @brief Helps with getting the buffer range and filling the buffer with data
  */
+template <typename dataT, int dims>
+struct buffer_helper;
+
 template <typename dataT>
-struct buffer_helper {
+struct buffer_helper<dataT, 1> {
   static cl::sycl::range<1> construct_range(size_t elemsPerDim) {
     return {elemsPerDim};
   }
@@ -39,24 +36,62 @@ struct buffer_helper {
   }
 };
 
+template <typename dataT>
+struct buffer_helper<dataT, 2> {
+  static cl::sycl::range<2> construct_range(size_t elemsPerDim) {
+    return {elemsPerDim, elemsPerDim};
+  }
+  static void fill(cl::sycl::buffer<dataT, 2>& buf, const dataT& value) {
+    auto r = buf.get_range();
+    auto acc = buf.template get_access<mode_t::discard_write>();
+    for (int r0 = 0; r0 < r[0]; ++r0) {
+      for (int r1 = 0; r1 < r[1]; ++r1) {
+        acc[r0][r1] = value;
+      }
+    }
+  }
+};
+
+template <typename dataT>
+struct buffer_helper<dataT, 3> {
+  static cl::sycl::range<3> construct_range(size_t elemsPerDim) {
+    return {elemsPerDim, elemsPerDim, elemsPerDim};
+  }
+  static void fill(cl::sycl::buffer<dataT, 3>& buf, const dataT& value) {
+    auto r = buf.get_range();
+    auto acc = buf.template get_access<mode_t::discard_write>();
+    for (int r0 = 0; r0 < r[0]; ++r0) {
+      for (int r1 = 0; r1 < r[1]; ++r1) {
+        for (int r2 = 0; r2 < r[2]; ++r2) {
+          acc[r0][r1][r2] = value;
+        }
+      }
+    }
+  }
+};
+
 /**
  * @brief Base class that stores some data that helps with checks
  */
-template <typename dataT>
+template <typename dataT, int dim_src, int dim_dst>
 struct test_single_copy_function_base {
   using host_shared_ptr = cl::sycl::shared_ptr_class<dataT>;
-  using buffer_t = cl::sycl::buffer<dataT, 1>;
+  using buffer_src_t = cl::sycl::buffer<dataT, dim_src>;
+  using buffer_dst_t = cl::sycl::buffer<dataT, dim_dst>;
 
-  static constexpr size_t elemsPerDim = 42;
-  static constexpr size_t offsetPerDim = 4;
-  static constexpr size_t regionPerDim = 16;
-  static constexpr size_t numElems = elemsPerDim;
+  static constexpr int get_elems(int dim) {
+    return (dim == 1) ? 64 : (dim == 2) ? 8 : 4;
+  }
+
+  static constexpr size_t numElems = 64;
+  static constexpr size_t elemsSrcPerDim = get_elems(dim_src);
+  static constexpr size_t elemsDstPerDim = get_elems(dim_dst);
   static constexpr size_t bufferInitValue = 17;
 
-  buffer_t m_bufRead =
-      buffer_t(buffer_helper<dataT>::construct_range(elemsPerDim));
-  buffer_t m_bufWrite =
-      buffer_t(buffer_helper<dataT>::construct_range(elemsPerDim));
+  buffer_src_t m_bufRead = buffer_src_t(
+      buffer_helper<dataT, dim_src>::construct_range(elemsSrcPerDim));
+  buffer_dst_t m_bufWrite = buffer_dst_t(
+      buffer_helper<dataT, dim_dst>::construct_range(elemsDstPerDim));
 
   host_shared_ptr m_hostPtrRead =
       host_shared_ptr(new dataT[numElems], std::default_delete<dataT[]>());
@@ -64,9 +99,10 @@ struct test_single_copy_function_base {
       host_shared_ptr(new dataT[numElems], std::default_delete<dataT[]>());
 
   void reset_data() {
-    buffer_helper<dataT>::fill(this->m_bufRead,
-                               static_cast<dataT>(bufferInitValue));
-    buffer_helper<dataT>::fill(this->m_bufWrite, static_cast<dataT>(0));
+    buffer_helper<dataT, dim_src>::fill(this->m_bufRead,
+                                        static_cast<dataT>(bufferInitValue));
+    buffer_helper<dataT, dim_dst>::fill(this->m_bufWrite,
+                                        static_cast<dataT>(0));
     for (int i = 0; i < numElems; ++i) {
       m_hostPtrRead.get()[i] = static_cast<dataT>(i);
       m_hostPtrWrite.get()[i] = static_cast<dataT>(0);
@@ -77,77 +113,79 @@ struct test_single_copy_function_base {
 /**
  * @brief Creates an accessor based on the access target
  */
-template <typename dataT, mode_t mode, target_t target>
+template <typename dataT, int dims, mode_t mode, target_t target>
 struct accessor_helper;
 
-template <typename dataT, mode_t mode>
-struct accessor_helper<dataT, mode, target_t::global_buffer> {
+template <typename dataT, int dims, mode_t mode>
+struct accessor_helper<dataT, dims, mode, target_t::global_buffer> {
   static constexpr target_t target = target_t::global_buffer;
-  static cl::sycl::accessor<dataT, 1, mode, target> get(
-      cl::sycl::handler& cgh, cl::sycl::buffer<dataT, 1>& buf) {
+  static cl::sycl::accessor<dataT, dims, mode, target> get(
+      cl::sycl::handler& cgh, cl::sycl::buffer<dataT, dims>& buf) {
     return buf.template get_access<mode, target>(cgh);
   }
 };
-template <typename dataT, mode_t mode>
-struct accessor_helper<dataT, mode, target_t::constant_buffer> {
+template <typename dataT, int dims, mode_t mode>
+struct accessor_helper<dataT, dims, mode, target_t::constant_buffer> {
   static constexpr target_t target = target_t::constant_buffer;
-  static cl::sycl::accessor<dataT, 1, mode, target> get(
-      cl::sycl::handler& cgh, cl::sycl::buffer<dataT, 1>& buf) {
+  static cl::sycl::accessor<dataT, dims, mode, target> get(
+      cl::sycl::handler& cgh, cl::sycl::buffer<dataT, dims>& buf) {
     return buf.template get_access<mode, target>(cgh);
   }
 };
-template <typename dataT, mode_t mode>
-struct accessor_helper<dataT, mode, target_t::host_buffer> {
+template <typename dataT, int dims, mode_t mode>
+struct accessor_helper<dataT, dims, mode, target_t::host_buffer> {
   static constexpr target_t target = target_t::host_buffer;
-  static cl::sycl::accessor<dataT, 1, mode, target> get(
-      cl::sycl::handler& cgh, cl::sycl::buffer<dataT, 1>& buf) {
+  static cl::sycl::accessor<dataT, dims, mode, target> get(
+      cl::sycl::handler& cgh, cl::sycl::buffer<dataT, dims>& buf) {
     return buf.template get_access<mode>();
   }
 };
-template <typename dataT, mode_t mode>
-struct accessor_helper<dataT, mode, target_t::local> {
+template <typename dataT, int dims, mode_t mode>
+struct accessor_helper<dataT, dims, mode, target_t::local> {
   static constexpr target_t target = target_t::local;
-  static cl::sycl::accessor<dataT, 1, mode, target> get(
-      cl::sycl::handler& cgh, cl::sycl::buffer<dataT, 1>& buf) {
-    const auto elemsPerDim = test_single_copy_function_base<dataT>::elemsPerDim;
-    auto allocationSize = buffer_helper<dataT>::construct_range(elemsPerDim);
-    return cl::sycl::accessor<dataT, 1, mode, target>(allocationSize, cgh);
+  static cl::sycl::accessor<dataT, dims, mode, target> get(
+      cl::sycl::handler& cgh, cl::sycl::buffer<dataT, dims>& buf) {
+    const auto elemsPerDim =
+        test_single_copy_function_base<dataT, dims, dims>::numElems / dims;
+    auto allocationSize =
+        buffer_helper<dataT, dims>::construct_range(elemsPerDim);
+    return cl::sycl::accessor<dataT, dims, mode, target>(allocationSize, cgh);
   }
 };
 
 /**
  * @brief Checks whether copy functions that accept a read accessor work.
  */
-#define TEST_SINGLE_COPY_FUNCTION_ACC_READ(dataT, readMode, target, queue, \
-                                           func)                           \
-  {                                                                        \
-    test_single_copy_function_base<dataT> testBase;                        \
-    testBase.reset_data();                                                 \
-    queue.submit([&](cl::sycl::handler& cgh) {                             \
-      auto accRead = accessor_helper<dataT, readMode, target>::get(        \
-          cgh, testBase.m_bufRead);                                        \
-      func(cgh, accRead, testBase.m_hostPtrWrite);                         \
-    });                                                                    \
-    queue.wait_and_throw();                                                \
+#define TEST_SINGLE_COPY_FUNCTION_ACC_READ(dataT, dims, readMode, target, \
+                                           queue, func)                   \
+  {                                                                       \
+    test_single_copy_function_base<dataT, dims, dims> testBase;           \
+    testBase.reset_data();                                                \
+    queue.submit([&](cl::sycl::handler& cgh) {                            \
+      auto accRead = accessor_helper<dataT, dims, readMode, target>::get( \
+          cgh, testBase.m_bufRead);                                       \
+      func(cgh, accRead, testBase.m_hostPtrWrite);                        \
+    });                                                                   \
+    queue.wait_and_throw();                                               \
   }
 
 /**
  * @brief Checks whether copy functions that accept a write accessor work.
  */
-#define TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, readMode, writeMode, \
-                                            target, queue, func)        \
-  {                                                                     \
-    test_single_copy_function_base<dataT> testBase;                     \
-    testBase.reset_data();                                              \
-    queue.submit([&](cl::sycl::handler& cgh) {                          \
-      auto accRead = accessor_helper<dataT, readMode, target>::get(     \
-          cgh, testBase.m_bufRead);                                     \
-      auto accWrite = accessor_helper<dataT, writeMode, target>::get(   \
-          cgh, testBase.m_bufWrite);                                    \
-      func(cgh, accRead, accWrite, testBase.m_hostPtrRead,              \
-           testBase.m_hostPtrWrite);                                    \
-    });                                                                 \
-    queue.wait_and_throw();                                             \
+#define TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, dim_src, dim_dst, readMode, \
+                                            writeMode, target, queue, func)    \
+  {                                                                            \
+    test_single_copy_function_base<dataT, dim_src, dim_dst> testBase;          \
+    testBase.reset_data();                                                     \
+    queue.submit([&](cl::sycl::handler& cgh) {                                 \
+      auto accRead = accessor_helper<dataT, dim_src, readMode, target>::get(   \
+          cgh, testBase.m_bufRead);                                            \
+      auto accWrite = accessor_helper<dataT, dim_dst, writeMode, target>::get( \
+          cgh, testBase.m_bufWrite);                                           \
+      func(cgh, accRead, accWrite, testBase.m_hostPtrRead,                     \
+           testBase.m_hostPtrWrite);                                           \
+    });                                                                        \
+    queue.wait_and_throw();                                                    \
   }
 
 /**
@@ -155,9 +193,9 @@ struct accessor_helper<dataT, mode, target_t::local> {
  *        on to be tested. This doesn't include functions that expect a write
  *        accessor.
  */
-template <typename dataT, mode_t readMode, target_t target>
+template <typename dataT, int dim, mode_t readMode, target_t target>
 void test_read_acc_copy_functions(cl::sycl::queue& queue) {
-  using acc_read_t = cl::sycl::accessor<dataT, 1, readMode, target>;
+  using acc_read_t = cl::sycl::accessor<dataT, dim, readMode, target>;
   using host_shared_ptr = cl::sycl::shared_ptr_class<dataT>;
 
   {
@@ -166,7 +204,8 @@ void test_read_acc_copy_functions(cl::sycl::queue& queue) {
                          host_shared_ptr hostPtrWrite) {
       cgh.copy(accRead, hostPtrWrite);
     };
-    TEST_SINGLE_COPY_FUNCTION_ACC_READ(dataT, readMode, target, queue, func);
+    TEST_SINGLE_COPY_FUNCTION_ACC_READ(dataT, dim, readMode, target, queue,
+                                       func);
   }
   {
     // Check copy(accessor, dataT*)
@@ -174,7 +213,8 @@ void test_read_acc_copy_functions(cl::sycl::queue& queue) {
                          host_shared_ptr hostPtrWrite) {
       cgh.copy(accRead, hostPtrWrite.get());
     };
-    TEST_SINGLE_COPY_FUNCTION_ACC_READ(dataT, readMode, target, queue, func);
+    TEST_SINGLE_COPY_FUNCTION_ACC_READ(dataT, dim, readMode, target, queue,
+                                       func);
   }
   {
     // Check update_host(accessor)
@@ -182,7 +222,8 @@ void test_read_acc_copy_functions(cl::sycl::queue& queue) {
                          host_shared_ptr hostPtrWrite) {
       cgh.update_host(accRead);
     };
-    TEST_SINGLE_COPY_FUNCTION_ACC_READ(dataT, readMode, target, queue, func);
+    TEST_SINGLE_COPY_FUNCTION_ACC_READ(dataT, dim, readMode, target, queue,
+                                       func);
   }
 }
 
@@ -190,10 +231,11 @@ void test_read_acc_copy_functions(cl::sycl::queue& queue) {
  * @brief Creates lambdas with the actual tested functionality and passes them
  *        on to be tested. This includes functions that expect a write accessor.
  */
-template <typename dataT, mode_t readMode, mode_t writeMode, target_t target>
+template <typename dataT, int dim_src, int dim_dst, mode_t readMode,
+          mode_t writeMode, target_t target>
 void test_write_acc_copy_functions(cl::sycl::queue& queue) {
-  using acc_read_t = cl::sycl::accessor<dataT, 1, readMode, target>;
-  using acc_write_t = cl::sycl::accessor<dataT, 1, writeMode, target>;
+  using acc_read_t = cl::sycl::accessor<dataT, dim_src, readMode, target>;
+  using acc_write_t = cl::sycl::accessor<dataT, dim_dst, writeMode, target>;
   using host_shared_ptr = cl::sycl::shared_ptr_class<dataT>;
 
   {
@@ -203,8 +245,8 @@ void test_write_acc_copy_functions(cl::sycl::queue& queue) {
                          host_shared_ptr hostPtrWrite) {
       cgh.copy(hostPtrRead, accWrite);
     };
-    TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, readMode, writeMode, target,
-                                        queue, func);
+    TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, dim_src, dim_dst, readMode,
+                                        writeMode, target, queue, func);
   }
   {
     // Check copy(dataT*, accessor)
@@ -213,8 +255,8 @@ void test_write_acc_copy_functions(cl::sycl::queue& queue) {
                          host_shared_ptr hostPtrWrite) {
       cgh.copy(hostPtrRead.get(), accWrite);
     };
-    TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, readMode, writeMode, target,
-                                        queue, func);
+    TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, dim_src, dim_dst, readMode,
+                                        writeMode, target, queue, func);
   }
   {
     // Check copy(accessor, accessor)
@@ -223,8 +265,8 @@ void test_write_acc_copy_functions(cl::sycl::queue& queue) {
                          host_shared_ptr hostPtrWrite) {
       cgh.copy(accRead, accWrite);
     };
-    TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, readMode, writeMode, target,
-                                        queue, func);
+    TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, dim_src, dim_dst, readMode,
+                                        writeMode, target, queue, func);
   }
   {
     // Check fill(accessor, dataT)
@@ -234,8 +276,8 @@ void test_write_acc_copy_functions(cl::sycl::queue& queue) {
       const auto pattern = dataT(117);
       cgh.fill(accWrite, pattern);
     };
-    TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, readMode, writeMode, target,
-                                        queue, func);
+    TEST_SINGLE_COPY_FUNCTION_ACC_WRITE(dataT, dim_src, dim_dst, readMode,
+                                        writeMode, target, queue, func);
   }
 }
 
@@ -243,41 +285,63 @@ void test_write_acc_copy_functions(cl::sycl::queue& queue) {
  * @brief Tests all valid combinations of source and destination accessor access
  *        modes.
  */
-template <typename dataT>
+template <typename dataT, int dim_src, int dim_dst>
 void test_all_copy_functions(cl::sycl::queue& queue) {
   {
     // target == global_buffer
 
-    test_read_acc_copy_functions<dataT, mode_t::read, target_t::global_buffer>(
+    test_read_acc_copy_functions<dataT, dim_src, mode_t::read,
+                                 target_t::global_buffer>(queue);
+    test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read,
+                                  mode_t::write, target_t::global_buffer>(
         queue);
-    test_write_acc_copy_functions<dataT, mode_t::read, mode_t::write,
+    test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read,
+                                  mode_t::read_write, target_t::global_buffer>(
+        queue);
+    test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read,
+                                  mode_t::discard_write,
                                   target_t::global_buffer>(queue);
-    test_write_acc_copy_functions<dataT, mode_t::read, mode_t::read_write,
-                                  target_t::global_buffer>(queue);
-    test_write_acc_copy_functions<dataT, mode_t::read, mode_t::discard_write,
-                                  target_t::global_buffer>(queue);
-    test_write_acc_copy_functions<dataT, mode_t::read,
+    test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read,
                                   mode_t::discard_read_write,
                                   target_t::global_buffer>(queue);
 
-    test_read_acc_copy_functions<dataT, mode_t::read_write,
+    test_read_acc_copy_functions<dataT, dim_src, mode_t::read_write,
                                  target_t::global_buffer>(queue);
-    test_write_acc_copy_functions<dataT, mode_t::read_write, mode_t::write,
-                                  target_t::global_buffer>(queue);
-    test_write_acc_copy_functions<dataT, mode_t::read_write, mode_t::read_write,
-                                  target_t::global_buffer>(queue);
-    test_write_acc_copy_functions<dataT, mode_t::read_write,
+    test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read_write,
+                                  mode_t::write, target_t::global_buffer>(
+        queue);
+    test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read_write,
+                                  mode_t::read_write, target_t::global_buffer>(
+        queue);
+    test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read_write,
                                   mode_t::discard_write,
                                   target_t::global_buffer>(queue);
-    test_write_acc_copy_functions<dataT, mode_t::read_write,
+    test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read_write,
                                   mode_t::discard_read_write,
                                   target_t::global_buffer>(queue);
   }
   {
     // target == constant_buffer
-    test_read_acc_copy_functions<dataT, mode_t::read,
+    test_read_acc_copy_functions<dataT, dim_src, mode_t::read,
                                  target_t::constant_buffer>(queue);
   }
+}
+
+template <int dim_src, int dim_dst>
+void test_all_dimensions(cl::sycl::queue& queue) {
+  test_all_copy_functions<char, dim_src, dim_dst>(queue);
+  test_all_copy_functions<short, dim_src, dim_dst>(queue);
+  test_all_copy_functions<int, dim_src, dim_dst>(queue);
+  test_all_copy_functions<long, dim_src, dim_dst>(queue);
+  test_all_copy_functions<float, dim_src, dim_dst>(queue);
+  test_all_copy_functions<double, dim_src, dim_dst>(queue);
+
+  test_all_copy_functions<cl::sycl::char2, dim_src, dim_dst>(queue);
+  test_all_copy_functions<cl::sycl::short3, dim_src, dim_dst>(queue);
+  test_all_copy_functions<cl::sycl::int4, dim_src, dim_dst>(queue);
+  test_all_copy_functions<cl::sycl::long8, dim_src, dim_dst>(queue);
+  test_all_copy_functions<cl::sycl::float8, dim_src, dim_dst>(queue);
+  test_all_copy_functions<cl::sycl::double16, dim_src, dim_dst>(queue);
 }
 
 /** tests the API for cl::sycl::handler
@@ -296,19 +360,15 @@ class TEST_NAME : public util::test_base {
     try {
       auto queue = util::get_cts_object::queue();
 
-      test_all_copy_functions<char>(queue);
-      test_all_copy_functions<short>(queue);
-      test_all_copy_functions<int>(queue);
-      test_all_copy_functions<long>(queue);
-      test_all_copy_functions<float>(queue);
-      test_all_copy_functions<double>(queue);
-
-      test_all_copy_functions<cl::sycl::char2>(queue);
-      test_all_copy_functions<cl::sycl::short3>(queue);
-      test_all_copy_functions<cl::sycl::int4>(queue);
-      test_all_copy_functions<cl::sycl::long8>(queue);
-      test_all_copy_functions<cl::sycl::float8>(queue);
-      test_all_copy_functions<cl::sycl::double16>(queue);
+      test_all_dimensions<1, 1>(queue);
+      test_all_dimensions<1, 2>(queue);
+      test_all_dimensions<1, 3>(queue);
+      test_all_dimensions<2, 1>(queue);
+      test_all_dimensions<2, 2>(queue);
+      test_all_dimensions<2, 3>(queue);
+      test_all_dimensions<3, 1>(queue);
+      test_all_dimensions<3, 2>(queue);
+      test_all_dimensions<3, 3>(queue);
 
     } catch (const cl::sycl::exception& e) {
       log_exception(log, e);


### PR DESCRIPTION
Add new tests covering cases when source and destination parameters of
"explicit copy API" have different types.