### PR TITLE
Add a test plan for spec constants

### DIFF
--- a/test_plans/README.md
+++ b/test_plans/README.md
@@ -1,0 +1,13 @@
+This directory contains test plans for new features in SYCL 2020.  A test plan
+is simply a description of the tests that we plan to add to the CTS.  Since the
+test plans are more concise than the actual test, we can review and change them
+more quickly that reviewing and changing the actual tests.  Once a plan has
+been approved, we can write the tests according to the plan.
+
+Test plans do not have a strict format.  A plan should have enough information
+to tell which APIs will be tested and to explain how they will be tested.  The
+goal of a plan is to get feedback, so include enough detail for the reader to
+understand the core purpose of each test.  Most test plans have one section
+for each test, and each section has a bulleted list that describes that test.
+When writing a new test plan, it's often easiest to use an existing plan as a
+model.

--- a/test_plans/README.md
+++ b/test_plans/README.md
@@ -1,7 +1,7 @@
 This directory contains test plans for new features in SYCL 2020.  A test plan
 is simply a description of the tests that we plan to add to the CTS.  Since the
 test plans are more concise than the actual test, we can review and change them
-more quickly that reviewing and changing the actual tests.  Once a plan has
+more quickly than reviewing and changing the actual tests.  Once a plan has
 been approved, we can write the tests according to the plan.
 
 Test plans do not have a strict format.  A plan should have enough information

--- a/test_plans/spec-constants.asciidoc
+++ b/test_plans/spec-constants.asciidoc
@@ -219,43 +219,108 @@ constant's default value.
 [[sec:declarations]]
 === Spec constant defined in various ways
 
-Do the following test for a `specialization_id` variable defined in the
+Create an application with `specialization_id` variables defined in the
 following ways:
 
-* Defined in a non-global namespace.
-* Defined in the global namespace as `const`.
-* Defined in the global namespace as `constexpr`.
-* Defined in the global namespace as `inline`.
-* Defined in the global namespace as `inline const`.
+* Defined in a non-global named namespace.
+* Defined in an unnamed namespace.
 * Defined in the global namespace as `inline constexpr`.
+* Defined in the global namespace as `static constexpr`.
 * A static member variable of a struct in the global namespace.
 * A static member variable of a struct in a non-global namespace.
-* A static member variable declared `const` of a struct in the global namespace.
-* A static member variable declared `constexpr` of a struct in the global
-  namespace.
-* A static member variable declared `inline` of a struct in the global
-  namespace.
-* A static member variable declared `inline const` of a struct in the global
-  namespace.
+* A static member variable of a struct in an unnamed namespace.
 * A static member variable declared `inline constexpr` of a struct in the global
   namespace.
+* A static member variable of a templated struct in the global namespace.
 
-The test that is performed is:
+Perform the following test:
 
 * Create a `queue` from the tested device and call `queue::submit()`.
-* Set the value of the spec constant via
+* Set each spec constant to a different value via
   `handler::set_specialization_constant()`.
 * Submit a kernel via `handler::single_task()`.
-* Read the value of the spec constant via
-  `kernel_handler::get_specialization_constant()` and make sure we get the same
+* Read the value of each spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get its
    value back.
 
 === Spec constant defined in various ways and set via `kernel_bundle`
 
-* Same test as in <<sec:declarations>>, except:
-  - Set spec constants in a `kernel_bundle`.
-  - Call `build()` to build the `kernel_bundle` into `executable` state.
-  - Register the bundle with a handler via `use_kernel_bundle()`.
+Define the same set of `specialization_id` variables as in <<sec:declarations>>
+and perform this test:
+
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Get a `kernel_bundle` in `input` state.
+* Set each spec constant to a different value via
+  `kernel_bundle::set_specialization_constant()`.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Register the bundle with a handler via `use_kernel_bundle()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of each spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get its
+  value back.
+
+[[sec:same-name]]
+=== Same name stress test
+
+Create several `specialization_id` variables, each with the same name but in
+different namespaces as shown below.
+
+```
+constexpr sycl::specialization_id<T> same_name{...};
+namespace outer {
+  constexpr sycl::specialization_id<T> same_name{...};
+  namespace inner {
+    constexpr sycl::specialization_id<T> same_name{...};
+  }
+  namespace {
+    constexpr sycl::specialization_id<T> same_name{...};
+    namespace inner {
+      constexpr sycl::specialization_id<T> same_name{...};
+      namespace {
+        constexpr sycl::specialization_id<T> same_name{...};
+      }
+    }
+  }
+}
+namespace {
+  constexpr sycl::specialization_id<T> same_name{...};
+  namespace outer {
+    constexpr sycl::specialization_id<T> same_name{...};
+    namespace {
+      constexpr sycl::specialization_id<T> same_name{...};
+      namespace inner {
+        constexpr sycl::specialization_id<T> same_name{...};
+      }
+    }
+  }
+}
+```
+
+Perform the following test:
+
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Set each spec constant to a different value via
+  `handler::set_specialization_constant()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of each spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get its
+  value back.
+
+=== Same name stress test with `kernel_bundle`
+
+Define the same set of `specialization_id` variables as in <<sec:same-name>>
+and perform this test:
+
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Get a `kernel_bundle` in `input` state.
+* Set each spec constant to a different value via
+  `kernel_bundle::set_specialization_constant()`.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Register the bundle with a handler via `use_kernel_bundle()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of each spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get its
+  value back.
 
 [[sec:other-tu]]
 === Spec constant defined in another translation unit

--- a/test_plans/spec-constants.asciidoc
+++ b/test_plans/spec-constants.asciidoc
@@ -1,4 +1,7 @@
-# Test plan for specialization constants
+:sectnums:
+:xrefstyle: short
+
+= Test plan for specialization constants
 
 This is a test plan for the APIs described in SYCL 2020 section 4.9.5.
 "Specialization constants" and for the
@@ -6,14 +9,15 @@ This is a test plan for the APIs described in SYCL 2020 section 4.9.5.
 `kernel_bundle::get_specialization_constant()` APIs that are described
 in section 4.11.12.2. "Specialization constant support".
 
-## Testing scope
+== Testing scope
 
-### Device coverage
+=== Device coverage
 
 All of the tests described below are performed only on the default device that
 is selected on the CTS command line.
 
-### Specialization constant types
+[[sec:types]]
+=== Specialization constant types
 
 All of tests described below (with the exception of those tests described under
 "Tests which are not run for all types") are performed using each of the
@@ -66,9 +70,9 @@ In addition, if the device has `aspect::fp16`, the following types are tested:
 * `marray<sycl::half, size_t dim>` where `dim` is `2`, `5`, and `10`.
 
 
-## Tests
+== Tests
 
-### Basic tests with handler
+=== Basic tests with handler
 
 All of the following basic tests have these initial steps:
 
@@ -76,13 +80,13 @@ All of the following basic tests have these initial steps:
   tested type.  The variable's default value has some non-zero value.
 * Create a `queue` from the tested device and call `queue::submit()`.
 
-#### Read a spec constant from a handler without writing its value
+==== Read a spec constant from a handler without writing its value
 
 * Call `handler::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-#### Write and read a spec constant from a handler
