### PR TITLE
Add fixed range construction helper

### DIFF
--- a/tests/common/get_cts_object.h
+++ b/tests/common/get_cts_object.h
@@ -176,6 +176,15 @@ struct get_cts_object::range<1> {
   static cl::sycl::range<1> get(size_t r0, size_t, size_t) {
     return cl::sycl::range<1>(r0);
   }
+  /**
+   * @brief Constructs a range<1> by only using total size given
+   * @tparam totalSize Value the size() call should return for the range
+   * @return range<1>
+   */
+  template <size_t totalSize>
+  static cl::sycl::range<1> get_fixed_size(size_t, size_t) {
+    return cl::sycl::range<1>(totalSize);
+  }
 };
 
 /**
@@ -191,6 +200,17 @@ struct get_cts_object::range<2> {
    */
   static cl::sycl::range<2> get(size_t r0, size_t r1, size_t) {
     return cl::sycl::range<2>(r0, r1);
+  }
+  /**
+   * @brief Constructs a range<2> by only using first component and the
+   *        total size given
+   * @tparam totalSize Value the size() call should return for the range
+   * @param r0 Value of the first component of the range
+   * @return range<2>
+   */
+  template <size_t totalSize>
+  static cl::sycl::range<2> get_fixed_size(size_t r0, size_t) {
+    return cl::sycl::range<2>(r0, totalSize / r0);
   }
 };
 
@@ -208,6 +228,18 @@ struct get_cts_object::range<3> {
    */
   static cl::sycl::range<3> get(size_t r0, size_t r1, size_t r2) {
     return cl::sycl::range<3>(r0, r1, r2);
+  }
+  /**
+   * @brief Constructs a range<3> by only using two components and the
+   *        total size given
+   * @tparam totalSize Value the size() call should return for the range
+   * @param r0 Value of the first component of the range
+   * @param r0 Value of the second component of the range
+   * @return range<3>
+   */
+  template <size_t totalSize>
+  static cl::sycl::range<3> get_fixed_size(size_t r0, size_t r1) {
+    return cl::sycl::range<3>(r0, r1, totalSize / r0 / r1);
   }
 };
 


### PR DESCRIPTION
We have tests where running multiple work-items used mainly to avoid
false-positives, running the same test N times. Barriers is an
example of such functionality.
When we extend such tests for multiple dimensions, it's reasonable to
run the same number of checks for different dimensionality. This
function allows us to easily provide custom ranges for different
dimensions, still using the same number of work-items.