### PR TITLE
Extending Type coverage for nd_item and group classes

### DIFF
--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -6,21 +6,16 @@
 //
 *******************************************************************************/
 
-#include "../common/common.h"
+#include "group_async_work_group_copy_common.h"
 
-#define TEST_NAME group_async_work_group_copy
+#define TEST_NAME group_async_work_group_copy_core
 
 namespace TEST_NAMESPACE {
-using namespace sycl_cts;
 
 static constexpr size_t GROUP_RANGE_1D = 2;
 static constexpr size_t GROUP_RANGE_2D = 4;
 static constexpr size_t GROUP_RANGE_3D = 8;
 static constexpr size_t BUFFER_SIZE = 128;
-
-class group_async_work_group_copy_1d;
-class group_async_work_group_copy_2d;
-class group_async_work_group_copy_3d;
 
 class TEST_NAME : public util::test_base {
  public:
@@ -33,112 +28,65 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
-      auto queue = util::get_cts_object::queue();
+    check_type<size_t>(log);
+    check_type_and_vec<bool>(log);
+    check_type_and_vec<char>(log);
+    check_type_and_vec<signed char>(log);
+    check_type_and_vec<unsigned char>(log);
+    check_type_and_vec<short int>(log);
+    check_type_and_vec<unsigned short int>(log);
+    check_type_and_vec<int>(log);
+    check_type_and_vec<unsigned int>(log);
+    check_type_and_vec<long int>(log);
+    check_type_and_vec<unsigned long int>(log);
+    check_type_and_vec<long long int>(log);
+    check_type_and_vec<unsigned long long int>(log);
+    check_type_and_vec<float>(log);
 
-      {
-        auto buf = cl::sycl::buffer<size_t, 1>(cl::sycl::range<1>(BUFFER_SIZE));
+    check_type_and_vec<cl::sycl::byte>(log);
+    check_type_and_vec<cl::sycl::cl_bool>(log);
+    check_type_and_vec<cl::sycl::cl_char>(log);
+    check_type_and_vec<cl::sycl::cl_uchar>(log);
+    check_type_and_vec<cl::sycl::cl_short>(log);
+    check_type_and_vec<cl::sycl::cl_ushort>(log);
+    check_type_and_vec<cl::sycl::cl_int>(log);
+    check_type_and_vec<cl::sycl::cl_uint>(log);
+    check_type_and_vec<cl::sycl::cl_long>(log);
+    check_type_and_vec<cl::sycl::cl_ulong>(log);
+    check_type_and_vec<cl::sycl::cl_float>(log);
 
-        queue.submit([&](cl::sycl::handler &cgh) {
-          auto accGlobal =
-              buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-
-          auto accLocal =
-              cl::sycl::accessor<size_t, 1, cl::sycl::access::mode::read_write,
-                                 cl::sycl::access::target::local>(
-                  cl::sycl::range<1>(BUFFER_SIZE), cgh);
-
-          // Test 1D
-          cgh.parallel_for_work_group<class group_async_work_group_copy_1d>(
-              cl::sycl::range<1>(GROUP_RANGE_1D),
-              [=](cl::sycl::group<1> my_group) {
-                auto ptrGlobal = accGlobal.get_pointer();
-                auto ptrLocal = accLocal.get_pointer();
-
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal,
-                                               BUFFER_SIZE);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal,
-                                               BUFFER_SIZE);
-
-                constexpr size_t stride = 2;
-                constexpr size_t numElements = BUFFER_SIZE / stride;
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
-                                               stride);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
-                                               stride);
-              });
-        });
-
-        queue.submit([&](cl::sycl::handler &cgh) {
-          auto accGlobal =
-              buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-
-          auto accLocal =
-              cl::sycl::accessor<size_t, 1, cl::sycl::access::mode::read_write,
-                                 cl::sycl::access::target::local>(
-                  cl::sycl::range<1>(BUFFER_SIZE), cgh);
-
-          // Test 2D
-          cgh.parallel_for_work_group<class group_async_work_group_copy_2d>(
-              cl::sycl::range<2>(GROUP_RANGE_1D, GROUP_RANGE_2D),
-              [=](cl::sycl::group<2> my_group) {
-                auto ptrGlobal = accGlobal.get_pointer();
-                auto ptrLocal = accLocal.get_pointer();
-
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal,
-                                               BUFFER_SIZE);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal,
-                                               BUFFER_SIZE);
-
-                constexpr size_t stride = 2;
-                constexpr size_t numElements = BUFFER_SIZE / stride;
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
-                                               stride);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
-                                               stride);
-              });
-        });
-
-        queue.submit([&](cl::sycl::handler &cgh) {
-          auto accGlobal =
-              buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-
-          auto accLocal =
-              cl::sycl::accessor<size_t, 1, cl::sycl::access::mode::read_write,
-                                 cl::sycl::access::target::local>(
-                  cl::sycl::range<1>(BUFFER_SIZE), cgh);
-
-          // Test 3D
-          cgh.parallel_for_work_group<class group_async_work_group_copy_3d>(
-              cl::sycl::range<3>(GROUP_RANGE_1D, GROUP_RANGE_2D,
-                                 GROUP_RANGE_3D),
-              [=](cl::sycl::group<3> my_group) {
-                auto ptrGlobal = accGlobal.get_pointer();
-                auto ptrLocal = accLocal.get_pointer();
-
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal,
-                                               BUFFER_SIZE);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal,
-                                               BUFFER_SIZE);
-
-                constexpr size_t stride = 2;
-                constexpr size_t numElements = BUFFER_SIZE / stride;
-                my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
-                                               stride);
-                my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
-                                               stride);
-              });
-        });
-      }
-
-      queue.wait_and_throw();
-
-    } catch (const cl::sycl::exception &e) {
-      log_exception(log, e);
-      cl::sycl::string_class errorMsg =
-          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
-      FAIL(log, errorMsg.c_str());
-    }
+#ifdef INT8_MAX
+    if (!std::is_same<cl::sycl::cl_char, std::int8_t>::value)
+      check_type_and_vec<std::int8_t>(log);
+#endif
+#ifdef INT16_MAX
+    if (!std::is_same<cl::sycl::cl_short, std::int16_t>::value)
+      check_type_and_vec<std::int16_t>(log);
+#endif
+#ifdef INT32_MAX
+    if (!std::is_same<cl::sycl::cl_int, std::int32_t>::value)
+      check_type_and_vec<std::int32_t>(log);
+#endif
+#ifdef INT64_MAX
+    if (!std::is_same<cl::sycl::cl_long, std::int64_t>::value)
+      check_type_and_vec<std::int64_t>(log);
+#endif
+#ifdef UINT8_MAX
+    if (!std::is_same<cl::sycl::cl_uchar, std::uint8_t>::value)
+      check_type_and_vec<std::uint8_t>(log);
+#endif
+#ifdef UINT16_MAX
+    if (!std::is_same<cl::sycl::cl_ushort, std::uint16_t>::value)
+      check_type_and_vec<std::uint16_t>(log);
+#endif
+#ifdef UINT32_MAX
+    if (!std::is_same<cl::sycl::cl_uint, std::uint32_t>::value)
+      check_type_and_vec<std::uint32_t>(log);
+#endif
+#ifdef UINT64_MAX
+    if (!std::is_same<cl::sycl::cl_ulong, std::uint64_t>::value)
+      check_type_and_vec<std::uint64_t>(log);
+#endif
   }
 };
 

