### PR TITLE
Add extensive mode cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,15 @@ endif()
 include(AddSYCLExecutable)
 
 # ------------------
+# Extensive mode for improved coverage
+option(SYCL_CTS_ENABLE_EXTENSIVE_MODE
+       "Enable extensive mode with extended type coverage" OFF)
+if(SYCL_CTS_ENABLE_EXTENSIVE_MODE)
+    add_definitions(-DSYCL_CTS_EXTENSIVE_MODE)
+endif()
+# ------------------
+
+# ------------------
 # Double and Half variables
 option(SYCL_CTS_ENABLE_DOUBLE_TESTS "Enable Double tests." ON)
 option(SYCL_CTS_ENABLE_HALF_TESTS "Enable Half tests." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,16 @@ endif()
 include(AddSYCLExecutable)
 
 # ------------------
-# Extensive mode for improved coverage
-option(SYCL_CTS_ENABLE_EXTENSIVE_MODE
-       "Enable extensive mode with extended type coverage" OFF)
-if(SYCL_CTS_ENABLE_EXTENSIVE_MODE)
-    add_definitions(-DSYCL_CTS_EXTENSIVE_MODE)
+# Extensive mode for full coverage
+option(SYCL_CTS_ENABLE_FULL_CONFORMANCE
+       "Enable full conformance mode with extensive tests" OFF)
+if(SYCL_CTS_ENABLE_FULL_CONFORMANCE)
+    message(STATUS "Full conformance mode: ON")
+    add_definitions(-DSYCL_CTS_FULL_CONFORMANCE)
+else()
+    message(STATUS "Full conformance mode: OFF")
+    message(WARNING
+            "Full conformance mode should be used for conformance submission")
 endif()
 # ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,9 @@ When configuring CMake, it is possible to use these flags:
 ``SYCL_CTS_TEST_FILTER``
   Specify which filter to use when building tests.
 
-``SYCL_CTS_ENABLE_EXTENSIVE_MODE``
-  Enable extended coverage with huge compilation and execution time
+``SYCL_CTS_ENABLE_FULL_CONFORMANCE``
+  Enable extensive coverage with huge compilation and execution time.
+  This mode is switched off by default. Should be swithed on for conformance.
 
 ``HOST_COMPILER_FLAGS``
   Flags that will be passed to the host compiler.
@@ -189,4 +190,9 @@ quickly identify failures and conformance rate::
 This report should be packaged with the run tests and sent to Khronos for
 conformance submission.
 
-The conformance submission requires the use of the core.csv filter.
+Conformance submission
+----------------------
+
+The conformance submission requires the use of the core.csv filter alongside
+with the run_conformance_tests.py script. Please, note that this script will
+switch on the SYCL_CTS_ENABLE_FULL_CONFORMANCE option.

--- a/README.rst
+++ b/README.rst
@@ -193,6 +193,6 @@ conformance submission.
 Conformance submission
 ----------------------
 
-The conformance submission requires the use of the core.csv filter alongside
-with the run_conformance_tests.py script. Please, note that this script will
-switch on the SYCL_CTS_ENABLE_FULL_CONFORMANCE option.
+The conformance submission requires the use of the ``core.csv`` filter alongside
+with the ``run_conformance_tests.py`` script. Please, note that this script will
+switch the ``SYCL_CTS_ENABLE_FULL_CONFORMANCE`` option on.

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,9 @@ When configuring CMake, it is possible to use these flags:
 ``SYCL_CTS_TEST_FILTER``
   Specify which filter to use when building tests.
 
+``SYCL_CTS_ENABLE_EXTENSIVE_MODE``
+  Enable extended coverage with huge compilation and execution time
+
 ``HOST_COMPILER_FLAGS``
   Flags that will be passed to the host compiler.
 

--- a/run_conformance_tests.py
+++ b/run_conformance_tests.py
@@ -103,12 +103,14 @@ def handle_args(argv):
             args.additional_ctest_args, args.build_only)
 
 def split_additional_args(additional_args):
