### PR TITLE
Improve copy tests

### DIFF
--- a/tests/handler/handler_copy.cpp
+++ b/tests/handler/handler_copy.cpp
@@ -792,7 +792,8 @@ void test_write_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
     copy_test_context<dataT, dim_src, dim_dst, strided, transposed> ctx(queue);
     ctx.verify_fill(
         [&](cl::sycl::handler& cgh) {
-          auto w = ctx.getDstBuf().template get_access<mode_dst, target>(cgh);
+          auto w = ctx.getDstBuf().template get_access<mode_dst, target>(
+              cgh, ctx.getDstCopyRange(), ctx.getDstCopyOffset());
           cgh.fill(w, pattern);
         },
         pattern,

--- a/tests/handler/handler_copy.cpp
+++ b/tests/handler/handler_copy.cpp
@@ -6,6 +6,11 @@
 //
 *******************************************************************************/
 
+#include <regex>
+#include <mutex>
+#include <sstream>
+#include <memory>
+
 #include "../common/common.h"
 
 #define TEST_NAME handler_copy
@@ -17,106 +22,417 @@ using mode_t = cl::sycl::access::mode;
 using target_t = cl::sycl::access::target;
 
 /**
- * @brief Helps with getting the buffer range and filling the buffer with data
+ * @brief Helper class designed to construct useful failure messages for all
+ * test case permutations.
  */
+class log_helper {
+ public:
+  log_helper(util::logger* logger) : logger(logger) {}
+
+  template <typename dataT>
+  log_helper set_data_type() const {
+    auto result = *this;
+    if (std::is_same<dataT, char>::value) result.dataType = "char";
+    if (std::is_same<dataT, short>::value) result.dataType = "short";
+    if (std::is_same<dataT, int>::value) result.dataType = "int";
+    if (std::is_same<dataT, long>::value) result.dataType = "long";
+    if (std::is_same<dataT, float>::value) result.dataType = "float";
+    if (std::is_same<dataT, double>::value) result.dataType = "double";
+    if (std::is_same<dataT, cl::sycl::char2>::value)
+      result.dataType = "cl::sycl::char2";
+    if (std::is_same<dataT, cl::sycl::short3>::value)
+      result.dataType = "cl::sycl::short3";
+    if (std::is_same<dataT, cl::sycl::int4>::value)
+      result.dataType = "cl::sycl::int4";
+    if (std::is_same<dataT, cl::sycl::long8>::value)
+      result.dataType = "cl::sycl::long8";
+    if (std::is_same<dataT, cl::sycl::float8>::value)
+      result.dataType = "cl::sycl::float8";
+    if (std::is_same<dataT, cl::sycl::double16>::value)
+      result.dataType = "cl::sycl::double16";
+    return result;
+  }
+
+  log_helper set_dim_src(int dim) const {
+    auto result = *this;
+    result.dimSrc = dim;
+    return result;
+  }
+
+  log_helper set_dim_dst(int dim) const {
+    auto result = *this;
+    result.dimDst = dim;
+    return result;
+  }
+
+  log_helper set_mode_src(mode_t mode) const {
+    auto result = *this;
+    result.modeSrc = get_mode_string(mode);
+    return result;
+  }
+
+  log_helper set_mode_dst(mode_t mode) const {
+    auto result = *this;
+    result.modeDst = get_mode_string(mode);
+    return result;
+  }
+
+  log_helper set_target(target_t target) const {
+    auto result = *this;
+    result.target = get_target_string(target);
+    return result;
+  }
+
+  log_helper set_line(int line) const {
+    auto result = *this;
+    result.line = line;
+    return result;
+  }
+
+  log_helper set_op(const std::string& pattern) const {
+    auto result = *this;
+    result.pattern = pattern;
+    return result;
+  }
+
+  void fail(const std::string& reason) const {
+    logger->fail(make_description() + " failed: " + reason, line);
+  }
+
+  void note(const std::string& message) const {
+    logger->note(make_description() + " info: " + message);
+  }
+
+ private:
+  util::logger* logger;
+  std::string dataType = "(unknown data type)";
+  int dimSrc = -1;
+  int dimDst = -1;
+  std::string modeSrc = "(unknown mode)";
+  std::string modeDst = "(unknown mode)";
+  std::string target = "(unknown target)";
+  int line = __LINE__;
+  std::string pattern = "";
+
+  static std::string get_mode_string(mode_t mode) {
+    switch (mode) {
+      case mode_t::read:
+        return "read";
+      case mode_t::write:
+        return "write";
+      case mode_t::read_write:
+        return "read_write";
+      case mode_t::discard_write:
+        return "discard_write";
+      case mode_t::discard_read_write:
+        return "discard_read_write";
+      case mode_t::atomic:
+        return "atomic";
+      default:
+        return "(unknown mode)";
+    }
+  }
+
+  static std::string get_target_string(target_t target) {
+    switch (target) {
+      case target_t::global_buffer:
+        return "global_buffer";
+      case target_t::constant_buffer:
+        return "constant_buffer";
+      default:
+        return "(unknown target)";
+    }
+  }
+
+  std::string make_description() const {
+    auto desc = pattern;
+    desc = std::regex_replace(desc, std::regex("\\$dataT"), dataType);
+    desc = std::regex_replace(desc, std::regex("\\$dim_src"),
+                              std::to_string(dimSrc));
+    desc = std::regex_replace(desc, std::regex("\\$dim_dst"),
+                              std::to_string(dimDst));
+    desc = std::regex_replace(desc, std::regex("\\$mode_src"), modeSrc);
+    desc = std::regex_replace(desc, std::regex("\\$mode_dst"), modeDst);
+    desc = std::regex_replace(desc, std::regex("\\$target"), target);
+    return desc;
+  }
+};
+
+template <typename T>
+struct type_helper {
+  static T make(size_t v) { return static_cast<T>(v); }
+  static size_t value(const T& v) { return static_cast<size_t>(v); }
+  static bool equal(const T& lhs, const T& rhs) {
+    return value(lhs) == value(rhs);
+  }
+};
+
+template <typename dataT, int numElements>
+struct type_helper<cl::sycl::vec<dataT, numElements>> {
+  using T = cl::sycl::vec<dataT, numElements>;
+  static T make(size_t v) {
+    return T{static_cast<typename T::element_type>(v)};
+  }
+  static size_t value(const T& v) { return static_cast<size_t>(v.s0()); }
+  static bool equal(const T& lhs, const T& rhs) {
+    // Ideally we'd check that all components are equal, however unfortunately
+    // SYCL 1.2.1 doesn't specify a generic subscript operator for vector types.
+    return value(lhs) == value(rhs);
+  }
+};
+
 template <typename dataT, int dims>
-struct buffer_helper;
+class fill_kernel;
 
-template <typename dataT>
-struct buffer_helper<dataT, 1> {
-  static cl::sycl::range<1> construct_range(size_t elemsPerDim) {
-    return {elemsPerDim};
-  }
-  static void fill(cl::sycl::buffer<dataT, 1>& buf, const dataT& value) {
-    auto r = buf.get_range();
-    auto acc = buf.template get_access<mode_t::discard_write>();
-    for (size_t i = 0; i < r[0]; ++i) {
-      acc[i] = value;
-    }
+template <typename dataT, int dims>
+void fill_buffer(cl::sycl::queue& queue, cl::sycl::buffer<dataT, dims>& buf,
+                 dataT value) {
+  queue.submit([&](cl::sycl::handler& cgh) {
+    auto acc = buf.template get_access<mode_t::discard_write>(cgh);
+    cgh.parallel_for<fill_kernel<dataT, dims>>(
+        buf.get_range(), [=](cl::sycl::id<dims> id) { acc[id] = value; });
+  });
+}
+
+template <template <int> class T, int dims, size_t default_value>
+struct range_id_helper {};
+
+template <template <int> class T, size_t default_value>
+struct range_id_helper<T, 1, default_value> {
+  static T<1> make(size_t d0, size_t, size_t) { return T<1>{d0}; }
+
+  template <template <int> class other, int other_dims,
+            size_t dv = default_value>
+  static T<1> cast(const other<other_dims>& o) {
+    return T<1>{o[0]};
   }
 };
 
-template <typename dataT>
-struct buffer_helper<dataT, 2> {
-  static cl::sycl::range<2> construct_range(size_t elemsPerDim) {
-    return {elemsPerDim, elemsPerDim};
-  }
-  static void fill(cl::sycl::buffer<dataT, 2>& buf, const dataT& value) {
-    auto r = buf.get_range();
-    auto acc = buf.template get_access<mode_t::discard_write>();
-    for (size_t r0 = 0; r0 < r[0]; ++r0) {
-      for (size_t r1 = 0; r1 < r[1]; ++r1) {
-        acc[r0][r1] = value;
-      }
-    }
+template <template <int dims> class T, size_t default_value>
+struct range_id_helper<T, 2, default_value> {
+  static T<2> make(size_t d0, size_t d1, size_t) { return T<2>{d0, d1}; }
+
+  template <template <int> class other, int other_dims,
+            size_t dv = default_value>
+  static T<2> cast(const other<other_dims>& o) {
+    return T<2>{o[0], other_dims >= 2 ? o[1] : dv};
   }
 };
 
-template <typename dataT>
-struct buffer_helper<dataT, 3> {
-  static cl::sycl::range<3> construct_range(size_t elemsPerDim) {
-    return {elemsPerDim, elemsPerDim, elemsPerDim};
-  }
-  static void fill(cl::sycl::buffer<dataT, 3>& buf, const dataT& value) {
-    auto r = buf.get_range();
-    auto acc = buf.template get_access<mode_t::discard_write>();
-    for (size_t r0 = 0; r0 < r[0]; ++r0) {
-      for (size_t r1 = 0; r1 < r[1]; ++r1) {
-        for (size_t r2 = 0; r2 < r[2]; ++r2) {
-          acc[r0][r1][r2] = value;
-        }
-      }
-    }
+template <template <int dims> class T, size_t default_value>
+struct range_id_helper<T, 3, default_value> {
+  static T<3> make(size_t d0, size_t d1, size_t d2) { return T<3>{d0, d1, d2}; }
+
+  template <template <int> class other, int other_dims,
+            size_t dv = default_value>
+  static T<3> cast(const other<other_dims>& o) {
+    return T<3>{o[0], other_dims >= 2 ? o[1] : dv, other_dims == 3 ? o[2] : dv};
   }
 };
+
+template <int dims>
+using range_helper = range_id_helper<cl::sycl::range, dims, 1>;
+
+template <int dims>
+using id_helper = range_id_helper<cl::sycl::id, dims, 0>;
 
 /**
- * @brief Test context that stores some data that helps with checks
+ * @brief The copy_test_context encapsulates all host and device data required
+ * for testing, and provides utility functions for verifying the result
+ * of the various explicit memory operations.
  */
 template <typename dataT, int dim_src, int dim_dst>
-struct copy_test_context {
+class copy_test_context {
   using host_shared_ptr = cl::sycl::shared_ptr_class<dataT>;
   using buffer_src_t = cl::sycl::buffer<dataT, dim_src>;
   using buffer_dst_t = cl::sycl::buffer<dataT, dim_dst>;
+  using th = type_helper<dataT>;
 
-  static constexpr int get_elems(int dim) {
-    return (dim == 1) ? 64 : (dim == 2) ? 8 : 4;
+ public:
+  explicit copy_test_context(cl::sycl::queue& queue) : queue(queue) {
+    setup_ranges();
+
+    srcBufHostMemory =
+        host_shared_ptr(new dataT[numElems], std::default_delete<dataT[]>());
+    srcHostPtr =
+        host_shared_ptr(new dataT[numElems], std::default_delete<dataT[]>());
+    dstHostPtr =
+        host_shared_ptr(new dataT[numElems], std::default_delete<dataT[]>());
+
+    for (size_t i = 0; i < numElems; ++i) {
+      srcBufHostMemory.get()[i] = hostCanary;
+      srcHostPtr.get()[i] = bufferInitValue;
+      dstHostPtr.get()[i] = hostCanary;
+    }
+
+    srcBuf = std::unique_ptr<buffer_src_t>(new buffer_src_t(
+        srcBufHostMemory, srcBufRange,
+        cl::sycl::property_list{
+            cl::sycl::property::buffer::use_mutex{srcBufHostMemoryMutex}}));
+    dstBuf = std::unique_ptr<buffer_dst_t>(new buffer_dst_t(dstBufRange));
+
+    fill_buffer(queue, *srcBuf, bufferInitValue);
+    fill_buffer(queue, *dstBuf, deviceCanary);
+
+    queue.wait_and_throw();
   }
 
-  static constexpr size_t numElems = 64;
-  static constexpr size_t elemsSrcPerDim = get_elems(dim_src);
-  static constexpr size_t elemsDstPerDim = get_elems(dim_dst);
-  static constexpr size_t bufferInitValue = 17;
+  /**
+   * @brief Verifies a device to host copy.
+   */
+  template <typename test_fn>
+  void verify_d2h_copy(test_fn fn, const log_helper& lh) const {
+    run_test_function(fn, lh);
 
-  buffer_src_t srcBuf;
-  buffer_dst_t dstBuf;
+    for (size_t i = 0; i < numElems; ++i) {
+      const auto expected = bufferInitValue;
+      const auto received = dstHostPtr.get()[i];
+      if (!th::equal(received, expected)) {
+        log_error(lh, cl::sycl::id<3>(i, 0, 0), received, expected);
+        return;
+      }
+    }
+  }
+
+  /**
+   * @brief Verifies that the host memory backing the source buffer has been
+   * updated correctly.
+   */
+  template <typename test_fn>
+  void verify_update_host(test_fn fn, const log_helper& lh) const {
+    run_test_function(fn, lh);
+
+    std::lock_guard<cl::sycl::mutex_class> lock(srcBufHostMemoryMutex);
+    for (size_t i = 0; i < numElems; ++i) {
+      const auto expected = bufferInitValue;
+      const auto received = srcBufHostMemory.get()[i];
+      if (!th::equal(received, expected)) {
+        log_error(lh, cl::sycl::id<3>(i, 0, 0), received, expected);
+        return;
+      }
+    }
+  }
+
+  /**
+   * @brief Verifies a host to device or device to device copy.
+   */
+  template <typename test_fn>
+  void verify_device_copy(test_fn fn, const log_helper& lh) {
+    run_test_function(fn, lh);
+
+    // TODO: Consider verifying directly on device.
+    auto acc = dstBuf->template get_access<cl::sycl::access::mode::read>();
+    for (size_t i = 0; i < numElems; ++i) {
+      const auto expected = bufferInitValue;
+      const auto dstIndex = reconstruct_index(dstBufRange, i);
+      const auto received = acc[dstIndex];
+
+      if (!th::equal(received, expected)) {
+        log_error(lh, id_helper<3>::cast(dstIndex), received, expected);
+        return;
+      }
+    }
+  }
+
+  /**
+   * @brief Verifies that the device buffer has been filled correctly.
+   *
+   * @param fn
+   * @param expected The value that was used to fill the region.
+   * @param lh
+   */
+  template <typename test_fn>
+  void verify_fill(test_fn fn, dataT expected, const log_helper& lh) {
+    run_test_function(fn, lh);
+
+    // TODO: Consider verifying directly on device.
+    auto acc = dstBuf->template get_access<cl::sycl::access::mode::read>();
+    for (size_t i = 0; i < numElems; ++i) {
+      const auto idx = reconstruct_index(dstBufRange, i);
+      const auto received = acc[idx];
+      if (!th::equal(received, expected)) {
+        log_error(lh, id_helper<3>::cast(idx), received, expected);
+        return;
+      }
+    }
+  }
+
+  buffer_src_t getSrcBuf() const { return *srcBuf; }
+  buffer_dst_t getDstBuf() const { return *dstBuf; }
+
+  host_shared_ptr getSrcHostPtr() const { return srcHostPtr; }
+  host_shared_ptr getDstHostPtr() const { return dstHostPtr; }
+
+ private:
+  cl::sycl::queue& queue;
+
+  const dataT bufferInitValue = th::make(17);
+  const dataT hostCanary = th::make(12345);
+  const dataT deviceCanary = th::make(54321);
+
+  cl::sycl::range<dim_src> srcBufRange = range_helper<dim_src>::make(0, 0, 0);
+  cl::sycl::range<dim_dst> dstBufRange = range_helper<dim_dst>::make(0, 0, 0);
+
+  std::unique_ptr<buffer_src_t> srcBuf;
+  std::unique_ptr<buffer_dst_t> dstBuf;
 
   host_shared_ptr srcHostPtr;
   host_shared_ptr dstHostPtr;
 
-  copy_test_context()
-      : srcBuf(buffer_helper<dataT, dim_src>::construct_range(elemsSrcPerDim)),
-        dstBuf(buffer_helper<dataT, dim_dst>::construct_range(elemsDstPerDim)),
-        srcHostPtr(new dataT[numElems], std::default_delete<dataT[]>()),
-        dstHostPtr(new dataT[numElems], std::default_delete<dataT[]>()) {
-    buffer_helper<dataT, dim_src>::fill(srcBuf,
-                                        static_cast<dataT>(bufferInitValue));
-    buffer_helper<dataT, dim_dst>::fill(dstBuf, static_cast<dataT>(0));
-    for (size_t i = 0; i < numElems; ++i) {
-      srcHostPtr.get()[i] = static_cast<dataT>(i);
-      dstHostPtr.get()[i] = static_cast<dataT>(0);
+  size_t numElems = 0;
+
+  // Host memory region backing srcBuf,
+  // used for testing handler::update_host().
+  host_shared_ptr srcBufHostMemory = nullptr;
+  mutable cl::sycl::mutex_class srcBufHostMemoryMutex;
+
+  template <int dim>
+  static cl::sycl::id<dim> reconstruct_index(cl::sycl::range<dim> range,
+                                             size_t linearIndex) {
+    assert(range.size() > 0);
+    const auto r3 = cl::sycl::range<3>(range[0], dim > 1 ? range[1] : 1,
+                                       dim > 2 ? range[2] : 1);
+    const auto d0 = linearIndex / (r3[1] * r3[2]);
+    const auto d1 = linearIndex % (r3[1] * r3[2]) / r3[2];
+    const auto d2 = linearIndex % (r3[1] * r3[2]) % r3[2];
+    return range_helper<dim>::make(d0, d1, d2);
+  }
+
+  static void log_error(const log_helper& lh, cl::sycl::id<3> index,
+                        dataT received, dataT expected) {
+    std::stringstream ss;
+    ss << "Unexpected value at index ";
+    ss << "[" << index[0] << "," << index[1] << "," << index[2] << "]: ";
+    ss << th::value(received) << " (received) != " << th::value(expected)
+       << " (expected)\n";
+    lh.fail(ss.str());
+  }
+
+  void setup_ranges() {
+    const auto elemsSrcPerDim = (dim_src == 1) ? 64 : (dim_src == 2) ? 8 : 4;
+    const auto elemsDstPerDim = (dim_dst == 1) ? 64 : (dim_dst == 2) ? 8 : 4;
+
+    srcBufRange = range_helper<dim_src>::make(elemsSrcPerDim, elemsSrcPerDim,
+                                              elemsSrcPerDim);
+    dstBufRange = range_helper<dim_dst>::make(elemsDstPerDim, elemsDstPerDim,
+                                              elemsDstPerDim);
+
+    assert(srcBufRange.size() == dstBufRange.size());
+    numElems = srcBufRange.size();
+  }
+
+  template <typename test_fn>
+  void run_test_function(test_fn fn, const log_helper& lh) const {
+    // lh.note("Running...");  // Enable for verbose debugging output
+    try {
+      queue.submit([&](cl::sycl::handler& cgh) { fn(cgh); });
+      queue.wait_and_throw();
+    } catch (cl::sycl::exception&) {
+      lh.fail("Exception thrown during call:");
+      throw;
     }
   }
 };
-
-template <typename dataT, int dimSrc, int dimDst, typename testFunction>
-copy_test_context<dataT, dimSrc, dimDst> submit_test_function(
-    cl::sycl::queue& queue, testFunction fn) {
-  copy_test_context<dataT, dimSrc, dimDst> ctx;
-  queue.submit([&](cl::sycl::handler& cgh) { fn(ctx, cgh); });
-  queue.wait_and_throw();
-  return ctx;
-}
 
 /**
  * @brief Creates lambdas with the actual tested functionality and passes them
@@ -124,33 +440,42 @@ copy_test_context<dataT, dimSrc, dimDst> submit_test_function(
  *        accessor.
  */
 template <typename dataT, int dim, mode_t mode_src, target_t target>
-void test_read_acc_copy_functions(cl::sycl::queue& queue) {
+void test_read_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
+  lh = lh.set_mode_src(mode_src).set_target(target);
   {
     // Check copy(accessor, shared_ptr_class)
-    submit_test_function<dataT, dim, dim>(
-        queue,
-        [](copy_test_context<dataT, dim, dim>& ctx, cl::sycl::handler& cgh) {
-          auto r = ctx.srcBuf.template get_access<mode_src, target>(cgh);
-          cgh.copy(r, ctx.dstHostPtr);
-        });
+    copy_test_context<dataT, dim, dim> ctx(queue);
+    ctx.verify_d2h_copy(
+        [&](cl::sycl::handler& cgh) {
+          auto r = ctx.getSrcBuf().template get_access<mode_src, target>(cgh);
+          cgh.copy(r, ctx.getDstHostPtr());
+        },
+        lh.set_line(__LINE__).set_op(
+            "copy(accessor<$dataT, $dim_src, $mode_src, $target>, "
+            "shared_ptr_class<$dataT>)"));
   }
   {
     // Check copy(accessor, dataT*)
-    submit_test_function<dataT, dim, dim>(
-        queue,
-        [](copy_test_context<dataT, dim, dim>& ctx, cl::sycl::handler& cgh) {
-          auto r = ctx.srcBuf.template get_access<mode_src, target>(cgh);
-          cgh.copy(r, ctx.dstHostPtr.get());
-        });
+    copy_test_context<dataT, dim, dim> ctx(queue);
+    ctx.verify_d2h_copy(
+        [&](cl::sycl::handler& cgh) {
+          auto r = ctx.getSrcBuf().template get_access<mode_src, target>(cgh);
+          cgh.copy(r, ctx.getDstHostPtr().get());
+        },
+        lh.set_line(__LINE__).set_op(
+            "copy(accessor<$dataT, $dim_src, $mode_src, $target>, "
+            "$dataT*)"));
   }
   {
     // Check update_host(accessor)
-    submit_test_function<dataT, dim, dim>(
-        queue,
-        [](copy_test_context<dataT, dim, dim>& ctx, cl::sycl::handler& cgh) {
-          auto r = ctx.srcBuf.template get_access<mode_src, target>(cgh);
+    copy_test_context<dataT, dim, dim> ctx(queue);
+    ctx.verify_update_host(
+        [&](cl::sycl::handler& cgh) {
+          auto r = ctx.getSrcBuf().template get_access<mode_src, target>(cgh);
           cgh.update_host(r);
-        });
+        },
+        lh.set_line(__LINE__).set_op(
+            "update_host(accessor<$dataT, $dim_src, $mode_src, $target>)"));
   }
 }
 
@@ -160,44 +485,56 @@ void test_read_acc_copy_functions(cl::sycl::queue& queue) {
  */
 template <typename dataT, int dim_src, int dim_dst, mode_t mode_src,
           mode_t mode_dst, target_t target>
-void test_write_acc_copy_functions(cl::sycl::queue& queue) {
+void test_write_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
+  lh = lh.set_mode_src(mode_src).set_mode_dst(mode_dst).set_target(target);
   {
     // Check copy(shared_ptr_class, accessor)
-    submit_test_function<dataT, dim_src, dim_dst>(
-        queue, [](copy_test_context<dataT, dim_src, dim_dst>& ctx,
-                  cl::sycl::handler& cgh) {
-          auto w = ctx.dstBuf.template get_access<mode_dst, target>(cgh);
-          cgh.copy(ctx.srcHostPtr, w);
-        });
+    copy_test_context<dataT, dim_src, dim_dst> ctx(queue);
+    ctx.verify_device_copy(
+        [&](cl::sycl::handler& cgh) {
+          auto w = ctx.getDstBuf().template get_access<mode_dst, target>(cgh);
+          cgh.copy(ctx.getSrcHostPtr(), w);
+        },
+        lh.set_line(__LINE__).set_op(
+            "copy(shared_ptr_class<$dataT>, accessor<$dataT, $dim_dst, "
+            "$mode_dst, $target>)"));
   }
   {
     // Check copy(dataT*, accessor)
-    submit_test_function<dataT, dim_src, dim_dst>(
-        queue, [](copy_test_context<dataT, dim_src, dim_dst>& ctx,
-                  cl::sycl::handler& cgh) {
-          auto w = ctx.dstBuf.template get_access<mode_dst, target>(cgh);
-          cgh.copy(ctx.srcHostPtr.get(), w);
-        });
+    copy_test_context<dataT, dim_src, dim_dst> ctx(queue);
+    ctx.verify_device_copy(
+        [&](cl::sycl::handler& cgh) {
+          auto w = ctx.getDstBuf().template get_access<mode_dst, target>(cgh);
+          cgh.copy(ctx.getSrcHostPtr().get(), w);
+        },
+        lh.set_line(__LINE__).set_op(
+            "copy($dataT*, accessor<$dataT, $dim_dst, $mode_dst, $target>)"));
   }
   {
     // Check copy(accessor, accessor)
-    submit_test_function<dataT, dim_src, dim_dst>(
-        queue, [](copy_test_context<dataT, dim_src, dim_dst>& ctx,
-                  cl::sycl::handler& cgh) {
-          auto r = ctx.srcBuf.template get_access<mode_src, target>(cgh);
-          auto w = ctx.dstBuf.template get_access<mode_dst, target>(cgh);
+    copy_test_context<dataT, dim_src, dim_dst> ctx(queue);
+    ctx.verify_device_copy(
+        [&](cl::sycl::handler& cgh) {
+          auto r = ctx.getSrcBuf().template get_access<mode_src, target>(cgh);
+          auto w = ctx.getDstBuf().template get_access<mode_dst, target>(cgh);
           cgh.copy(r, w);
-        });
+        },
+        lh.set_line(__LINE__).set_op(
+            "copy(accessor<$dataT, $dim_src, $mode_src, $target>, "
+            "accessor<$dataT, $dim_dst, $mode_dst, $target>)"));
   }
   {
     // Check fill(accessor, dataT)
-    submit_test_function<dataT, dim_src, dim_dst>(
-        queue, [](copy_test_context<dataT, dim_src, dim_dst>& ctx,
-                  cl::sycl::handler& cgh) {
-          auto w = ctx.dstBuf.template get_access<mode_dst, target>(cgh);
-          const auto pattern = dataT(117);
+    const auto pattern = type_helper<dataT>::make(117);
+    copy_test_context<dataT, dim_src, dim_dst> ctx(queue);
+    ctx.verify_fill(
+        [&](cl::sycl::handler& cgh) {
+          auto w = ctx.getDstBuf().template get_access<mode_dst, target>(cgh);
           cgh.fill(w, pattern);
-        });
+        },
+        pattern,
+        lh.set_line(__LINE__).set_op(
+            "fill(accessor<$dataT, $dim_dst, $mode_dst, $target>)"));
   }
 }
 
@@ -205,16 +542,19 @@ void test_write_acc_copy_functions(cl::sycl::queue& queue) {
  * @brief Tests all valid combinations of access modes and buffer targets.
  */
 template <typename dataT, int dim_src>
-void test_all_read_acc_copy_functions(cl::sycl::queue& queue) {
+void test_all_read_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
+  lh = lh.set_dim_src(dim_src);
   {
     constexpr auto target = target_t::global_buffer;
-    test_read_acc_copy_functions<dataT, dim_src, mode_t::read, target>(queue);
+    test_read_acc_copy_functions<dataT, dim_src, mode_t::read, target>(lh,
+                                                                       queue);
     test_read_acc_copy_functions<dataT, dim_src, mode_t::read_write, target>(
-        queue);
+        lh, queue);
   }
   {
     constexpr auto target = target_t::constant_buffer;
-    test_read_acc_copy_functions<dataT, dim_src, mode_t::read, target>(queue);
+    test_read_acc_copy_functions<dataT, dim_src, mode_t::read, target>(lh,
+                                                                       queue);
   }
 }
 
@@ -222,44 +562,49 @@ void test_all_read_acc_copy_functions(cl::sycl::queue& queue) {
  * @brief Tests all valid combinations of source and destination access modes.
  */
 template <typename dataT, int dim_src, int dim_dst>
-void test_all_write_acc_copy_functions(cl::sycl::queue& queue) {
+void test_all_write_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
+  lh = lh.set_dim_src(dim_src).set_dim_dst(dim_dst);
   constexpr auto target = target_t::global_buffer;
 
   test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read,
-                                mode_t::write, target>(queue);
+                                mode_t::write, target>(lh, queue);
   test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read,
-                                mode_t::read_write, target>(queue);
+                                mode_t::read_write, target>(lh, queue);
   test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read,
-                                mode_t::discard_write, target>(queue);
+                                mode_t::discard_write, target>(lh, queue);
   test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read,
-                                mode_t::discard_read_write, target>(queue);
+                                mode_t::discard_read_write, target>(lh, queue);
 
   test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read_write,
-                                mode_t::write, target>(queue);
+                                mode_t::write, target>(lh, queue);
   test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read_write,
-                                mode_t::read_write, target>(queue);
+                                mode_t::read_write, target>(lh, queue);
   test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read_write,
-                                mode_t::discard_write, target>(queue);
+                                mode_t::discard_write, target>(lh, queue);
   test_write_acc_copy_functions<dataT, dim_src, dim_dst, mode_t::read_write,
-                                mode_t::discard_read_write, target>(queue);
+                                mode_t::discard_read_write, target>(lh, queue);
 }
 
+/**
+ * @brief Tests all valid combinations of source and destination dimensions.
+ */
 template <typename dataT>
-void test_all_dimensions(cl::sycl::queue& queue) {
-  test_all_read_acc_copy_functions<dataT, 1>(queue);
-  test_all_write_acc_copy_functions<dataT, 1, 1>(queue);
-  test_all_write_acc_copy_functions<dataT, 1, 2>(queue);
-  test_all_write_acc_copy_functions<dataT, 1, 3>(queue);
+void test_all_dimensions(log_helper lh, cl::sycl::queue& queue) {
+  lh = lh.set_data_type<dataT>();
+  test_all_read_acc_copy_functions<dataT, 1>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 1, 1>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 1, 2>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 1, 3>(lh, queue);
 
-  test_all_read_acc_copy_functions<dataT, 2>(queue);
-  test_all_write_acc_copy_functions<dataT, 2, 1>(queue);
-  test_all_write_acc_copy_functions<dataT, 2, 2>(queue);
-  test_all_write_acc_copy_functions<dataT, 2, 3>(queue);
+  test_all_read_acc_copy_functions<dataT, 2>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 2, 1>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 2, 2>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 2, 3>(lh, queue);
 
-  test_all_read_acc_copy_functions<dataT, 3>(queue);
-  test_all_write_acc_copy_functions<dataT, 3, 1>(queue);
-  test_all_write_acc_copy_functions<dataT, 3, 2>(queue);
-  test_all_write_acc_copy_functions<dataT, 3, 3>(queue);
+  test_all_read_acc_copy_functions<dataT, 3>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 3, 1>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 3, 2>(lh, queue);
+  test_all_write_acc_copy_functions<dataT, 3, 3>(lh, queue);
 }
 
 /** tests the API for cl::sycl::handler
@@ -278,19 +623,21 @@ class TEST_NAME : public util::test_base {
     try {
       auto queue = util::get_cts_object::queue();
 
-      test_all_dimensions<char>(queue);
-      test_all_dimensions<short>(queue);
-      test_all_dimensions<int>(queue);
-      test_all_dimensions<long>(queue);
-      test_all_dimensions<float>(queue);
-      test_all_dimensions<double>(queue);
+      log_helper lh(&log);
 
-      test_all_dimensions<cl::sycl::char2>(queue);
-      test_all_dimensions<cl::sycl::short3>(queue);
-      test_all_dimensions<cl::sycl::int4>(queue);
-      test_all_dimensions<cl::sycl::long8>(queue);
-      test_all_dimensions<cl::sycl::float8>(queue);
-      test_all_dimensions<cl::sycl::double16>(queue);
+      test_all_dimensions<char>(lh, queue);
+      test_all_dimensions<short>(lh, queue);
+      test_all_dimensions<int>(lh, queue);
+      test_all_dimensions<long>(lh, queue);
+      test_all_dimensions<float>(lh, queue);
+      test_all_dimensions<double>(lh, queue);
+
+      test_all_dimensions<cl::sycl::char2>(lh, queue);
+      test_all_dimensions<cl::sycl::short3>(lh, queue);
+      test_all_dimensions<cl::sycl::int4>(lh, queue);
+      test_all_dimensions<cl::sycl::long8>(lh, queue);
+      test_all_dimensions<cl::sycl::float8>(lh, queue);
+      test_all_dimensions<cl::sycl::double16>(lh, queue);
 
     } catch (const cl::sycl::exception& e) {
       log_exception(log, e);

--- a/tests/handler/handler_copy.cpp
+++ b/tests/handler/handler_copy.cpp
@@ -21,6 +21,8 @@ using namespace sycl_cts;
 using mode_t = cl::sycl::access::mode;
 using target_t = cl::sycl::access::target;
 
+namespace {
+
 /**
  * @brief Helper class designed to construct useful failure messages for all
  * test case permutations.
@@ -711,7 +713,8 @@ class copy_test_context {
  */
 template <typename dataT, int dim, mode_t mode_src, target_t target,
           bool strided, bool transposed>
-void test_read_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
+static void test_read_acc_copy_functions(log_helper lh,
+                                         cl::sycl::queue& queue) {
   lh = lh.set_mode_src(mode_src).set_target(target);
   {
     // Check copy(accessor, shared_ptr_class)
@@ -759,7 +762,8 @@ void test_read_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
  */
 template <typename dataT, int dim_src, int dim_dst, mode_t mode_src,
           mode_t mode_dst, target_t target, bool strided, bool transposed>
-void test_write_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
+static void test_write_acc_copy_functions(log_helper lh,
+                                          cl::sycl::queue& queue) {
   lh = lh.set_mode_src(mode_src).set_mode_dst(mode_dst).set_target(target);
   {
     // Check copy(shared_ptr_class, accessor)
@@ -821,7 +825,8 @@ void test_write_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
  * @brief Tests all valid combinations of access modes and buffer targets.
  */
 template <typename dataT, int dim_src, bool strided, bool transposed>
-void test_all_read_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
+static void test_all_read_acc_copy_functions(log_helper lh,
+                                             cl::sycl::queue& queue) {
   lh = lh.set_dim_src(dim_src);
   {
     constexpr auto target = target_t::global_buffer;
@@ -842,7 +847,8 @@ void test_all_read_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
  */
 template <typename dataT, int dim_src, int dim_dst, bool strided,
           bool transposed>
-void test_all_write_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
+static void test_all_write_acc_copy_functions(log_helper lh,
+                                              cl::sycl::queue& queue) {
   lh = lh.set_dim_src(dim_src).set_dim_dst(dim_dst);
   constexpr auto target = target_t::global_buffer;
 
@@ -876,7 +882,7 @@ void test_all_write_acc_copy_functions(log_helper lh, cl::sycl::queue& queue) {
  * @brief Tests all valid combinations of source and destination dimensions.
  */
 template <typename dataT, bool strided, bool transposed>
-void test_all_dimensions(log_helper lh, cl::sycl::queue& queue) {
+static void test_all_dimensions(log_helper lh, cl::sycl::queue& queue) {
   const std::string strided_note = strided ? "strided" : "";
   const std::string transposed_note = transposed ? "transposed" : "";
   lh = lh.set_extra_info(strided_note + (strided && transposed ? ", " : "") +
@@ -906,7 +912,7 @@ void test_all_dimensions(log_helper lh, cl::sycl::queue& queue) {
  *        non-transposed explicit memory operations.
  */
 template <typename dataT>
-void test_all_variants(log_helper lh, cl::sycl::queue& queue) {
+static void test_all_variants(log_helper lh, cl::sycl::queue& queue) {
   lh = lh.set_data_type<dataT>();
 
   test_all_dimensions<dataT, false, false>(lh, queue);
@@ -914,6 +920,8 @@ void test_all_variants(log_helper lh, cl::sycl::queue& queue) {
   test_all_dimensions<dataT, false, true>(lh, queue);
   test_all_dimensions<dataT, true, true>(lh, queue);
 }
+
+}  // namespace
 
 /** tests the API for cl::sycl::handler
  * TODO: Also test image accessors
@@ -935,19 +943,22 @@ class TEST_NAME : public util::test_base {
 
       log_helper lh(&log);
 
+      test_all_variants<int>(lh, queue);
+      test_all_variants<double>(lh, queue);
+      test_all_variants<cl::sycl::double16>(lh, queue);
+
+#if defined(SYCL_CTS_FULL_CONFORMANCE)
       test_all_variants<char>(lh, queue);
       test_all_variants<short>(lh, queue);
-      test_all_variants<int>(lh, queue);
       test_all_variants<long>(lh, queue);
       test_all_variants<float>(lh, queue);
-      test_all_variants<double>(lh, queue);
 
       test_all_variants<cl::sycl::char2>(lh, queue);
       test_all_variants<cl::sycl::short3>(lh, queue);
       test_all_variants<cl::sycl::int4>(lh, queue);
       test_all_variants<cl::sycl::long8>(lh, queue);
       test_all_variants<cl::sycl::float8>(lh, queue);
-      test_all_variants<cl::sycl::double16>(lh, queue);
+#endif
 
     } catch (const cl::sycl::exception& e) {
       log_exception(log, e);


### PR DESCRIPTION
In similar vein to #54, this PR improves the "handler_copy" tests to be much more robust, verifying that the various explicit memory operations actually do what they are supposed to do. Since these operations are highly configurable and thus prone to edge case bugs, I've spent considerable time on a solution that (I think) covers most if not all possible combinations.

Note that the test suite should probably be called "handler_explicit_memory_operations" or something similar, but I've decided to stick with the existing file name and terminology used within the test cases. So do keep in mind that while I'll mostly be talking about "copies" here, this usually also includes the `handler::fill` and to a lesser extent the `handler::update_host` function.

For a more complete changelog please see the commit messages, but here is the basic gist:

- Copies can now be strided (using ranged accessors) as well as transposed (for example, copying from a 2D buffer of shape [4,8] to a buffer of shape [8,4]).
- Copy results are being validated.
- Source buffers are filled with unique values for each index (a scalar encoding of the N-dimensional index) to make error detection more robust.
- Target buffers are filled with canary values to detect whether an implementation writes somewhere it shouldn't.
- Since there is a ton of test case permutations, making debugging a real challenge, I've also added a logging utility that can produce helpful error messages to pinpoint the exact template instantiation of a test case where something went wrong. Note that there are certain operations that are only parameterized by a subset of the various template parameters, which means that they are executed several times using the same configuration (this was however already the case previously).

With that being said, I think explicit memory operations are rather underspecified as of SYCL 1.2.1 Rev 7 (and not much has changed in SYCL 2020 Provisional, as far I can tell). This is apparently not just my opinion, because when you look at the results below it seems like implementors also have very different ideas as to what these functions should do. The tests I've implemented reflect my understanding of the spec, but it's entirely possible that I've made a wrong assumption somewhere. I've created a [corresponding issue in the SYCL-Docs repository](https://github.com/KhronosGroup/SYCL-Docs/issues/104), asking to clarify some of the underspecified points.

What this doesn't test yet is explicit memory operations on image accessors, and copying between buffers holding different data types.

## Results

I've done extensive testing to come up with these tables of the current state of implementors' support for explicit memory operations. Note that because there are _a lot_ of permutations to these test cases, I will only report results for a single data type (`long`), and a single writing access mode (`access::mode::write`). While results seem to be mostly the same across the different types and modes, I've seen some crashes for various combinations here and there -- while I tried to be careful, I won't rule out any mistakes on my part here.

Tested configurations:

- ComputeCpp 2.1 Intel OpenCL, Ubuntu 20.04 / Intel Xeon E5-4650
- ComputeCpp 2.1 NVIDIA OpenCL (experimental PTX), Ubuntu 18.04 / RTX 2070
- ComputeCpp 2.1 Host Device, Ubuntu 18.04
- hipSYCL CUDA (641d8990, Aug 22), Ubuntu 18.04 / RTX 2070 (CUDA 10.2)
  - As in #54, hipSYCL requires some additional workarounds within the CTS to compile at all (mostly related to OpenCL interop).
- LLVM (Intel SYCL / DPC++) OpenCL (14e227c4, Sep 16) Ubuntu 20.04 / Intel Xeon E5-4650
- LLVM (Intel SYCL / DPC++) CUDA (cb3a5d71, Sep 17) Ubuntu 18.04 / RTX 2070 (CUDA 10.2)
- LLVM (Intel SYCL / DPC++) Host Device (cb3a5d71, Sep 17) Ubuntu 18.04

### Copying

These are the results for `handler::copy` for various combinations of parameters. I'm differentiating between host-to-device (H2D) copies (`copy(ptr, accessor)`), device-to-device (D2D) copies (`copy(accessor, accessor)`) and device-to-host (D2H) copies (`copy(accessor, ptr)`). All variants can be dense (copying the full buffer) or strided (using a ranged accessor). For strided copies, the host pointer in H2D/D2H copies is always assumed to be dense (which is in accordance to my reading of the spec). D2D copies can additionally be transposed, where the shape of the source and destination accessor is mirrored (really only relevant in 2D/3D). On top of this, all copies are tested between all different combinations of source and destination dimensionalities (e.g., copying from a 2D accessor to a 3D accessor).

|           | H2D Dense          | H2D Strided        | D2D Dense            | D2D Strided          | D2D Transposed         | D2H Dense          | D2H Strided        |
| --------- | ------------------ | ------------------ | -------------------- | -------------------- | ---------------------- | ------------------ | ------------------ |
| CCPP OCL  | ✔                  | ❌<sup>CCPP1</sup> | ✔                    | ❌<sup>CCPP2</sup>   | ❌<sup>CCPP2</sup>     | ✔                  | ❌<sup>CCPP3</sup> |
| CCPP PTX  | ✔                  | ❌<sup>CCPP4</sup> | ✔                    | ❌<sup>CCPP2</sup>   | ❌<sup>CCPP2</sup>     | ✔                  | ❌<sup>CCPP4</sup> |
| CCPP Host | ✔                  | ❌<sup>CCPP5</sup> | ✔                    | ❌<sup>CCPP2</sup>   | ❌<sup>CCPP2</sup>     | ✔                  | ❌<sup>CCPP6</sup> |
| hipSYCL   | ✔                  | ✔                  | ✔<sup>HIPSYCL1</sup> | ✔<sup>HIPSYCL1</sup> | N/A<sup>HIPSYCL1</sup> | ✔                  | ✔                  |
| LLVM OCL  | ✔                  | ❌<sup>LLVM1</sup> | ✔                    | ❌<sup>LLVM2</sup>   | ✔                      | ✔                  | ❌<sup>LLVM3</sup> |
| LLVM CUDA | ✔                  | ❌<sup>LLVM4</sup> | ✔                    | ❌<sup>LLVM2</sup>   | ✔                      | ✔                  | ❌<sup>LLVM5</sup> |
| LLVM Host | ❌<sup>LLVM6</sup> | ❌<sup>LLVM7</sup> | ✔                    | ✔                    | ✔                      | ❌<sup>LLVM8</sup> | ❌<sup>LLVM3</sup> |

<sup>CCPP1</sup> Works for 1D. Segfaults for 2D / 3D.

<sup>CCPP2</sup> Only seems to work if `dim_src == dim_dst`. Segfaults for certain combinations of dimensions on Intel OCL.

<sup>CCPP3</sup> Appears to start copying from wrong offset.

<sup>CCPP4</sup> Works for 1D. Throws for 2D / 3D.

<sup>CCPP5</sup> Works for 1D. This appears to start to copy from the first host byte, but then assumes a stride on the host as well, ultimately reading beyond `accessor::get_size()` bytes.

<sup>CCPP6</sup> Works for 1D. This appears to start to copy from the first accessed element, but then assumes a stride on the host as well, ultimately writing beyond `accessor::get_size()` bytes.

<sup>HIPSYCL1</sup> hipSYCL does not support copying between buffers of different dimensionalities, or between differently shaped accessors (transposed copy). It also doesn't support `constant_buffer` accessors.

<sup>LLVM1</sup> Works for 1D, where the first byte pointed to by the host pointer is being copied to the first element at the specified offset (i.e., no offset is added to the host pointer, which is what I would expect). In 2D, the first host byte is also copied, but to the wrong location on the device. Not sure what is happening in 3D.

<sup>LLVM2</sup> Works for 1D. This is interesting, as dense, transposed and strided + transposed (not shown in table above) works. Likely an optimization gone wrong.

<sup>LLVM3</sup> Works for 1D. Writes directly to the first byte pointed to by the host pointer (i.e., again, no offset is added), however seems to start reading at the wrong location in the source accessor.

<sup>LLVM4</sup> Works for 1D and 2D. Not sure what is happening in 3D.

<sup>LLVM5</sup> Works for 1D, throws for 2D. Writes to first byte pointed to by the host pointer, but seems to start reading at wrong location in source accessor.

<sup>LLVM6</sup> Works for 1D, segfaults in 2D and produces wrong result in 3D.

<sup>LLVM7</sup> Works for 1D only.

<sup>LLVM8</sup> Works for 1D and 2D. Seems to start reading at wrong location in accessor.

### Fill / Update Host

These are the results for the (arguably somewhat less important) `handler::fill` and `handler::update_host` functions. For `fill`, im differentiating between dense fills, which fill the entire buffer, and ranged fills, which use a ranged accessor to only fill parts of a buffer with the specified value.

|           | Dense Fill | Ranged Fill | Update Host |
| --------- | ---------- | ----------- | ----------- |
| CCPP OCL  | ✔          | ❌          | ❌          |
| CCPP PTX  | ✔          | ❌          | ❌          |
| CCPP Host | ✔          | ❌          | ❌          |
| hipSYCL   | ✔          | ✔          | ✔           |
| LLVM OCL  | ✔          | ?*          | ✔           |
| LLVM CUDA | ✔          | ✔          | ✔           |
| LLVM Host | ✔          | ✔          | ✔           |

\* LLVM OCL currently crashes on me during linking, I haven't had time to look into this yet.

EDIT: There was a bug in the ranged fill test, in that it didn't create ranged accessors in the first place. The results above were updated after this was fixed.

**Key Takeaways:**

- As you can see, the current state of affairs surrounding `handler::copy` is rather dire, once one wants to go beyond a basic dense copy. However, for every test there is at least one implementation that behaves as I would expect. Full disclosure: I originally implemented support for `handler::copy` in hipSYCL, which might be a reason as to why it behaves as I would expect ;-).
- ~~None of the tested implementations supports a "ranged fill", i.e., calling `handler::fill` on a ranged accessor. Instead of only filling the accessed range, all tested implementations fill the entire buffer.~~ EDIT: This turned out to be a bug, see above.
- The CTS needs to test this.