### PR TITLE
Changing the conformance tests to use const kernel functions

### DIFF
--- a/tests/accessor/accessor_api_common_buffer_local.h
+++ b/tests/accessor/accessor_api_common_buffer_local.h
@@ -50,7 +50,7 @@ template <typename T, cl::sycl::access::mode mode,
           cl::sycl::access::target target,
           cl::sycl::access::placeholder placeholder>
 T multidim_subscript_read(
-    cl::sycl::accessor<T, 1, mode, target, placeholder>& acc,
+    const cl::sycl::accessor<T, 1, mode, target, placeholder>& acc,
     cl::sycl::id<1> idx) {
   return acc[idx[0]];
 }
@@ -59,7 +59,7 @@ template <typename T, cl::sycl::access::mode mode,
           cl::sycl::access::target target,
           cl::sycl::access::placeholder placeholder>
 T multidim_subscript_read(
-    cl::sycl::accessor<T, 2, mode, target, placeholder>& acc,
+    const cl::sycl::accessor<T, 2, mode, target, placeholder>& acc,
     cl::sycl::id<2> idx) {
   return acc[idx[0]][idx[1]];
 }
@@ -68,7 +68,7 @@ template <typename T, cl::sycl::access::mode mode,
           cl::sycl::access::target target,
           cl::sycl::access::placeholder placeholder>
 T multidim_subscript_read(
-    cl::sycl::accessor<T, 3, mode, target, placeholder>& acc,
+    const cl::sycl::accessor<T, 3, mode, target, placeholder>& acc,
     cl::sycl::id<3> idx) {
   return acc[idx[0]][idx[1]][idx[2]];
 }
@@ -77,7 +77,7 @@ template <typename T, cl::sycl::access::mode mode,
           cl::sycl::access::target target,
           cl::sycl::access::placeholder placeholder>
 void multidim_subscript_write(
-    cl::sycl::accessor<T, 1, mode, target, placeholder>& acc,
+    const cl::sycl::accessor<T, 1, mode, target, placeholder>& acc,
     cl::sycl::id<1> idx, T value) {
   acc[idx[0]] = value;
 }
@@ -86,7 +86,7 @@ template <typename T, cl::sycl::access::mode mode,
           cl::sycl::access::target target,
           cl::sycl::access::placeholder placeholder>
 void multidim_subscript_write(
-    cl::sycl::accessor<T, 2, mode, target, placeholder>& acc,
+    const cl::sycl::accessor<T, 2, mode, target, placeholder>& acc,
     cl::sycl::id<2> idx, T value) {
   acc[idx[0]][idx[1]] = value;
 }
@@ -95,7 +95,7 @@ template <typename T, cl::sycl::access::mode mode,
           cl::sycl::access::target target,
           cl::sycl::access::placeholder placeholder>
 void multidim_subscript_write(
-    cl::sycl::accessor<T, 3, mode, target, placeholder>& acc,
+    const cl::sycl::accessor<T, 3, mode, target, placeholder>& acc,
     cl::sycl::id<3> idx, T value) {
   acc[idx[0]][idx[1]][idx[2]] = value;
 }
