### PR TITLE
[CMake] Update C++ and SYCL versions for 2020.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(sycl_cts)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON) # Required for hex floats in C++11 mode on gcc 6+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")

--- a/cmake/FindComputeCpp.cmake
+++ b/cmake/FindComputeCpp.cmake
@@ -35,16 +35,11 @@ set_target_properties(ComputeCpp::Runtime PROPERTIES
     IMPORTED_LOCATION                    "${ComputeCpp_LIBRARIES}"
     INTERFACE_INCLUDE_DIRECTORIES        "${ComputeCpp_INCLUDE_DIRS}"
     INTERFACE_LINK_LIBRARIES             "OpenCL::OpenCL;Threads::Threads"
-    INTERFACE_DEVICE_COMPILE_OPTIONS     "-sycl")
+    INTERFACE_DEVICE_COMPILE_OPTIONS     "-sycl;-DSYCL_LANGUAGE_VERSION=2020")
 if (WIN32)
     set_property(TARGET ComputeCpp::Runtime APPEND PROPERTY
                  INTERFACE_DEVICE_COMPILE_DEFINITIONS
                  "_SIZE_T_DEFINED;_NO_CRT_STDIO_INLINE")
-    set_property(TARGET ComputeCpp::Runtime APPEND PROPERTY
-                 INTERFACE_DEVICE_COMPILE_OPTIONS "-std=c++14")
-else()
-    set_property(TARGET ComputeCpp::Runtime APPEND PROPERTY
-                 INTERFACE_DEVICE_COMPILE_OPTIONS "-std=c++11")
 endif()
 
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
@@ -80,6 +75,7 @@ function(build_spir exe_name spir_target_name source_file output_path)
             -O2
             -mllvm -inline-threshold=1000
             -intelspirmetadata
+            -DSYCL_LANGUAGE_VERSION=2020
             ${COMPUTECPP_USER_FLAGS}
             ${platform_specific_args}
             $<$<BOOL:${include_directories}>:-I\"$<JOIN:${include_directories},\"\t-I\">\">

--- a/cmake/FindComputeCpp.cmake
+++ b/cmake/FindComputeCpp.cmake
@@ -35,7 +35,10 @@ set_target_properties(ComputeCpp::Runtime PROPERTIES
     IMPORTED_LOCATION                    "${ComputeCpp_LIBRARIES}"
     INTERFACE_INCLUDE_DIRECTORIES        "${ComputeCpp_INCLUDE_DIRS}"
     INTERFACE_LINK_LIBRARIES             "OpenCL::OpenCL;Threads::Threads"
-    INTERFACE_DEVICE_COMPILE_OPTIONS     "-sycl;-DSYCL_LANGUAGE_VERSION=2020")
+    INTERFACE_COMPILE_DEFINITIONS        "-DSYCL_LANGUAGE_VERSION=2020"
+    INTERFACE_DEVICE_COMPILE_DEFINITIONS "-DSYCL_LANGUAGE_VERSION=2020"
+    INTERFACE_DEVICE_COMPILE_OPTIONS     "-sycl;-std=c++17"
+  )
 if (WIN32)
     set_property(TARGET ComputeCpp::Runtime APPEND PROPERTY
                  INTERFACE_DEVICE_COMPILE_DEFINITIONS
@@ -75,7 +78,6 @@ function(build_spir exe_name spir_target_name source_file output_path)
             -O2
             -mllvm -inline-threshold=1000
             -intelspirmetadata
-            -DSYCL_LANGUAGE_VERSION=2020
             ${COMPUTECPP_USER_FLAGS}
             ${platform_specific_args}
             $<$<BOOL:${include_directories}>:-I\"$<JOIN:${include_directories},\"\t-I\">\">

--- a/cmake/FindIntel_SYCL.cmake
+++ b/cmake/FindIntel_SYCL.cmake
@@ -11,7 +11,7 @@ if(NOT DEFINED INTEL_SYCL_TRIPLE)
 endif()
 message("Intel SYCL target triple: ${INTEL_SYCL_TRIPLE}")
 
-set(INTEL_SYCL_FLAGS "-fsycl;-fsycl-targets=${INTEL_SYCL_TRIPLE};-sycl-std=121;-ffp-model=precise;${INTEL_SYCL_FLAGS}")
+set(INTEL_SYCL_FLAGS "-fsycl;-fsycl-targets=${INTEL_SYCL_TRIPLE};-sycl-std=2020;-ffp-model=precise;${INTEL_SYCL_FLAGS}")
 message("Intel SYCL compiler flags: `${INTEL_SYCL_FLAGS}`")
 
 add_library(INTEL_SYCL::Runtime INTERFACE IMPORTED GLOBAL)

--- a/cmake/FindhipSYCL.cmake
+++ b/cmake/FindhipSYCL.cmake
@@ -7,7 +7,6 @@ endif()
 
 set(CMAKE_C_COMPILER    ${SYCLCC_EXECUTABLE})
 set(CMAKE_CXX_COMPILER  ${SYCLCC_EXECUTABLE})
-set(CMAKE_CXX_STANDARD 14)
 
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 # add_sycl_executable_implementation function


### PR DESCRIPTION
SYCL 2020 requires compiler to support C++17 at least.
Update SYCL version for DPC++ compiler from 1.2.1 to 2020.