### PR TITLE
Update .clang-format config to sort includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -58,6 +58,6 @@ CommentPragmas:  '^ IWYU pragma:'
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 SpaceBeforeParens: ControlStatements
 DisableFormat:   false
-SortIncludes:   false
+SortIncludes:   true
 ...
 

--- a/tests/accessor/accessor_api_buffer.cpp
+++ b/tests/accessor/accessor_api_buffer.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_buffer_common.h"
+#include "accessor_utility.h"
 
 #define TEST_NAME accessor_api_buffer
 

--- a/tests/accessor/accessor_api_buffer_common.h
+++ b/tests/accessor/accessor_api_buffer_common.h
@@ -10,9 +10,9 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
-#include "accessor_api_common_buffer_local.h"
 #include "accessor_api_common_all.h"
+#include "accessor_api_common_buffer_local.h"
+#include "accessor_utility.h"
 
 namespace {
 

--- a/tests/accessor/accessor_api_buffer_fp16.cpp
+++ b/tests/accessor/accessor_api_buffer_fp16.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_buffer_common.h"
+#include "accessor_utility.h"
 
 #define TEST_NAME accessor_api_buffer_fp16
 

--- a/tests/accessor/accessor_api_buffer_fp64.cpp
+++ b/tests/accessor/accessor_api_buffer_fp64.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_buffer_common.h"
+#include "accessor_utility.h"
 
 #define TEST_NAME accessor_api_buffer_fp64
 

--- a/tests/accessor/accessor_api_common_buffer_local.h
+++ b/tests/accessor/accessor_api_common_buffer_local.h
@@ -13,8 +13,8 @@
 
 #include "../common/common.h"
 #include "accessor_utility.h"
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 

--- a/tests/accessor/accessor_api_image.cpp
+++ b/tests/accessor/accessor_api_image.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_image_common.h"
+#include "accessor_utility.h"
 
 #include <array>
 #include <numeric>

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -10,8 +10,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_common_all.h"
+#include "accessor_utility.h"
 
 #include <array>
 #include <numeric>

--- a/tests/accessor/accessor_api_image_fp16.cpp
+++ b/tests/accessor/accessor_api_image_fp16.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_image_common.h"
+#include "accessor_utility.h"
 
 #include <array>
 #include <numeric>

--- a/tests/accessor/accessor_api_local.cpp
+++ b/tests/accessor/accessor_api_local.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_local_common.h"
+#include "accessor_utility.h"
 
 #include <array>
 #include <numeric>

--- a/tests/accessor/accessor_api_local_common.h
+++ b/tests/accessor/accessor_api_local_common.h
@@ -10,9 +10,9 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
-#include "accessor_api_common_buffer_local.h"
 #include "accessor_api_common_all.h"
+#include "accessor_api_common_buffer_local.h"
+#include "accessor_utility.h"
 
 #include <array>
 #include <numeric>

--- a/tests/accessor/accessor_api_local_fp16.cpp
+++ b/tests/accessor/accessor_api_local_fp16.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_local_common.h"
+#include "accessor_utility.h"
 
 #include <array>
 #include <numeric>

--- a/tests/accessor/accessor_api_local_fp64.cpp
+++ b/tests/accessor/accessor_api_local_fp64.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 #include "./../../util/math_helper.h"
-#include "accessor_utility.h"
 #include "accessor_api_local_common.h"
+#include "accessor_utility.h"
 
 #include <array>
 #include <numeric>

--- a/tests/accessor/accessor_constructors_buffer.cpp
+++ b/tests/accessor/accessor_constructors_buffer.cpp
@@ -9,8 +9,8 @@
 #define TEST_NAME accessor_constructors_buffer
 
 #include "../common/common.h"
-#include "accessor_constructors_utility.h"
 #include "accessor_constructors_buffer_utility.h"
+#include "accessor_constructors_utility.h"
 
 namespace TEST_NAMESPACE {
 

--- a/tests/accessor/accessor_constructors_buffer_placeholder.cpp
+++ b/tests/accessor/accessor_constructors_buffer_placeholder.cpp
@@ -9,8 +9,8 @@
 #define TEST_NAME accessor_constructors_buffer_placeholder
 
 #include "../common/common.h"
-#include "accessor_constructors_utility.h"
 #include "accessor_constructors_buffer_utility.h"
+#include "accessor_constructors_utility.h"
 
 namespace TEST_NAMESPACE {
 

--- a/tests/accessor/accessor_constructors_fp16.cpp
+++ b/tests/accessor/accessor_constructors_fp16.cpp
@@ -9,10 +9,10 @@
 #define TEST_NAME accessor_constructors_fp16
 
 #include "../common/common.h"
-#include "accessor_constructors_utility.h"
 #include "accessor_constructors_buffer_utility.h"
-#include "accessor_constructors_local_utility.h"
 #include "accessor_constructors_image_utility.h"
+#include "accessor_constructors_local_utility.h"
+#include "accessor_constructors_utility.h"
 
 namespace TEST_NAMESPACE {
 /** tests the constructors for cl::sycl::accessor

--- a/tests/accessor/accessor_constructors_fp64.cpp
+++ b/tests/accessor/accessor_constructors_fp64.cpp
@@ -9,10 +9,10 @@
 #define TEST_NAME accessor_constructors_fp64
 
 #include "../common/common.h"
-#include "accessor_constructors_utility.h"
 #include "accessor_constructors_buffer_utility.h"
-#include "accessor_constructors_local_utility.h"
 #include "accessor_constructors_image_utility.h"
+#include "accessor_constructors_local_utility.h"
+#include "accessor_constructors_utility.h"
 
 namespace TEST_NAMESPACE {
 

--- a/tests/accessor/accessor_constructors_image.cpp
+++ b/tests/accessor/accessor_constructors_image.cpp
@@ -9,8 +9,8 @@
 #define TEST_NAME accessor_constructors_image
 
 #include "../common/common.h"
-#include "accessor_constructors_utility.h"
 #include "accessor_constructors_image_utility.h"
+#include "accessor_constructors_utility.h"
 
 namespace TEST_NAMESPACE {
 

--- a/tests/accessor/accessor_constructors_local.cpp
+++ b/tests/accessor/accessor_constructors_local.cpp
@@ -9,8 +9,8 @@
 #define TEST_NAME accessor_constructors_local
 
 #include "../common/common.h"
-#include "accessor_constructors_utility.h"
 #include "accessor_constructors_local_utility.h"
+#include "accessor_constructors_utility.h"
 
 namespace TEST_NAMESPACE {
 

--- a/tests/accessor/accessor_utility.h
+++ b/tests/accessor/accessor_utility.h
@@ -12,8 +12,8 @@
 #define SYCL_1_2_1_TESTS_ACCESSOR_ACCESSOR_UTILITY_H
 
 #include "../common/common.h"
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 

--- a/tests/address_space/address_space.cpp
+++ b/tests/address_space/address_space.cpp
@@ -8,8 +8,8 @@
 
 #include "../common/common.h"
 
-#include <cassert>
 #include <array>
+#include <cassert>
 #include <type_traits>
 
 #define EXPECT_EQUALS(lhs, rhs) \

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -12,20 +12,18 @@
 // include our proxy to the real sycl header
 #include "sycl.h"
 
-// test framework specific device selector
-#include "../common/cts_selector.h"
-#include "../common/cts_async_handler.h"
-#include "../common/get_cts_object.h"
+#include "../../util/math_vector.h"
 #include "../../util/proxy.h"
+#include "../../util/test_base.h"
+#include "../common/cts_async_handler.h"
+#include "../common/cts_selector.h"
+#include "../common/get_cts_object.h"
 #include "macros.h"
 
-#include "../../util/test_base.h"
-#include "../../util/math_vector.h"
-
-#include <string>
-#include <sstream>
-#include <type_traits>
 #include <numeric>
+#include <sstream>
+#include <string>
+#include <type_traits>
 
 namespace {
 

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -12,16 +12,14 @@
 // include our proxy to the real sycl header
 #include "sycl.h"
 
-// test framework specific device selector
-#include "../common/common.h"
-#include "../common/cts_selector.h"
-#include "../common/cts_async_handler.h"
-#include "../common/get_cts_object.h"
-#include "../../util/proxy.h"
-#include "macros.h"
-
-#include "../../util/test_base.h"
 #include "../../util/math_vector.h"
+#include "../../util/proxy.h"
+#include "../../util/test_base.h"
+#include "../common/common.h"
+#include "../common/cts_async_handler.h"
+#include "../common/cts_selector.h"
+#include "../common/get_cts_object.h"
+#include "macros.h"
 
 #include <string>
 #include <type_traits>

--- a/tests/common/macros.h
+++ b/tests/common/macros.h
@@ -9,9 +9,9 @@
 #ifndef __SYCLCTS_TESTS_COMMON_MACROS_H
 #define __SYCLCTS_TESTS_COMMON_MACROS_H
 
-#include "sycl.h"
 #include "../../util/opencl_helper.h"
 #include "../../util/type_names.h"
+#include "sycl.h"
 
 #define TEST_FILE __FILE__
 #define TEST_BUILD_DATE __DATE__

--- a/tests/common/main.cpp
+++ b/tests/common/main.cpp
@@ -9,8 +9,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "./../../util/test_manager.h"
 #include "./../../util/collection.h"
+#include "./../../util/test_manager.h"
 
 using namespace sycl_cts::util;
 

--- a/tests/image/image_api.cpp
+++ b/tests/image/image_api.cpp
@@ -6,8 +6,8 @@
 //
 *******************************************************************************/
 
-#include "image_common.h"
 #include "../common/common.h"
+#include "image_common.h"
 
 #define TEST_NAME image_api_core
 

--- a/tests/image/image_api_fp16.cpp
+++ b/tests/image/image_api_fp16.cpp
@@ -6,8 +6,8 @@
 //
 *******************************************************************************/
 
-#include "image_common.h"
 #include "../common/common.h"
+#include "image_common.h"
 
 #define TEST_NAME image_api_fp16
 

--- a/tests/image/image_constructors.cpp
+++ b/tests/image/image_constructors.cpp
@@ -6,8 +6,8 @@
 //
 *******************************************************************************/
 
-#include "image_common.h"
 #include "../common/common.h"
+#include "image_common.h"
 
 #define TEST_NAME image_constructors
 

--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -6,9 +6,9 @@
 //
 *******************************************************************************/
 
-#include "../common/common.h"
 #include "../../util/opencl_helper.h"
 #include "../../util/test_base_opencl.h"
+#include "../common/common.h"
 
 #define TEST_NAME opencl_interop_constructors
 

--- a/tests/opencl_interop/opencl_interop_get.cpp
+++ b/tests/opencl_interop/opencl_interop_get.cpp
@@ -6,9 +6,9 @@
 //
 *******************************************************************************/
 
-#include "../common/common.h"
 #include "../../util/opencl_helper.h"
 #include "../../util/test_base_opencl.h"
+#include "../common/common.h"
 
 #define TEST_NAME opencl_interop_get
 

--- a/tests/opencl_interop/opencl_interop_kernel.cpp
+++ b/tests/opencl_interop/opencl_interop_kernel.cpp
@@ -6,9 +6,9 @@
 //
 *******************************************************************************/
 
-#include "../common/common.h"
 #include "../../util/opencl_helper.h"
 #include "../../util/test_base_opencl.h"
+#include "../common/common.h"
 
 #define TEST_NAME opencl_interop_kernel
 

--- a/util/cmdarg.h
+++ b/util/cmdarg.h
@@ -9,8 +9,8 @@
 #ifndef __SYCLCTS_UTIL_CMDARG_H
 #define __SYCLCTS_UTIL_CMDARG_H
 
-#include "stl.h"
 #include "singleton.h"
+#include "stl.h"
 
 namespace sycl_cts {
 namespace util {

--- a/util/collection.cpp
+++ b/util/collection.cpp
@@ -7,8 +7,8 @@
 *******************************************************************************/
 
 #include "collection.h"
-#include "printer.h"
 #include "csv.h"
+#include "printer.h"
 
 // conformance test suite namespace
 namespace sycl_cts {

--- a/util/collection.h
+++ b/util/collection.h
@@ -9,9 +9,9 @@
 #ifndef __SYCLCTS_UTIL_COLLECTION_H
 #define __SYCLCTS_UTIL_COLLECTION_H
 
+#include "singleton.h"
 #include "stl.h"
 #include "test_base.h"
-#include "singleton.h"
 
 namespace sycl_cts {
 namespace util {

--- a/util/executor.cpp
+++ b/util/executor.cpp
@@ -7,10 +7,10 @@
 *******************************************************************************/
 
 #include "executor.h"
-#include "singleton.h"
-#include "printer.h"
 #include "collection.h"
 #include "logger.h"
+#include "printer.h"
+#include "singleton.h"
 
 namespace sycl_cts {
 namespace util {

--- a/util/logger.cpp
+++ b/util/logger.cpp
@@ -10,9 +10,9 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include <stdarg.h>
 #include <assert.h>
 #include <cstdio>
+#include <stdarg.h>
 
 #include "logger.h"
 #include "printer.h"

--- a/util/math_helper.h
+++ b/util/math_helper.h
@@ -9,8 +9,8 @@
 #ifndef __SYCLCTS_UTIL_MATH_HELPER_H
 #define __SYCLCTS_UTIL_MATH_HELPER_H
 
-#include "../util/stl.h"
 #include "../tests/common/sycl.h"
+#include "../util/stl.h"
 #include "./../oclmath/mt19937.h"
 #include "./math_vector.h"
 

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -9,9 +9,9 @@
 #ifndef __SYCLCTS_UTIL_MATH_REFERENCE_H
 #define __SYCLCTS_UTIL_MATH_REFERENCE_H
 
-#include "./stl.h"
 #include "../tests/common/sycl.h"
 #include "./math_helper.h"
+#include "./stl.h"
 
 namespace reference {
 /* two argument relational reference */

--- a/util/opencl_helper.h
+++ b/util/opencl_helper.h
@@ -11,8 +11,8 @@
 
 #include <CL/cl.h>
 
-#include "singleton.h"
 #include "logger.h"
+#include "singleton.h"
 
 namespace sycl_cts {
 namespace util {

--- a/util/printer.cpp
+++ b/util/printer.cpp
@@ -10,13 +10,13 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include <stdarg.h>
-#include <iostream>
 #include <assert.h>
 #include <cstdio>
+#include <iostream>
+#include <stdarg.h>
 
-#include "printer.h"
 #include "logger.h"
+#include "printer.h"
 
 namespace sycl_cts {
 namespace util {

--- a/util/printer.h
+++ b/util/printer.h
@@ -9,8 +9,8 @@
 #ifndef __SYCLCTS_UTIL_PRINTER_H
 #define __SYCLCTS_UTIL_PRINTER_H
 
-#include "stl.h"
 #include "singleton.h"
+#include "stl.h"
 #include "test_base.h"
 
 namespace sycl_cts {

--- a/util/selector.h
+++ b/util/selector.h
@@ -9,8 +9,8 @@
 #ifndef __SYCLCTS_UTIL_SELECTOR_H
 #define __SYCLCTS_UTIL_SELECTOR_H
 
-#include "stl.h"
 #include "singleton.h"
+#include "stl.h"
 
 namespace sycl_cts {
 namespace util {

--- a/util/stl.h
+++ b/util/stl.h
@@ -26,8 +26,8 @@
 #include <memory>
 
 // cout
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 // std::sort()
 #include <algorithm>

--- a/util/test_manager.cpp
+++ b/util/test_manager.cpp
@@ -8,13 +8,13 @@
 
 #include <stdlib.h>
 
-#include "test_manager.h"
+#include "../tests/common/cts_selector.h"
 #include "cmdarg.h"
 #include "collection.h"
+#include "executor.h"
 #include "printer.h"
 #include "selector.h"
-#include "executor.h"
-#include "../tests/common/cts_selector.h"
+#include "test_manager.h"
 
 #if defined(_MSC_VER)
 extern "C" extern long __stdcall IsDebuggerPresent();


### PR DESCRIPTION
This updates the `.clang-format` configuration file to `SortIncludes: true`.

I've also run the new configuration on all existing test and util files, however, as not all files fully conform to clang-format, this only adds the changes to includes. Unfortunately I cannot confirm whether this breaks compilation of any of the tests (I mean, it shouldn't, but you never know...), as I've never been able to compile the full CTS without errors, with any SYCL implementation.

cc @keryell 