### PR TITLE
Improved data type coverage for stream

### DIFF
--- a/tests/stream/stream_api_common.h
+++ b/tests/stream/stream_api_common.h
@@ -1,11 +1,3 @@
-/*******************************************************************************
-//
-//  SYCL 1.2.1 Conformance Test Suite
-//
-//  Copyright:	(c) 2020 by Codeplay Software LTD. All Rights Reserved.
-//
-*******************************************************************************/
-
 #ifndef SYCL_1_2_1_TESTS_STREAM_API_COMMON_H
 #define SYCL_1_2_1_TESTS_STREAM_API_COMMON_H
 

--- a/tests/stream/stream_api_common.h
+++ b/tests/stream/stream_api_common.h
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Copyright:	(c) 2020 by Codeplay Software LTD. All Rights Reserved.
+//
+*******************************************************************************/
+
+#ifndef SYCL_1_2_1_TESTS_STREAM_API_COMMON_H
+#define SYCL_1_2_1_TESTS_STREAM_API_COMMON_H
+
+#include "../common/common.h"
+#include <type_traits>
+
+/**
+ * Function to force const-correctness check for cl::sycl::stream usage with scalar types
+ */
+template <typename T>
+void check_type(const cl::sycl::stream &os, T&& var ) {
+  typename std::decay<T>::type const scalar{var};
+  os << scalar;
+}
+
+/**
+ * Function that streams a scalar and vec for each type using the cl::sycl::stream object
+ */
+template <typename T>
+void check_all_vec_dims(const cl::sycl::stream &os, T&& var){
+  check_type(os, var);
+
+  const cl::sycl::vec<T, 1> vec1(var);
+  os << vec1;
+  const cl::sycl::vec<T, 2> vec2(var);
+  os << vec2;
+  const cl::sycl::vec<T, 3> vec3(var);
+  os << vec3;
+  const cl::sycl::vec<T, 4> vec4(var);
+  os << vec4;
+  const cl::sycl::vec<T, 8> vec8(var);
+  os << vec8;
+  const cl::sycl::vec<T, 16> vec16(var);
+  os << vec16;
+}
+
+#endif // SYCL_1_2_1_TESTS_STREAM_API_COMMON_H

--- a/tests/stream/stream_api_common.h
+++ b/tests/stream/stream_api_common.h
@@ -1,3 +1,11 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Provides common methods for stream tests
+//
+*******************************************************************************/
+
 #ifndef SYCL_1_2_1_TESTS_STREAM_API_COMMON_H
 #define SYCL_1_2_1_TESTS_STREAM_API_COMMON_H
 

--- a/tests/stream/stream_api_fp16.cpp
+++ b/tests/stream/stream_api_fp16.cpp
@@ -34,7 +34,11 @@ class TEST_NAME : public util::test_base {
       {
         auto testQueue = util::get_cts_object::queue();
 
-        if (!testQueue.get_device().has_extension("cl_khr_fp16")) return;
+        if (!testQueue.get_device().has_extension("cl_khr_fp16")) {
+          log.note(
+            "Device does not support half precision floating point operations");
+        return;
+      }
 
         testQueue.submit([&](cl::sycl::handler &cgh) {
           cl::sycl::stream os(2048, 80, cgh);

--- a/tests/stream/stream_api_fp64.cpp
+++ b/tests/stream/stream_api_fp64.cpp
@@ -33,7 +33,11 @@ class TEST_NAME : public util::test_base {
       // Check stream operator for cl::sycl::cl_double and double
       auto testQueue = util::get_cts_object::queue();
 
-      if (!testQueue.get_device().has_extension("cl_khr_fp64")) return;
+      if (!testQueue.get_device().has_extension("cl_khr_fp64")) {
+        log.note(
+            "Device does not support double precision floating point operations");
+        return;
+      }
 
       testQueue.submit([&](cl::sycl::handler &cgh) {
 
@@ -46,7 +50,7 @@ class TEST_NAME : public util::test_base {
       });
 
       testQueue.wait_and_throw();
-      
+
     } catch (const cl::sycl::exception &e) {
       log_exception(log, e);
       cl::sycl::string_class errorMsg =

--- a/tests/stream/stream_api_fp64.cpp
+++ b/tests/stream/stream_api_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 1.2.1 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Provides stream tests for double and cl::sycl::cl_double
 //
 *******************************************************************************/
 

--- a/tests/stream/stream_api_fp64.cpp
+++ b/tests/stream/stream_api_fp64.cpp
@@ -8,7 +8,7 @@
 
 #include "stream_api_common.h"
 
-#define TEST_NAME stream_api_fp16
+#define TEST_NAME stream_api_fp64
 
 namespace TEST_NAMESPACE {
 
@@ -30,23 +30,23 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     try {
-      // Check stream operator for cl::sycl::half
-      {
-        auto testQueue = util::get_cts_object::queue();
+      // Check stream operator for cl::sycl::cl_double and double
+      auto testQueue = util::get_cts_object::queue();
 
-        if (!testQueue.get_device().has_extension("cl_khr_fp16")) return;
+      if (!testQueue.get_device().has_extension("cl_khr_fp64")) return;
 
-        testQueue.submit([&](cl::sycl::handler &cgh) {
-          cl::sycl::stream os(2048, 80, cgh);
+      testQueue.submit([&](cl::sycl::handler &cgh) {
 
-          cgh.single_task<class test_kernel>([=]() {
-            check_all_vec_dims(os, cl::sycl::half(0.2f));
-            check_all_vec_dims(os, cl::sycl::cl_half(0.3f));
-          });
+        cl::sycl::stream os(2048, 80, cgh);
+
+        cgh.single_task<class test_kernel>([=]() {
+          check_all_vec_dims(os, double(5.5));
+          check_all_vec_dims(os, cl::sycl::cl_double(5.5));
         });
+      });
 
-        testQueue.wait_and_throw();
-      }
+      testQueue.wait_and_throw();
+      
     } catch (const cl::sycl::exception &e) {
       log_exception(log, e);
       cl::sycl::string_class errorMsg =


### PR DESCRIPTION
Changed test name stream_api to stream_api_core to allow it to be run separately from other stream_api tests.

Added type coverage for
- id<dim = 1,2>, range<dim = 1,2>, item<dim = 1,2>, nd_item<dim = 1,2>,
  group<dim = 1,2>, nd_range<dim = 1,2>, h_item<dim = 1,2>
- stream_manipulator::flush
- vec<typename T, int numElements = (1, 2, 3, 4, 8 or 16)>
where T = (char, signed char, unsigned char, int, unsigned int, short,
unsigned short, long int, unsigned long int, long long int, unsigned
long long int, cl_char, cl_uchar, cl_int, cl_uint, cl_short,
cl_ushort, cl_long, cl_ulong, byte, float, double, half, cl_float,
cl_double, cl_half)

Added const correctness check

Remaining gap (test coverage): get_size() result correctness,
                               get_work_item_buffer_size()
                               exceeding totalBufferSize and workItemBufferSize,
                               actual console output verification
Possible remaining gaps (type coverage): vec<cl_bool, N>, vec<bool, N>