### PR TITLE
Allow small ULP errors for vec operator/

### DIFF
--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -138,35 +138,35 @@ all_type_test_template = Template("""
     resArr[i] = static_cast<${type}>(${test_value_1}) / static_cast<${type}>(${test_value_2});
   }
   resVec = testVec1 / testVec2;
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1 / testVec2.${swizzle};
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1 / static_cast<${type}>(${test_value_2});
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1.${swizzle} / testVec2;
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1.${swizzle} / testVec2.${swizzle};
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1.${swizzle} / static_cast<${type}>(${test_value_2});
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = static_cast<${type}>(${test_value_1}) / testVec2;
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = static_cast<${type}>(${test_value_1}) / testVec2.${swizzle};
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
 
@@ -359,32 +359,32 @@ all_type_test_template = Template("""
   }
   resVec = testVec1;
   resVec /= testVec2;
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1;
   resVec /= testVec2.${swizzle};
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1;
   resVec /= static_cast<${type}>(${test_value_2});
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1;
   resVec.${swizzle} /= testVec2;
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1;
   resVec.${swizzle} /= testVec2.${swizzle};
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
   resVec = testVec1;
   resVec.${swizzle} /= static_cast<${type}>(${test_value_2});
-  if (!check_vector_values(resVec, resArr)) {
+  if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
 """)

--- a/util/accuracy.h
+++ b/util/accuracy.h
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Support for accuracy check
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_UTIL_ACCURACY_H
+#define __SYCLCTS_UTIL_ACCURACY_H
+
+#include <cmath>
+#include <limits>
+
+/**
+ * @brief Provides ulp(x) by definition given in OpenCL 1.2 rev. 19, 7.4
+ *        See Jean-Michel Muller "On the definition of ulp (x)", definition 7
+ *        Using sycl functions.
+ */
+template <typename T> T get_ulp_sycl(T x) {
+  const T inf = std::numeric_limits<T>::infinity();
+  const T negative = cl::sycl::fabs(cl::sycl::nextafter(x, -1.0f * inf) - x);
+  const T positive = cl::sycl::fabs(cl::sycl::nextafter(x, inf) - x);
+  return cl::sycl::fmin(negative, positive);
+}
+template <>
+inline cl::sycl::half get_ulp_sycl<cl::sycl::half>(cl::sycl::half x) {
+  const auto ulp = get_ulp_sycl<float>(x);
+  const float multiplier = 8192.0f;
+  // Multiplier is set according to the difference in precision
+  return static_cast<cl::sycl::half>(ulp * multiplier);
+}
+
+#endif // __SYCLCTS_UTIL_ACCURACY_H

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -1,0 +1,28 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Common type traits support
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_UTIL_TYPE_TRAITS_H
+#define __SYCLCTS_UTIL_TYPE_TRAITS_H
+
+#include <type_traits>
+
+namespace {
+/**
+ * @brief Checks whether T is a floating-point sycl type
+ */
+template <typename T> struct is_cl_float_type {
+  static constexpr bool value = std::is_floating_point<T>::value ||
+                                std::is_same<cl::sycl::half, T>::value ||
+                                std::is_same<cl::sycl::cl_float, T>::value ||
+                                std::is_same<cl::sycl::cl_double, T>::value ||
+                                std::is_same<cl::sycl::cl_half, T>::value;
+};
+
+} // namespace
+
+#endif // __SYCLCTS_UTIL_TYPE_TRAITS_H


### PR DESCRIPTION
Changing the verification of vec division operator for floating point types to allow errors within 2.5 ulp (according to OpenCL spec, section 7.4)