+==== Write and read a spec constant from a handler
 
 * Set the value of the spec constant via
   `handler::set_specialization_constant()`.
@@ -90,7 +94,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Write the value twice from a handler and make sure we read the second value
+==== Write the value twice from a handler and make sure we read the second value
 
 * Set the value of the spec constant via
   `handler::set_specialization_constant()`.
@@ -99,14 +103,14 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a kernel without writing its value
+==== Read a spec constant from a kernel without writing its value
 
 * Submit a kernel via `handler::single_task()`.
 * Read the value of the spec constant via
   `kernel_handler::get_specialization_constant()` and make sure we get the
    default value back.
 
-#### Write the value from a handler and read it from a kernel
+==== Write the value from a handler and read it from a kernel
 
 * Set the value of the spec constant via
   `handler::set_specialization_constant()`.
@@ -115,7 +119,7 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure we get the same
    value back.
 
-#### Write the value twice from a handler and read it from a kernel
+==== Write the value twice from a handler and read it from a kernel
 
 * Set the value of the spec constant via
   `handler::set_specialization_constant()`.
@@ -125,7 +129,7 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure we get the second
    value back.
 
-#### Write the value from a handler and read it twice from a kernel
+==== Write the value from a handler and read it twice from a kernel
 
 * Set the value of the spec constant via
   `handler::set_specialization_constant()`.
@@ -134,7 +138,8 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure that each time
   we get that value that was written.
 
-#### Pass kernel handler object by reference to another function
+[[sec:hander-by-ref]]
+==== Pass kernel handler object by reference to another function
 
 * Set the value of the spec constant via
   `handler::set_specialization_constant()`.
@@ -145,27 +150,30 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure we get the same
    value back.
 
-#### Pass kernel handler object by value to another function
+==== Pass kernel handler object by value to another function
 
-* Same test as above, except pass the `kernel_handler` object by value.
+* Same test as in <<sec:hander-by-ref>>, except pass the `kernel_handler`
+  object by value.
 
-#### Pass kernel handler object by reference to a `SYCL_EXTERNAL` function
+[[sec:external-handler-by-ref]]
+==== Pass kernel handler object by reference to a `SYCL_EXTERNAL` function
 
 * This test runs only if the implementation defines `SYCL_EXTERNAL`.
-* Same test as above except:
+* Same test as in <<sec:hander-by-ref>> except:
   - The helper function is defined in a separate translation unit via
     `SYCL_EXTERNAL`.
   - The separate translation unit has an external declaration for the
     `specialization_id` variable, which is defined in the first translation
     unit.
-  - The `kernel_handler` object is passed by reference.
 
-#### Pass kernel handler object by value to a `SYCL_EXTERNAL` function
+==== Pass kernel handler object by value to a `SYCL_EXTERNAL` function
 
 * This test runs only if the implementation defines `SYCL_EXTERNAL`.
-* Same test as above, except pass the `kernel_handler` object by value.
+* Same test as in <<sec:external-handler-by-ref>>, except pass the
+  `kernel_handler` object by value.
 
-### Multiple spec constants
+[[sec:multiple]]
+=== Multiple spec constants
 
 * Declare several `specialization_id` variables of the tested type in the
   global namespace.  All the default values are different and none are zero.
@@ -178,12 +186,13 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure we get the
   expected value from each (either the value we set or the default value).
 
-### Multiple spec constants with `kernel_bundle`
+=== Multiple spec constants with `kernel_bundle`
 
-* Same test as above, except set spec constants in a `kernel_bundle`,
-  build the bundle and register the bundle with a handler.
+* Same test as in <<sec:multiple>>, except set spec constants in a
+  `kernel_bundle`, build the bundle and register the bundle with a handler.
 
-### Two command groups that read the same spec constant, both set value
+[[sec:two-command]]
+=== Two command groups that read the same spec constant, both set value
 
 * Declare a `specialization_id` variable in the global namespace for the
   tested type.  The variable's default value has some non-zero value.
@@ -200,13 +209,15 @@ All of the following basic tests have these initial steps:
   the command group handler which launched that kernel instance.
 * The two kernels should run in parallel for this test.
 
-### Two command groups that read the same spec constant, only one sets value
+=== Two command groups that read the same spec constant, only one sets value
 
-Same test as above except only one of the command group handlers sets the value
-of the spec constant.  The kernel instance that is launched from the handler
-that does not set a value should read the spec constant's default value.
+Same test as in <<sec:two-command>> except only one of the command group
+handlers sets the value of the spec constant.  The kernel instance that is
+launched from the handler that does not set a value should read the spec
+constant's default value.
 
-### Spec constant defined in various ways
+[[sec:declarations]]
+=== Spec constant defined in various ways
 
 Do the following test for a `specialization_id` variable defined in the
 following ways:
@@ -239,12 +250,15 @@ The test that is performed is:
   `kernel_handler::get_specialization_constant()` and make sure we get the same
    value back.
 
-### Spec constant defined in various ways and set via `kernel_bundle`
+=== Spec constant defined in various ways and set via `kernel_bundle`
 
-* Same test as above, except set spec constants in a `kernel_bundle`,
-  build the bundle and register the bundle with a handler.
+* Same test as in <<sec:declarations>>, except:
+  - Set spec constants in a `kernel_bundle`.
+  - Call `build()` to build the `kernel_bundle` into `executable` state.
+  - Register the bundle with a handler via `use_kernel_bundle()`.
 
-### Spec constant defined in another translation unit
+[[sec:other-tu]]
+=== Spec constant defined in another translation unit
 
 * In one translation unit:
   - Define a `specialization_id` variable in the global namespace for the
