### PR TITLE
Enable half/double cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ include(AddSYCLExecutable)
 
 # ------------------
 # Double and Half variables
-option(SYCL_CTS_ENABLE_DOUBLE_TESTS "Enable Double tests." OFF)
-option(SYCL_CTS_ENABLE_HALF_TESTS "Enable Half tests." OFF)
+option(SYCL_CTS_ENABLE_DOUBLE_TESTS "Enable Double tests." ON)
+option(SYCL_CTS_ENABLE_HALF_TESTS "Enable Half tests." ON)
 if(SYCL_CTS_ENABLE_DOUBLE_TESTS)
     add_definitions(-DSYCL_CTS_TEST_DOUBLE)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,12 +120,20 @@ add_executable(test_all)
 function(add_cts_test)
   get_filename_component(test_dir ${CMAKE_CURRENT_SOURCE_DIR} NAME)
   set(test_exe_name test_${test_dir})
+  set(test_cases_list ${ARGN})
+
+  if(NOT SYCL_CTS_ENABLE_HALF_TESTS)
+    list(FILTER test_cases_list EXCLUDE REGEX .*_fp16\\.cpp$)
+  endif()
+  if(NOT SYCL_CTS_ENABLE_DOUBLE_TESTS)
+    list(FILTER test_cases_list EXCLUDE REGEX .*_fp64\\.cpp$)
+  endif()
 
   message(STATUS "Adding test: " ${test_exe_name})
 
   add_sycl_executable(NAME           ${test_exe_name}
                       OBJECT_LIBRARY ${test_exe_name}_objects
-                      TESTS          ${ARGN})
+                      TESTS          ${test_cases_list})
 
   target_include_directories(${test_exe_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
Enable cmake options filtering out half/double tests at compile time:
 - SYCL_CTS_ENABLE_HALF_TESTS
 - SYCL_CTS_ENABLE_DOUBLE_TESTS

Default option values are switched to ON, because:
- neither SYCL_CTS_ENABLE_DOUBLE_TESTS nor SYCL_CTS_ENABLE_HALF_TESTS
  affect any of the current tests in the CTS:
  tests currently behave like if these options are ON by default
- half types should be available at the compile time according to the
  SYCL 1.2.1, 5.1 and SYCL 2020, D.6.1
- in case there is no  fp16/fp64 extension available for device, a
  feature_not_supported exception should be thrown at the runtime
- double types should be available at the compile time according to
  the SYCL 1.2.1, 4.10.1 and 6.5
- according to the SYCL 2020, 6.5 an implementation may not raise an
  error in case application did not specifically ask to submit the
  kernel to the specific device or to compile the kernel for it

Options are enabled for new fp16/fp64 tests naming convention only;
any elder tests can be modified to use macro defines if required