### PR TITLE
Improve data type coverage for Image.

### DIFF
--- a/tests/image/image_api.cpp
+++ b/tests/image/image_api.cpp
@@ -9,357 +9,10 @@
 #include "image_common.h"
 #include "../common/common.h"
 
-#define TEST_NAME image_api
+#define TEST_NAME image_api_core
 
-template <int dims>
-struct image_kernel_read;
-template <int dims>
-struct image_kernel_write;
-template <int dims>
-struct image_kernel_get_access;
-
-namespace image_api__ {
+namespace TEST_NAMESPACE {
 using namespace sycl_cts;
-
-template <int dims>
-class image_ctors {
- public:
-  void operator()(util::logger &log, cl::sycl::range<dims> &r,
-                  cl::sycl::range<dims - 1> *p = nullptr) const {
-    auto numElems = 1;
-    switch (dims) {
-      case 1:
-        log.note("Testing image combination: dims[%d], range[%d]", dims, r[0]);
-        numElems = r[0];
-        break;
-      case 2:
-        log.note(
-            "Testing image combination: dims[%d], range[%d, %d], pitch[%d]",
-            dims, r[0], r[1], (p != nullptr));
-        numElems = r[0] * r[1];
-        break;
-      case 3:
-        log.note(
-            "Testing image combination: dims[%d], range[%d, %d, %d], pitch[%d]",
-            dims, r[0], r[1], r[2], (p != nullptr));
-        numElems = r[0] * r[1] * r[2];
-        break;
-      default:
-        break;
-    }
-
-    // This combination is required to be supported by the OpenCL spec
-    const auto channelOrder = cl::sycl::image_channel_order::rgba;
-    const auto channelType = cl::sycl::image_channel_type::fp32;
-
-    // Prepare variables
-    const auto channelCount = get_channel_order_count(channelOrder);
-    const auto channelTypeSize = get_channel_type_size(channelType);
-    const auto elementSize = channelTypeSize * channelCount;
-
-    // Pitch has to be at least as large as the multiple of element size
-    image_generic<dims>::multiply_pitch(p, elementSize);
-
-    // Create image host data
-    auto imageHost =
-        get_image_host<dims>(numElems, channelTypeSize, channelCount);
-
-    // Create final data
-    // Must outlive the image
-    auto finalData =
-        get_image_host<dims>(numElems, channelTypeSize, channelCount);
-
-    // Creates an image, either with a pitch or without
-    // The pitch is not used for a 1D image or when null
-    cl::sycl::image<dims> img = image_generic<dims>::create_with_pitch(
-        static_cast<void *>(imageHost.data()), channelOrder, channelType, r, p);
-
-    // Check get_range()
-    if (dims == 3) {
-      if ((!CHECK_VALUE_SCALAR(log, img.get_range()[0], r.get(0))) ||
-          (!CHECK_VALUE_SCALAR(log, img.get_range()[1], r.get(1))) ||
-          (!CHECK_VALUE_SCALAR(log, img.get_range()[2], r.get(2)))) {
-        FAIL(log, "Ranges are not the same.");
-      }
-    }
-    if (dims == 2) {
-      if ((!CHECK_VALUE_SCALAR(log, img.get_range()[0], r.get(0))) ||
-          (!CHECK_VALUE_SCALAR(log, img.get_range()[1], r.get(1)))) {
-        FAIL(log, "Ranges are not the same.");
-      }
-    }
-    if (dims == 1) {
-      if ((!CHECK_VALUE_SCALAR(log, img.get_range()[0], r.get(0)))) {
-        FAIL(log, "Ranges are not the same.");
-      }
-    }
-
-    // Check get_pitch()
-    if (!image_generic<dims>::compare_pitch(log, img, p)) {
-      FAIL(log, "Pitches are not the same.");
-    }
-
-    // Check get_size()
-    if (img.get_size() < (numElems * elementSize)) {
-      cl::sycl::string_class message =
-          cl::sycl::string_class("Sizes are not the same: expected at least ") +
-          std::to_string(numElems * elementSize) + ", got " +
-          std::to_string(img.get_size());
-      FAIL(log, message);
-    }
-
-    // Check get_count()
-    if (!CHECK_VALUE_SCALAR(log, img.get_count(), numElems)) {
-      FAIL(log, "Counts are not the same.");
-    }
-
-    // Check get_allocator()
-    {
-      using AllocatorT = std::allocator<cl::sycl::byte>;
-
-      /* create another image with a custom allocator */
-      auto imgAlloc =
-          image_generic<dims>::template create_with_pitch_and_allocator<
-              AllocatorT>(static_cast<void *>(imageHost.data()), channelOrder,
-                          channelType, r, p);
-
-      auto allocator = imgAlloc.get_allocator();
-
-      check_return_type<AllocatorT>(log, allocator, "get_allocator()");
-
-      auto ptr = allocator.allocate(1);
-      if (ptr == nullptr) {
-        FAIL(log, "get_allocator() returned an invalid allocator");
-      }
-      allocator.deallocate(ptr, 1);
-    }
-
-    /* Check image properties */
-    {
-      cl::sycl::mutex_class mutex;
-      auto context = util::get_cts_object::context();
-      const cl::sycl::property_list propList{
-          cl::sycl::property::image::use_host_ptr(),
-          cl::sycl::property::image::use_mutex(mutex),
-          cl::sycl::property::image::context_bound(context)};
-
-      // Create another image
-      auto img2 = cl::sycl::image<dims>(static_cast<void *>(imageHost.data()),
-                                        channelOrder, channelType, r, propList);
-
-      /* check has_property() */
-
-      auto hasHostPtrProperty =
-          img2.template has_property<cl::sycl::property::image::use_host_ptr>();
-      check_return_type<bool>(log, hasHostPtrProperty,
-                              "has_property<use_host_ptr>()");
-
-      auto hasUseMutexProperty =
-          img2.template has_property<cl::sycl::property::image::use_mutex>();
-      check_return_type<bool>(log, hasUseMutexProperty,
-                              "has_property<use_mutex>()");
-
-      auto hasContentBoundProperty = img2.template has_property<
-          cl::sycl::property::image::context_bound>();
-      check_return_type<bool>(log, hasContentBoundProperty,
-                              "has_property<context_bound>()");
-
-      /* check get_property() */
-
-      auto hostPtrProperty =
-          img2.template get_property<cl::sycl::property::image::use_host_ptr>();
-      check_return_type<cl::sycl::property::image::use_host_ptr>(
-          log, hostPtrProperty, "get_property<use_host_ptr>()");
-
-      auto useMutexProperty =
-          img2.template get_property<cl::sycl::property::image::use_mutex>();
-      check_return_type<cl::sycl::property::image::use_mutex>(
-          log, useMutexProperty, "get_property<use_mutex>()");
-      check_return_type<cl::sycl::mutex_class *>(
-          log, useMutexProperty.get_mutex_ptr(),
-          "image::use_mutex::get_mutex_ptr()");
-
-      auto contextBoundProperty = img2.template get_property<
-          cl::sycl::property::image::context_bound>();
-      check_return_type<cl::sycl::property::image::context_bound>(
-          log, contextBoundProperty, "get_property<context_bound>()");
-      check_return_type<cl::sycl::context>(
-          log, contextBoundProperty.get_context(),
-          "image::context_bound::get_context()");
-    }
-
-    // Check image enum classes
-    {
-      // Check image channel orders
-      check_enum_class_value(cl::sycl::image_channel_order::a);
-      check_enum_class_value(cl::sycl::image_channel_order::r);
-      check_enum_class_value(cl::sycl::image_channel_order::rx);
-      check_enum_class_value(cl::sycl::image_channel_order::rg);
-      check_enum_class_value(cl::sycl::image_channel_order::rgx);
-      check_enum_class_value(cl::sycl::image_channel_order::ra);
-      check_enum_class_value(cl::sycl::image_channel_order::rgb);
-      check_enum_class_value(cl::sycl::image_channel_order::rgbx);
-      check_enum_class_value(cl::sycl::image_channel_order::rgba);
-      check_enum_class_value(cl::sycl::image_channel_order::argb);
-      check_enum_class_value(cl::sycl::image_channel_order::bgra);
-      check_enum_class_value(cl::sycl::image_channel_order::intensity);
-      check_enum_class_value(cl::sycl::image_channel_order::luminance);
-
-      // Check image channel types
-      check_enum_class_value(cl::sycl::image_channel_type::snorm_int8);
-      check_enum_class_value(cl::sycl::image_channel_type::snorm_int16);
-      check_enum_class_value(cl::sycl::image_channel_type::unorm_int8);
-      check_enum_class_value(cl::sycl::image_channel_type::unorm_int16);
-      check_enum_class_value(cl::sycl::image_channel_type::unorm_short_565);
-      check_enum_class_value(cl::sycl::image_channel_type::unorm_short_555);
-      check_enum_class_value(cl::sycl::image_channel_type::unorm_int_101010);
-      check_enum_class_value(cl::sycl::image_channel_type::signed_int8);
-      check_enum_class_value(cl::sycl::image_channel_type::signed_int16);
-      check_enum_class_value(cl::sycl::image_channel_type::signed_int32);
-      check_enum_class_value(cl::sycl::image_channel_type::unsigned_int8);
-      check_enum_class_value(cl::sycl::image_channel_type::unsigned_int16);
-      check_enum_class_value(cl::sycl::image_channel_type::unsigned_int32);
-      check_enum_class_value(cl::sycl::image_channel_type::fp16);
-      check_enum_class_value(cl::sycl::image_channel_type::fp32);
-    }
-
-    // Check set_write_back()
-    {
-      img.set_write_back();
-      img.set_write_back(false);
-      img.set_write_back(true);
-    }
-
-    // Check set_final_data()
-    {
-      auto rawPtr = finalData.data();
-      auto rawPtrVoid = static_cast<void *>(rawPtr);
-      auto rawPtrFloat = static_cast<float *>(rawPtrVoid);
-      auto sharedPtrVoid =
-          cl::sycl::shared_ptr_class<void>(rawPtrVoid, [](void *) {});
-      auto sharedPtrFloat =
-          cl::sycl::shared_ptr_class<float>(rawPtrFloat, [](float *) {});
-      auto weakPtrVoid = cl::sycl::weak_ptr_class<void>(sharedPtrVoid);
-      auto weakPtrFloat = cl::sycl::weak_ptr_class<float>(sharedPtrFloat);
-      auto iterator = finalData.begin();
-
-      img.set_final_data();
-      img.set_final_data(nullptr);
-      img.set_final_data(rawPtr);
-      img.set_final_data(rawPtrVoid);
-      img.set_final_data(rawPtrFloat);
-      img.set_final_data(sharedPtrVoid);
-      img.set_final_data(sharedPtrFloat);
-      img.set_final_data(weakPtrVoid);
-      img.set_final_data(weakPtrFloat);
-      img.set_final_data(iterator);
-    }
-
-    // Check get_access()
-    {
-      // Create another image
-      auto img2 = cl::sycl::image<dims>(static_cast<void *>(imageHost.data()),
-                                        channelOrder, channelType, r);
-      {
-        // target::host_image
-        img2.template get_access<cl::sycl::float4,
-                                 cl::sycl::access::mode::read_write>();
-      }
-
-      auto queue = util::get_cts_object::queue();
-      try {
-        queue.submit([&](cl::sycl::handler &cgh) {
-          // target::image
-          auto imgAcc =
-              img2.template get_access<cl::sycl::float4,
-                                       cl::sycl::access::mode::write>(cgh);
-          cgh.single_task<image_kernel_get_access<dims>>([]() {});
-        });
-
-        queue.wait_and_throw();
-      } catch (const cl::sycl::feature_not_supported &fnse) {
-        if (!queue.get_device()
-                 .template get_info<cl::sycl::info::device::image_support>()) {
-          log.note("device does not support images -- skipping check");
-        } else {
-          throw;
-        }
-      }
-    }
-
-    const auto expected = 0.5f;
-
-    // Check read/write APIs.
-    {
-      auto queue = util::get_cts_object::queue();
-
-      try {
-        {
-          cl::sycl::image<dims> img2 = image_generic<dims>::create_with_pitch(
-              static_cast<void *>(imageHost.data()), channelOrder, channelType,
-              r, p);
-          queue.submit([&](cl::sycl::handler &cgh) {
-            auto img_acc =
-                img2.template get_access<cl::sycl::float4,
-                                         cl::sycl::access::mode::read>(cgh);
-
-            auto sampler = cl::sycl::sampler(
-                cl::sycl::coordinate_normalization_mode::unnormalized,
-                cl::sycl::addressing_mode::clamp,
-                cl::sycl::filtering_mode::nearest);
-
-            auto myKernel = [img_acc, sampler](cl::sycl::item<dims> item) {
-              // Read image data using integer coordinates
-              cl::sycl::float4 dataFromInt =
-                  img_acc.read(image_access<dims>::get_int(item));
-              (void)dataFromInt;  // silent warning
-              // Read image data using integer coordinates and a sampler
-              cl::sycl::float4 dataFromIntWithSampler =
-                  img_acc.read(image_access<dims>::get_int(item), sampler);
-              (void)dataFromIntWithSampler;  // silent warning
-              // Read image data using floating point coordinates
-              // Only works with a sampler
-              cl::sycl::float4 dataFromFloat =
-                  img_acc.read(image_access<dims>::get_float(item), sampler);
-              (void)dataFromFloat;  // silent warning
-            };
-            cgh.parallel_for<image_kernel_read<dims>>(r, myKernel);
-          });
-
-          queue.submit([&](cl::sycl::handler &cgh) {
-            auto img_acc =
-                img2.template get_access<cl::sycl::float4,
-                                         cl::sycl::access::mode::write>(cgh);
-            auto myKernel = [expected, img_acc](cl::sycl::item<dims> item) {
-              // Write image data
-              img_acc.write(image_access<dims>::get_int(item),
-                            cl::sycl::float4(expected));
-            };
-            cgh.parallel_for<image_kernel_write<dims>>(r, myKernel);
-          });
-
-          queue.wait_and_throw();
-        }  // End of scope for img2 object.
-
-        // Check image values
-        const auto floatData = reinterpret_cast<float *>(imageHost.data());
-        for (int i = 0; i < numElems; ++i) {
-          if (!CHECK_VALUE(log, floatData[i], 0.5f, i)) {
-            FAIL(log, "Image contains wrong values.");
-          }
-        }
-
-      } catch (const cl::sycl::feature_not_supported &fnse) {
-        if (!queue.get_device()
-                 .template get_info<cl::sycl::info::device::image_support>()) {
-          log.note("device does not support images -- skipping check");
-        } else {
-          throw;
-        }
-      }
-    }
-  }
-};
 
 /**
  * test cl::sycl::image initialization
@@ -387,9 +40,9 @@ class TEST_NAME : public util::test_base {
 
       // Test without pitch
       {
-        image_ctors<1> img_1d;
-        image_ctors<2> img_2d;
-        image_ctors<3> img_3d;
+        image_api_check<1> img_1d;
+        image_api_check<2> img_2d;
+        image_api_check<3> img_3d;
         img_1d(log, range_1d);
         img_2d(log, range_2d);
         img_3d(log, range_3d);
@@ -400,10 +53,46 @@ class TEST_NAME : public util::test_base {
         cl::sycl::range<1> pitch_1d(elemsPerDim2);
         cl::sycl::range<2> pitch_2d(elemsPerDim3, elemsPerDim3 * elemsPerDim3);
 
-        image_ctors<2> img_2d;
-        image_ctors<3> img_3d;
+        image_api_check<2> img_2d;
+        image_api_check<3> img_3d;
         img_2d(log, range_2d, &pitch_1d);
         img_3d(log, range_3d, &pitch_2d);
+      }
+
+      // Check image enum classes
+      {
+        // Check image channel orders
+        check_enum_class_value(cl::sycl::image_channel_order::a);
+        check_enum_class_value(cl::sycl::image_channel_order::r);
+        check_enum_class_value(cl::sycl::image_channel_order::rx);
+        check_enum_class_value(cl::sycl::image_channel_order::rg);
+        check_enum_class_value(cl::sycl::image_channel_order::rgx);
+        check_enum_class_value(cl::sycl::image_channel_order::ra);
+        check_enum_class_value(cl::sycl::image_channel_order::rgb);
+        check_enum_class_value(cl::sycl::image_channel_order::rgbx);
+        check_enum_class_value(cl::sycl::image_channel_order::rgba);
+        check_enum_class_value(cl::sycl::image_channel_order::argb);
+        check_enum_class_value(cl::sycl::image_channel_order::bgra);
+        check_enum_class_value(cl::sycl::image_channel_order::intensity);
+        check_enum_class_value(cl::sycl::image_channel_order::luminance);
+        check_enum_class_value(cl::sycl::image_channel_order::abgr);
+
+        // Check image channel types
+        check_enum_class_value(cl::sycl::image_channel_type::snorm_int8);
+        check_enum_class_value(cl::sycl::image_channel_type::snorm_int16);
+        check_enum_class_value(cl::sycl::image_channel_type::unorm_int8);
+        check_enum_class_value(cl::sycl::image_channel_type::unorm_int16);
+        check_enum_class_value(cl::sycl::image_channel_type::unorm_short_565);
+        check_enum_class_value(cl::sycl::image_channel_type::unorm_short_555);
+        check_enum_class_value(cl::sycl::image_channel_type::unorm_int_101010);
+        check_enum_class_value(cl::sycl::image_channel_type::signed_int8);
+        check_enum_class_value(cl::sycl::image_channel_type::signed_int16);
+        check_enum_class_value(cl::sycl::image_channel_type::signed_int32);
+        check_enum_class_value(cl::sycl::image_channel_type::unsigned_int8);
+        check_enum_class_value(cl::sycl::image_channel_type::unsigned_int16);
+        check_enum_class_value(cl::sycl::image_channel_type::unsigned_int32);
+        check_enum_class_value(cl::sycl::image_channel_type::fp16);
+        check_enum_class_value(cl::sycl::image_channel_type::fp32);
       }
     } catch (const cl::sycl::exception &e) {
       log_exception(log, e);
@@ -417,4 +106,4 @@ class TEST_NAME : public util::test_base {
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-} /* namespace image_api__ */
+} /* namespace TEST_NAMESPACE */

--- a/tests/image/image_api_fp16.cpp
+++ b/tests/image/image_api_fp16.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 1.2.1 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Provides image get_access test for cl_half4
 //
 *******************************************************************************/
 

--- a/tests/image/image_api_fp16.cpp
+++ b/tests/image/image_api_fp16.cpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+*******************************************************************************/
+
+#include "image_common.h"
+#include "../common/common.h"
+
+#define TEST_NAME image_api_fp16
+
+namespace TEST_NAMESPACE {
+
+/**
+ * test cl::sycl::image initialization
+ */
+class TEST_NAME : public util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  template <int dims>
+  void check_allocs(util::logger &log, image_api_check<dims> &img_check,
+                    cl::sycl::range<dims> &r,
+                    cl::sycl::range<dims - 1> *p = nullptr) {
+      img_check.template check_get_access<cl::sycl::cl_half4,
+                            cl::sycl::image_allocator>(
+                              log, cl::sycl::image_channel_order::rgba,
+                              cl::sycl::image_channel_type::fp16, r, p, true);
+      img_check.template check_get_access<cl::sycl::cl_half4,
+                            std::allocator<cl::sycl::byte>>(
+                              log, cl::sycl::image_channel_order::rgba,
+                              cl::sycl::image_channel_type::fp16, r, p, true);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    try {
+      auto queue = util::get_cts_object::queue();
+
+      if (!queue.get_device().has_extension("cl_khr_fp16")) {
+        log.note(
+            "Device does not support half precision floating point operations");
+        return;
+      }
+
+      // Ensure the image always has 64 elements
+      const int elemsPerDim1 = 64;
+      const int elemsPerDim2 = 8;
+      const int elemsPerDim3 = 4;
+
+      cl::sycl::range<1> range_1d(elemsPerDim1);
+      cl::sycl::range<2> range_2d(elemsPerDim2, elemsPerDim2);
+      cl::sycl::range<3> range_3d(elemsPerDim3, elemsPerDim3, elemsPerDim3);
+
+      // Test without pitch
+      {
+        image_api_check<1> img_1d;
+        image_api_check<2> img_2d;
+        image_api_check<3> img_3d;
+        check_allocs(log, img_1d, range_1d);
+        check_allocs(log, img_2d, range_2d);
+        check_allocs(log, img_3d, range_3d);
+      }
+
+      // Test with pitch
+      {
+        cl::sycl::range<1> pitch_1d(elemsPerDim2);
+        cl::sycl::range<2> pitch_2d(elemsPerDim3, elemsPerDim3 * elemsPerDim3);
+
+        image_api_check<2> img_2d;
+        image_api_check<3> img_3d;
+        check_allocs(log, img_2d, range_2d, &pitch_1d);
+        check_allocs(log, img_3d, range_3d, &pitch_2d);
+      }
+    } catch (const cl::sycl::exception &e) {
+      log_exception(log, e);
+      cl::sycl::string_class errorMsg =
+          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
+      FAIL(log, errorMsg.c_str());
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+} /* namespace TEST_NAMESPACE */

--- a/tests/image/image_common.h
+++ b/tests/image/image_common.h
@@ -490,8 +490,7 @@ class image_api_check {
 
     // Check get_size()
     if (img.get_size() < (numElems * elementSize)) {
-      cl::sycl::string_class message =
-          cl::sycl::string_class("Sizes are not the same: expected at least ") +
+      std::string message = "Sizes are not the same: expected at least " +
           std::to_string(numElems * elementSize) + ", got " +
           std::to_string(img.get_size());
       FAIL(log, message);
@@ -755,7 +754,7 @@ class image_api_check {
           auto myKernel = [img_acc, sampler](cl::sycl::item<dims> item) {
               // Read image data using integer coordinates
               cl::sycl::float4 dataFromInt =
-                  img_acc.read(image_access<dims>::get_int(item));
+                              img_acc.read(image_access<dims>::get_int(item));
               (void)dataFromInt;  // silent warning
               // Read image data using integer coordinates and a sampler
               cl::sycl::float4 dataFromIntWithSampler =
@@ -771,15 +770,14 @@ class image_api_check {
           });
 
           queue.submit([&](cl::sycl::handler &cgh) {
-          auto img_acc =
-              img2.template get_access<cl::sycl::float4,
-                                      cl::sycl::access::mode::write>(cgh);
-          auto myKernel = [expected, img_acc](cl::sycl::item<dims> item) {
+            auto img_acc = img2.template get_access<cl::sycl::float4,
+                                          cl::sycl::access::mode::write>(cgh);
+            auto myKernel = [expected, img_acc](cl::sycl::item<dims> item) {
               // Write image data
               img_acc.write(image_access<dims>::get_int(item),
-                          cl::sycl::float4(expected));
-          };
-          cgh.parallel_for<image_kernel_write<dims>>(r, myKernel);
+                                                  cl::sycl::float4(expected));
+            };
+            cgh.parallel_for<image_kernel_write<dims>>(r, myKernel);
           });
 
           queue.wait_and_throw();

--- a/tests/image/image_common.h
+++ b/tests/image/image_common.h
@@ -19,8 +19,9 @@ using namespace sycl_cts;
  * @brief Helps to smooth out some differences between 1D and higher-dimensional
  *        images
  * @tparam dims Number of image dimensions
+ * @tparam AllocatorT Allocator type to use to allocate image data
  */
-template <int dims>
+template <int dims, typename AllocatorT = cl::sycl::image_allocator >
 struct image_generic {
   /**
    * @brief Compares an image pitch to the provided pitch. If the provided pitch
@@ -30,7 +31,7 @@ struct image_generic {
    * @param pitch Pointer to the pitch that the image pitch will be compared to
    * return True if pitches are equal
    */
-  static bool compare_pitch(util::logger &log, cl::sycl::image<3> &img,
+  static bool compare_pitch(util::logger &log, cl::sycl::image<3, AllocatorT> &img,
                             cl::sycl::range<2> *pitch) {
     if (pitch == nullptr) {
       // Don't compare if pitch is null
@@ -43,7 +44,7 @@ struct image_generic {
     return true;
   }
 
-  static bool compare_pitch(util::logger &log, cl::sycl::image<2> &img,
+  static bool compare_pitch(util::logger &log, cl::sycl::image<2, AllocatorT> &img,
                             cl::sycl::range<1> *pitch) {
     if (pitch == nullptr) {
       // Don't compare if pitch is null
@@ -62,8 +63,8 @@ struct image_generic {
    * @param imgB Second image where the pitch will be retrieved from
    * return True if pitches are equal
    */
-  static bool compare_pitch(util::logger &log, cl::sycl::image<dims> &imgA,
-                            cl::sycl::image<dims> &imgB) {
+  static bool compare_pitch(util::logger &log, cl::sycl::image<dims, AllocatorT> &imgA,
+                            cl::sycl::image<dims, AllocatorT> &imgB) {
     auto pitch = imgB.get_pitch();
     return compare_pitch(log, imgA, &pitch);
   }
@@ -71,7 +72,6 @@ struct image_generic {
   /**
    * @brief Constructs an image, using a pitch parameter. If the provided pitch
    *        is null, it is not used for construction.
-   * @tparam AllocatorT Allocator type to use to allocate image data
    * @param imageData Host data that will be used to construct the image
    * @param channelOrder Image channel order
    * @param channelType Image channel type
@@ -79,8 +79,7 @@ struct image_generic {
    * @param pitch Image pitch
    * @return The constructed image
    */
-  template <class AllocatorT>
-  static cl::sycl::image<dims, AllocatorT> create_with_pitch_and_allocator(
+    static cl::sycl::image<dims, AllocatorT> create_with_pitch_and_allocator(
       void *imageData, cl::sycl::image_channel_order channelOrder,
       cl::sycl::image_channel_type channelType, cl::sycl::range<dims> &r,
       cl::sycl::range<dims - 1> *pitch) {
@@ -107,7 +106,7 @@ struct image_generic {
       void *imageData, cl::sycl::image_channel_order channelOrder,
       cl::sycl::image_channel_type channelType, cl::sycl::range<dims> &r,
       cl::sycl::range<dims - 1> *pitch) {
-    return create_with_pitch_and_allocator<cl::sycl::image_allocator>(
+    return create_with_pitch_and_allocator(
         imageData, channelOrder, channelType, r, pitch);
   }
 
@@ -127,19 +126,18 @@ struct image_generic {
 /**
  * @brief Specialization for one dimension
  */
-template <>
-struct image_generic<1> {
-  static bool compare_pitch(util::logger &log, cl::sycl::image<1> &img,
+template <typename AllocatorT>
+struct image_generic<1, AllocatorT> {
+  static bool compare_pitch(util::logger &log, cl::sycl::image<1, AllocatorT> &img,
                             void *pitch) {
     // 1D images don't have a get_pitch() method
     return true;
   }
-  static bool compare_pitch(util::logger &log, cl::sycl::image<1> &imgA,
-                            cl::sycl::image<1> &imgB) {
+  static bool compare_pitch(util::logger &log, cl::sycl::image<1, AllocatorT> &imgA,
+                            cl::sycl::image<1, AllocatorT> &imgB) {
     // 1D images don't have a get_pitch() method
     return true;
   }
-  template <class AllocatorT>
   static cl::sycl::image<1, AllocatorT> create_with_pitch_and_allocator(
       void *imageData, cl::sycl::image_channel_order channelOrder,
       cl::sycl::image_channel_type channelType, cl::sycl::range<1> &r,
@@ -153,7 +151,7 @@ struct image_generic<1> {
       cl::sycl::image_channel_type channelType, cl::sycl::range<1> &r,
       void *pitch) {
     // 1D images cannot be constructed with a pitch
-    return create_with_pitch_and_allocator<cl::sycl::image_allocator>(
+    return create_with_pitch_and_allocator(
         imageData, channelOrder, channelType, r, pitch);
   }
 
@@ -244,6 +242,7 @@ channel_order_count g_channelOrderCount[] = {
     {cl::sycl::image_channel_order::bgra, 4, "bgra"},
 
     {cl::sycl::image_channel_order::argb, 4, "argb"},
+    {cl::sycl::image_channel_order::abgr, 4, "abgr"},
 
     {cl::sycl::image_channel_order::r, 1, "r"},
     {cl::sycl::image_channel_order::a, 1, "a"},
@@ -420,6 +419,383 @@ cl::sycl::vector_class<cl::sycl::byte> get_image_host(
   }
   return imageHost;
 }
+
+template <int dims>
+struct image_kernel_read;
+template <int dims>
+struct image_kernel_write;
+class empty_kernel {
+ public:
+  void operator()() const {}
+};
+
+template <int dims>
+class image_api_check {
+  int calc_numElems(util::logger &log, cl::sycl::range<dims> &r,
+                    cl::sycl::range<dims - 1> *p) const {
+    auto numElems = 1;
+    switch (dims) {
+      case 1:
+        log.note("Testing image combination: dims[%d], range[%d]", dims, r[0]);
+        numElems = r[0];
+        break;
+      case 2:
+        log.note(
+            "Testing image combination: dims[%d], range[%d, %d], pitch[%d]",
+            dims, r[0], r[1], (p != nullptr));
+        numElems = r[0] * r[1];
+        break;
+      case 3:
+        log.note(
+            "Testing image combination: dims[%d], range[%d, %d, %d], pitch[%d]",
+            dims, r[0], r[1], r[2], (p != nullptr));
+        numElems = r[0] * r[1] * r[2];
+        break;
+      default:
+        break;
+    }
+    return numElems;
+  }
+
+  template <typename AllocatorT = cl::sycl::image_allocator>
+  void check_api(util::logger &log, cl::sycl::image<dims, AllocatorT> &img,
+                  cl::sycl::range<dims> &r, cl::sycl::range<dims - 1> *p,
+                  int numElems, int elementSize,
+                  cl::sycl::vector_class<cl::sycl::byte> &finalData) const {
+
+    // Check get_range()
+    if (dims == 3) {
+      if ((!CHECK_VALUE_SCALAR(log, img.get_range()[0], r.get(0))) ||
+          (!CHECK_VALUE_SCALAR(log, img.get_range()[1], r.get(1))) ||
+          (!CHECK_VALUE_SCALAR(log, img.get_range()[2], r.get(2)))) {
+        FAIL(log, "Ranges are not the same.");
+      }
+    }
+    if (dims == 2) {
+      if ((!CHECK_VALUE_SCALAR(log, img.get_range()[0], r.get(0))) ||
+          (!CHECK_VALUE_SCALAR(log, img.get_range()[1], r.get(1)))) {
+        FAIL(log, "Ranges are not the same.");
+      }
+    }
+    if (dims == 1) {
+      if ((!CHECK_VALUE_SCALAR(log, img.get_range()[0], r.get(0)))) {
+        FAIL(log, "Ranges are not the same.");
+      }
+    }
+
+    // Check get_pitch()
+    if (!image_generic<dims, AllocatorT>::compare_pitch(log, img, p)) {
+      FAIL(log, "Pitches are not the same.");
+    }
+
+    // Check get_size()
+    if (img.get_size() < (numElems * elementSize)) {
+      cl::sycl::string_class message =
+          cl::sycl::string_class("Sizes are not the same: expected at least ") +
+          std::to_string(numElems * elementSize) + ", got " +
+          std::to_string(img.get_size());
+      FAIL(log, message);
+    }
+
+    // Check get_count()
+    if (!CHECK_VALUE_SCALAR(log, img.get_count(), numElems)) {
+      FAIL(log, "Counts are not the same.");
+    }
+
+    // Check set_write_back()
+    {
+      img.set_write_back();
+      img.set_write_back(false);
+      img.set_write_back(true);
+    }
+
+    // Check set_final_data()
+    {
+      auto rawPtr = finalData.data();
+      auto rawPtrVoid = static_cast<void *>(rawPtr);
+      auto rawPtrFloat = static_cast<float *>(rawPtrVoid);
+      auto sharedPtrVoid =
+          cl::sycl::shared_ptr_class<void>(rawPtrVoid, [](void *) {});
+      auto sharedPtrFloat =
+          cl::sycl::shared_ptr_class<float>(rawPtrFloat, [](float *) {});
+      auto weakPtrVoid = cl::sycl::weak_ptr_class<void>(sharedPtrVoid);
+      auto weakPtrFloat = cl::sycl::weak_ptr_class<float>(sharedPtrFloat);
+      auto iterator = finalData.begin();
+
+      img.set_final_data();
+      img.set_final_data(nullptr);
+      img.set_final_data(rawPtr);
+      img.set_final_data(rawPtrVoid);
+      img.set_final_data(rawPtrFloat);
+      img.set_final_data(sharedPtrVoid);
+      img.set_final_data(sharedPtrFloat);
+      img.set_final_data(weakPtrVoid);
+      img.set_final_data(weakPtrFloat);
+      img.set_final_data(iterator);
+    }
+
+  }
+
+  template <typename AllocatorT = cl::sycl::image_allocator>
+  void check_image_properties(util::logger &log, cl::sycl::image<dims, AllocatorT> &img) const {
+    /* check has_property() */
+
+      auto hasHostPtrProperty =
+          img.template has_property<cl::sycl::property::image::use_host_ptr>();
+      check_return_type<bool>(log, hasHostPtrProperty,
+                              "has_property<use_host_ptr>()");
+
+      auto hasUseMutexProperty =
+          img.template has_property<cl::sycl::property::image::use_mutex>();
+      check_return_type<bool>(log, hasUseMutexProperty,
+                              "has_property<use_mutex>()");
+
+      auto hasContentBoundProperty = img.template has_property<
+          cl::sycl::property::image::context_bound>();
+      check_return_type<bool>(log, hasContentBoundProperty,
+                              "has_property<context_bound>()");
+
+      /* check get_property() */
+
+      auto hostPtrProperty =
+          img.template get_property<cl::sycl::property::image::use_host_ptr>();
+      check_return_type<cl::sycl::property::image::use_host_ptr>(
+          log, hostPtrProperty, "get_property<use_host_ptr>()");
+
+      auto useMutexProperty =
+          img.template get_property<cl::sycl::property::image::use_mutex>();
+      check_return_type<cl::sycl::property::image::use_mutex>(
+          log, useMutexProperty, "get_property<use_mutex>()");
+      check_return_type<cl::sycl::mutex_class *>(
+          log, useMutexProperty.get_mutex_ptr(),
+          "image::use_mutex::get_mutex_ptr()");
+
+      auto contextBoundProperty = img.template get_property<
+          cl::sycl::property::image::context_bound>();
+      check_return_type<cl::sycl::property::image::context_bound>(
+          log, contextBoundProperty, "get_property<context_bound>()");
+      check_return_type<cl::sycl::context>(
+          log, contextBoundProperty.get_context(),
+          "image::context_bound::get_context()");
+  }
+
+ public:
+  template <typename T, typename AllocatorT>
+  void check_get_access(util::logger &log, cl::sycl::image_channel_order channelOrder,
+                        cl::sycl::image_channel_type channelType, cl::sycl::range<dims> &r,
+                        cl::sycl::range<dims - 1> *p, bool multiply) const {
+
+      auto numElems = calc_numElems(log, r, p);
+
+      const auto channelCount = get_channel_order_count(channelOrder);
+      const auto channelTypeSize = get_channel_type_size(channelType);
+      const auto elementSize = channelTypeSize * channelCount;
+
+      // Pitch has to be at least as large as the multiple of element size
+      if (multiply) {
+        image_generic<dims>::multiply_pitch(p, elementSize);
+      }
+
+      // Create image host data
+      auto imageHost =
+          get_image_host<dims>(numElems, channelTypeSize, channelCount);
+
+      // Creates an image, either with a pitch or without
+      // The pitch is not used for a 1D image or when null
+      cl::sycl::image<dims, AllocatorT> img =
+              image_generic<dims, AllocatorT>::create_with_pitch_and_allocator(
+                static_cast<void *>(imageHost.data()), channelOrder, channelType, r, p);
+      {
+        // target::host_image
+        img.template get_access<T, cl::sycl::access::mode::read_write>();
+      }
+
+      auto testQueue = sycl_cts::util::get_cts_object::queue();
+      try {
+        testQueue.submit([&](cl::sycl::handler &cgh) {
+          // target::image
+          auto imgAcc =
+              img.template get_access<T, cl::sycl::access::mode::write>(cgh);
+          cgh.single_task(empty_kernel());
+        });
+
+        testQueue.wait_and_throw();
+      } catch (const cl::sycl::feature_not_supported &fnse) {
+        if (!testQueue.get_device()
+                 .template get_info<cl::sycl::info::device::image_support>()) {
+          log.note("device does not support images -- skipping check");
+        } else {
+          throw;
+        }
+      }
+  }
+
+  void operator()(util::logger &log, cl::sycl::range<dims> &r,
+                  cl::sycl::range<dims - 1> *p = nullptr) const {
+    auto numElems = calc_numElems(log, r, p);
+
+    // This combination is required to be supported by the OpenCL spec
+    const auto channelOrder = cl::sycl::image_channel_order::rgba;
+    const auto channelType = cl::sycl::image_channel_type::fp32;
+
+    // Prepare variables
+    const auto channelCount = get_channel_order_count(channelOrder);
+    const auto channelTypeSize = get_channel_type_size(channelType);
+    const auto elementSize = channelTypeSize * channelCount;
+
+    // Pitch has to be at least as large as the multiple of element size
+    image_generic<dims>::multiply_pitch(p, elementSize);
+
+    // Create image host data
+    auto imageHost =
+        get_image_host<dims>(numElems, channelTypeSize, channelCount);
+
+    // Create final data
+    // Must outlive the image
+    auto finalData =
+        get_image_host<dims>(numElems, channelTypeSize, channelCount);
+
+    using AllocatorT = std::allocator<cl::sycl::byte>;
+
+    // Creates an image, either with a pitch or without
+    // The pitch is not used for a 1D image or when null
+    cl::sycl::image<dims> img = image_generic<dims>::create_with_pitch(
+        static_cast<void *>(imageHost.data()), channelOrder, channelType, r, p);
+
+    check_api(log, img, r, p, numElems, elementSize, finalData);
+
+    auto imgAlloc = image_generic<dims, AllocatorT>::create_with_pitch_and_allocator
+                        (static_cast<void *>(imageHost.data()), channelOrder,
+                          channelType, r, p);
+
+    check_api<AllocatorT>(log, imgAlloc, r, p, numElems, elementSize, finalData);
+
+
+    // Check get_allocator()
+    {
+      auto defaultAllocator = img.get_allocator();
+
+      check_return_type<cl::sycl::image_allocator>(log, defaultAllocator, "get_allocator()");
+
+      /* create another image with a custom allocator */
+      auto imgAlloc2 =
+          image_generic<dims, AllocatorT>::create_with_pitch_and_allocator
+                        (static_cast<void *>(imageHost.data()), channelOrder,
+                          channelType, r, p);
+
+      auto allocator = imgAlloc2.get_allocator();
+
+      check_return_type<AllocatorT>(log, allocator, "get_allocator()");
+
+      auto ptr = allocator.allocate(1);
+      if (ptr == nullptr) {
+        FAIL(log, "get_allocator() returned an invalid allocator");
+      }
+      allocator.deallocate(ptr, 1);
+    }
+
+    /* Check image properties */
+    {
+      cl::sycl::mutex_class mutex;
+      auto context = util::get_cts_object::context();
+      const cl::sycl::property_list propList{
+          cl::sycl::property::image::use_host_ptr(),
+          cl::sycl::property::image::use_mutex(mutex),
+          cl::sycl::property::image::context_bound(context)};
+
+      // Create another image
+      auto img2 = cl::sycl::image<dims>(static_cast<void *>(imageHost.data()),
+                                        channelOrder, channelType, r, propList);
+
+      check_image_properties(log, img2);
+
+      auto imgAlloc2 = cl::sycl::image<dims, AllocatorT>(static_cast<void *>(imageHost.data()),
+                                        channelOrder, channelType, r, AllocatorT(), propList);
+      check_image_properties<AllocatorT>(log, imgAlloc2);
+    }
+
+    // Check get_access()
+    {
+      check_get_access<cl::sycl::cl_int4, cl::sycl::image_allocator>(log,
+              channelOrder, cl::sycl::image_channel_type::signed_int32, r, p, false);
+      check_get_access<cl::sycl::cl_uint4, cl::sycl::image_allocator>(log,
+              channelOrder, cl::sycl::image_channel_type::unsigned_int32, r, p, false);
+      check_get_access<cl::sycl::cl_float4, cl::sycl::image_allocator>(log,
+              channelOrder, channelType, r, p, false);
+
+      check_get_access<cl::sycl::cl_int4, AllocatorT>(log, channelOrder,
+                            cl::sycl::image_channel_type::signed_int32, r, p, false);
+      check_get_access<cl::sycl::cl_uint4, AllocatorT>(log, channelOrder,
+                            cl::sycl::image_channel_type::unsigned_int32, r, p, false);
+      check_get_access<cl::sycl::cl_float4, AllocatorT>(log, channelOrder,
+                              channelType, r, p, false);
+    }
+    const auto expected = 0.5f;
+
+    // Check read/write APIs.
+    {
+      auto queue = util::get_cts_object::queue();
+
+      if (queue.get_device()
+                 .template get_info<cl::sycl::info::device::image_support>()) {
+        {
+          cl::sycl::image<dims> img2 = image_generic<dims>::create_with_pitch(
+              static_cast<void *>(imageHost.data()), channelOrder, channelType,
+              r, p);
+          queue.submit([&](cl::sycl::handler &cgh) {
+          auto img_acc =
+              img2.template get_access<cl::sycl::float4,
+                                      cl::sycl::access::mode::read>(cgh);
+
+          auto sampler = cl::sycl::sampler(
+              cl::sycl::coordinate_normalization_mode::unnormalized,
+              cl::sycl::addressing_mode::clamp,
+              cl::sycl::filtering_mode::nearest);
+
+          auto myKernel = [img_acc, sampler](cl::sycl::item<dims> item) {
+              // Read image data using integer coordinates
+              cl::sycl::float4 dataFromInt =
+                  img_acc.read(image_access<dims>::get_int(item));
+              (void)dataFromInt;  // silent warning
+              // Read image data using integer coordinates and a sampler
+              cl::sycl::float4 dataFromIntWithSampler =
+                  img_acc.read(image_access<dims>::get_int(item), sampler);
+              (void)dataFromIntWithSampler;  // silent warning
+              // Read image data using floating point coordinates
+              // Only works with a sampler
+              cl::sycl::float4 dataFromFloat =
+                  img_acc.read(image_access<dims>::get_float(item), sampler);
+              (void)dataFromFloat;  // silent warning
+          };
+          cgh.parallel_for<image_kernel_read<dims>>(r, myKernel);
+          });
+
+          queue.submit([&](cl::sycl::handler &cgh) {
+          auto img_acc =
+              img2.template get_access<cl::sycl::float4,
+                                      cl::sycl::access::mode::write>(cgh);
+          auto myKernel = [expected, img_acc](cl::sycl::item<dims> item) {
+              // Write image data
+              img_acc.write(image_access<dims>::get_int(item),
+                          cl::sycl::float4(expected));
+          };
+          cgh.parallel_for<image_kernel_write<dims>>(r, myKernel);
+          });
+
+          queue.wait_and_throw();
+        }  // End of scope for img2 object.
+
+        // Check image values
+        const auto floatData = reinterpret_cast<float *>(imageHost.data());
+        for (int i = 0; i < numElems; ++i) {
+          if (!CHECK_VALUE(log, floatData[i], 0.5f, i)) {
+            FAIL(log, "Image contains wrong values.");
+          }
+        }
+      }
+    }
+  }
+};
 
 }  // namespace
 

--- a/tests/image/image_constructors.cpp
+++ b/tests/image/image_constructors.cpp
@@ -16,9 +16,9 @@ using namespace sycl_cts;
 
 void no_delete(void *) {}
 
-template <int dims>
+template <int dims, typename AllocatorT>
 inline void check_constructed_correctly(util::logger &log,
-                                        cl::sycl::image<dims> &img,
+                                        cl::sycl::image<dims, AllocatorT> &img,
                                         int numElems, unsigned int elementSize,
                                         bool &combinationSuccess) {
   // Check get_size()
@@ -32,7 +32,7 @@ inline void check_constructed_correctly(util::logger &log,
   }
 }
 
-template <int dims>
+template <typename AllocatorT, int dims>
 void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
                                 cl::sycl::range<dims> &r, int numElems,
                                 unsigned int elementSize,
@@ -45,8 +45,8 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const property_list& = {})
    */
   {
-    cl::sycl::image<dims> img =
-        cl::sycl::image<dims>(imageHostPtr, channelOrder, channelType, r);
+    cl::sycl::image<dims, AllocatorT> img =
+        cl::sycl::image<dims, AllocatorT>(imageHostPtr, channelOrder, channelType, r);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
   }
@@ -55,7 +55,7 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              image_channel_type, const range<dims>&, const property_list&)
    */
   {
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
         imageHostPtr, channelOrder, channelType, r, propList);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
@@ -66,8 +66,8 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const property_list& = {})
    */
   {
-    cl::sycl::image_allocator imgAlloc;
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(
+    AllocatorT imgAlloc;
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
         imageHostPtr, channelOrder, channelType, r, imgAlloc);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
@@ -78,20 +78,21 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const property_list&)
    */
   {
-    cl::sycl::image_allocator imgAlloc;
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(
+    AllocatorT imgAlloc;
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
         imageHostPtr, channelOrder, channelType, r, imgAlloc, propList);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
   }
+
   /* Constructor (const void*, image_channel_order,
    *              image_channel_type, const range<dims>&,
    *              const property_list& = {})
    */
   {
     const auto constHostPtr = imageHostPtr;
-    cl::sycl::image<dims> img =
-        cl::sycl::image<dims>(constHostPtr, channelOrder, channelType, r);
+    cl::sycl::image<dims, AllocatorT> img =
+        cl::sycl::image<dims, AllocatorT>(constHostPtr, channelOrder, channelType, r);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
   }
@@ -101,7 +102,7 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    */
   {
     const auto constHostPtr = imageHostPtr;
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
         constHostPtr, channelOrder, channelType, r, propList);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
@@ -113,8 +114,8 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    */
   {
     const auto constHostPtr = imageHostPtr;
-    cl::sycl::image_allocator imgAlloc;
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(
+    AllocatorT imgAlloc;
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
         constHostPtr, channelOrder, channelType, r, imgAlloc);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
@@ -126,8 +127,8 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    */
   {
     const auto constHostPtr = imageHostPtr;
-    cl::sycl::image_allocator imgAlloc;
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(
+    AllocatorT imgAlloc;
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
         constHostPtr, channelOrder, channelType, r, imgAlloc, propList);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
@@ -140,8 +141,8 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
   {
     auto hostPointer =
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
-    cl::sycl::image<dims> img =
-        cl::sycl::image<dims>(hostPointer, channelOrder, channelType, r);
+    cl::sycl::image<dims, AllocatorT> img =
+        cl::sycl::image<dims, AllocatorT>(hostPointer, channelOrder, channelType, r);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
   }
@@ -152,7 +153,7 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
   {
     auto hostPointer =
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(hostPointer, channelOrder,
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(hostPointer, channelOrder,
                                                       channelType, r, propList);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
@@ -163,10 +164,10 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const property_list& = {})
    */
   {
-    cl::sycl::image_allocator imgAlloc;
+    AllocatorT imgAlloc;
     auto hostPointer =
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(hostPointer, channelOrder,
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(hostPointer, channelOrder,
                                                       channelType, r, imgAlloc);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
@@ -177,10 +178,10 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const property_list&)
    */
   {
-    cl::sycl::image_allocator imgAlloc;
+    AllocatorT imgAlloc;
     auto hostPointer =
         cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
-    cl::sycl::image<dims> img = cl::sycl::image<dims>(
+    cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
         hostPointer, channelOrder, channelType, r, imgAlloc, propList);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
@@ -190,8 +191,8 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const range<dims>&, const property_list& = {})
    */
   {
-    cl::sycl::image<dims> img =
-        cl::sycl::image<dims>(channelOrder, channelType, r);
+    cl::sycl::image<dims, AllocatorT> img =
+        cl::sycl::image<dims, AllocatorT>(channelOrder, channelType, r);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
   }
@@ -200,8 +201,8 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const range<dims>&, const property_list&)
    */
   {
-    cl::sycl::image<dims> img =
-        cl::sycl::image<dims>(channelOrder, channelType, r, propList);
+    cl::sycl::image<dims, AllocatorT> img =
+        cl::sycl::image<dims, AllocatorT>(channelOrder, channelType, r, propList);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
   }
@@ -210,9 +211,9 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const range<dims>&, allocator, const property_list& = {})
    */
   {
-    cl::sycl::image_allocator imgAlloc;
-    cl::sycl::image<dims> img =
-        cl::sycl::image<dims>(channelOrder, channelType, r, imgAlloc);
+    AllocatorT imgAlloc;
+    cl::sycl::image<dims, AllocatorT> img =
+        cl::sycl::image<dims, AllocatorT>(channelOrder, channelType, r, imgAlloc);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
   }
@@ -221,15 +222,15 @@ void test_constructors_no_pitch(util::logger &log, void *imageHostPtr,
    *              const range<dims>&, allocator, const property_list&)
    */
   {
-    cl::sycl::image_allocator imgAlloc;
-    cl::sycl::image<dims> img =
-        cl::sycl::image<dims>(channelOrder, channelType, r, imgAlloc, propList);
+    AllocatorT imgAlloc;
+    cl::sycl::image<dims, AllocatorT> img =
+        cl::sycl::image<dims, AllocatorT>(channelOrder, channelType, r, imgAlloc, propList);
     check_constructed_correctly(log, img, numElems, elementSize,
                                 combinationSuccess);
   }
 }
 
-template <int dims>
+template <typename AllocatorT, int dims>
 struct test_constructors_with_pitch {
   test_constructors_with_pitch(util::logger &log, void *imageHostPtr,
                                cl::sycl::range<dims> &r, int numElems,
@@ -244,7 +245,7 @@ struct test_constructors_with_pitch {
      *              const range<dims - 1>&, const property_list& = {})
      */
     {
-      cl::sycl::image<dims> img = cl::sycl::image<dims>(
+      cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
           imageHostPtr, channelOrder, channelType, r, *pitch);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -255,7 +256,7 @@ struct test_constructors_with_pitch {
      *              const range<dims - 1>&, const property_list&)
      */
     {
-      cl::sycl::image<dims> img = cl::sycl::image<dims>(
+      cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
           imageHostPtr, channelOrder, channelType, r, *pitch, propList);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -267,8 +268,8 @@ struct test_constructors_with_pitch {
      *              const property_list& = {})
      */
     {
-      cl::sycl::image_allocator imgAlloc;
-      cl::sycl::image<dims> img = cl::sycl::image<dims>(
+      AllocatorT imgAlloc;
+      cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
           imageHostPtr, channelOrder, channelType, r, *pitch, imgAlloc);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -279,9 +280,9 @@ struct test_constructors_with_pitch {
      *              const range<dims - 1>&, allocator, const property_list&)
      */
     {
-      cl::sycl::image_allocator imgAlloc;
-      cl::sycl::image<dims> img =
-          cl::sycl::image<dims>(imageHostPtr, channelOrder, channelType, r,
+      AllocatorT imgAlloc;
+      cl::sycl::image<dims, AllocatorT> img =
+          cl::sycl::image<dims, AllocatorT>(imageHostPtr, channelOrder, channelType, r,
                                 *pitch, imgAlloc, propList);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -294,7 +295,7 @@ struct test_constructors_with_pitch {
     {
       auto hostPointer =
           cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
-      cl::sycl::image<dims> img = cl::sycl::image<dims>(
+      cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
           hostPointer, channelOrder, channelType, r, *pitch);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -307,7 +308,7 @@ struct test_constructors_with_pitch {
     {
       auto hostPointer =
           cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
-      cl::sycl::image<dims> img = cl::sycl::image<dims>(
+      cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
           hostPointer, channelOrder, channelType, r, *pitch, propList);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -319,10 +320,10 @@ struct test_constructors_with_pitch {
      *              const property_list& = {})
      */
     {
-      cl::sycl::image_allocator imgAlloc;
+      AllocatorT imgAlloc;
       auto hostPointer =
           cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
-      cl::sycl::image<dims> img = cl::sycl::image<dims>(
+      cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
           hostPointer, channelOrder, channelType, r, *pitch, imgAlloc);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -333,11 +334,11 @@ struct test_constructors_with_pitch {
      *              const range<dims - 1>&, allocator, const property_list&)
      */
     {
-      cl::sycl::image_allocator imgAlloc;
+      AllocatorT imgAlloc;
       auto hostPointer =
           cl::sycl::shared_ptr_class<void>(imageHostPtr, &no_delete);
-      cl::sycl::image<dims> img =
-          cl::sycl::image<dims>(hostPointer, channelOrder, channelType, r,
+      cl::sycl::image<dims, AllocatorT> img =
+          cl::sycl::image<dims, AllocatorT>(hostPointer, channelOrder, channelType, r,
                                 *pitch, imgAlloc, propList);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -348,8 +349,8 @@ struct test_constructors_with_pitch {
      *              const property_list& = {})
      */
     {
-      cl::sycl::image<dims> img =
-          cl::sycl::image<dims>(channelOrder, channelType, r, *pitch);
+      cl::sycl::image<dims, AllocatorT> img =
+          cl::sycl::image<dims, AllocatorT>(channelOrder, channelType, r, *pitch);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
     }
@@ -359,8 +360,8 @@ struct test_constructors_with_pitch {
      *              const property_list&)
      */
     {
-      cl::sycl::image<dims> img =
-          cl::sycl::image<dims>(channelOrder, channelType, r, *pitch, propList);
+      cl::sycl::image<dims, AllocatorT> img =
+          cl::sycl::image<dims, AllocatorT>(channelOrder, channelType, r, *pitch, propList);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
     }
@@ -370,9 +371,9 @@ struct test_constructors_with_pitch {
      *              const property_list& = {})
      */
     {
-      cl::sycl::image_allocator imgAlloc;
-      cl::sycl::image<dims> img =
-          cl::sycl::image<dims>(channelOrder, channelType, r, *pitch, imgAlloc);
+      AllocatorT imgAlloc;
+      cl::sycl::image<dims, AllocatorT> img =
+          cl::sycl::image<dims, AllocatorT>(channelOrder, channelType, r, *pitch, imgAlloc);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
     }
@@ -382,8 +383,8 @@ struct test_constructors_with_pitch {
      *              const property_list&)
      */
     {
-      cl::sycl::image_allocator imgAlloc;
-      cl::sycl::image<dims> img = cl::sycl::image<dims>(
+      AllocatorT imgAlloc;
+      cl::sycl::image<dims, AllocatorT> img = cl::sycl::image<dims, AllocatorT>(
           channelOrder, channelType, r, *pitch, imgAlloc, propList);
       check_constructed_correctly(log, img, numElems, elementSize,
                                   combinationSuccess);
@@ -391,8 +392,8 @@ struct test_constructors_with_pitch {
   }
 };
 
-template <>
-struct test_constructors_with_pitch<1> {
+template <typename AllocatorT>
+struct test_constructors_with_pitch<AllocatorT, 1> {
   test_constructors_with_pitch(util::logger &log, void *imageHostPtr,
                                cl::sycl::range<1> &r, int numElems,
                                unsigned int elementSize,
@@ -440,7 +441,7 @@ class image_ctors {
     // For each channel order
     for (itOrder = 0; itOrder < MINIMUM_CHANNEL_ORDERS; ++itOrder) {
       // Set up the test set for each channel separately
-      auto testSet = get_test_set_minimum(g_channelOrderCount[itOrder].order);
+      auto testSet = get_test_set_full(g_channelOrderCount[itOrder].order);
 
       // Get number of channels
       const auto channelOrder = testSet.order;
@@ -466,13 +467,21 @@ class image_ctors {
         void *imageHost2Ptr = static_cast<void *>(imageHost2.data());
 
         // Test all constructors that don't take a pitch
-        test_constructors_no_pitch(log, imageHostPtr, r, numElems, elementSize,
+        test_constructors_no_pitch<cl::sycl::image_allocator>(log, imageHostPtr, r, numElems, elementSize,
+                                   channelOrder, channelType,
+                                   combinationSuccess, propList);
+
+        test_constructors_no_pitch<std::allocator<cl::sycl::byte>>(log, imageHostPtr, r, numElems, elementSize,
                                    channelOrder, channelType,
                                    combinationSuccess, propList);
 
         // Test all constructors that take a pitch
         if (pitch != nullptr) {
-          test_constructors_with_pitch<dims>(
+          test_constructors_with_pitch<cl::sycl::image_allocator, dims>(
+              log, imageHostPtr, r, numElems, elementSize, channelOrder,
+              channelType, pitch, combinationSuccess, propList);
+
+          test_constructors_with_pitch<std::allocator<cl::sycl::byte>, dims>(
               log, imageHostPtr, r, numElems, elementSize, channelOrder,
               channelType, pitch, combinationSuccess, propList);
         }


### PR DESCRIPTION
Added type coverage for get_access() for cl_int4, cl_uint4, cl_half4
Added type coverage for Image<N, AllocatorT> for AllocatorT - not default
Added type coverage for constructors for:
 image_channel_order = (image_channel_order::a, r, rx, rg, rgx, ra, rgb, rgbx, argb, intensity, luminance, abgr)
 image_channel_type = (image_channel_type::snorm_int8, snorm_int16, unorm_short_565, unorm_short_555, unorm_int_101010)

Changed test name image_api to image_api_core to allow it to be run separately from image_api_fp16.

Remaining gap (test coverage): other accessMode for get_access(),
                               constructor image(cl_mem , const context &, event )