@@ -259,12 +273,14 @@ The test that is performed is:
     `kernel_handler::get_specialization_constant()` and make sure we get the
     same value back.
 
-### Spec constant defined in another translation unit and set via `kernel_bundle`
+=== Spec constant defined in another translation unit and set via `kernel_bundle`
 
-* Same test as above, except set spec constants in a `kernel_bundle`,
-  build the bundle and register the bundle with a handler.
+* Same test as in <<sec:other-tu>>, except:
+  - Set spec constants in a `kernel_bundle`.
+  - Call `build()` to build the `kernel_bundle` into `executable` state.
+  - Register the bundle with a handler via `use_kernel_bundle()`.
 
-### Basic tests with `kernel_bundle` for all kernel bundle states
+=== Basic tests with `kernel_bundle` for all kernel bundle states
 
 All of the following basic tests have these initial steps:
 
@@ -274,29 +290,29 @@ All of the following basic tests have these initial steps:
 * Create `kernel_bundle` using all kernel bundle states
   `State` == (`bundle_state::input`, `bundle_state::object`, `bundle_state::executable`)
 
-#### Read a spec constant from a `kernel_bundle` without writing its value
+==== Read a spec constant from a `kernel_bundle` without writing its value
 
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-#### Read a spec constant from a joined `kernel_bundle` without writing its value
+==== Read a spec constant from a joined `kernel_bundle` without writing its value
 
 * Join bundle with another bundle.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-### Tests for with `kernel_bundle` specific to `bundle_state::input`
+=== Tests for with `kernel_bundle` specific to `bundle_state::input`
 
 All of the following basic tests have these initial steps:
 
 * Declare a `specialization_id` variable in the global namespace for the
   tested type.  The variable's default value has some non-zero value.
 * Create a `queue` from the tested device and call `queue::submit()`.
-* Create `kernel_bundle` with`State` == `bundle_state::input`.
+* Create `kernel_bundle` with `State` == `bundle_state::input`.
 
-#### Set the value in a `kernel_bundle` and then read it from the same bundle
+==== Set the value in a `kernel_bundle` and then read it from the same bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -304,7 +320,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` twice and then read it from the same bundle
+==== Set the value in a `kernel_bundle` twice and then read it from the same bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -313,14 +329,14 @@ All of the following basic tests have these initial steps:
    value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a compiled `kernel_bundle` without writing its value
+==== Read a spec constant from a compiled `kernel_bundle` without writing its value
 
 * Call `compile()` to compile the `kernel_bundle` into `object` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` and read it from the compiled bundle.
+==== Set the value in a `kernel_bundle` and read it from the compiled bundle.
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -329,7 +345,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` twice and read it from the compiled bundle.
+==== Set the value in a `kernel_bundle` twice and read it from the compiled bundle.
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -339,7 +355,7 @@ All of the following basic tests have these initial steps:
    value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a linked `kernel_bundle` without writing its value
+==== Read a spec constant from a linked `kernel_bundle` without writing its value
 
 * Call `compile()` and then `link` to compile and link the `kernel_bundle` into
   `executable` state.
@@ -347,7 +363,7 @@ All of the following basic tests have these initial steps:
   default value.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` and read it from the linked bundle.
+==== Set the value in a `kernel_bundle` and read it from the linked bundle.
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -357,7 +373,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` twice and read it from the linked bundle.
+==== Set the value in a `kernel_bundle` twice and read it from the linked bundle.
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -368,14 +384,14 @@ All of the following basic tests have these initial steps:
    value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a built `kernel_bundle` without writing its value
+==== Read a spec constant from a built `kernel_bundle` without writing its value
 
 * Call `build()` to build the `kernel_bundle` into `executable` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` and read it from the built bundle
+==== Set the value in a `kernel_bundle` and read it from the built bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -384,7 +400,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` twice and read it from the built bundle
+==== Set the value in a `kernel_bundle` twice and read it from the built bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -394,7 +410,7 @@ All of the following basic tests have these initial steps:
    value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` and read it from the joined bundle
+==== Set the value in a `kernel_bundle` and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -403,7 +419,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` twice and read it from the joined bundle
+==== Set the value in a `kernel_bundle` twice and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -413,7 +429,7 @@ All of the following basic tests have these initial steps:
    value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle`, compile and read it from the joined bundle
+==== Set the value in a `kernel_bundle`, compile and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -423,7 +439,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` twice, compile and read it from the joined bundle
+==== Set the value in a `kernel_bundle` twice, compile and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -434,7 +450,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle`, build and read it from the joined bundle
+==== Set the value in a `kernel_bundle`, build and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -444,7 +460,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a `kernel_bundle` twice, build and read it from the joined bundle
+==== Set the value in a `kernel_bundle` twice, build and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -455,7 +471,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a kernel without writing its value
+==== Read a spec constant from a kernel without writing its value
 
 * Call `build()` to build the `kernel_bundle` into `executable` state.
 * Register the bundle with a handler via `use_kernel_bundle()`.
@@ -464,7 +480,7 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure we get the
    default value back.
 
-#### Set the value in a `kernel_bundle` and read it from a kernel
+==== Set the value in a `kernel_bundle` and read it from a kernel
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -474,7 +490,7 @@ All of the following basic tests have these initial steps:
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 
-#### Set the value in a `kernel_bundle` twice and read it from a kernel
+==== Set the value in a `kernel_bundle` twice and read it from a kernel
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -485,7 +501,7 @@ All of the following basic tests have these initial steps:
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
    value back.
 
-#### Set the value in a `kernel_bundle` and read it twice from a kernel
+==== Set the value in a `kernel_bundle` and read it twice from a kernel
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -496,9 +512,9 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure that each time
   we get the value that was written.
 
-### Check expected exceptions
+=== Check expected exceptions
 
-#### Try to get specialization constant via handler that bound to a `kernel_bundle`
+==== Try to get specialization constant via handler that bound to a `kernel_bundle`
 
 * Create a `queue` from the tested device and call `queue::submit()`.
 * Call `build()` to build the `kernel_bundle` into `executable` state.
@@ -506,7 +522,7 @@ All of the following basic tests have these initial steps:
 * Try to call `handler::get_specialization_constant()`
 * Catch exception and make sure it's with the `errc::invalid` error code.
 
