### PR TITLE
Improve test coverage for nd_item and group range, id and subscripts

### DIFF
--- a/tests/nd_item/nd_item_api.cpp
+++ b/tests/nd_item/nd_item_api.cpp
@@ -8,7 +8,7 @@
 
 #include "../common/common.h"
 
-#define TEST_NAME nd_item
+#define TEST_NAME nd_item_api
 
 namespace test_nd_item__ {
 using namespace sycl_cts;
@@ -80,19 +80,29 @@ class kernel_nd_item {
 
     /* test range*/
     cl::sycl::range<dimensions> globalRange = myitem.get_global_range();
+    size_t global_ranges[dimensions];
 
     size_t globalIndex = getIndex(global_id, globalRange);
+    if (m_globalID[global_id] != globalIndex) {
+      failed = true;
+    }
     for (int i = 0; i < dimensions; ++i) {
-      if (m_globalID[global_id] != globalIndex) {
+      global_ranges[i] = myitem.get_global_range(i);
+      if (global_ranges[i] != globalRange.get(i)) {
         failed = true;
       }
     }
 
     cl::sycl::range<dimensions> localRange = myitem.get_local_range();
+    size_t local_ranges[dimensions];
 
     size_t localIndex = getIndex(local_id, localRange);
+    if (m_localID[local_id] != localIndex) {
+      failed = true;
+    }
     for (int i = 0; i < dimensions; ++i) {
-      if (m_localID[local_id] != localIndex) {
+      local_ranges[i] = myitem.get_local_range(i);
+      if (local_ranges[i] != localRange.get(i)) {
         failed = true;
       }
     }
@@ -141,6 +151,14 @@ class kernel_nd_item {
     size_t glid = myitem.get_global_linear_id();
     size_t llid = myitem.get_local_linear_id();
     size_t grlid = myitem.get_group_linear_id();
+    size_t groupIndex = getIndex(group_id.get_id(), myitem.get_group_range());
+
+    if (glid != globalIndex)
+      failed = true;
+    if (llid != localIndex)
+      failed = true;
+    if (grlid != groupIndex)
+      failed = true;
 
     /* write back success or failure*/
     m_o[global_id] = failed ? 0 : 1;


### PR DESCRIPTION
Changed test name nd_item to nd_item_api along with its file name
to allow it to be run separately from other nd_item tests.

Fixed gaps:
  - nd_item::get_global_range()
  - nd_item::get_local_range()
  - dimensions 1 and 2 for tests in group_api.cpp
  - added result verification for nd_item::get_*_linear_id()

Extra gaps fixed:
  - added return type verification for group_api calls

Not covered by this commit:
  - nd_item and group constructors and equality operators gaps
  - nd_item and group mem_fence() and barrier() gaps
  - nd_item and group async_work_group_copy() and wait_for() gaps
  - group::parallel_for_work_item()
 
Depends on PR: #80 
Commit to start review: b8e60f0 - "Improve test coverage for nd_item and group range, id and subscripts"