### PR TITLE
Change accessor image channel data types when using DPCPP CUDA backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS)
 endif()
 # ------------------
 
+if(${INTEL_SYCL_TRIPLE} MATCHES ".*-nvidia-cuda-.*")
+    add_definitions(-DSYCL_CTS_INTEL_PI_CUDA)
+endif()
+
 enable_testing()
 
 add_subdirectory(util)

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -166,11 +166,17 @@ struct image_format_channel;
 */
 template <>
 struct image_format_channel<cl::sycl::cl_int4> {
+#ifdef SYCL_CTS_INTEL_PI_CUDA
+  static constexpr cl::sycl::image_channel_type type =
+      cl::sycl::image_channel_type::signed_int32;
+  using storage_t = cl::sycl::cl_int;
+#else
   static constexpr cl::sycl::image_channel_type type =
       cl::sycl::image_channel_type::signed_int8;
+  using storage_t = cl::sycl::cl_char;
+#endif
   static constexpr cl::sycl::image_channel_order order =
       cl::sycl::image_channel_order::rgba;
-  using storage_t = cl::sycl::cl_char;
   static constexpr size_t elementSize = 4 * sizeof(storage_t);
 };
 
@@ -178,11 +184,17 @@ struct image_format_channel<cl::sycl::cl_int4> {
 */
 template <>
 struct image_format_channel<cl::sycl::cl_uint4> {
+#ifdef SYCL_CTS_INTEL_PI_CUDA
+  static constexpr cl::sycl::image_channel_type type =
+      cl::sycl::image_channel_type::unsigned_int32;
+  using storage_t = cl::sycl::cl_uint;
+#else
   static constexpr cl::sycl::image_channel_type type =
       cl::sycl::image_channel_type::unsigned_int8;
+  using storage_t = cl::sycl::cl_uchar;
+#endif
   static constexpr cl::sycl::image_channel_order order =
       cl::sycl::image_channel_order::rgba;
-  using storage_t = cl::sycl::cl_uchar;
   static constexpr size_t elementSize = 4 * sizeof(storage_t);
 };
 


### PR DESCRIPTION
The DPCPP CUDA backend currently only support reading from and writing to image accessors with data type corresponding to the channel data type of the underlying image.

This changes the channel types of images used in the accessor tests to correspond to the supported accessor data types when using the DPCPP CUDA backend.