--- a/tests/group/group_async_work_group_copy_common.h
+++ b/tests/group/group_async_work_group_copy_common.h
@@ -2,7 +2,7 @@
 //
 //  SYCL 1.2.1 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Provides common methods for group async_work_group_copy tests
 //
 *******************************************************************************/
 

--- a/tests/group/group_async_work_group_copy_common.h
+++ b/tests/group/group_async_work_group_copy_common.h
@@ -1,0 +1,98 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+*******************************************************************************/
+
+#ifndef SYCL_1_2_1_TESTS_GROUP_ASYNC_WORK_GROUP_COPY_COMMON_H
+#define SYCL_1_2_1_TESTS_GROUP_ASYNC_WORK_GROUP_COPY_COMMON_H
+
+#include "../common/common.h"
+
+namespace {
+  inline cl::sycl::queue makeQueueOnce() {
+    static cl::sycl::queue q = sycl_cts::util::get_cts_object::queue();
+    return q;
+  }
+
+  using namespace sycl_cts;
+
+  static constexpr size_t GROUP_RANGE_1D = 2;
+  static constexpr size_t GROUP_RANGE_2D = 4;
+  static constexpr size_t GROUP_RANGE_3D = 8;
+  static constexpr size_t BUFFER_SIZE = 128;
+
+  template<typename T, int dim>
+  class test_kernel;
+
+  template<typename T, int dim>
+  void check_dim(cl::sycl::queue &queue, cl::sycl::buffer<T, 1> &buf, cl::sycl::range<dim> range) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+    auto accGlobal =
+        buf.template get_access<cl::sycl::access::mode::read_write>(cgh);
+
+    auto accLocal =
+        cl::sycl::accessor<T, 1, cl::sycl::access::mode::read_write,
+                            cl::sycl::access::target::local>(
+            cl::sycl::range<1>(BUFFER_SIZE), cgh);
+
+    cgh.parallel_for_work_group<test_kernel<T, dim>>(range,
+        [=](cl::sycl::group<dim> my_group) {
+        auto ptrGlobal = accGlobal.get_pointer();
+        auto ptrLocal = accLocal.get_pointer();
+
+        my_group.async_work_group_copy(ptrLocal, ptrGlobal,
+                                        BUFFER_SIZE);
+        my_group.async_work_group_copy(ptrGlobal, ptrLocal,
+                                        BUFFER_SIZE);
+
+        constexpr size_t stride = 2;
+        constexpr size_t numElements = BUFFER_SIZE / stride;
+        my_group.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
+                                        stride);
+        my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
+                                        stride);
+        });
+});
+
+  }
+
+  template<typename T>
+  void check_type(util::logger &log) {
+    try {
+      auto queue = makeQueueOnce();
+
+      {
+        auto buf = cl::sycl::buffer<T, 1>(cl::sycl::range<1>(BUFFER_SIZE));
+        check_dim<T, 1>(queue, buf, cl::sycl::range<1>(BUFFER_SIZE));
+        check_dim<T, 2>(queue, buf, cl::sycl::range<2>(GROUP_RANGE_1D, GROUP_RANGE_2D));
+        check_dim<T, 3>(queue, buf, cl::sycl::range<3>(GROUP_RANGE_1D, GROUP_RANGE_2D,
+                                 GROUP_RANGE_3D));
+      }
+
+      queue.wait_and_throw();
+
+    } catch (const cl::sycl::exception &e) {
+      log_exception(log, e);
+      cl::sycl::string_class errorMsg =
+          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
+      FAIL(log, errorMsg.c_str());
+    }
+  }
+
+  template<typename T>
+  void check_type_and_vec(util::logger &log) {
+    check_type<T>(log);
+    check_type<cl::sycl::vec<T, 1>>(log);
+    check_type<cl::sycl::vec<T, 2>>(log);
+    check_type<cl::sycl::vec<T, 3>>(log);
+    check_type<cl::sycl::vec<T, 4>>(log);
+    check_type<cl::sycl::vec<T, 8>>(log);
+    check_type<cl::sycl::vec<T, 16>>(log);
+  }
+
+}  // namespace
+
+#endif // SYCL_1_2_1_TESTS_GROUP_ASYNC_WORK_GROUP_COPY_COMMON_H