-#### Try to set specialization constant via handler that bound to a `kernel_bundle`
+==== Try to set specialization constant via handler that bound to a `kernel_bundle`
 
 * Create a `queue` from the tested device and call `queue::submit()`.
 * Call `build()` to build the `kernel_bundle` into `executable` state.
@@ -514,13 +530,12 @@ All of the following basic tests have these initial steps:
 * Try to call `handler::set_specialization_constant()`.
 * Catch exception and make sure it's with the `errc::invalid` error code.
 
-### Tests which are not run for all types
+=== Tests which are not run for all types
 
-The following tests are not run for each of the types defined above under
-"Specialization constant types".  Instead, each of these tests specifies the
-type of the specialization constant.
+The following tests are not run for each of the types defined in <<sec:types>>.
+Instead, each of these tests specifies the type of the specialization constant.
 
-#### Class with a member function that accesses members
+==== Class with a member function that accesses members
 
 * Declare a type that is a class with at least one member variable and a member
   function which accesses that member variable.  For example:

--- a/test_plans/spec-constants.asciidoc
+++ b/test_plans/spec-constants.asciidoc
@@ -345,6 +345,33 @@ and perform this test:
   - Call `build()` to build the `kernel_bundle` into `executable` state.
   - Register the bundle with a handler via `use_kernel_bundle()`.
 
+[[sec:internal-linkage]]
+=== Spec constants with same name and internal linkage
+
+* In one translation unit:
+  - Define a `specialization_id` variable in the global namespace for the
+    tested type.  The variable must have internal linkage.
+* In a second translation unit:
+  - Define a `specialization_id` variable in the global namespace for the
+    tested type.  The variable must have internal linkage, and it's name must
+    be the same as the variable in the first translation unit.
+* In both translation units:
+  - Create a `queue` from the tested device and call `queue::submit()`.
+  - Set the spec constant to some value via
+    `handler::set_specialization_constant()`.  The value must be different in
+    each translation unit.
+  - Submit a kernel via `handler::single_task()`.
+  - Read the value of the spec constant via
+    `kernel_handler::get_specialization_constant()` and make sure we get its
+    value back.
+
+=== Spec constants with same name and internal linkage in `kernel_bundle`
+
+* Same test as in <<sec:internal-linkage>>, except:
+  - Set spec constants in a `kernel_bundle`.
+  - Call `build()` to build the `kernel_bundle` into `executable` state.
+  - Register the bundle with a handler via `use_kernel_bundle()`.
+
 === Basic tests with `kernel_bundle` for all kernel bundle states
 
 All of the following basic tests have these initial steps:

--- a/test_plans/spec-constants.md
+++ b/test_plans/spec-constants.md
@@ -1,7 +1,10 @@
 # Test plan for specialization constants
 
 This is a test plan for the APIs described in SYCL 2020 section 4.9.5.
-"Specialization constants".
+"Specialization constants" and for the
+`kernel_bundle::set_specialization_constant()` and
+`kernel_bundle::get_specialization_constant()` APIs that are described
+in section 4.11.12.2. "Specialization constant support".
 
 ## Testing scope
 
@@ -436,12 +439,9 @@ All of the following basic tests have these initial steps:
   `kernel_bundle::set_specialization_constant()`.
 * Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
 * Submit a kernel via `handler::single_task()`.
-* Read the value of the spec constant via
-  `kernel_handler::get_specialization_constant()` and make sure we get the
-   default value back.
 * Read the value of the spec constant twice via
   `kernel_handler::get_specialization_constant()` and make sure that each time
-  we get that value that was written.
+  we get the value that was written.
 
 ### Check expected exceptions
 
@@ -451,7 +451,7 @@ All of the following basic tests have these initial steps:
 * Create and build a kernel_bundle, register the bundle with a handler
   via `use_kernel_bundle()`.
 * Try to call `handler::get_specialization_constant()`
-* Catch exception and make sure it's with the errc::invalid error code.
+* Catch exception and make sure it's with the `errc::invalid` error code.
 
 #### Try to set specialization constant via handler that bound to a kernel_bundle
 
@@ -459,4 +459,4 @@ All of the following basic tests have these initial steps:
 * Create and build a kernel_bundle, register the bundle with a handler
   via `use_kernel_bundle()`.
 * Try to call `handler::set_specialization_constant()`.
-* Catch exception and make sure it's with the errc::invalid error code.
+* Catch exception and make sure it's with the `errc::invalid` error code.

--- a/test_plans/spec-constants.md
+++ b/test_plans/spec-constants.md
@@ -65,7 +65,7 @@ In addition, if the device has `aspect::fp16`, the following types are tested:
 
 ## Tests
 
-### Basic tests
+### Basic tests with handler
 
 All of the following basic tests have these initial steps:
 
@@ -175,6 +175,11 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure we get the
   expected value from each (either the value we set or the default value).
 
+### Multiple spec constants with kernel_bundle
+
+* Same test as above, except set spec constants in a kernel_bundle,
+  build the bundle and register the bundle with a handler.
+
 ### Two command groups that read the same spec constant, both set value
 
 * Declare a `specialization_id` variable in the global namespace for the
@@ -231,6 +236,11 @@ The test that is performed is:
   `kernel_handler::get_specialization_constant()` and make sure we get the same
    value back.
 
+### Spec constant defined in various ways and set via kernel_bundle
+
+* Same test as above, except set spec constants in a kernel_bundle,
+  build the bundle and register the bundle with a handler.
+
 ### Spec constant defined in another translation unit
 
 * In one translation unit:
@@ -245,3 +255,208 @@ The test that is performed is:
   - Read the value of the spec constant via
     `kernel_handler::get_specialization_constant()` and make sure we get the
     same value back.
