### PR TITLE
Update image accessors API

### DIFF
--- a/tests/accessor/accessor_constructors_image_utility.h
+++ b/tests/accessor/accessor_constructors_image_utility.h
@@ -40,9 +40,8 @@ class check_accessor_constructor_image<T, dims, kMode,
     // check the accessor
     check_accessor_members<T, dims, kMode, cl::sycl::access::target::image,
                            cl::sycl::access::placeholder::false_t>::
-        check(a, getElementsCount<dims>(range) * elementSize,
-              getElementsCount<dims>(range), "constructor(image, handler)",
-              log);
+        check(a, range, getElementsCount<dims>(range),
+              "constructor(image, handler)", log);
   }
 };
 
@@ -64,8 +63,8 @@ class check_accessor_constructor_image<T, dims, kMode,
     // check the accessor
     check_accessor_members<T, dims, kMode, cl::sycl::access::target::host_image,
                            cl::sycl::access::placeholder::false_t>::
-        check(a, getElementsCount<dims>(range) * elementSize,
-              getElementsCount<dims>(range), "constructor(image)", log);
+        check(a, range, getElementsCount<dims>(range), "constructor(image)",
+              log);
   }
 };
 
@@ -88,9 +87,8 @@ class check_accessor_constructor_image<T, dims, kMode,
     check_accessor_members<T, dims, kMode,
                            cl::sycl::access::target::image_array,
                            cl::sycl::access::placeholder::false_t>::
-        check(a, getElementsCount<dims + 1>(range) * elementSize,
-              getElementsCount<dims + 1>(range), "constructor(image, handler)",
-              log);
+        check(a, range, getElementsCount<dims + 1>(range),
+              "constructor(image, handler)", log);
   }
 };
 
