### PR TITLE
OpenCL interoperabilty tests option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,22 @@ include(AddSYCLExecutable)
 
 # ------------------
 # Double and Half variables
-option(SYCL_CTS_ENABLE_DOUBLE_TESTS OFF "Enable Double tests.")
-option(SYCL_CTS_ENABLE_HALF_TESTS OFF "Enable Half tests.")
+option(SYCL_CTS_ENABLE_DOUBLE_TESTS "Enable Double tests." OFF)
+option(SYCL_CTS_ENABLE_HALF_TESTS "Enable Half tests." OFF)
 if(SYCL_CTS_ENABLE_DOUBLE_TESTS)
     add_definitions(-DSYCL_CTS_TEST_DOUBLE)
 endif()
 if(SYCL_CTS_ENABLE_HALF_TESTS)
     add_definitions(-DSYCL_CTS_TEST_HALF)
+endif()
+# ------------------
+
+# ------------------
+# OpenCL interoperability
+option(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+       "Enable OpenCL interoperability tests." ON)
+if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS)
+    add_definitions(-DSYCL_CTS_TEST_OPENCL_INTEROP)
 endif()
 # ------------------
 

--- a/tests/context/context_constructors.cpp
+++ b/tests/context/context_constructors.cpp
@@ -128,9 +128,11 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "context was not copied correctly (is_host)");
         }
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!selector.is_host() && (contextA.get() != contextB.get())) {
           FAIL(log, "context was not copied correctly (get)");
         }
+#endif
       }
 
       /** check assignment operator
@@ -144,9 +146,11 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "context was not assigned correctly (is_host)");
         }
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!selector.is_host() && (contextA.get() != contextB.get())) {
           FAIL(log, "context was not assigned correctly (get)");
         }
+#endif
       }
 
       /** check move constructor

--- a/tests/device/device_api.cpp
+++ b/tests/device/device_api.cpp
@@ -73,6 +73,7 @@ class TEST_NAME : public util::test_base {
                                               "device::get_platform()");
       }
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
       /** check get() member function
        */
       {
@@ -83,6 +84,7 @@ class TEST_NAME : public util::test_base {
           check_return_type<cl_device_id>(log, clDeviceId, "device::get()");
         }
       }
+#endif
 
       /** check is_host() member function
        */

--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -59,9 +59,11 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "device was not copied correctly (is_host)");
         }
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!selector.is_host() && deviceA.get() != deviceB.get()) {
           FAIL(log, "device was not assigned correctly (get)");
         }
+#endif
       }
 
       /** check assignment operator
@@ -74,9 +76,11 @@ class TEST_NAME : public util::test_base {
         if (deviceA.is_host() != deviceB.is_host()) {
           FAIL(log, "device was not assigned correctly (is_host)");
         }
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!selector.is_host() && deviceA.get() != deviceB.get()) {
           FAIL(log, "device was not assigned correctly (get)");
         }
+#endif
       }
 
       /** check move constructor

--- a/tests/event/event_api.cpp
+++ b/tests/event/event_api.cpp
@@ -36,6 +36,8 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     try {
+
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
       /** check get()
       */
       {
@@ -48,6 +50,7 @@ class TEST_NAME : public util::test_base {
         }
         queue.wait_and_throw();
       }
+#endif
 
       /** check is_host()
       */

--- a/tests/event/event_constructors.cpp
+++ b/tests/event/event_constructors.cpp
@@ -57,9 +57,11 @@ class TEST_NAME : public util::test_base {
         auto eventA = get_queue_event<class event_constructors_0>(queue);
         cl::sycl::event eventB(eventA);
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!selector.is_host() && (eventA.get() != eventB.get())) {
           FAIL(log, "event was not copied correctly.");
         }
+#endif
 
         queue.wait_and_throw();
       }
@@ -74,9 +76,11 @@ class TEST_NAME : public util::test_base {
         auto eventB = get_queue_event<class event_constructors_2>(queue);
         eventB = eventA;
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!selector.is_host() && (eventA.get() != eventB.get())) {
           FAIL(log, "event was not assigned correctly.");
         }
+#endif
 
         queue.wait_and_throw();
       }