+    """
+    Split any 'additional argument' parameter passed to the script into the list
+    """
+
+    # shlex doesn't support None
     if additional_args is None:
         return []
-    if os.path.sep is '\\':
-        return shlex.split(additional_args.replace('\\','\\\\'))
-    else:
-        return shlex.split(additional_args)
+    return shlex.split(shlex.quote(additional_args))
 
 def generate_cmake_call(cmake_exe, build_system_name, full_conformance,
                         conformance_filter, additional_cmake_args, host_names,

--- a/run_conformance_tests.py
+++ b/run_conformance_tests.py
@@ -96,6 +96,13 @@ def handle_args(argv):
             args.additional_cmake_args, host_names, opencl_names,
             args.additional_ctest_args, args.build_only)
 
+def split_additional_args(additional_args):
+    if additional_args is None:
+        return []
+    if os.path.sep is '\\':
+        return shlex.split(additional_args.replace('\\','\\\\'))
+    else:
+        return shlex.split(additional_args)
 
 def generate_cmake_call(cmake_exe, build_system_name, conformance_filter,
                         additional_cmake_args, host_names, opencl_names):
@@ -112,7 +119,7 @@ def generate_cmake_call(cmake_exe, build_system_name, conformance_filter,
         '-Dhost_device_name=' + host_names[1],
         '-Dopencl_platform_name=' + opencl_names[0],
         '-Dopencl_device_name=' + opencl_names[1],
-    ] + shlex.split(additional_cmake_args)
+    ] + split_additional_args(additional_cmake_args)
 
 
 def generate_ctest_call(additional_ctest_args):
@@ -123,7 +130,7 @@ def generate_ctest_call(additional_ctest_args):
     return [
         'ctest', '.', '-T', 'Test', '--no-compress-output',
         '--test-output-size-passed', '0', '--test-output-size-failed', '0'
-    ] + shlex.split(additional_ctest_args)
+    ] + split_additional_args(additional_ctest_args)
 
 
 def subprocess_call(parameter_list):

