### PR TITLE
Provide std::array replacement for kernel code

### DIFF
--- a/tests/group/group_constructors.cpp
+++ b/tests/group/group_constructors.cpp
@@ -9,6 +9,7 @@
 #include "../common/common.h"
 #include "../common/common_by_value.h"
 #include "../common/invoke.h"
+#include "../../util/array.h"
 
 #include <array>
 
@@ -48,11 +49,11 @@ template <int numDims>
 class state_storage {
 private:
   size_t m_linearId;
-  std::array<size_t, numDims> m_id;
-  std::array<size_t, numDims> m_subscript;
-  std::array<size_t, numDims> m_globalRange;
-  std::array<size_t, numDims> m_groupRange;
-  std::array<size_t, numDims> m_localRange;
+  sycl_cts::util::array<size_t, numDims> m_id;
+  sycl_cts::util::array<size_t, numDims> m_subscript;
+  sycl_cts::util::array<size_t, numDims> m_globalRange;
+  sycl_cts::util::array<size_t, numDims> m_groupRange;
+  sycl_cts::util::array<size_t, numDims> m_localRange;
 public:
   state_storage(const cl::sycl::group<numDims>& state)
   {

--- a/tests/nd_item/nd_item_constructors.cpp
+++ b/tests/nd_item/nd_item_constructors.cpp
@@ -9,6 +9,7 @@
 #include "../common/common.h"
 #include "../common/common_by_value.h"
 #include "../common/invoke.h"
+#include "../../util/array.h"
 
 #include <array>
 
@@ -50,13 +51,13 @@ private:
   size_t m_globalLinearId;
   size_t m_groupLinearId;
   size_t m_localLinearId;
-  std::array<size_t, numDims> m_globalId;
-  std::array<size_t, numDims> m_groupId;
-  std::array<size_t, numDims> m_localId;
-  std::array<size_t, numDims> m_globalRange;
-  std::array<size_t, numDims> m_groupRange;
-  std::array<size_t, numDims> m_localRange;
-  std::array<size_t, numDims> m_offset;
+  sycl_cts::util::array<size_t, numDims> m_globalId;
+  sycl_cts::util::array<size_t, numDims> m_groupId;
+  sycl_cts::util::array<size_t, numDims> m_localId;
+  sycl_cts::util::array<size_t, numDims> m_globalRange;
+  sycl_cts::util::array<size_t, numDims> m_groupRange;
+  sycl_cts::util::array<size_t, numDims> m_localRange;
+  sycl_cts::util::array<size_t, numDims> m_offset;
 public:
   state_storage(const cl::sycl::nd_item<numDims>& state)
   {

--- a/util/array.h
+++ b/util/array.h
@@ -36,7 +36,7 @@ struct array {
    */
   value_type values[N];
 
-  reference operator[](size_type pos) {
+  constexpr reference operator[](size_type pos) {
     return values[pos];
   }
   constexpr const_reference operator[](size_type pos) const {
@@ -47,13 +47,13 @@ struct array {
     return N;
   }
 
-  reference front() {
+  constexpr reference front() {
     return values[0];
   }
   constexpr const_reference front() const {
     return values[0];
   }
-  reference back() {
+  constexpr reference back() {
     return values[N-1];
   }
   constexpr const_reference back() const {
@@ -62,13 +62,13 @@ struct array {
 
   /** @brief Support for C++ ranged-for syntax
    */
-  iterator begin() noexcept {
+  constexpr iterator begin() noexcept {
     return &front();
   }
   constexpr const_iterator begin() const noexcept {
     return &front();
   }
-  iterator end() noexcept {
+  constexpr iterator end() noexcept {
     return &back();
   }
   constexpr const_iterator end() const noexcept {

--- a/util/array.h
+++ b/util/array.h
@@ -1,0 +1,82 @@
+/*******************************************************************************
+//
+//  SYCL 1.2.1 Conformance Test Suite
+//
+//  Provide fixed-width array implementation for usage in kernel functions
+//  because std::array methods are not required to be noexcept by C++ spec,
+//  while exceptions are not allowed in a device function
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_UTIL_ARRAY_H
+#define __SYCLCTS_UTIL_ARRAY_H
+
+namespace sycl_cts {
+namespace util {
+
+/** @brief Fixed width array to use in kernel functions
+ */
+template <class T, std::size_t N>
+struct array {
+  // Should be aggregate type, so no explicit constructors
+  // and private attributes
+
+  using value_type = T;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using size_type = std::size_t;
+
+  /** @brief Iterator type; is safe to use on host or device side only
+   */
+  using iterator = value_type*;
+  using const_iterator = const iterator;
+
+  /** @brief Internal data storage;
+   *         public for aggregate initialization availability
+   */
+  value_type values[N];
+
+  reference operator[](size_type pos) {
+    return values[pos];
+  }
+  const_reference operator[](size_type pos) const {
+    return values[pos];
+  }
+
+  inline constexpr size_type size() const noexcept {
+    return N;
+  }
+
+  reference front() {
+    return values[0];
+  }
+  const_reference front() const {
+    return values[0];
+  }
+  reference back() {
+    return values[N-1];
+  }
+  const_reference back() const {
+    return values[N-1];
+  }
+
+  /** @brief Support for C++ ranged-for syntax
+   */
+  iterator begin() noexcept {
+    return &front();
+  }
+  const_iterator begin() const noexcept {
+    return &front();
+  }
+  iterator end() noexcept {
+    return &back();
+  }
+  const_iterator end() const noexcept {
+    return &back();
+  }
+};
+
+}  // namespace util
+}  // namespace sycl_cts
+
+#endif  // __SYCLCTS_TESTS_COMMON_ARRAY_H

--- a/util/array.h
+++ b/util/array.h
@@ -43,7 +43,7 @@ struct array {
     return values[pos];
   }
 
-  inline constexpr size_type size() const noexcept {
+  constexpr size_type size() const noexcept {
     return N;
   }
 

--- a/util/array.h
+++ b/util/array.h
@@ -39,7 +39,7 @@ struct array {
   reference operator[](size_type pos) {
     return values[pos];
   }
-  const_reference operator[](size_type pos) const {
+  constexpr const_reference operator[](size_type pos) const {
     return values[pos];
   }
 
@@ -50,13 +50,13 @@ struct array {
   reference front() {
     return values[0];
   }
-  const_reference front() const {
+  constexpr const_reference front() const {
     return values[0];
   }
   reference back() {
     return values[N-1];
   }
-  const_reference back() const {
+  constexpr const_reference back() const {
     return values[N-1];
   }
 
@@ -65,13 +65,13 @@ struct array {
   iterator begin() noexcept {
     return &front();
   }
-  const_iterator begin() const noexcept {
+  constexpr const_iterator begin() const noexcept {
     return &front();
   }
   iterator end() noexcept {
     return &back();
   }
-  const_iterator end() const noexcept {
+  constexpr const_iterator end() const noexcept {
     return &back();
   }
 };

--- a/util/array.h
+++ b/util/array.h
@@ -29,7 +29,7 @@ struct array {
   /** @brief Iterator type; is safe to use on host or device side only
    */
   using iterator = value_type*;
-  using const_iterator = const iterator;
+  using const_iterator = const value_type*;
 
   /** @brief Internal data storage;
    *         public for aggregate initialization availability

--- a/util/array.h
+++ b/util/array.h
@@ -36,10 +36,10 @@ struct array {
    */
   value_type values[N];
 
-  constexpr reference operator[](size_type pos) {
+  constexpr reference operator[](size_type pos) noexcept {
     return values[pos];
   }
-  constexpr const_reference operator[](size_type pos) const {
+  constexpr const_reference operator[](size_type pos) const noexcept {
     return values[pos];
   }
 
@@ -47,16 +47,16 @@ struct array {
     return N;
   }
 
-  constexpr reference front() {
+  constexpr reference front() noexcept {
     return values[0];
   }
-  constexpr const_reference front() const {
+  constexpr const_reference front() const noexcept {
     return values[0];
   }
-  constexpr reference back() {
+  constexpr reference back() noexcept {
     return values[N-1];
   }
-  constexpr const_reference back() const {
+  constexpr const_reference back() const noexcept {
     return values[N-1];
   }
 

--- a/util/array.h
+++ b/util/array.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
 //
-//  SYCL 1.2.1 Conformance Test Suite
+//  SYCL 2020 Conformance Test Suite
 //
 //  Provide fixed-width array implementation for usage in kernel functions
 //  because std::array methods are not required to be noexcept by C++ spec,


### PR DESCRIPTION
Provide replacement type for fixed-width array to use in kernel functions. Implicitly uses pointer arithmetic for C++ ranged-for.