+
+### Spec constant defined in another translation unit and set via kernel_bundle
+
+* Same test as above, except set spec constants in a kernel_bundle,
+  build the bundle and register the bundle with a handler.
+
+### Basic tests with kernel_bundle
+
+All of the following basic tests have these initial steps:
+
+* Declare a `specialization_id` variable in the global namespace for the
+  tested type.  The variable's default value has some non-zero value.
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Create `kernel_bundle` with `State` == `bundle_state::input`.
+
+#### Read a spec constant from a kernel_bundle without writing its value
+
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the
+  default value.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle and then read it from the same bundle.
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
+  value back.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle twice and then read it from the same bundle.
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Set the value again to a different value.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
+   value back.
+* No kernel is submitted.
+
+#### Read a spec constant from a compiled kernel_bundle without writing its value
+
+* Compile kernel_bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the
+  default value.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle and read it from the compiled bundle.
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Compile kernel_bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
+  value back.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle twice and read it from the compiled bundle.
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Set the value again to a different value.
+* Compile kernel_bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
+   value back.
+* No kernel is submitted.
+
+#### Read a spec constant from a linked kernel_bundle without writing its value
+
+* Compile and link kernel_bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the
+  default value.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle and read it from the linked bundle.
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Compile and link kernel_bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
+  value back.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle twice and read it from the linked bundle.
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Set the value again to a different value.
+* Compile and link kernel_bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
+   value back.
+* No kernel is submitted.
+
+#### Read a spec constant from a built kernel_bundle without writing its value
+
+* Build the bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the
+  default value.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle and read it from the built bundle
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Build the bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
+  value back.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle twice and read it from the built bundle
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Set the value again to a different value.
+* Build the bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
+   value back.
+* No kernel is submitted.
+
+#### Read a spec constant from a joined kernel_bundle without writing its value
+
+* Join bundle with another bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the
+  default value.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle and read it from the joined bundle
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Join bundle with another bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
+  value back.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle twice and read it from the joined bundle
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Set the value again to a different value.
+* Join bundle with another bundle
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
+   value back.
+* No kernel is submitted.
+
+#### Read a spec constant from a kernel without writing its value
+
+* Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the
+   default value back.
+
+#### Set the value in a kernel_bundle and read it from a kernel
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the
+   default value back.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
+  value back.
+
+#### Set the value in a kernel_bundle twice and read it from a kernel
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Set the value again to a different value.
+* Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the
+   default value back.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
+   value back.
+
+#### Set the value in a kernel_bundle and read it twice from a kernel
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the
+   default value back.
+* Read the value of the spec constant twice via
+  `kernel_handler::get_specialization_constant()` and make sure that each time
+  we get that value that was written.
+
+### Check expected exceptions
+
+#### Try to get specialization constant via handler that bound to a kernel_bundle
+
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Create and build a kernel_bundle, register the bundle with a handler
+  via `use_kernel_bundle()`.
+* Try to call `handler::get_specialization_constant()`
+* Catch exception and make sure it's with the errc::invalid error code.
+
+#### Try to set specialization constant via handler that bound to a kernel_bundle
+
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Create and build a kernel_bundle, register the bundle with a handler
+  via `use_kernel_bundle()`.
+* Try to call `handler::set_specialization_constant()`.
+* Catch exception and make sure it's with the errc::invalid error code.

--- a/test_plans/spec-constants.md
+++ b/test_plans/spec-constants.md
@@ -15,8 +15,9 @@ is selected on the CTS command line.
 
 ### Specialization constant types
 
-All of tests described below are performed using each of the following
-types as the underlying type of a `specialization_id` variable.
+All of tests described below (with the exception of those tests described under
+"Tests which are not run for all types") are performed using each of the
+following types as the underlying type of a `specialization_id` variable.
 
 * `char`
 * `signed char`
@@ -47,9 +48,8 @@ types as the underlying type of a `specialization_id` variable.
   and `dim` is `2`, `5`, and `10`.
 * A user-defined struct with several scalar member variables, no constructor,
   destructor or member functions.
-* A user-defined class with several scalar member variables, a user-defined
-  default constructor, and some member functions that modify the member
-  variables.
+* A user-defined class with several scalar member variables and a user-defined
+  default constructor.
 * A user-defined class with several scalar member variables, a deleted default
   constructor, and a user-defined (non-default) constructor.
 
@@ -460,3 +460,35 @@ All of the following basic tests have these initial steps:
   via `use_kernel_bundle()`.
 * Try to call `handler::set_specialization_constant()`.
 * Catch exception and make sure it's with the `errc::invalid` error code.
+
+### Tests which are not run for all types
+
+The following tests are not run for each of the types defined above under
+"Specialization constant types".  Instead, each of these tests specifies the
+type of the specialization constant.
+
+#### Class with a member function that accesses members
+
+* Declare a type that is a class with at least one member variable and a member
+  function which accesses that member variable.  For example:
+
+```
+struct myType {
+  int a, b;
+  constexpr myType(int a, int b) : a(a), b(b) {}
+  int calculate(int c) const { return a * b * c; }
+};
+```
+
+* Declare a `specialization_id` variable templated on that type in the global
+  namespace.
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Set the value of the spec constant via
+  `handler::set_specialization_constant()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()`.  This will return an object
+  of the tested type (i.e. `myType`).
+* Call the member function on that object (i.e. `myType::calculate()`).
+* Verify the return value of the member function to make sure it executed
+  correctly.

--- a/test_plans/spec-constants.md
+++ b/test_plans/spec-constants.md
@@ -264,14 +264,15 @@ The test that is performed is:
 * Same test as above, except set spec constants in a kernel_bundle,
   build the bundle and register the bundle with a handler.
 
-### Basic tests with kernel_bundle
+### Basic tests with kernel_bundle for all kernel bundle states
 
 All of the following basic tests have these initial steps:
 
 * Declare a `specialization_id` variable in the global namespace for the
   tested type.  The variable's default value has some non-zero value.
 * Create a `queue` from the tested device and call `queue::submit()`.
-* Create `kernel_bundle` with `State` == `bundle_state::input`.
+* Create `kernel_bundle` using all kernel bundle states
+  `State` == (`bundle_state::input`, `bundle_state::object`, `bundle_state::executable`)
 
 #### Read a spec constant from a kernel_bundle without writing its value
 
@@ -279,7 +280,23 @@ All of the following basic tests have these initial steps:
   default value.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle and then read it from the same bundle.
+#### Read a spec constant from a joined kernel_bundle without writing its value
+
+* Join bundle with another bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the
+  default value.
+* No kernel is submitted.
+
+### Tests for with kernel_bundle specific to bundle_state::input
+
+All of the following basic tests have these initial steps:
+
+* Declare a `specialization_id` variable in the global namespace for the
+  tested type.  The variable's default value has some non-zero value.
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Create `kernel_bundle` with`State` == `bundle_state::input`.
+
+#### Set the value in a kernel_bundle and then read it from the same bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -287,7 +304,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle twice and then read it from the same bundle.
+#### Set the value in a kernel_bundle twice and then read it from the same bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -374,13 +391,6 @@ All of the following basic tests have these initial steps:
    value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a joined kernel_bundle without writing its value