--- a/tests/kernel/kernel_constructors.cpp
+++ b/tests/kernel/kernel_constructors.cpp
@@ -59,11 +59,13 @@ class TEST_NAME : public sycl_cts::util::test_base {
             cgh.single_task(test_kernel<0>());
           });
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
           if (!ctsSelector.is_host() && (kernelA.get() != kernelB.get())) {
             FAIL(log,
                  "kernel was not constructed correctly. (contains different "
                  "OpenCL kernel object)");
           }
+#endif
 
           ctsQueue.wait_and_throw();
         }
@@ -91,11 +93,13 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
           cl::sycl::kernel kernelB = kernelA;
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
           if (!ctsSelector.is_host() && (kernelA.get() != kernelB.get())) {
             FAIL(log,
                  "kernel was not constructed correctly. (contains different "
                  "OpenCL kernel object)");
           }
+#endif
 
           ctsQueue.wait_and_throw();
         }
@@ -189,6 +193,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
           });
 
           if (!ctsSelector.is_host()) {
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
             if (kernelA == kernelB &&
                 (kernelA.get() != kernelB.get() ||
                  kernelA.get_context().get() != kernelB.get_context().get() ||
@@ -204,6 +209,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
               FAIL(log,
                    "kernel equality does not work correctly (copy assigned)");
             }
+#endif
             if (kernelA != kernelB) {
               FAIL(log,
                    "kernel non-equality does not work correctly"

--- a/tests/opencl_interop/CMakeLists.txt
+++ b/tests/opencl_interop/CMakeLists.txt
@@ -1,3 +1,5 @@
-file(GLOB test_cases_list *.cpp)
 
-add_cts_test(${test_cases_list})
+if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS)
+    file(GLOB test_cases_list *.cpp)
+    add_cts_test(${test_cases_list})
+endif()

--- a/tests/platform/platform_constructors.cpp
+++ b/tests/platform/platform_constructors.cpp
@@ -59,9 +59,11 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "platform was not copy constructed correctly (is_host)");
         }
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!selector.is_host() && platformA.get() != platformB.get()) {
           FAIL(log, "platform was not copy constructed correctly (get)");
         }
+#endif
       }
 
       /** check assignment operator
@@ -75,9 +77,11 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "platform was not copy assigned correctly (is_host)");
         }
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!selector.is_host() && platformA.get() != platformB.get()) {
           FAIL(log, "platform was not copy assigned correctly (get)");
         }
+#endif
       }
 
       /** check move constructor

--- a/tests/program/program_api.cpp
+++ b/tests/program/program_api.cpp
@@ -83,10 +83,12 @@ class TEST_NAME : public sycl_cts::util::test_base {
           // Check get_build_options()
           cl::sycl::string_class progBuildOptions = prog.get_build_options();
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
           // Check get()
           if (!context.is_host()) {
             cl_program clProgram = prog.get();
           }
+#endif
 
           {
             auto q = cl::sycl::queue(context, selector);

--- a/tests/program/program_constructors.cpp
+++ b/tests/program/program_constructors.cpp
@@ -244,6 +244,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
         programC = programA;
         cl::sycl::program programD(context);
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
         if (!(programA == programB) &&
             (context.is_host() && (programA.get() != programB.get()))) {
           FAIL(log,
@@ -254,6 +255,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
           FAIL(log,
                "program equality does not work correctly. (copy assigned)");
         }
+#endif
         if (programA != programB) {
           FAIL(log,
                "program non-equality does not work correctly"

--- a/tests/queue/queue_api.cpp
+++ b/tests/queue/queue_api.cpp
@@ -64,6 +64,7 @@ class TEST_NAME : public util::test_base {
                                             "cl::sycl::queue::get_device()");
       }
 
+#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
       /** check get() member function
        */
       {
@@ -75,6 +76,7 @@ class TEST_NAME : public util::test_base {
                                               "cl::sycl::queue::get()");
         }
       }
+#endif
 
       /** check submit(command_group_scope) member function
       */


### PR DESCRIPTION
Adds the `SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS` CMake option (`ON` by default) which defines the `SYCL_CTS_TEST_OPENCL_INTEROP` macro. This is used to enable or disable OpenCL interoperability tests, such as uses of the `get` method on select SYCL objects.

This commit also fixes the `SYCL_CTS_ENABLE_DOUBLE_TESTS` and `SYCL_CTS_ENABLE_HALF_TESTS` options default values.