### PR TITLE
Remove overly strict test conditions.

### DIFF
--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -115,7 +115,6 @@ class TEST_NAME : public util::test_base {
         cl::sycl::device deviceB(deviceA);
         cl::sycl::device deviceC(selector);
         deviceC = deviceA;
-        cl::sycl::device deviceD(selector);
 
         if (!(deviceA == deviceB)) {
           FAIL(log,
@@ -133,16 +132,6 @@ class TEST_NAME : public util::test_base {
           FAIL(log,
                "device non-equality does not work correctly"
                "(copy assigned)");
-        }
-        if (deviceC == deviceD) {
-          FAIL(log,
-               "device equality does not work correctly"
-               "(comparing same)");
-        }
-        if (!(deviceC != deviceD)) {
-          FAIL(log,
-               "device non-equality does not work correctly"
-               "(comparing same)");
         }
       }
 

--- a/tests/platform/platform_constructors.cpp
+++ b/tests/platform/platform_constructors.cpp
@@ -116,7 +116,6 @@ class TEST_NAME : public util::test_base {
         cl::sycl::platform platformB = platformA;
         cl::sycl::platform platformC(selector);
         platformC = platformA;
-        cl::sycl::platform platformD(selector);
 
         if (!(platformA == platformB)) {
           FAIL(log,
@@ -135,16 +134,6 @@ class TEST_NAME : public util::test_base {
           FAIL(log,
                "platform non-equality does not work correctly"
                "(copy assigned)");
-        }
-        if (platformC == platformD) {
-          FAIL(log,
-               "platform equality does not work correctly"
-               "(comparing same)");
-        }
-        if (!(platformC != platformD)) {
-          FAIL(log,
-               "platform non-equality does not work correctly"
-               "(comparing same)");
         }
       }
 


### PR DESCRIPTION
The device/platform equality testing is overly strict.

It's performing negative testing that doesn't allow implementations to cache devices and platforms so that things can reasonably compare equal when users expect them to.

Signed-off-by: James Brodman <james.brodman@intel.com>