-
-* Join bundle with another bundle.
-* Call `kernel_bundle::get_specialization_constant()` and make sure we get the
-  default value.
-* No kernel is submitted.
-
 #### Set the value in a kernel_bundle and read it from the joined bundle
 
 * Set the value of the spec constant via
@@ -400,6 +410,48 @@ All of the following basic tests have these initial steps:
    value back.
 * No kernel is submitted.
 
+#### Set the value in a kernel_bundle, compile and read it from the joined bundle
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Compile kernel_bundle.
+* Join bundle with another bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
+  value back.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle twice, compile and read it from the joined bundle
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Set the value again to a different value.
+* Compile kernel_bundle.
+* Join bundle with another bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
+  value back.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle, build and read it from the joined bundle
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Build kernel_bundle.
+* Join bundle with another bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
+  value back.
+* No kernel is submitted.
+
+#### Set the value in a kernel_bundle twice, build and read it from the joined bundle
+
+* Set the value of the spec constant via
+  `kernel_bundle::set_specialization_constant()`.
+* Set the value again to a different value.
+* Build kernel_bundle.
+* Join bundle with another bundle.
+* Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
+  value back.
+* No kernel is submitted.
+
 #### Read a spec constant from a kernel without writing its value
 
 * Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
@@ -414,9 +466,6 @@ All of the following basic tests have these initial steps:
   `kernel_bundle::set_specialization_constant()`.
 * Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
 * Submit a kernel via `handler::single_task()`.
-* Read the value of the spec constant via
-  `kernel_handler::get_specialization_constant()` and make sure we get the
-   default value back.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 
@@ -427,9 +476,6 @@ All of the following basic tests have these initial steps:
 * Set the value again to a different value.
 * Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`
 * Submit a kernel via `handler::single_task()`.
-* Read the value of the spec constant via
-  `kernel_handler::get_specialization_constant()` and make sure we get the
-   default value back.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
    value back.
 

--- a/test_plans/spec-constants.md
+++ b/test_plans/spec-constants.md
@@ -1,0 +1,219 @@
+# Test plan for specialization constants
+
+This is a test plan for the APIs described in SYCL 2020 section 4.9.5.
+"Specialization constants".
+
+## Testing scope
+
+### Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line.
+
+### Specialization constant types
+
+All of tests described below are performed using each of the following
+types as the underlying type of a `specialization_id` variable.
+
+* `char`
+* `signed char`
+* `unsigned char`
+* `short int`
+* `unsigned short int`
+* `int`
+* `unsigned int`
+* `long int`
+* `unsigned long int`
+* `long long int`
+* `unsigned long long int`
+* `float`
+* `bool`
+* `std::byte`
+* `std::int8_t`
+* `std::int16_t`
+* `std::int32_t`
+* `std::int64_t`
+* `std::uint8_t`
+* `std::uint16_t`
+* `std::uint32_t`
+* `std::uint64_t`
+* `std::size_t`
+* `vec<T, int dim>` where `T` is each of the scalar types listed above except
+   for `bool` and `dim` is `1`, `2`, `3`, `4`, `8`, and `16`.
+* `marray<T, size_t dim>` where `T` is each of the scalar types listed above
+  and `dim` is `2`, `5`, and `10`.
+* A user-defined struct with several scalar fields.
+
+In addition, if the device has `aspect::fp64`, the following types are tested:
+
+* `double`
+* `vec<double, int dim>` where `dim` is `1`, `2`, `3`, `4`, `8`, and `16`.
+* `marray<double, size_t dim>` where `dim` is `2`, `5`, and `10`.
+
+In addition, if the device has `aspect::fp16`, the following types are tested:
+
+* `sycl::half`
+* `vec<sycl::half, int dim>` where `dim` is `1`, `2`, `3`, `4`, `8`, and `16`.
+* `marray<sycl::half, size_t dim>` where `dim` is `2`, `5`, and `10`.
+
+
+## Tests
+
+### Basic tests
+
+All of the following basic tests have these initial steps:
+
+* Declare a `specialization_id` variable in the global namespace for the
+  tested type.  The variable's default value has some non-zero value.
+* Create a `queue` from the tested device and call `queue::submit()`.
+
+#### Read a spec constant from a handler without writing its value
+
+* Call `handler::get_specialization_constant()` and make sure we get the
+  default value.
+* No kernel is submitted.
+
+#### Write and read a spec constant from a handler
+
+* Set the value of the spec constant via
+  `handler::set_specialization_constant()`.
+* Call `handler::get_specialization_constant()` and make sure we get the same
+  value back.
+* No kernel is submitted.
+
+#### Write the value twice from a handler and make sure we read the second value
+
+* Set the value of the spec constant via
+  `handler::set_specialization_constant()`.
+* Set the value again to a different value.
+* Call `handler::get_specialization_constant()` and make sure we get the second
+  value back.
+* No kernel is submitted.
+
+#### Read a spec constant from a kernel without writing its value
+
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the
+   default value back.
+
+#### Write the value from a handler and read it from a kernel
+
+* Set the value of the spec constant via
+  `handler::set_specialization_constant()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the same
+   value back.
+
+#### Write the value twice from a handler and read it from a kernel
+
+* Set the value of the spec constant via
+  `handler::set_specialization_constant()`.
+* Set the value again to a different value.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the second
+   value back.
+
+### Multiple spec constants
+
+* Declare several `specialization_id` variables of the tested type in the
+  global namespace.  All the default values are different and none are zero.
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Set the values of some of the spec constants via
+  `handler::set_specialization_constant()` but do not set the values for all of
+  them.
+* Submit a kernel via `handler::single_task()`.
+* Read the values of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the
+  expected value from each (either the value we set or the default value).
+
+### Two command groups that read the same spec constant, both set value
+
+* Declare a `specialization_id` variable in the global namespace for the
+  tested type.  The variable's default value has some non-zero value.
+* Declare a single object whose type is a class with `operator(handler &)`.
+  This object will be the command group handler for our test.
+* Create a `queue` from the tested device and call `queue::submit()` twice.
+  Each call passes the same command group handler object described above.
+* Each command group handler sets the value of the spec constant to a
+  different value.
+* Each command group handler submits a kernel via `handler::single_task()`.
+* Each kernel reads the spec constant via
+  `kernel_handler::get_specialization_constant()`.
+* Verify that the value read in the kernel is the same as the value set in
+  the command group handler which launched that kernel instance.
+* The two kernels should run in parallel for this test.
+
+### Two command groups that read the same spec constant, only one sets value
+
+Same test as above except only one of the command group handlers sets the value
+of the spec constant.  The kernel instance that is launched from the handler
+that does not set a value should read the spec constant's default value.
+
+### Spec constant defined in various ways
+
+Do the following test for a `specialization_id` variable defined in the
+following ways:
+
+* Defined in a non-global namespace.
+* Defined in the global namespace as `const`.
+* Defined in the global namespace as `constexpr`.
+* Defined in the global namespace as `inline`.
+* Defined in the global namespace as `inline const`.
+* Defined in the global namespace as `inline constexpr`.
+* A static member variable of a struct in the global namespace.
+* A static member variable of a struct in a non-global namespace.
+* A static member variable declared `const` of a struct in the global namespace.
+* A static member variable declared `constexpr` of a struct in the global
+  namespace.
+* A static member variable declared `inline` of a struct in the global
+  namespace.
+* A static member variable declared `inline const` of a struct in the global
+  namespace.
+* A static member variable declared `inline constexpr` of a struct in the global
+  namespace.
+
+The test that is performed is:
+
+* Create a `queue` from the tested device and call `queue::submit()`.
+* Set the value of the spec constant via
+  `handler::set_specialization_constant()`.
+* Submit a kernel via `handler::single_task()`.
+* Read the value of the spec constant via
+  `kernel_handler::get_specialization_constant()` and make sure we get the same
+   value back.
+
+### Spec constant defined in another translation unit
+
+* In one translation unit:
+  - Define a `specialization_id` variable in the global namespace for the
+    tested type.  The variable's default value has some non-zero value.
+* In a second translation unit:
+  - Declare an external reference to the `specialization_id` variable.
+  - Create a `queue` from the tested device and call `queue::submit()`.
+  - Set the value of the spec constant via
+    `handler::set_specialization_constant()`.
+  - Submit a kernel via `handler::single_task()`.
+  - Read the value of the spec constant via
+    `kernel_handler::get_specialization_constant()` and make sure we get the
+    same value back.
+
+### Spec constant defined and set in another translation unit
+
+* This test runs only if the implementation defines `SYCL_EXTERNAL`.
+* In one translation unit:
+  - Define a `specialization_id` variable in the global namespace for the
+    tested type.  The variable's default value has some non-zero value.
+  - Create a `queue` from the tested device and call `queue::submit()`.
+  - Set the value of the spec constant via
+    `handler::set_specialization_constant()`.
+  - Submit a kernel via `handler::single_task()`.  The kernel is declared
+    `SYCL_EXTERNAL`.
+* In a second translation unit:
+  - Declare an external reference to the `specialization_id` variable.
+  - Define the kernel which is declared `SYCL_EXTERNAL` above.
+  - Read the value of the spec constant via
+    `kernel_handler::get_specialization_constant()` and make sure we get the
+    value we set in the first translation unit.

