### PR TITLE
Add sycl = ::cl::sycl namespace alias

### DIFF
--- a/tests/common/sycl.h
+++ b/tests/common/sycl.h
@@ -21,4 +21,8 @@
 #include <CL/sycl.hpp>
 #endif
 
+// TODO: Switch to canonical <sycl/sycl.hpp> header
+// once CTS has been fully converted to ::sycl namespace
+namespace sycl = ::cl::sycl;
+
 #endif  // __SYCLCTS_TESTS_COMMON_H


### PR DESCRIPTION
SYCL 2020 introduces a new canonical namespace, `::sycl`, which is defined within the new `<sycl/sycl.hpp>` header. To ease the transition of the CTS to the new namespace, this creates an alias `sycl = cl::sycl`, while keeping the SYCL 1.2.1 header path `<CL/sycl.hpp>` for the time being.

For the record, I also tried going the reverse route, i.e., including `<sycl/sycl.hpp>`, and defining `namespace cl { namespace sycl = ::sycl; }`. However that didn't work, as DPC++ already exports that alias (while e.g. hipSYCL doesn't - the spec isn't super clear on this), and ComputeCpp 2.4 doesn't seem to support the new header at all.