@@ -147,7 +145,7 @@ class image_accessor_dims {
           check_accessor_members<T, dims, cl::sycl::access::mode::read,
                                  cl::sycl::access::target::image,
                                  cl::sycl::access::placeholder::false_t>::
-              check(b, a.get_size(), a.get_count(), "copy construction", log);
+              check(b, a.get_range(), a.get_count(), "copy construction", log);
         }
 
         /** check accessor is Copy Assignable
@@ -166,7 +164,7 @@ class image_accessor_dims {
           check_accessor_members<
               T, dims, cl::sycl::access::mode::read,
               cl::sycl::access::target::image,
-              cl::sycl::access::placeholder::false_t>::check(b, a.get_size(),
+              cl::sycl::access::placeholder::false_t>::check(b, a.get_range(),
                                                              a.get_count(),
                                                              "copy assignment",
                                                              log);
@@ -184,8 +182,8 @@ class image_accessor_dims {
           check_accessor_members<T, dims, cl::sycl::access::mode::read,
                                  cl::sycl::access::target::image,
                                  cl::sycl::access::placeholder::false_t>::
-              check(b, image.get_size(), image.get_count(), "move construction",
-                    log);
+              check(b, image.get_range(), image.get_count(),
+                    "move construction", log);
         }
 
         /** check accessor is Move Assignable
@@ -205,7 +203,7 @@ class image_accessor_dims {
               T, dims, cl::sycl::access::mode::read,
               cl::sycl::access::target::image,
               cl::sycl::access::placeholder::false_t>::check(b,
-                                                             image.get_size(),
+                                                             image.get_range(),
                                                              image.get_count(),
                                                              "move assignment",
                                                              log);
@@ -251,7 +249,7 @@ class image_accessor_dims {
         check_accessor_members<
             T, dims, cl::sycl::access::mode::read,
             cl::sycl::access::target::host_image,
-            cl::sycl::access::placeholder::false_t>::check(b, a.get_size(),
+            cl::sycl::access::placeholder::false_t>::check(b, a.get_range(),
                                                            a.get_count(),
                                                            "copy construction",
                                                            log);
@@ -273,7 +271,7 @@ class image_accessor_dims {
         check_accessor_members<
             T, dims, cl::sycl::access::mode::read,
             cl::sycl::access::target::host_image,
-            cl::sycl::access::placeholder::false_t>::check(b, a.get_size(),
+            cl::sycl::access::placeholder::false_t>::check(b, a.get_range(),
                                                            a.get_count(),
                                                            "copy assignment",
                                                            log);
@@ -291,7 +289,7 @@ class image_accessor_dims {
         check_accessor_members<
             T, dims, cl::sycl::access::mode::read,
             cl::sycl::access::target::host_image,
-            cl::sycl::access::placeholder::false_t>::check(b, image.get_size(),
+            cl::sycl::access::placeholder::false_t>::check(b, image.get_range(),
                                                            image.get_count(),
                                                            "move construction",
                                                            log);
@@ -313,7 +311,7 @@ class image_accessor_dims {
         check_accessor_members<
             T, dims, cl::sycl::access::mode::read,
             cl::sycl::access::target::host_image,
-            cl::sycl::access::placeholder::false_t>::check(b, image.get_size(),
+            cl::sycl::access::placeholder::false_t>::check(b, image.get_range(),
                                                            image.get_count(),
                                                            "move assignment",
                                                            log);
@@ -370,7 +368,7 @@ class image_array_accessor_dims {
           check_accessor_members<T, dims, cl::sycl::access::mode::read,
                                  cl::sycl::access::target::image_array,
                                  cl::sycl::access::placeholder::false_t>::
-              check(a, b.get_size(), b.get_count(), "copy construction", log);
+              check(a, b.get_range(), b.get_count(), "copy construction", log);
         }
 
         /** check accessor is Copy Assignable
@@ -389,7 +387,7 @@ class image_array_accessor_dims {
           check_accessor_members<
               T, dims, cl::sycl::access::mode::read,
               cl::sycl::access::target::image_array,
-              cl::sycl::access::placeholder::false_t>::check(b, a.get_size(),
+              cl::sycl::access::placeholder::false_t>::check(b, a.get_range(),
                                                              a.get_count(),
                                                              "copy assignment",
                                                              log);
@@ -407,8 +405,8 @@ class image_array_accessor_dims {
           check_accessor_members<T, dims, cl::sycl::access::mode::read,
                                  cl::sycl::access::target::image_array,
                                  cl::sycl::access::placeholder::false_t>::
-              check(b, image.get_size(), image.get_count(), "move construction",
-                    log);
+              check(b, image.get_range(), image.get_count(),
+                    "move construction", log);
         }
 
         /** check accessor is Move Assignable
@@ -428,7 +426,7 @@ class image_array_accessor_dims {
               T, dims, cl::sycl::access::mode::read,
               cl::sycl::access::target::image_array,
               cl::sycl::access::placeholder::false_t>::check(b,
-                                                             image.get_size(),
+                                                             image.get_range(),
                                                              image.get_count(),
                                                              "move assignmnet",
                                                              log);

--- a/tests/accessor/accessor_constructors_utility.h
+++ b/tests/accessor/accessor_constructors_utility.h
@@ -266,13 +266,14 @@ class check_accessor_members<T, dims, kMode, cl::sycl::access::target::image,
       const cl::sycl::accessor<T, dims, kMode, cl::sycl::access::target::image,
                                cl::sycl::access::placeholder::false_t>
           a,
-      size_t size, size_t count, std::string operation, util::logger &log) {
+      cl::sycl::range<dims> range, size_t count, std::string operation,
+      util::logger &log) {
     std::string error_message =
         get_error_message(dims, kMode, cl::sycl::access::target::image,
                           cl::sycl::access::placeholder::false_t, operation);
 
-    if (a.get_size() < size) {
-      FAIL(log, (error_message + " check(get_size)").c_str());
+    if (a.get_range() != range) {
+      FAIL(log, (error_message + " check(get_range)").c_str());
     }
 
     if (a.get_count() != count) {
@@ -292,14 +293,14 @@ class check_accessor_members<T, dims, kMode,
                         T, dims, kMode, cl::sycl::access::target::host_image,
                         cl::sycl::access::placeholder::false_t>
                         a,
-                    size_t size, size_t count, std::string operation,
-                    util::logger &log) {
+                    cl::sycl::range<dims> range, size_t count,
+                    std::string operation, util::logger &log) {
     std::string error_message =
         get_error_message(dims, kMode, cl::sycl::access::target::host_image,
                           cl::sycl::access::placeholder::false_t, operation);
 
-    if (a.get_size() < size) {
-      FAIL(log, (error_message + " check(get_size)").c_str());
+    if (a.get_range() != range) {
+      FAIL(log, (error_message + " check(get_range)").c_str());
     }
 
     if (a.get_count() != count) {
@@ -319,14 +320,14 @@ class check_accessor_members<T, dims, kMode,
                         T, dims, kMode, cl::sycl::access::target::image_array,
                         cl::sycl::access::placeholder::false_t>
                         a,
-                    size_t size, size_t count, std::string operation,
-                    util::logger &log) {
+                    cl::sycl::range<dims + 1> range, size_t count,
+                    std::string operation, util::logger &log) {
     std::string error_message =
         get_error_message(dims, kMode, cl::sycl::access::target::image_array,
                           cl::sycl::access::placeholder::false_t, operation);
 
-    if (a.get_size() < size) {
-      FAIL(log, (error_message + " check(get_size)").c_str());
+    if (a.get_range() != range) {
+      FAIL(log, (error_message + " check(get_range)").c_str());
     }
 
     if (a.get_count() != count) {


### PR DESCRIPTION
Follow-up https://github.com/KhronosGroup/SYCL-CTS/pull/35, which
adjusts accessor API change from
https://github.com/KhronosGroup/SYCL-Docs/pull/31.