--- a/tests/group/group_async_work_group_copy_common.h
+++ b/tests/group/group_async_work_group_copy_common.h
@@ -55,7 +55,7 @@ namespace {
         my_group.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
                                         stride);
         });
-});
+    });
 
   }
 

--- a/tests/group/group_async_work_group_copy_fp16.cpp
+++ b/tests/group/group_async_work_group_copy_fp16.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+*******************************************************************************/
+
+#include "group_async_work_group_copy_common.h"
+
+#define TEST_NAME group_async_work_group_copy_fp16
+
+namespace TEST_NAMESPACE {
+
+class TEST_NAME : public util::test_base {
+ public:
+  /** return information about this test
+  */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+  */
+  void run(util::logger &log) override {
+
+    if(makeQueueOnce().get_device().has_extension("cl_khr_fp16")){
+      check_type_and_vec<cl::sycl::half>(log);
+      check_type_and_vec<cl::sycl::cl_half>(log);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/group/group_async_work_group_copy_fp16.cpp
+++ b/tests/group/group_async_work_group_copy_fp16.cpp
@@ -26,11 +26,11 @@ class TEST_NAME : public util::test_base {
 
     auto queue = util::get_cts_object::queue();
 
-    if (!queue().get_device().has_extension("cl_khr_fp16")) {
-        log.note(
-            "Device does not support half precision floating point operations");
-        return;
-      }
+    if (!queue.get_device().has_extension("cl_khr_fp16")) {
+      log.note(
+          "Device does not support half precision floating point operations");
+      return;
+    }
 
     check_type_and_vec<cl::sycl::half>(log);
     check_type_and_vec<cl::sycl::cl_half>(log);

--- a/tests/group/group_async_work_group_copy_fp16.cpp
+++ b/tests/group/group_async_work_group_copy_fp16.cpp
@@ -24,10 +24,16 @@ class TEST_NAME : public util::test_base {
   */
   void run(util::logger &log) override {
 
-    if(makeQueueOnce().get_device().has_extension("cl_khr_fp16")){
-      check_type_and_vec<cl::sycl::half>(log);
-      check_type_and_vec<cl::sycl::cl_half>(log);
-    }
+    auto queue = util::get_cts_object::queue();
+
+    if (!queue().get_device().has_extension("cl_khr_fp16")) {
+        log.note(
+            "Device does not support half precision floating point operations");
+        return;
+      }
+
+    check_type_and_vec<cl::sycl::half>(log);
+    check_type_and_vec<cl::sycl::cl_half>(log);
   }
 };
 

--- a/tests/group/group_async_work_group_copy_fp16.cpp
+++ b/tests/group/group_async_work_group_copy_fp16.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 1.2.1 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Provides group async_work_group_copy tests for half and cl_half
 //
 *******************************************************************************/
 

--- a/tests/group/group_async_work_group_copy_fp64.cpp
+++ b/tests/group/group_async_work_group_copy_fp64.cpp
@@ -27,11 +27,10 @@ class TEST_NAME : public util::test_base {
     auto queue = util::get_cts_object::queue();
 
     if (!queue.get_device().has_extension("cl_khr_fp64")) {
-        log.note(
-            "Device does not support double precision floating point "
-            "operations");
-        return;
-      }
+      log.note(
+        "Device does not support double precision floating point operations");
+      return;
+    }
 
     check_type_and_vec<double>(log);
     check_type_and_vec<cl::sycl::cl_double>(log);

--- a/tests/group/group_async_work_group_copy_fp64.cpp
+++ b/tests/group/group_async_work_group_copy_fp64.cpp
@@ -24,10 +24,17 @@ class TEST_NAME : public util::test_base {
   */
   void run(util::logger &log) override {
 
-    if(makeQueueOnce().get_device().has_extension("cl_khr_fp64")){
-      check_type_and_vec<double>(log);
-      check_type_and_vec<cl::sycl::cl_double>(log);
-    }
+    auto queue = util::get_cts_object::queue();
+
+    if (!queue.get_device().has_extension("cl_khr_fp64")) {
+        log.note(
+            "Device does not support double precision floating point "
+            "operations");
+        return;
+      }
+
+    check_type_and_vec<double>(log);
+    check_type_and_vec<cl::sycl::cl_double>(log);
   }
 };
 

--- a/tests/group/group_async_work_group_copy_fp64.cpp
+++ b/tests/group/group_async_work_group_copy_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 1.2.1 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Provides group async_work_group_copy tests for double and cl_double
 //
 *******************************************************************************/
 

--- a/tests/group/group_async_work_group_copy_fp64.cpp
+++ b/tests/group/group_async_work_group_copy_fp64.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+*******************************************************************************/
+
+#include "group_async_work_group_copy_common.h"
+
+#define TEST_NAME group_async_work_group_copy_fp64
+
+namespace TEST_NAMESPACE {
+
+class TEST_NAME : public util::test_base {
+ public:
+  /** return information about this test
+  */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+  */
+  void run(util::logger &log) override {
+
+    if(makeQueueOnce().get_device().has_extension("cl_khr_fp64")){
+      check_type_and_vec<double>(log);
+      check_type_and_vec<cl::sycl::cl_double>(log);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/nd_item/nd_item_async_work_group_copy.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy.cpp
@@ -6,21 +6,11 @@
 //
 *******************************************************************************/
 
-#include "../common/common.h"
+#include "nd_item_async_work_group_copy_common.h"
 
-#define TEST_NAME nd_item_async_work_group_copy
+#define TEST_NAME nd_item_async_work_group_copy_core
 
 namespace TEST_NAMESPACE {
-using namespace sycl_cts;
-
-static constexpr size_t RANGE_SIZE_1D = 2;
-static constexpr size_t RANGE_SIZE_2D = 4;
-static constexpr size_t RANGE_SIZE_3D = 8;
-static constexpr size_t BUFFER_SIZE = 128;
-
-class nd_item_async_work_group_copy_1d;
-class nd_item_async_work_group_copy_2d;
-class nd_item_async_work_group_copy_3d;
 
 class TEST_NAME : public util::test_base {
  public:
@@ -33,111 +23,65 @@ class TEST_NAME : public util::test_base {
   /** execute the test
   */
   void run(util::logger &log) override {
-    try {
-      auto queue = util::get_cts_object::queue();
+    check_type<size_t>(log);
+    check_type_and_vec<bool>(log);
+    check_type_and_vec<char>(log);
+    check_type_and_vec<signed char>(log);
+    check_type_and_vec<unsigned char>(log);
+    check_type_and_vec<short int>(log);
+    check_type_and_vec<unsigned short int>(log);
+    check_type_and_vec<int>(log);
+    check_type_and_vec<unsigned int>(log);
+    check_type_and_vec<long int>(log);
+    check_type_and_vec<unsigned long int>(log);
+    check_type_and_vec<long long int>(log);
+    check_type_and_vec<unsigned long long int>(log);
+    check_type_and_vec<float>(log);
 
-      {
-        auto buf = cl::sycl::buffer<size_t, 1>(cl::sycl::range<1>(BUFFER_SIZE));
+    check_type_and_vec<cl::sycl::byte>(log);
+    check_type_and_vec<cl::sycl::cl_bool>(log);
+    check_type_and_vec<cl::sycl::cl_char>(log);
+    check_type_and_vec<cl::sycl::cl_uchar>(log);
+    check_type_and_vec<cl::sycl::cl_short>(log);
+    check_type_and_vec<cl::sycl::cl_ushort>(log);
+    check_type_and_vec<cl::sycl::cl_int>(log);
+    check_type_and_vec<cl::sycl::cl_uint>(log);
+    check_type_and_vec<cl::sycl::cl_long>(log);
+    check_type_and_vec<cl::sycl::cl_ulong>(log);
+    check_type_and_vec<cl::sycl::cl_float>(log);
 
-        queue.submit([&](cl::sycl::handler &cgh) {
-          auto accGlobal =
-              buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-
-          auto accLocal =
-              cl::sycl::accessor<size_t, 1, cl::sycl::access::mode::read_write,
-                                 cl::sycl::access::target::local>(
-                  cl::sycl::range<1>(BUFFER_SIZE), cgh);
-
-          // Test 1D
-          cgh.parallel_for<class nd_item_async_work_group_copy_1d>(
-              cl::sycl::nd_range<1>(cl::sycl::range<1>(RANGE_SIZE_1D),
-                                    cl::sycl::range<1>(1)),
-              [=](cl::sycl::nd_item<1> ndItem) {
-                auto ptrGlobal = accGlobal.get_pointer();
-                auto ptrLocal = accLocal.get_pointer();
-
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
-
-                constexpr size_t stride = 2;
-                constexpr size_t numElements = BUFFER_SIZE / stride;
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
-                                             stride);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
-                                             stride);
-              });
-        });
-
-        queue.submit([&](cl::sycl::handler &cgh) {
-          auto accGlobal =
-              buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-
-          auto accLocal =
-              cl::sycl::accessor<size_t, 1, cl::sycl::access::mode::read_write,
-                                 cl::sycl::access::target::local>(
-                  cl::sycl::range<1>(BUFFER_SIZE), cgh);
-
-          // Test 2D
-          cgh.parallel_for<class nd_item_async_work_group_copy_2d>(
-              cl::sycl::nd_range<2>(
-                  cl::sycl::range<2>(RANGE_SIZE_1D, RANGE_SIZE_2D),
-                  cl::sycl::range<2>(1, 1)),
-              [=](cl::sycl::nd_item<2> ndItem) {
-                auto ptrGlobal = accGlobal.get_pointer();
-                auto ptrLocal = accLocal.get_pointer();
-
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
-
-                constexpr size_t stride = 2;
-                constexpr size_t numElements = BUFFER_SIZE / stride;
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
-                                             stride);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
-                                             stride);
-              });
-        });
-
-        queue.submit([&](cl::sycl::handler &cgh) {
-          auto accGlobal =
-              buf.get_access<cl::sycl::access::mode::read_write>(cgh);
-
-          auto accLocal =
-              cl::sycl::accessor<size_t, 1, cl::sycl::access::mode::read_write,
-                                 cl::sycl::access::target::local>(
-                  cl::sycl::range<1>(BUFFER_SIZE), cgh);
-
-          // Test 3D
-          cgh.parallel_for<class nd_item_async_work_group_copy_3d>(
-              cl::sycl::nd_range<3>(
-                  cl::sycl::range<3>(RANGE_SIZE_1D, RANGE_SIZE_2D,
-                                     RANGE_SIZE_3D),
-                  cl::sycl::range<3>(1, 1, 1)),
-              [=](cl::sycl::nd_item<3> ndItem) {
-                auto ptrGlobal = accGlobal.get_pointer();
-                auto ptrLocal = accLocal.get_pointer();
-
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
-
-                constexpr size_t stride = 2;
-                constexpr size_t numElements = BUFFER_SIZE / stride;
-                ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
-                                             stride);
-                ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
-                                             stride);
-              });
-        });
-      }
-
-      queue.wait_and_throw();
-
-    } catch (const cl::sycl::exception &e) {
-      log_exception(log, e);
-      cl::sycl::string_class errorMsg =
-          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
-      FAIL(log, errorMsg.c_str());
-    }
+#ifdef INT8_MAX
+    if (!std::is_same<cl::sycl::cl_char, std::int8_t>::value)
+      check_type_and_vec<std::int8_t>(log);
+#endif
+#ifdef INT16_MAX
+    if (!std::is_same<cl::sycl::cl_short, std::int16_t>::value)
+      check_type_and_vec<std::int16_t>(log);
+#endif
+#ifdef INT32_MAX
+    if (!std::is_same<cl::sycl::cl_int, std::int32_t>::value)
+      check_type_and_vec<std::int32_t>(log);
+#endif
+#ifdef INT64_MAX
+    if (!std::is_same<cl::sycl::cl_long, std::int64_t>::value)
+      check_type_and_vec<std::int64_t>(log);
+#endif
+#ifdef UINT8_MAX
+    if (!std::is_same<cl::sycl::cl_uchar, std::uint8_t>::value)
+      check_type_and_vec<std::uint8_t>(log);
+#endif
+#ifdef UINT16_MAX
+    if (!std::is_same<cl::sycl::cl_ushort, std::uint16_t>::value)
+      check_type_and_vec<std::uint16_t>(log);
+#endif
+#ifdef UINT32_MAX
+    if (!std::is_same<cl::sycl::cl_uint, std::uint32_t>::value)
+      check_type_and_vec<std::uint32_t>(log);
+#endif
+#ifdef UINT64_MAX
+    if (!std::is_same<cl::sycl::cl_ulong, std::uint64_t>::value)
+      check_type_and_vec<std::uint64_t>(log);
+#endif
   }
 };
 

--- a/tests/nd_item/nd_item_async_work_group_copy_common.h
+++ b/tests/nd_item/nd_item_async_work_group_copy_common.h
@@ -2,7 +2,7 @@
 //
 //  SYCL 1.2.1 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Provides common methods for nd_item async_work_group_copy tests
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_async_work_group_copy_common.h
+++ b/tests/nd_item/nd_item_async_work_group_copy_common.h
@@ -1,0 +1,99 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+*******************************************************************************/
+
+#ifndef SYCL_1_2_1_TESTS_ND_ITEM_ASYNC_WORK_GROUP_COPY_COMMON_H
+#define SYCL_1_2_1_TESTS_ND_ITEM_ASYNC_WORK_GROUP_COPY_COMMON_H
+
+#include "../common/common.h"
+
+namespace {
+  inline cl::sycl::queue makeQueueOnce() {
+    static cl::sycl::queue q = sycl_cts::util::get_cts_object::queue();
+    return q;
+  }
+
+  using namespace sycl_cts;
+
+  static constexpr size_t RANGE_SIZE_1D = 2;
+  static constexpr size_t RANGE_SIZE_2D = 4;
+  static constexpr size_t RANGE_SIZE_3D = 8;
+  static constexpr size_t BUFFER_SIZE = 128;
+
+  template<typename T, int dim>
+  class test_kernel;
+
+ template<typename T, int dim>
+  void check_dim(cl::sycl::queue &queue, cl::sycl::buffer<T, 1> &buf, cl::sycl::range<dim> range1, cl::sycl::range<dim> range2) {
+    queue.submit([&](cl::sycl::handler &cgh) {
+    auto accGlobal =
+        buf.template get_access<cl::sycl::access::mode::read_write>(cgh);
+
+    auto accLocal =
+        cl::sycl::accessor<T, 1, cl::sycl::access::mode::read_write,
+                            cl::sycl::access::target::local>(
+            cl::sycl::range<1>(BUFFER_SIZE), cgh);
+
+    cgh.parallel_for<test_kernel<T, dim>>(
+        cl::sycl::nd_range<dim>(range1, range2),
+        [=](cl::sycl::nd_item<dim> ndItem) {
+          auto ptrGlobal = accGlobal.get_pointer();
+          auto ptrLocal = accLocal.get_pointer();
+
+          ndItem.async_work_group_copy(ptrLocal, ptrGlobal, BUFFER_SIZE);
+          ndItem.async_work_group_copy(ptrGlobal, ptrLocal, BUFFER_SIZE);
+
+          constexpr size_t stride = 2;
+          constexpr size_t numElements = BUFFER_SIZE / stride;
+          ndItem.async_work_group_copy(ptrLocal, ptrGlobal, numElements,
+                                       stride);
+          ndItem.async_work_group_copy(ptrGlobal, ptrLocal, numElements,
+                                        stride);
+        });
+    });
+
+  }
+
+  template<typename T>
+  void check_type(util::logger &log) {
+    try {
+      auto queue = makeQueueOnce();
+
+      {
+        auto buf = cl::sycl::buffer<T, 1>(cl::sycl::range<1>(BUFFER_SIZE));
+        check_dim<T, 1>(queue, buf, cl::sycl::range<1>(RANGE_SIZE_1D), cl::sycl::range<1>(1));
+        check_dim<T, 2>(queue, buf, cl::sycl::range<2>(RANGE_SIZE_1D, RANGE_SIZE_2D),
+                      cl::sycl::range<2>(1, 1));
+        check_dim<T, 3>(queue, buf, cl::sycl::range<3>(RANGE_SIZE_1D, RANGE_SIZE_2D,
+                                        RANGE_SIZE_3D),
+                      cl::sycl::range<3>(1, 1, 1));
+      }
+
+      queue.wait_and_throw();
+
+    } catch (const cl::sycl::exception &e) {
+      log_exception(log, e);
+      cl::sycl::string_class errorMsg =
+          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
+      FAIL(log, errorMsg.c_str());
+    }
+  }
+
+  template<typename T>
+  void check_type_and_vec(util::logger &log) {
+    check_type<T>(log);
+    check_type<cl::sycl::vec<T, 1>>(log);
+    check_type<cl::sycl::vec<T, 2>>(log);
+    check_type<cl::sycl::vec<T, 3>>(log);
+    check_type<cl::sycl::vec<T, 4>>(log);
+    check_type<cl::sycl::vec<T, 8>>(log);
+    check_type<cl::sycl::vec<T, 16>>(log);
+  }
+
+} // namespace
+
+#endif // SYCL_1_2_1_TESTS_ND_ITEM_ASYNC_WORK_GROUP_COPY_COMMON_H

--- a/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
 
     auto queue = util::get_cts_object::queue();
 
-    if (!queue().get_device().has_extension("cl_khr_fp16")) {
+    if (!queue.get_device().has_extension("cl_khr_fp16")) {
       log.note(
         "Device does not support half precision floating point operations");
       return;

--- a/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
@@ -24,10 +24,16 @@ class TEST_NAME : public util::test_base {
   */
   void run(util::logger &log) override {
 
-    if(makeQueueOnce().get_device().has_extension("cl_khr_fp16")){
-      check_type_and_vec<cl::sycl::half>(log);
-      check_type_and_vec<cl::sycl::cl_half>(log);
+    auto queue = util::get_cts_object::queue();
+
+    if (!queue().get_device().has_extension("cl_khr_fp16")) {
+      log.note(
+        "Device does not support half precision floating point operations");
+      return;
     }
+
+    check_type_and_vec<cl::sycl::half>(log);
+    check_type_and_vec<cl::sycl::cl_half>(log);
   }
 };
 

--- a/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+*******************************************************************************/
+
+#include "nd_item_async_work_group_copy_common.h"
+
+#define TEST_NAME nd_item_async_work_group_copy_fp16
+
+namespace TEST_NAMESPACE {
+
+class TEST_NAME : public util::test_base {
+ public:
+  /** return information about this test
+  */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+  */
+  void run(util::logger &log) override {
+
+    if(makeQueueOnce().get_device().has_extension("cl_khr_fp16")){
+      check_type_and_vec<cl::sycl::half>(log);
+      check_type_and_vec<cl::sycl::cl_half>(log);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 1.2.1 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Provides nd_item async_work_group_copy tests for half and cl_half
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
@@ -27,11 +27,10 @@ class TEST_NAME : public util::test_base {
     auto queue = util::get_cts_object::queue();
 
     if (!queue.get_device().has_extension("cl_khr_fp64")) {
-        log.note(
-            "Device does not support double precision floating point "
-            "operations");
-        return;
-      }
+      log.note(
+        "Device does not support double precision floating point operations");
+      return;
+    }
 
     check_type_and_vec<double>(log);
     check_type_and_vec<cl::sycl::cl_double>(log);

--- a/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
@@ -24,10 +24,17 @@ class TEST_NAME : public util::test_base {
   */
   void run(util::logger &log) override {
 
-    if(makeQueueOnce().get_device().has_extension("cl_khr_fp64")){
-      check_type_and_vec<double>(log);
-      check_type_and_vec<cl::sycl::cl_double>(log);
-    }
+    auto queue = util::get_cts_object::queue();
+
+    if (!queue.get_device().has_extension("cl_khr_fp64")) {
+        log.note(
+            "Device does not support double precision floating point "
+            "operations");
+        return;
+      }
+
+    check_type_and_vec<double>(log);
+    check_type_and_vec<cl::sycl::cl_double>(log);
   }
 };
 

--- a/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 1.2.1 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Provides nd_item async_work_group_copy tests for double and cl_double
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+*******************************************************************************/
+
+#include "nd_item_async_work_group_copy_common.h"
+
+#define TEST_NAME nd_item_async_work_group_copy_fp64
+
+namespace TEST_NAMESPACE {
+
+class TEST_NAME : public util::test_base {
+ public:
+  /** return information about this test
+  */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+  */
+  void run(util::logger &log) override {
+
+    if(makeQueueOnce().get_device().has_extension("cl_khr_fp64")){
+      check_type_and_vec<double>(log);
+      check_type_and_vec<cl::sycl::cl_double>(log);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
Changed test names *work_group_copy to *work_group_copy_core to allow it to be run separately from other *work_group_copy tests.

Added type coverage for
  - nd_item::async_work_group_copy member functions
  - group::async_work_group_copy member functions