### PR TITLE
Extend type coverage for relational and integer functions

### DIFF
--- a/tests/math_builtin_api/modules/sycl_types.py
+++ b/tests/math_builtin_api/modules/sycl_types.py
@@ -444,7 +444,7 @@ def create_basic_types():
 
     # Generic Types
 def create_types():
-    type_dic = create_basic_types(
+    type_dic = create_basic_types()
     
     t_float_n = argtype("floatn", "NULL", "NULL", 0, ["cl::sycl::float2","cl::sycl::float3","cl::sycl::float4","cl::sycl::float8","cl::sycl::float16"])
     type_dic["floatn"] = t_float_n

--- a/tests/math_builtin_api/modules/sycl_types.py
+++ b/tests/math_builtin_api/modules/sycl_types.py
@@ -15,7 +15,7 @@ class argtype:
     def __hash__(self):
         return hash(name)
 
-def create_types():
+def create_basic_types():
     type_dic = {}
     
     # Basic Types
@@ -439,8 +439,12 @@ def create_types():
     t_uint64t_16 = argtype("cl::sycl::vec<uint64_t, 16>", "vector", "int64_t", 16, [], True)
     type_dic["cl::sycl::vec<uint64_t, 16>"] = t_uint64t_16
 
+    return type_dic
+    
 
     # Generic Types
+def create_types():
+    type_dic = create_basic_types(
     
     t_float_n = argtype("floatn", "NULL", "NULL", 0, ["cl::sycl::float2","cl::sycl::float3","cl::sycl::float4","cl::sycl::float8","cl::sycl::float16"])
     type_dic["floatn"] = t_float_n

--- a/tests/math_builtin_api/modules/test_generator.py
+++ b/tests/math_builtin_api/modules/test_generator.py
@@ -1,4 +1,5 @@
 from . import sycl_functions
+from . import sycl_types
 import random
 
 test_case_templates = { "private" : ("\n\n{\n"
@@ -153,22 +154,26 @@ def generate_test_cases(test_id, types, sig_list):
 # We attempt to find a combination that is part of the current generic type (e.g. floatn)
 
 def attempt_match(runner, var_type, base_type, dim, unsigned, current_type):
+    ct_keys = list(current_type.keys())
+    ct_part_keys = []
+    for t in ct_keys:
+        ct_part_keys.append(t[:-1])
     # Change sign.
-    if (var_type, base_type, dim, not unsigned) in list(current_type.keys()):
+    if (var_type, base_type, dim, not unsigned) in ct_part_keys:
         return (var_type, base_type, dim, not unsigned)
     # Change type and sign, same dimensionality.
     for new_sign in [unsigned, not unsigned]:
         for new_type in runner.base_types:
-            if (var_type, new_type, dim, new_sign) in list(current_type.keys()):
+            if (var_type, new_type, dim, new_sign) in ct_part_keys:
                 return (var_type, new_type, dim, new_sign)
     # Change to base type (for scalars).
     for new_sign in [unsigned, not unsigned]:
-        if ("scalar", base_type, 1, new_sign) in list(current_type.keys()):
+        if ("scalar", base_type, 1, new_sign) in ct_part_keys:
             return ("scalar", base_type, 1, new_sign)
     # See if any other scalar type match.
     for new_sign in [unsigned, not unsigned]:
         for new_type in runner.base_types:
-            if ("scalar", new_type, 1, new_sign) in list(current_type.keys()):
+            if ("scalar", new_type, 1, new_sign) in ct_part_keys:
                 return ("scalar", new_type, 1, new_sign)
     return None
 
@@ -181,52 +186,71 @@ def expand_signature(runner, types, signature):
     for arg in signature.arg_types:
         current_types.extend([types[arg]])
 
-    # Itterate over all possible combinations of namespace, base type, dimension and sign flag.
+    # Iterate over all basic types
     # Try to match all function types (return type and argument types).
-    for var_type in runner.var_types:
-        for base_type in runner.base_types:
-            for dim in runner.dimensions:
-                for unsigned in runner.unsigned:
-                    match = False
-                    nomatch = []
-                    index = 0
-                    for ct in current_types:
-                        if (var_type, base_type, dim, unsigned) in list(ct.keys()):
-                            match = True
+    all_types = sycl_types.create_basic_types()
+    for name in list(all_types.keys()):
+        match = False
+        nomatch = []
+        index = 0
+        for ct in current_types:
+            ct_keys = list(ct.keys())
+            ct_part_keys = []
+            for t in ct_keys:
+                ct_part_keys.append(t[4:])
+            if (name, ) in ct_part_keys:
+                match = True
+            else:
+                nomatch.append(index)
+            index += 1
+        if match is True:
+            # Return value and all arguments are of the same type.
+            if len(nomatch) == 0:
+                new_sig = sycl_functions.funsig(signature.namespace, name, signature.name, [
+                                                name for i in range(len(signature.arg_types))], signature.pntr_indx[:])
+                exp_sig.append(new_sig)
+            else:
+                function_types = []
+                function_types_extra = []
+                all_matched = True
+                extra = False
+                for ct in current_types:
+                    ct_keys = list(ct.keys())
+                    ct_part_keys = []
+                    for t in ct_keys:
+                        ct_part_keys.append(t[4:])
+                    # Current function type already matches - no need for mutation.
+                    if (name, ) in ct_part_keys:
+                        function_types.append(name)
+                        function_types_extra.append(name)
+                    else:
+                        var_type = all_types[name].var_type
+                        base_type = all_types[name].base_type
+                        dim = all_types[name].dim
+                        unsigned = all_types[name].unsigned
+
+                        # Get var_type, base_type, dim, unsigned of suitable type
+                        mutation = attempt_match(runner, var_type, base_type, dim, unsigned, ct)
+                        if mutation is not None:
+                            # Find suitable type by all key members except name
+                            new_types = [ct[key] for key in ct.keys() if key[:-1] == mutation]
+                            function_types.append(new_types[0].name)
+                            if len(new_types) > 1:
+                                function_types_extra.append(new_types[1].name)
+                                extra = True
                         else:
-                            nomatch.append(index)
-                        index += 1
-                    if match is True:
-                        # Return value and all arguments are of the same type.
-                        if len(nomatch) == 0:
-                            common_type = current_types[0][(
-                                var_type, base_type, dim, unsigned)]
-                            new_sig = sycl_functions.funsig(signature.namespace, common_type.name, signature.name, [
-                                                            common_type.name for i in range(len(signature.arg_types))], signature.pntr_indx[:])
-                            exp_sig.append(new_sig)
-                        else:
-                            function_types = []
-                            all_matched = True
-                            for ct in current_types:
-                                # Current function type already matches - no need for mutation.
-                                if (var_type, base_type, dim, unsigned) in list(ct.keys()):
-                                    function_types.append(
-                                        ct[(var_type, base_type, dim, unsigned)].name)
-                                else:
-                                    mutation = attempt_match(
-                                        runner, var_type, base_type, dim, unsigned, ct)
-                                    if mutation is not None:
-                                        function_types.append(
-                                            ct[mutation].name)
-                                    else:
-                                        all_matched = False
-                            if all_matched is True:
-                                new_sig = sycl_functions.funsig(
-                                    signature.namespace, function_types[0], signature.name, function_types[1:], signature.pntr_indx[:])
-                                exp_sig.append(new_sig)
-                            else:
-                                print("[WARNING] Unable to fully match function " + signature.name + " for: " +
-                                      var_type + ", " + base_type + ", " + str(dim) + ", " + str(unsigned))
+                            all_matched = False
+                if all_matched is True:
+                    new_sig = sycl_functions.funsig(
+                        signature.namespace, function_types[0], signature.name, function_types[1:], signature.pntr_indx[:])
+                    exp_sig.append(new_sig)
+                    if extra:
+                        new_sig = sycl_functions.funsig(
+                        signature.namespace, function_types_extra[0], signature.name, function_types_extra[1:], signature.pntr_indx[:])
+                        exp_sig.append(new_sig)
+                else:
+                    print("[WARNING] Unable to fully match function " + signature.name + " for: " +
+                            var_type + ", " + base_type + ", " + str(dim) + ", " + str(unsigned))
     return exp_sig
 
 def get_unique_signatures(signatures):
@@ -252,8 +276,9 @@ def expand_signatures(runner, types, signatures):
 def expand_type(types, current):
     # If this is a basic type, stop.
     if types[current].dim > 0:
-        return {(types[current].var_type, types[current].base_type, types[current].dim, types[current].unsigned): types[current]}
-
+        # Name should be in the key too or we'll lose char or signed char - they both have the same var_type, base_type, dim, unsigned
+        return {(types[current].var_type, types[current].base_type, types[current].dim, types[current].unsigned, types[current].name) : types[current]}
+        
     base_types = {}
     for ct in types[current].child_types:
         base_types.update(expand_type(types, ct))

--- a/tests/math_builtin_api/modules/test_generator.py
+++ b/tests/math_builtin_api/modules/test_generator.py
@@ -82,11 +82,11 @@ def generate_arguments(types, sig, memory):
     for arg in sig.arg_types:
         # Get argument type.
         arg_type = extract_type(types[arg])
-        
+
         # Create argument name.
         arg_name = "inputData_" + str(arg_index)
         arg_names.append(arg_name)
-        
+
         # Identify whether aegument is a pointer.
         is_pointer = False
         # Value 0 in pntr_indx is reserved for the return type.
@@ -98,7 +98,7 @@ def generate_arguments(types, sig, memory):
             current_arg = generate_multi_ptr(arg_name, arg_type, arg_index, memory)
         else:
             current_arg = generate_variable(arg_name, arg_type, arg_index)
-        
+
         arg_src += current_arg
         arg_index += 1
     return (arg_names, arg_src)
@@ -154,9 +154,8 @@ def generate_test_cases(test_id, types, sig_list):
 # We attempt to find a combination that is part of the current generic type (e.g. floatn)
 
 def attempt_match(runner, var_type, base_type, dim, unsigned, current_type):
-    ct_keys = list(current_type.keys())
     ct_part_keys = []
-    for t in ct_keys:
+    for t in current_type.keys():
         ct_part_keys.append(t[:-1])
     # Change sign.
     if (var_type, base_type, dim, not unsigned) in ct_part_keys:
@@ -189,12 +188,12 @@ def expand_signature(runner, types, signature):
     # Iterate over all basic types
     # Try to match all function types (return type and argument types).
     all_types = sycl_types.create_basic_types()
-    for name in list(all_types.keys()):
+    for name in all_types.keys():
         match = False
         nomatch = []
         index = 0
         for ct in current_types:
-            ct_keys = list(ct.keys())
+            ct_keys = ct.keys()
             ct_part_keys = []
             for t in ct_keys:
                 ct_part_keys.append(t[4:])
@@ -215,7 +214,7 @@ def expand_signature(runner, types, signature):
                 all_matched = True
                 extra = False
                 for ct in current_types:
-                    ct_keys = list(ct.keys())
+                    ct_keys = ct.keys()
                     ct_part_keys = []
                     for t in ct_keys:
                         ct_part_keys.append(t[4:])
@@ -278,7 +277,7 @@ def expand_type(types, current):
     if types[current].dim > 0:
         # Name should be in the key too or we'll lose char or signed char - they both have the same var_type, base_type, dim, unsigned
         return {(types[current].var_type, types[current].base_type, types[current].dim, types[current].unsigned, types[current].name) : types[current]}
-        
+
     base_types = {}
     for ct in types[current].child_types:
         base_types.update(expand_type(types, ct))


### PR DESCRIPTION
Fixed ommiting tests for char and vec<char,N>

Remaining gap (test coverage): result correctness isn't checked