--- a/test_plans/spec-constants.md
+++ b/test_plans/spec-constants.md
@@ -178,9 +178,9 @@ All of the following basic tests have these initial steps:
   `kernel_handler::get_specialization_constant()` and make sure we get the
   expected value from each (either the value we set or the default value).
 
-### Multiple spec constants with kernel_bundle
+### Multiple spec constants with `kernel_bundle`
 
-* Same test as above, except set spec constants in a kernel_bundle,
+* Same test as above, except set spec constants in a `kernel_bundle`,
   build the bundle and register the bundle with a handler.
 
 ### Two command groups that read the same spec constant, both set value
@@ -239,9 +239,9 @@ The test that is performed is:
   `kernel_handler::get_specialization_constant()` and make sure we get the same
    value back.
 
-### Spec constant defined in various ways and set via kernel_bundle
+### Spec constant defined in various ways and set via `kernel_bundle`
 
-* Same test as above, except set spec constants in a kernel_bundle,
+* Same test as above, except set spec constants in a `kernel_bundle`,
   build the bundle and register the bundle with a handler.
 
 ### Spec constant defined in another translation unit
@@ -259,12 +259,12 @@ The test that is performed is:
     `kernel_handler::get_specialization_constant()` and make sure we get the
     same value back.
 
-### Spec constant defined in another translation unit and set via kernel_bundle
+### Spec constant defined in another translation unit and set via `kernel_bundle`
 
-* Same test as above, except set spec constants in a kernel_bundle,
+* Same test as above, except set spec constants in a `kernel_bundle`,
   build the bundle and register the bundle with a handler.
 
-### Basic tests with kernel_bundle for all kernel bundle states
+### Basic tests with `kernel_bundle` for all kernel bundle states
 
 All of the following basic tests have these initial steps:
 
@@ -274,20 +274,20 @@ All of the following basic tests have these initial steps:
 * Create `kernel_bundle` using all kernel bundle states
   `State` == (`bundle_state::input`, `bundle_state::object`, `bundle_state::executable`)
 
-#### Read a spec constant from a kernel_bundle without writing its value
+#### Read a spec constant from a `kernel_bundle` without writing its value
 
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-#### Read a spec constant from a joined kernel_bundle without writing its value
+#### Read a spec constant from a joined `kernel_bundle` without writing its value
 
 * Join bundle with another bundle.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-### Tests for with kernel_bundle specific to bundle_state::input
+### Tests for with `kernel_bundle` specific to `bundle_state::input`
 
 All of the following basic tests have these initial steps:
 
@@ -296,7 +296,7 @@ All of the following basic tests have these initial steps:
 * Create a `queue` from the tested device and call `queue::submit()`.
 * Create `kernel_bundle` with`State` == `bundle_state::input`.
 
-#### Set the value in a kernel_bundle and then read it from the same bundle
+#### Set the value in a `kernel_bundle` and then read it from the same bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -304,7 +304,7 @@ All of the following basic tests have these initial steps:
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle twice and then read it from the same bundle
+#### Set the value in a `kernel_bundle` twice and then read it from the same bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
@@ -313,177 +313,184 @@ All of the following basic tests have these initial steps:
    value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a compiled kernel_bundle without writing its value
+#### Read a spec constant from a compiled `kernel_bundle` without writing its value
 
