### PR TITLE
Re-enabled hierarchical_implicit_reduce

### DIFF
--- a/tests/hierarchical/hierarchical_implicit_reduce.cpp
+++ b/tests/hierarchical/hierarchical_implicit_reduce.cpp
@@ -8,17 +8,26 @@
 
 #include "../common/common.h"
 
-#define TEST_NAME hierarchical_reduce
+#define TEST_NAME hierarchical_implicit_reduce
 
 namespace TEST_NAMESPACE {
 
-static const int groupItems1d = 2;
-static const int localItems1d = 2;
-static const int groupItemsTotal = groupItems1d * groupItems1d * groupItems1d;
-static const int localItemsTotal = localItems1d * localItems1d * localItems1d;
-static const int numGroups = groupItemsTotal / localItemsTotal;
+static constexpr int globalItems1d = 26;
+static constexpr int globalItems2d = 33;
+static constexpr int globalItems3d = 35;
+static constexpr int localItems1d = 2;
+static constexpr int localItems2d = 3;
+static constexpr int localItems3d = 5;
+static constexpr int groupItems1d = (globalItems1d / localItems1d);
+static constexpr int groupItems2d = (globalItems2d / localItems2d);
+static constexpr int groupItems3d = (globalItems3d / localItems3d);
+static constexpr int globalItemsTotal =
+    (globalItems1d * globalItems2d * globalItems3d);
+static constexpr int localItemsTotal =
+    (localItems1d * localItems2d * localItems3d);
+static constexpr int numGroups = (globalItemsTotal / localItemsTotal);
 
-static const int inputSize = 32;
+static constexpr int inputSize = 59;
 
 using namespace sycl_cts;
 
@@ -29,29 +38,24 @@ template <typename T>
 class sth_else {};
 
 template <typename T>
-T reduce(T input[inputSize], cl::sycl::device_selector *selector) {
-  T mTotal;
+T reduce(T input[inputSize], cl::sycl::device_selector* selector) {
   T mGroupSums[numGroups];
 
   auto myQueue = util::get_cts_object::queue(*selector);
   cl::sycl::buffer<T, 1> input_buf(input, cl::sycl::range<1>(inputSize));
   cl::sycl::buffer<T, 1> group_sums_buf(mGroupSums,
                                         cl::sycl::range<1>(numGroups));
-  cl::sycl::buffer<T, 1> total_buf(&mTotal, cl::sycl::range<1>(1));
 
-  myQueue.submit([&](cl::sycl::handler &cgh) {
+  myQueue.submit([&](cl::sycl::handler& cgh) {
     cl::sycl::accessor<T, 1, cl::sycl::access::mode::read,
                        cl::sycl::access::target::global_buffer>
         input_ptr(input_buf, cgh);
-    cl::sycl::accessor<T, 1, cl::sycl::access::mode::read,
-                       cl::sycl::access::target::global_buffer>
-        groupSumsPtr(group_sums_buf, cgh);
     cl::sycl::accessor<T, 1, cl::sycl::access::mode::write,
                        cl::sycl::access::target::global_buffer>
-        totalPtr(total_buf, cgh);
+        groupSumsPtr(group_sums_buf, cgh);
         cgh.parallel_for_work_group<class sth<T>>(
-                    cl::sycl::range<3>( groupItems1d, groupItems1d, groupItems1d ),
-                    cl::sycl::range<3>( localItems1d, localItems1d, localItems1d ),
+                    cl::sycl::range<3>( groupItems1d, groupItems2d, groupItems3d ),
+                    cl::sycl::range<3>( localItems1d, localItems2d, localItems3d ),
                     [=]( cl::sycl::group<3> group )
         {
           T localSums[localItemsTotal];
@@ -59,81 +63,85 @@ T reduce(T input[inputSize], cl::sycl::device_selector *selector) {
           // process items in each work item
           group.parallel_for_work_item([=,
                                         &localSums](cl::sycl::h_item<3> item) {
+            int globalId = item.get_global().get_linear_id();
             int localId = item.get_local().get_linear_id();
             /* Split the array into work-group-size different arrays */
-            int valuesPerItem = (inputSize / numGroups) / localItemsTotal;
-            int idStart = 0;
-            int idEnd = valuesPerItem * localId;
+            int valuesPerItem = (inputSize / globalItemsTotal);
+            valuesPerItem = (valuesPerItem == 0) ? 1 : valuesPerItem;
+            int idStart = valuesPerItem * globalId;
+            int idEnd = valuesPerItem * (globalId + 1);
 
             /* Handle the case where the number of input values is not divisible
-            * by
-            * the number of items. */
+             * by the number of items. */
             if (idEnd > inputSize - 1) {
-              idEnd = inputSize - 1;
+              idEnd = inputSize;
             }
 
+            localSums[localId] = T{};
             for (int i = idStart; i < idEnd; i++) {
-              localSums[i].increment(input_ptr[i]);
+              localSums[localId].increment(input_ptr[i]);
             }
           });
 
           /* Sum items in each work group */
+          int groupId = group.get_linear_id();
+          groupSumsPtr[groupId] = T{};
           for (int i = 0; i < localItemsTotal; i++) {
-            groupSumsPtr[group.get_id(0)].increment(localSums[i]);
+            groupSumsPtr[groupId].increment(localSums[i]);
           }
-        });
+      });
   });
 
-  myQueue.submit([&](cl::sycl::handler &cgh) {
-    cl::sycl::accessor<T, 1, cl::sycl::access::mode::read,
-                       cl::sycl::access::target::global_buffer>
-        groupSumsPtr(group_sums_buf, cgh);
-    cl::sycl::accessor<T, 1, cl::sycl::access::mode::write,
-                       cl::sycl::access::target::global_buffer>
-        totalPtr(total_buf, cgh);
+  T mTotal;
+  {
+    cl::sycl::buffer<T, 1> total_buf(&mTotal, cl::sycl::range<1>(1));
+    myQueue.submit([&](cl::sycl::handler& cgh) {
+      cl::sycl::accessor<T, 1, cl::sycl::access::mode::read,
+                         cl::sycl::access::target::global_buffer>
+          groupSumsPtr(group_sums_buf, cgh);
+      cl::sycl::accessor<T, 1, cl::sycl::access::mode::write,
+                         cl::sycl::access::target::global_buffer>
+          totalPtr(total_buf, cgh);
 
-        cgh.single_task<class sth_else<T>>([=]()
-        {
+        cgh.single_task<class sth_else<T> >([=]() {
           /* Sum items in all work groups */
+          totalPtr[0] = T{};
           for (int i = 0; i < numGroups; i++) {
-            totalPtr[0].value = totalPtr[i].value + groupSumsPtr[i].value;
+            totalPtr[0].increment(groupSumsPtr[i]);
           }
         });
-  });
-
-  myQueue.wait_and_throw();
+    });
+  }
 
   return mTotal;
 }
 
 class Adder {
  public:
-  Adder() { value = 0; }
-  Adder(int val) { value = val; }
+  using type = std::int64_t;
 
-  static Adder default_value() { return Adder(0); }
+  constexpr Adder(type val = 0) : value{val} {}
 
-  Adder increment(Adder rhs) {
+  Adder& increment(const Adder& rhs) noexcept {
     value += rhs.value;
     return *this;
   }
 
-  int value;
+  type value;
 };
 
 class Multiplier {
  public:
-  Multiplier() { value = 1; }
-  Multiplier(int val) { value = val; }
+  using type = std::int64_t;
 
-  static Multiplier default_value() { return Multiplier(0); }
+  constexpr Multiplier(type val = 1) : value{val} {}
 
-  Multiplier increment(Multiplier rhs) {
+  Multiplier& increment(const Multiplier& rhs) noexcept {
     value *= rhs.value;
     return *this;
   }
 
-  int value;
+  type value;
 };
 
 /** test cl::sycl::range::get(int index) return size_t
@@ -142,14 +150,13 @@ class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
    */
-  void get_info(test_base::info &out) const override {
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
    */
-  void run(util::logger &log) override {
-    return;
+  void run(util::logger& log) override {
     try {
       cts_selector sel;
       {
@@ -161,7 +168,10 @@ class TEST_NAME : public util::test_base {
         int expectedResult = inputSize * 2;
 
         if (result.value != expectedResult) {
-          FAIL(log, "Incorrect result in Adder");
+          const auto msg =
+              "Incorrect result in Adder: " + std::to_string(result.value) +
+              " != " + std::to_string(expectedResult);
+          FAIL(log, msg);
         }
       }
 
@@ -171,14 +181,16 @@ class TEST_NAME : public util::test_base {
 
         Multiplier result = reduce<Multiplier>(data, &sel);
 
-        int expectedResult = 1;
-        for (int i = 0; i < inputSize; ++i) expectedResult *= 2;
+        auto expectedResult = std::int64_t{1} << inputSize;
 
         if (result.value != expectedResult) {
-          FAIL(log, "Incorrect result in Multiplier");
+          const auto msg = "Incorrect result in Multiplier: " +
+                           std::to_string(result.value) +
+                           " != " + std::to_string(expectedResult);
+          FAIL(log, msg);
         }
       }
-    } catch (const cl::sycl::exception &e) {
+    } catch (const cl::sycl::exception& e) {
       log_exception(log, e);
       cl::sycl::string_class errorMsg =
           "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
@@ -190,4 +202,4 @@ class TEST_NAME : public util::test_base {
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-} /* namespace hierarchical_reduce__ */
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
Fixes #46 

* Removed early return
* Fixed segfault
    * Use `localId` as index instead of `i` for local data
* Use 64-bit integers
* Simplified `Adder` and `Multiplier`
* Fixed default value for `Multiplier`
* Use `write` access mode for group sums in first pass
* Ensure `mTotal` is written to `parallel_for_work_group`
* Pass proper ranges to
* Better error messages
* clang-format