### PR TITLE
Implicit capture of 'this' by '=' is not allowed

### DIFF
--- a/tests/hierarchical/hierarchical_functor.cpp
+++ b/tests/hierarchical/hierarchical_functor.cpp
@@ -24,7 +24,7 @@ class kernel0 {
                            cl::sycl::access::target::global_buffer>(cgh)) {}
 
   void operator()(cl::sycl::group<2> group_pid) const {
-    group_pid.parallel_for_work_item([=](cl::sycl::h_item<2> itemID) {
+    group_pid.parallel_for_work_item([&](cl::sycl::h_item<2> itemID) {
       auto globalIdL = itemID.get_global().get_linear_id();
       ptr[globalIdL] = globalIdL;
     });


### PR DESCRIPTION
'this' with a capture default of '=' is not allowed for kernel
functions in SYCL 1.2.1. Fix hierarchical_functor test to capture by
reference in parallel_for_work_item.

Patch by Artur Gainullin <artur.gainullin@intel.com>