### PR TITLE
[2020] Set CMake project language to CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # check CMake Version
 cmake_minimum_required(VERSION 3.13)
-project(sycl_cts)
+project(sycl_cts LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/cmake/FindIntel_SYCL.cmake
+++ b/cmake/FindIntel_SYCL.cmake
@@ -1,7 +1,5 @@
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
    ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    find_program(INTEL_SYCL_C_EXECUTABLE NAMES dpcpp clang HINTS ${INTEL_SYCL_ROOT}
-        PATH_SUFFIXES bin)
     find_program(INTEL_SYCL_CXX_EXECUTABLE NAMES dpcpp clang++ HINTS ${INTEL_SYCL_ROOT}
         PATH_SUFFIXES bin)
 else()
@@ -9,8 +7,6 @@ else()
     string(REPLACE "/machine:x64" "" CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
     # Remove /subsystem option which is not supported by clang-cl
     string(REPLACE "/subsystem:console" "" CMAKE_CREATE_CONSOLE_EXE ${CMAKE_CREATE_CONSOLE_EXE})
-    find_program(INTEL_SYCL_C_EXECUTABLE NAMES dpcpp clang-cl HINTS ${INTEL_SYCL_ROOT}
-        PATH_SUFFIXES bin)
     find_program(INTEL_SYCL_CXX_EXECUTABLE NAMES dpcpp clang-cl HINTS ${INTEL_SYCL_ROOT}
         PATH_SUFFIXES bin)
 endif()
@@ -47,10 +43,8 @@ else()
         INTERFACE_LINK_OPTIONS      "${INTEL_SYCL_FLAGS};-fsycl-device-code-split=per_source")
 endif()
 
-set(CMAKE_C_COMPILER            ${INTEL_SYCL_C_EXECUTABLE})
 set(CMAKE_CXX_COMPILER          ${INTEL_SYCL_CXX_EXECUTABLE})
 # Use SYCL compiler instead of default linker for building SYCL application
-set(CMAKE_C_LINK_EXECUTABLE     "${INTEL_SYCL_CXX_EXECUTABLE} <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
 set(CMAKE_CXX_LINK_EXECUTABLE   "${INTEL_SYCL_CXX_EXECUTABLE} <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
 
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)

--- a/cmake/FindhipSYCL.cmake
+++ b/cmake/FindhipSYCL.cmake
@@ -5,7 +5,6 @@ if(NOT SYCLCC_EXECUTABLE)
   message(SEND_ERROR "Could not find hipSYCL syclcc-clang compiler")
 endif()
 
-set(CMAKE_C_COMPILER    ${SYCLCC_EXECUTABLE})
 set(CMAKE_CXX_COMPILER  ${SYCLCC_EXECUTABLE})
 
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)


### PR DESCRIPTION
Same as #87, but for `SYCL-2020`. Actually there have been some changes to `FindIntel_SYCL.cmake` (e.g. in #76), so I had to adjust the patch slightly.