### PR TITLE
Improve event_info tests

### DIFF
--- a/tests/event/event_info.cpp
+++ b/tests/event/event_info.cpp
@@ -13,9 +13,10 @@
 namespace TEST_NAMESPACE {
 
 using namespace sycl_cts;
+namespace sycl = cl::sycl;
 
-/** test the api for cl::sycl::event
-*/
+/** test the get_info and get_profiling_info apis for sycl::event
+ */
 class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
@@ -28,59 +29,93 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     try {
-      /** check cl::sycl::info::event_command_status
-      */
-      check_enum_class_value(cl::sycl::info::event_command_status::complete);
-      check_enum_class_value(cl::sycl::info::event_command_status::running);
-      check_enum_class_value(cl::sycl::info::event_command_status::submitted);
+      /** check sycl::info::event_command_status
+       */
+      check_enum_class_value(sycl::info::event_command_status::complete);
+      check_enum_class_value(sycl::info::event_command_status::running);
+      check_enum_class_value(sycl::info::event_command_status::submitted);
 
-      /** check cl::sycl::info::event
-      */
-      check_enum_class_value(cl::sycl::info::event::command_execution_status);
-      check_enum_class_value(cl::sycl::info::event::reference_count);
+      /** check sycl::info::event
+       */
+      check_enum_class_value(sycl::info::event::command_execution_status);
 
-      /** check cl::sycl::info::event_profiling
-      */
-      check_enum_class_value(cl::sycl::info::event_profiling::command_submit);
-      check_enum_class_value(cl::sycl::info::event_profiling::command_start);
-      check_enum_class_value(cl::sycl::info::event_profiling::command_end);
+      /** check sycl::info::event_profiling
+       */
+      check_enum_class_value(sycl::info::event_profiling::command_submit);
+      check_enum_class_value(sycl::info::event_profiling::command_start);
+      check_enum_class_value(sycl::info::event_profiling::command_end);
 
-      /** check get_info & get_profiling_info parameters
-      */
+      /** check get_info
+       */
       {
-        const cl::sycl::device_selector &selector = cts_selector();
-        static cts_async_handler asyncHandler;
-        cl::sycl::queue queue =
-            cl::sycl::queue(selector, asyncHandler,
-                            {cl::sycl::property::queue::enable_profiling()});
+        auto queue = util::get_cts_object::queue();
+        auto e1 = queue.submit(
+            [&](sycl::handler &cgh) { cgh.single_task(dummy_functor()); });
+        auto e2 = queue.submit([&](sycl::handler &cgh) {
+          cgh.depends_on(e1);
+          cgh.single_task(dummy_functor());
+        });
+        // Check that query returns the expected type.
+        check_get_info_param<sycl::info::event,
+                             sycl::info::event_command_status,
+                             sycl::info::event::command_execution_status>(log,
+                                                                          e2);
+        e2.wait();
+        // Since e2's CGF depends on e1, the latter must have completed by now.
+        const auto status =
+            e1.get_info<sycl::info::event::command_execution_status>();
+        if (status != sycl::info::event_command_status::complete) {
+          FAIL(log, "event returned unexpected command execution status");
+        }
+      }
 
-        cl::sycl::event event = queue.submit([&](cl::sycl::handler &handler) {
-          handler.single_task(dummy_functor<class TEST_NAME>());
+      /** check get_profiling_info
+       */
+      {
+        const sycl::device_selector &selector = cts_selector();
+        static cts_async_handler asyncHandler;
+        sycl::queue queue =
+            sycl::queue(selector, asyncHandler,
+                        {sycl::property::queue::enable_profiling()});
+
+        sycl::event event = queue.submit([&](sycl::handler &handler) {
+          handler.single_task(dummy_functor());
         });
 
         event.wait();
 
-        check_get_info_param<cl::sycl::info::event,
-                             cl::sycl::info::event_command_status,
-                             cl::sycl::info::event::command_execution_status>(
-            log, event);
-        check_get_info_param<cl::sycl::info::event, cl::sycl::cl_uint,
-                             cl::sycl::info::event::reference_count>(log,
-                                                                     event);
+        // Check that queries return the expected type.
         check_get_profiling_info_param<
-            cl::sycl::info::event_profiling, cl::sycl::cl_ulong,
-            cl::sycl::info::event_profiling::command_submit>(log, event);
+            sycl::info::event_profiling, uint64_t,
+            sycl::info::event_profiling::command_submit>(log, event);
         check_get_profiling_info_param<
-            cl::sycl::info::event_profiling, cl::sycl::cl_ulong,
-            cl::sycl::info::event_profiling::command_start>(log, event);
+            sycl::info::event_profiling, uint64_t,
+            sycl::info::event_profiling::command_start>(log, event);
         check_get_profiling_info_param<
-            cl::sycl::info::event_profiling, cl::sycl::cl_ulong,
-            cl::sycl::info::event_profiling::command_end>(log, event);
+            sycl::info::event_profiling, uint64_t,
+            sycl::info::event_profiling::command_end>(log, event);
+
+        const uint64_t submit_time = event.get_profiling_info<
+            sycl::info::event_profiling::command_submit>();
+        const uint64_t start_time = event.get_profiling_info<
+            sycl::info::event_profiling::command_start>();
+        const uint64_t end_time =
+            event
+                .get_profiling_info<sycl::info::event_profiling::command_end>();
+
+        // While the returned values are implementation defined, we can still
+        // perform some basic sanity checks.
+        if (!(submit_time <= start_time)) {
+          FAIL(log, "command submit time > start time");
+        }
+        if (!(start_time <= end_time)) {
+          FAIL(log, "command start time > end time");
+        }
       }
-    } catch (const cl::sycl::exception &e) {
+    } catch (const sycl::exception &e) {
       log_exception(log, e);
-      cl::sycl::string_class errorMsg =
-          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
+      sycl::string_class errorMsg =
+          "a SYCL exception was caught: " + sycl::string_class(e.what());
       FAIL(log, errorMsg.c_str());
     }
   }


### PR DESCRIPTION
This improves the tests for `event::get_info` and `event::get_profiling_info`:

- Remove query for deprecated `sycl::info::event::reference_count`.
- Check that command execution status is updated correctly without prior call to `event::wait`. This was the initial reason for taking this up, as the DPC++ CUDA backend currently has this bug.
- Update return types of `event::get_profiling_info` for SYCL 2020.
- Do basic sanity checks on profiling timestamps.
- Transition everything to the new `::sycl` namespace (for which I added a local alias, as to not depend on #108).