@@ -126,7 +126,7 @@ class buffer_accessor_api_r {
         m_range(rng),
         size(size_) {}
 
-  void operator()(sycl_id_t<dim> idx) {
+  void operator()(sycl_id_t<dim> idx) const {
     return check_subscripts(idx, is_zero_dim<dim>{});
   }
 
@@ -136,7 +136,7 @@ class buffer_accessor_api_r {
    *        Only executed when (dim != 0).
    * @param idx Work-item ID
    */
-  void check_subscripts(sycl_id_t<dim> idx, generic_dim_tag) {
+  void check_subscripts(sycl_id_t<dim> idx, generic_dim_tag) const {
     size_t linearID = compute_linear_id(idx, m_range);
     const auto expectedRead = static_cast<T>(linearID);
 
@@ -159,7 +159,7 @@ class buffer_accessor_api_r {
    * @brief Checks reading from an accessor using the subscript operators.
    *        Only executed when (dim == 0).
    */
-  void check_subscripts(sycl_id_t<dim> /*idx*/, zero_dim_tag) {
+  void check_subscripts(sycl_id_t<dim> /*idx*/, zero_dim_tag) const {
     const auto expectedRead = get_zero_dim_buffer_value<T>();
 
     /** check operator dataT&() read syntax
@@ -193,7 +193,7 @@ class buffer_accessor_api_w {
         m_range(r),
         size(size_) {}
 
-  void operator()(sycl_id_t<dim> idx) {
+  void operator()(sycl_id_t<dim> idx) const {
     return check_subscripts(idx, is_zero_dim<dim>{});
   }
 
@@ -203,7 +203,7 @@ class buffer_accessor_api_w {
    *        Only executed when (dim != 0).
    * @param idx Work-item ID
    */
-  void check_subscripts(sycl_id_t<dim> idx, generic_dim_tag) {
+  void check_subscripts(sycl_id_t<dim> idx, generic_dim_tag) const {
     size_t linearID = compute_linear_id(idx, m_range);
     const auto expected = static_cast<T>(linearID);
 
@@ -220,7 +220,7 @@ class buffer_accessor_api_w {
    * @brief Checks writing to an accessor using the subscript operators.
    *        Only executed when (dim == 0).
    */
-  void check_subscripts(sycl_id_t<dim> /*idx*/, zero_dim_tag) {
+  void check_subscripts(sycl_id_t<dim> /*idx*/, zero_dim_tag) const {
     const auto expected = get_zero_dim_buffer_value<T>();
 
     /** check operator dataT&() write syntax
@@ -255,7 +255,7 @@ class buffer_accessor_api_rw {
         m_range(rng),
         size(size_) {}
 
-  void operator()(sycl_id_t<dim> idx) {
+  void operator()(sycl_id_t<dim> idx) const {
     return check_subscripts(idx, is_zero_dim<dim>{});
   }
 
@@ -265,7 +265,7 @@ class buffer_accessor_api_rw {
    *        Only executed when (dim != 0).
    * @param idx Work-item ID
    */
-  void check_subscripts(sycl_id_t<dim> idx, generic_dim_tag) {
+  void check_subscripts(sycl_id_t<dim> idx, generic_dim_tag) const {
     size_t linearID = compute_linear_id(idx, m_range);
 
     T elem;
@@ -318,7 +318,7 @@ class buffer_accessor_api_rw {
    * @brief Checks writing to an accessor using the subscript operators.
    *        Only executed when (dim == 0).
    */
-  void check_subscripts(sycl_id_t<dim> /*idx*/, zero_dim_tag) {
+  void check_subscripts(sycl_id_t<dim> /*idx*/, zero_dim_tag) const {
     /** check operator dataT&() read syntax, only the interface
      */
     T elem = m_accIdSyntax;

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -317,13 +317,13 @@ cl::sycl::vector_class<cl::sycl::byte> get_image_input_data(
 
 template <typename T, int dims, cl::sycl::access::target target,
           cl::sycl::access::mode mode>
-T read_image_acc(cl::sycl::accessor<T, dims, mode, target> &acc,
+T read_image_acc(const cl::sycl::accessor<T, dims, mode, target> &acc,
                  cl::sycl::id<dims> idx) {
   return acc.read(image_access<dims>::get_int(idx));
 }
 
 template <typename T, int dims, cl::sycl::access::mode mode>
-T read_image_acc(cl::sycl::accessor<T, dims, mode,
+T read_image_acc(const cl::sycl::accessor<T, dims, mode,
                                     cl::sycl::access::target::image_array> &acc,
                  image_array_id_t<dims> idx) {
   const auto coords = image_array_coords<dims>::get(idx);
@@ -332,14 +332,14 @@ T read_image_acc(cl::sycl::accessor<T, dims, mode,
 
 template <typename T, int dims, cl::sycl::access::target target,
           cl::sycl::access::mode mode>
-T read_image_acc_sampled(cl::sycl::accessor<T, dims, mode, target> &acc,
+T read_image_acc_sampled(const cl::sycl::accessor<T, dims, mode, target> &acc,
                          cl::sycl::sampler smpl, cl::sycl::id<dims> idx) {
   return acc.read(image_access<dims>::get_int(idx), smpl);
 }
 
 template <typename T, int dims, cl::sycl::access::mode mode>
 T read_image_acc_sampled(
-    cl::sycl::accessor<T, dims, mode, cl::sycl::access::target::image_array>
+    const cl::sycl::accessor<T, dims, mode, cl::sycl::access::target::image_array>
         &acc,
     cl::sycl::sampler smpl, image_array_id_t<dims> idx) {
   const auto coords = image_array_coords<dims>::get(idx);
@@ -348,7 +348,7 @@ T read_image_acc_sampled(
 
 template <typename T, int dims, cl::sycl::access::target target,
           cl::sycl::access::mode mode>
-void write_image_acc(cl::sycl::accessor<T, dims, mode, target> &acc,
+void write_image_acc(const cl::sycl::accessor<T, dims, mode, target> &acc,
                      cl::sycl::id<dims> idx, T value) {
   const auto coords = image_access<dims>::get_int(idx);
   acc.write(coords, value);
@@ -356,7 +356,7 @@ void write_image_acc(cl::sycl::accessor<T, dims, mode, target> &acc,
 
 template <typename T, int dims, cl::sycl::access::mode mode>
 void write_image_acc(
-    cl::sycl::accessor<T, dims, mode, cl::sycl::access::target::image_array>
+    const cl::sycl::accessor<T, dims, mode, cl::sycl::access::target::image_array>
         &acc,
     image_array_id_t<dims> idx, T value) {
   const auto coords = image_array_coords<dims>::get(idx);
@@ -395,7 +395,7 @@ class image_accessor_api_r {
         m_range(rng),
         size(size_) {}
 
-  void operator()(image_id_t<dim, target> idx) {
+  void operator()(image_id_t<dim, target> idx) const {
     const auto expected = get_expected_image_elem<T>();
     T elem;
 
@@ -433,7 +433,7 @@ class image_accessor_api_w {
                        image_range_t<dim, target> rng)
       : m_accCoordsSyntax(accCoordsSyntax), m_range(rng), size(size_) {}
 
-  void operator()(image_id_t<dim, target> idx) {
+  void operator()(image_id_t<dim, target> idx) const {
     const auto elem = get_expected_image_elem<T>();
 
     /** check coords write syntax

--- a/tests/atomic/atomic_api_32.cpp
+++ b/tests/atomic/atomic_api_32.cpp
@@ -27,7 +27,7 @@ class check_atomics_32 {
       cl::sycl::accessor<T, 1, cl::sycl::access::mode::atomic, target> acc)
       : m_acc(acc) {}
 
-  void operator()() {
+  void operator()() const {
     static constexpr auto addressSpace = target_map<target>::addressSpace;
     cl::sycl::memory_order order = cl::sycl::memory_order::relaxed;
     cl::sycl::atomic<T, addressSpace> a = m_acc[0];
@@ -105,7 +105,7 @@ class check_atomics_32<float, target> {
       cl::sycl::accessor<float, 1, cl::sycl::access::mode::atomic, target> acc)
       : m_acc(acc) {}
 
-  void operator()() {
+  void operator()() const {
     static constexpr auto addressSpace = target_map<target>::addressSpace;
     cl::sycl::memory_order order = cl::sycl::memory_order::relaxed;
     cl::sycl::atomic<float, addressSpace> a = m_acc[0];

--- a/tests/atomic/atomic_api_64_base.cpp
+++ b/tests/atomic/atomic_api_64_base.cpp
@@ -27,7 +27,7 @@ class check_base_atomics {
       cl::sycl::accessor<T, 1, cl::sycl::access::mode::atomic, target> acc)
       : m_acc(acc) {}
 
-  void operator()() {
+  void operator()() const {
     static constexpr auto addressSpace = target_map<target>::addressSpace;
     cl::sycl::memory_order order = cl::sycl::memory_order::relaxed;
     cl::sycl::atomic<T, addressSpace> a = m_acc[0];

--- a/tests/atomic/atomic_api_64_extended.cpp
+++ b/tests/atomic/atomic_api_64_extended.cpp
@@ -27,7 +27,7 @@ class check_extended_atomics {
       cl::sycl::accessor<T, 1, cl::sycl::access::mode::atomic, target> acc)
       : m_acc(acc) {}
 
-  void operator()() {
+  void operator()() const {
     static constexpr auto addressSpace = target_map<target>::addressSpace;
     cl::sycl::memory_order order = cl::sycl::memory_order::relaxed;
     cl::sycl::atomic<T, addressSpace> a = m_acc[0];

--- a/tests/atomic/atomic_constructors_common.h
+++ b/tests/atomic/atomic_constructors_common.h
@@ -25,7 +25,7 @@ class check_atomic_constructors {
       cl::sycl::accessor<T, 1, cl::sycl::access::mode::read_write, target> acc)
       : m_acc(acc) {}
 
-  void operator()() {
+  void operator()() const {
     /** Check atomic constructor
     */
     cl::sycl::atomic<T, addressSpace> a(m_acc.get_pointer());

--- a/tests/common/get_cts_object.h
+++ b/tests/common/get_cts_object.h
@@ -19,8 +19,8 @@
  */
 template <class kernel_name = void>
 struct dummy_functor {
-  void operator()() {}
-  void operator()(cl::sycl::group<3> g) {}
+  void operator()() const {}
+  void operator()(cl::sycl::group<3> g) const {}
 };
 
 namespace sycl_cts {

--- a/tests/invoke/invoke_kernel_param_sizes.cpp
+++ b/tests/invoke/invoke_kernel_param_sizes.cpp
@@ -24,7 +24,7 @@ class type_size_kernel {
  public:
   type_size_kernel(write_t out_accessor) : m_out(out_accessor) {}
 
-  void operator()() { m_out[0] = sizeof(T); }
+  void operator()() const { m_out[0] = sizeof(T); }
 };
 
 template <typename T>

--- a/tests/invoke/invoke_kernel_params.cpp
+++ b/tests/invoke/invoke_kernel_params.cpp
@@ -50,7 +50,7 @@ struct test_kernel {
 
   void set(uint32_t i, int32_t v) { inner.int_array[i] = v; }
 
-  void operator()() {
+  void operator()() const {
     uint32_t pass = 1;
     pass &= (var_a == ref_a);
     pass &= (var_b.a == ref_b_a);

--- a/tests/invoke/invoke_template_kernels.cpp
+++ b/tests/invoke/invoke_template_kernels.cpp
@@ -28,7 +28,7 @@ class templated_functor {
  public:
   templated_functor(read_t in, write_t out) : m_in(in), m_out(out) {}
 
-  void operator()() { m_out[0] = m_in[0]; }
+  void operator()() const { m_out[0] = m_in[0]; }
 };
 
 template <typename T>

--- a/tests/item/item_1d.cpp
+++ b/tests/item/item_1d.cpp
@@ -28,7 +28,7 @@ class kernel_item_1d {
  public:
   kernel_item_1d(t_readAccess in_, t_writeAccess out_) : m_x(in_), m_o(out_) {}
 
-  void operator()(cl::sycl::item<1> item) {
+  void operator()(cl::sycl::item<1> item) const {
     cl::sycl::id<1> gid = item.get_id();
 
     size_t dim_a = item.get_id(0);

--- a/tests/item/item_2d.cpp
+++ b/tests/item/item_2d.cpp
@@ -28,7 +28,7 @@ class kernel_item_2d {
  public:
   kernel_item_2d(t_readAccess in_, t_writeAccess out_) : m_x(in_), m_o(out_) {}
 
-  void operator()(cl::sycl::item<2> item) {
+  void operator()(cl::sycl::item<2> item) const {
     cl::sycl::id<2> gid = item.get_id();
 
     size_t dim_a = item.get_id(0) + item.get_id(1);

--- a/tests/item/item_3d.cpp
+++ b/tests/item/item_3d.cpp
@@ -27,7 +27,7 @@ class kernel_item_3d {
  public:
   kernel_item_3d(t_readAccess in_, t_writeAccess out_) : m_x(in_), m_o(out_) {}
 
-  void operator()(cl::sycl::item<3> item) {
+  void operator()(cl::sycl::item<3> item) const {
     cl::sycl::id<3> gid = item.get_id();
 
     size_t dim_a = item.get_id(0) + item.get_id(1) + item.get_id(2);

--- a/tests/kernel/kernel_constructors.cpp
+++ b/tests/kernel/kernel_constructors.cpp
@@ -13,7 +13,7 @@
 template <int a>
 class test_kernel {
  public:
-  void operator()() {}
+  void operator()() const {}
 };
 
 class kernel0;

--- a/tests/nd_item/nd_item.cpp
+++ b/tests/nd_item/nd_item.cpp
@@ -43,7 +43,7 @@ class kernel_nd_item {
   kernel_nd_item(t_readAccess inG_, t_readAccess inL_, t_writeAccess out_)
       : m_globalID(inG_), m_localID(inL_), m_o(out_) {}
 
-  void operator()(cl::sycl::nd_item<dimensions> myitem) {
+  void operator()(cl::sycl::nd_item<dimensions> myitem) const {
     bool failed = false;
 
     /* test global ID*/

--- a/tests/program/program_constructors.cpp
+++ b/tests/program/program_constructors.cpp
@@ -28,7 +28,7 @@ class test_functor_1 {
           acc)
       : m_acc(acc) {}
 
-  void operator()() { m_acc[0] *= 2.0f; };
+  void operator()() const { m_acc[0] *= 2.0f; };
 };
 
 namespace program_constructors__ {

--- a/tests/stream/stream_constructors.cpp
+++ b/tests/stream/stream_constructors.cpp
@@ -15,7 +15,7 @@ namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 
 struct stream_kernel {
-  void operator()() {}
+  void operator()() const {}
 };
 
 /** tests the constructors for cl::sycl::stream


### PR DESCRIPTION
SYCL 2020 is changing kernel functions to be const.