--- a/run_conformance_tests.py
+++ b/run_conformance_tests.py
@@ -57,6 +57,11 @@ def handle_args(argv):
         type=str,
         required=True)
     parser.add_argument(
+        '--fast',
+        help='Disable full conformance mode to avoid extensive tests.',
+        required=False,
+        action='store_true')
+    parser.add_argument(
         '--host-platform-name',
         help='The name of the host platform to test on.',
         type=str,
@@ -90,9 +95,10 @@ def handle_args(argv):
 
     host_names = (args.host_platform_name, args.host_device_name)
     opencl_names = (args.opencl_platform_name, args.opencl_device_name)
+    full_conformance = 'OFF' if args.fast else 'ON'
 
     return (args.cmake_exe, args.build_system_name, args.build_system_call,
-            args.conformance_filter, args.implementation_name,
+            full_conformance, args.conformance_filter, args.implementation_name,
             args.additional_cmake_args, host_names, opencl_names,
             args.additional_ctest_args, args.build_only)
 
@@ -104,8 +110,9 @@ def split_additional_args(additional_args):
     else:
         return shlex.split(additional_args)
 
-def generate_cmake_call(cmake_exe, build_system_name, conformance_filter,
-                        additional_cmake_args, host_names, opencl_names):
+def generate_cmake_call(cmake_exe, build_system_name, full_conformance,
+                        conformance_filter, additional_cmake_args, host_names,
+                        opencl_names):
     """
     Generates a CMake call based on the input in a form accepted by
     subprocess.call().
@@ -114,6 +121,7 @@ def generate_cmake_call(cmake_exe, build_system_name, conformance_filter,
         cmake_exe,
         '..',
         '-G' + build_system_name,
+        '-DSYCL_CTS_ENABLE_FULL_CONFORMANCE=' + full_conformance,
         '-DSYCL_CTS_TEST_FILTER=' + conformance_filter,
         '-Dhost_platform_name=' + host_names[0],
         '-Dhost_device_name=' + host_names[1],
@@ -237,8 +245,8 @@ def get_xml_test_results():
 
 
 def update_xml_attribs(host_info_json, opencl_info_json, implementation_name,
-                       test_xml_root, cmake_call, build_system_name,
-                       build_system_call, ctest_call):
+                       test_xml_root, full_conformance, cmake_call,
+                       build_system_name, build_system_call, ctest_call):
     """
     Adds attributes to the root of the xml trees json required by the
     conformance report.
@@ -294,6 +302,7 @@ def update_xml_attribs(host_info_json, opencl_info_json, implementation_name,
         'device-3d-writes']
 
     # Set Build Information attribs
+    test_xml_root.attrib["FullConformanceMode"] = full_conformance
     test_xml_root.attrib["CMakeInput"] = ' '.join(cmake_call)
     test_xml_root.attrib["BuildSystemGenerator"] = build_system_name
     test_xml_root.attrib["BuildSystemCall"] = build_system_call
@@ -305,14 +314,15 @@ def update_xml_attribs(host_info_json, opencl_info_json, implementation_name,
 def main(argv=sys.argv[1:]):
 
     # Parse and gather all the script args
-    (cmake_exe, build_system_name, build_system_call, conformance_filter,
-     implementation_name, additional_cmake_args, host_names, opencl_names,
-     additional_ctest_args, build_only) = handle_args(argv)
+    (cmake_exe, build_system_name, build_system_call, full_conformance,
+     conformance_filter, implementation_name, additional_cmake_args, host_names,
+     opencl_names, additional_ctest_args, build_only) = handle_args(argv)
 
     # Generate a cmake call in a form accepted by subprocess.call()
     cmake_call = generate_cmake_call(cmake_exe, build_system_name,
-                                     conformance_filter, additional_cmake_args,
-                                     host_names, opencl_names)
+                                     full_conformance, conformance_filter,
+                                     additional_cmake_args, host_names,
+                                     opencl_names)
 
     # Generate a CTest call in a form accepted by subprocess.call()
     ctest_call = generate_ctest_call(additional_ctest_args)
@@ -338,8 +348,9 @@ def main(argv=sys.argv[1:]):
     result_xml_root = get_xml_test_results()
     result_xml_root = update_xml_attribs(host_info_json, opencl_info_json,
                                          implementation_name, result_xml_root,
-                                         cmake_call, build_system_name,
-                                         build_system_call, ctest_call)
+                                         full_conformance, cmake_call,
+                                         build_system_name, build_system_call,
+                                         ctest_call)
 
     # Get the xml report stylesheet and add it to the results.
     stylesheet_xml_file = os.path.join("..", "tools", "stylesheet.xml")

--- a/tools/stylesheet.xml
+++ b/tools/stylesheet.xml
@@ -119,6 +119,7 @@
 		<tr><td>Int64 Extended Atomics</td><td><xsl:value-of select="./@OpenCLDeviceInt64Extended" /></td></tr>
 		<tr><td>3D Image Write</td><td><xsl:value-of select="./@OpenCLDevice3DWrites" /></td></tr>
 		<tr><td class="site-header" colspan="2">Build Information</td></tr>
+		<tr><td>Full Conformance Mode</td><td><xsl:value-of select="./@FullConformanceMode" /></td></tr>
   	<tr><td>CMake Input</td><td><xsl:value-of select="./@CMakeInput" /></td></tr>
   	<tr><td>Build System Generator</td><td><xsl:value-of select="./@BuildSystemGenerator" /></td></tr>
   	<tr><td>Build System Call</td><td><xsl:value-of select="./@BuildSystemCall" /></td></tr>


### PR DESCRIPTION
Improving data type coverage up to the full one can give an
unreasonable performance overhead for the specific functionality,
like accessors.
Type coverage for the default mode should be balanced in terms of
coverage and performance, but there should be an option to make all
extra checks when performance doesn't matter.