-* Compile kernel_bundle.
+* Call `compile()` to compile the `kernel_bundle` into `object` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle and read it from the compiled bundle.
+#### Set the value in a `kernel_bundle` and read it from the compiled bundle.
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
-* Compile kernel_bundle.
+* Call `compile()` to compile the `kernel_bundle` into `object` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle twice and read it from the compiled bundle.
+#### Set the value in a `kernel_bundle` twice and read it from the compiled bundle.
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
 * Set the value again to a different value.
-* Compile kernel_bundle.
+* Call `compile()` to compile the `kernel_bundle` into `object` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
    value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a linked kernel_bundle without writing its value
+#### Read a spec constant from a linked `kernel_bundle` without writing its value
 
-* Compile and link kernel_bundle.
+* Call `compile()` and then `link` to compile and link the `kernel_bundle` into
+  `executable` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle and read it from the linked bundle.
+#### Set the value in a `kernel_bundle` and read it from the linked bundle.
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
-* Compile and link kernel_bundle.
+* Call `compile()` and then `link` to compile and link the `kernel_bundle` into
+  `executable` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle twice and read it from the linked bundle.
+#### Set the value in a `kernel_bundle` twice and read it from the linked bundle.
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
 * Set the value again to a different value.
-* Compile and link kernel_bundle.
+* Call `compile()` and then `link` to compile and link the `kernel_bundle` into
+  `executable` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
    value back.
 * No kernel is submitted.
 
-#### Read a spec constant from a built kernel_bundle without writing its value
+#### Read a spec constant from a built `kernel_bundle` without writing its value
 
-* Build the bundle.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the
   default value.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle and read it from the built bundle
+#### Set the value in a `kernel_bundle` and read it from the built bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
-* Build the bundle.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle twice and read it from the built bundle
+#### Set the value in a `kernel_bundle` twice and read it from the built bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
 * Set the value again to a different value.
-* Build the bundle.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
    value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle and read it from the joined bundle
+#### Set the value in a `kernel_bundle` and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
-* Join bundle with another bundle.
+* Call `join()` to join the bundle with another `input` bundle.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle twice and read it from the joined bundle
+#### Set the value in a `kernel_bundle` twice and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
 * Set the value again to a different value.
-* Join bundle with another bundle
+* Call `join()` to join the bundle with another `input` bundle.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
    value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle, compile and read it from the joined bundle
+#### Set the value in a `kernel_bundle`, compile and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
-* Compile kernel_bundle.
-* Join bundle with another bundle.
+* Call `compile()` to compile the `kernel_bundle` into `object` state.
+* Call `join()` to join the bundle with another `object` bundle.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle twice, compile and read it from the joined bundle
+#### Set the value in a `kernel_bundle` twice, compile and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
 * Set the value again to a different value.
-* Compile kernel_bundle.
-* Join bundle with another bundle.
+* Call `compile()` to compile the `kernel_bundle` into `object` state.
+* Join bundle with another `object` bundle.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle, build and read it from the joined bundle
+#### Set the value in a `kernel_bundle`, build and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
-* Build kernel_bundle.
-* Join bundle with another bundle.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Join bundle with another `executable` bundle.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 * No kernel is submitted.
 
-#### Set the value in a kernel_bundle twice, build and read it from the joined bundle
+#### Set the value in a `kernel_bundle` twice, build and read it from the joined bundle
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
 * Set the value again to a different value.
-* Build kernel_bundle.
-* Join bundle with another bundle.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Join bundle with another `executable` bundle.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
   value back.
 * No kernel is submitted.
 
 #### Read a spec constant from a kernel without writing its value
 
-* Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Register the bundle with a handler via `use_kernel_bundle()`.
 * Submit a kernel via `handler::single_task()`.
 * Read the value of the spec constant via
   `kernel_handler::get_specialization_constant()` and make sure we get the
    default value back.
 
-#### Set the value in a kernel_bundle and read it from a kernel
+#### Set the value in a `kernel_bundle` and read it from a kernel
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
-* Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Register the bundle with a handler via `use_kernel_bundle()`.
 * Submit a kernel via `handler::single_task()`.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the same
   value back.
 
-#### Set the value in a kernel_bundle twice and read it from a kernel
+#### Set the value in a `kernel_bundle` twice and read it from a kernel
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
 * Set the value again to a different value.
-* Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Register the bundle with a handler via `use_kernel_bundle()`
 * Submit a kernel via `handler::single_task()`.
 * Call `kernel_bundle::get_specialization_constant()` and make sure we get the second
    value back.
 
-#### Set the value in a kernel_bundle and read it twice from a kernel
+#### Set the value in a `kernel_bundle` and read it twice from a kernel
 
 * Set the value of the spec constant via
   `kernel_bundle::set_specialization_constant()`.
-* Build a kernel_bundle, register the bundle with a handler via `use_kernel_bundle()`.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Register the bundle with a handler via `use_kernel_bundle()`.
 * Submit a kernel via `handler::single_task()`.
 * Read the value of the spec constant twice via
   `kernel_handler::get_specialization_constant()` and make sure that each time
@@ -491,19 +498,19 @@ All of the following basic tests have these initial steps:
 
 ### Check expected exceptions
 
-#### Try to get specialization constant via handler that bound to a kernel_bundle
+#### Try to get specialization constant via handler that bound to a `kernel_bundle`
 
 * Create a `queue` from the tested device and call `queue::submit()`.
-* Create and build a kernel_bundle, register the bundle with a handler
-  via `use_kernel_bundle()`.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Register the bundle with a handler via `use_kernel_bundle()`.
 * Try to call `handler::get_specialization_constant()`
 * Catch exception and make sure it's with the `errc::invalid` error code.
 
-#### Try to set specialization constant via handler that bound to a kernel_bundle
+#### Try to set specialization constant via handler that bound to a `kernel_bundle`
 
 * Create a `queue` from the tested device and call `queue::submit()`.
-* Create and build a kernel_bundle, register the bundle with a handler
-  via `use_kernel_bundle()`.
+* Call `build()` to build the `kernel_bundle` into `executable` state.
+* Register the bundle with a handler via `use_kernel_bundle()`.
 * Try to call `handler::set_specialization_constant()`.
 * Catch exception and make sure it's with the `errc::invalid` error code.
 


### PR DESCRIPTION
We are starting to write test pans for SYCL 2020 features before
writing actual conformance tests.  This is at an example test plan,
which serves as an example plan and also describes the tests needed
for the specialization constant API.