### PR TITLE
[SYCL-1.2.1][CMake] Fix fp-model flag on windows for Intel Compiler

### DIFF
--- a/cmake/FindIntel_SYCL.cmake
+++ b/cmake/FindIntel_SYCL.cmake
@@ -11,7 +11,13 @@ if(NOT DEFINED INTEL_SYCL_TRIPLE)
 endif()
 message("Intel SYCL target triple: ${INTEL_SYCL_TRIPLE}")
 
-set(INTEL_SYCL_FLAGS "-fsycl;-fsycl-targets=${INTEL_SYCL_TRIPLE};-sycl-std=121;-ffp-model=precise;${INTEL_SYCL_FLAGS}")
+if(WIN32)
+    set(INTEL_FP_FLAG "/fp:precise") # clang-cl fp flag for windows
+else()
+    set(INTEL_FP_FLAG "-ffp-model=precise")
+endif()
+
+set(INTEL_SYCL_FLAGS "-fsycl;-fsycl-targets=${INTEL_SYCL_TRIPLE};-sycl-std=121;${INTEL_FP_FLAG};${INTEL_SYCL_FLAGS}")
 message("Intel SYCL compiler flags: `${INTEL_SYCL_FLAGS}`")
 
 add_library(INTEL_SYCL::Runtime INTERFACE IMPORTED GLOBAL)

--- a/cmake/FindIntel_SYCL.cmake
+++ b/cmake/FindIntel_SYCL.cmake
@@ -11,13 +11,15 @@ if(NOT DEFINED INTEL_SYCL_TRIPLE)
 endif()
 message("Intel SYCL target triple: ${INTEL_SYCL_TRIPLE}")
 
+# Set precise fp-model for Intel Compiler
 if(WIN32)
-    set(INTEL_FP_FLAG "/fp:precise") # clang-cl fp flag for windows
+    set(INTEL_FP_FLAG "/fp:precise")
 else()
     set(INTEL_FP_FLAG "-ffp-model=precise")
 endif()
+set(CMAKE_CXX_FLAGS "${INTEL_FP_FLAG} ${CMAKE_CXX_FLAGS}")
 
-set(INTEL_SYCL_FLAGS "-fsycl;-fsycl-targets=${INTEL_SYCL_TRIPLE};-sycl-std=121;${INTEL_FP_FLAG};${INTEL_SYCL_FLAGS}")
+set(INTEL_SYCL_FLAGS "-fsycl;-fsycl-targets=${INTEL_SYCL_TRIPLE};-sycl-std=121;${INTEL_SYCL_FLAGS}")
 message("Intel SYCL compiler flags: `${INTEL_SYCL_FLAGS}`")
 
 add_library(INTEL_SYCL::Runtime INTERFACE IMPORTED GLOBAL)


### PR DESCRIPTION
Intel Compiler on windows accepts `/fp:keyword` for fp-model control,
instead of `-ffp-model=keyword`.

Signed-off-by: Yilong Guo <yilong.guo@intel.com>