### PR TITLE
Improve result verification for h_item API

### DIFF
--- a/tests/h_item/h_item_api.cpp
+++ b/tests/h_item/h_item_api.cpp
@@ -6,11 +6,15 @@
 //
 *******************************************************************************/
 #include "../common/common.h"
+#include <string>
 
 #define TEST_NAME h_item_api
 
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
 template <int numDims>
-struct h_item_api_kernel_common;
+struct kernel_common;
 
 /**
  * @brief Kernel struct that tests retrieving a single value from a range or ID
@@ -19,26 +23,78 @@ struct h_item_api_kernel_common;
  * @tparam currentDim Current dimension to get the value for
  */
 template <int numDims, int currentDim>
-struct h_item_api_kernel_single {
+struct kernel_single {
+  using success_acc_t =
+      cl::sycl::accessor<bool, 1, cl::sycl::access::mode::write>;
+
   cl::sycl::range<numDims> kernelLogicalLocalRange;
+  success_acc_t success_acc;
 
   void operator()(cl::sycl::group<numDims> group) const {
     group.parallel_for_work_item(
         kernelLogicalLocalRange, [&](cl::sycl::h_item<numDims> item) {
-          size_t globalRange = item.get_global_range(currentDim);
-          size_t globalId = item.get_global_id(currentDim);
-          size_t localRange = item.get_local_range(currentDim);
-          size_t localId = item.get_local_id(currentDim);
-          size_t logicalLocalRange = item.get_logical_local_range(currentDim);
-          size_t logicalLocalId = item.get_logical_local_id(currentDim);
-          size_t physicalLocalRange = item.get_physical_local_range(currentDim);
-          size_t physicalLocalId = item.get_physical_local_id(currentDim);
+          bool success = true;
+          {
+            auto value = item.get_global_range(currentDim);
+            auto expected = item.get_global_range()[currentDim];
+            success &= value == expected;
+          }
+          {
+            auto value = item.get_global_id(currentDim);
+            auto expected = item.get_global_id()[currentDim];
+            success &= value == expected;
+          }
+          {
+            auto value = item.get_local_range(currentDim);
+            auto expected = item.get_local_range()[currentDim];
+            success &= value == expected;
+          }
+          {
+            auto value = item.get_local_id(currentDim);
+            auto expected = item.get_local_id()[currentDim];
+            success &= value == expected;
+          }
+          {
+            auto value = item.get_logical_local_range(currentDim);
+            auto expected = item.get_logical_local_range()[currentDim];
+            success &= value == expected;
+          }
+          {
+            auto value = item.get_logical_local_id(currentDim);
+            auto expected = item.get_logical_local_id()[currentDim];
+            success &= value == expected;
+          }
+          {
+            auto value = item.get_physical_local_range(currentDim);
+            auto expected = item.get_physical_local_range()[currentDim];
+            success &= value == expected;
+          }
+          {
+            auto value = item.get_physical_local_id(currentDim);
+            auto expected = item.get_physical_local_id()[currentDim];
+            success &= value == expected;
+          }
+
+          if (!success) success_acc[0] = false;
         });
   }
 };
 
-namespace TEST_NAME {
-using namespace sycl_cts;
+template <template <int> class T, int numDims>
+bool check_equal(const T<numDims>& lhs, const T<numDims>& rhs) {
+  bool result = true;
+  for (size_t i = 0; i < numDims; ++i) {
+    result &= lhs[i] == rhs[i];
+  }
+  return result;
+}
+
+template <int numDims>
+bool check_equal(cl::sycl::item<numDims, false> id1,
+                 cl::sycl::item<numDims, false> id2) {
+  return check_equal(id1.get_id(), id2.get_id()) &&
+         check_equal(id1.get_range(), id2.get_range());
+}
 
 /** test cl::sycl::device initialization
  */
@@ -56,94 +112,203 @@ class TEST_NAME : public util::test_base {
       auto testQueue = util::get_cts_object::queue();
 
       const auto kernelGroupRange =
-          util::get_cts_object::range<numDims>::get(8, 4, 2);
+          util::get_cts_object::range<numDims>::get(2, 2, 2);
       const auto kernelPhysicalLocalRange =
           util::get_cts_object::range<numDims>::get(4, 2, 1);
       const auto kernelLogicalLocalRange =
-          util::get_cts_object::range<numDims>::get(1, 2, 4);
+          util::get_cts_object::range<numDims>::get(8, 4, 3);
 
-      testQueue.submit([&](cl::sycl::handler& cgh) {
-        cgh.parallel_for_work_group<h_item_api_kernel_common<numDims>>(
-            kernelGroupRange, kernelPhysicalLocalRange,
+      const auto numWorkGroups = kernelGroupRange.size();
+      const auto numPhysicalPerGroup = kernelPhysicalLocalRange.size();
+      const auto numLogicalPerGroup = kernelLogicalLocalRange.size();
+      const auto numPhysicalWorkItems = numWorkGroups * numPhysicalPerGroup;
 
-            [=](cl::sycl::group<numDims> group) {
-              group.parallel_for_work_item(
-                  kernelLogicalLocalRange, [&](cl::sycl::h_item<numDims> item) {
-                    static constexpr bool with_offset = false;
+      bool isConsistent = true;  // stores result of API consistency check
 
-                    // Get items
-                    cl::sycl::item<numDims, with_offset> globalItem =
-                        item.get_global();
-                    cl::sycl::item<numDims, with_offset> localItem =
-                        item.get_local();
-                    cl::sycl::item<numDims, with_offset> logicalLocalItem =
-                        item.get_logical_local();
-                    cl::sycl::item<numDims, with_offset> physicalLocalItem =
-                        item.get_physical_local();
-                    // Silent warnings
-                    (void)globalItem;
-                    (void)localItem;
-                    (void)logicalLocalItem;
-                    (void)physicalLocalItem;
+      using dataT = size_t;
+      const dataT initialValue = 12345;
+      std::vector<dataT> globalIdData(numPhysicalWorkItems, initialValue);
+      std::vector<dataT> physicalLocalIdData(numPhysicalPerGroup, initialValue);
+      std::vector<dataT> logicalLocalIdData(numLogicalPerGroup, initialValue);
 
-                    // Get ranges
-                    cl::sycl::range<numDims> globalRange =
-                        item.get_global_range();
-                    cl::sycl::range<numDims> localRange =
-                        item.get_local_range();
-                    cl::sycl::range<numDims> logicalLocalRange =
-                        item.get_logical_local_range();
-                    cl::sycl::range<numDims> physicalLocalRange =
-                        item.get_physical_local_range();
-                    // Silent warnings
-                    (void)globalRange;
-                    (void)localRange;
-                    (void)logicalLocalRange;
-                    (void)physicalLocalRange;
+      {
+        cl::sycl::buffer<bool> consistency_buf(&isConsistent,
+                                               cl::sycl::range<1>(1));
 
-                    // Get IDs
-                    cl::sycl::id<numDims> globalId = item.get_global_id();
-                    cl::sycl::id<numDims> localId = item.get_local_id();
-                    cl::sycl::id<numDims> logicalLocalId =
-                        item.get_logical_local_id();
-                    cl::sycl::id<numDims> physicalLocalId =
-                        item.get_physical_local_id();
-                    // Silent warnings
-                    (void)globalId;
-                    (void)localId;
-                    (void)logicalLocalId;
-                    (void)physicalLocalId;
-                  });
-            });
-      });
+        cl::sycl::buffer<dataT> globalIdBuf(
+            globalIdData.data(), cl::sycl::range<1>(numPhysicalWorkItems));
+        cl::sycl::buffer<dataT> physicalLocalIdBuf(
+            physicalLocalIdData.data(),
+            cl::sycl::range<1>(numPhysicalPerGroup));
+        cl::sycl::buffer<dataT> logicalLocalIdBuf(
+            logicalLocalIdData.data(), cl::sycl::range<1>(numLogicalPerGroup));
 
-      if (numDims >= 1) {
         testQueue.submit([&](cl::sycl::handler& cgh) {
-          cgh.parallel_for_work_group(
+          auto consistency_acc =
+              consistency_buf.get_access<cl::sycl::access::mode::write>(cgh);
+
+          auto global_acc =
+              globalIdBuf.get_access<cl::sycl::access::mode::write>(cgh);
+          auto logical_acc =
+              logicalLocalIdBuf.get_access<cl::sycl::access::mode::write>(cgh);
+          auto physical_acc =
+              physicalLocalIdBuf.get_access<cl::sycl::access::mode::write>(cgh);
+
+          cgh.parallel_for_work_group<kernel_common<numDims>>(
               kernelGroupRange, kernelPhysicalLocalRange,
-              h_item_api_kernel_single<numDims, 0>{kernelLogicalLocalRange});
+
+              [=](cl::sycl::group<numDims> group) {
+                group.parallel_for_work_item(
+                    kernelLogicalLocalRange,
+                    [&](cl::sycl::h_item<numDims> item) {
+                      bool success = true;
+                      static constexpr bool with_offset = false;
+
+                      // Get items
+                      cl::sycl::item<numDims, with_offset> globalItem =
+                          item.get_global();
+                      cl::sycl::item<numDims, with_offset> localItem =
+                          item.get_local();
+                      cl::sycl::item<numDims, with_offset> logicalLocalItem =
+                          item.get_logical_local();
+                      cl::sycl::item<numDims, with_offset> physicalLocalItem =
+                          item.get_physical_local();
+
+                      // Check items
+                      success &= localItem == logicalLocalItem;
+
+                      // Store item linear IDs to verify all are present
+                      {
+                        const size_t globalId = globalItem.get_linear_id();
+                        const size_t physicalId =
+                            physicalLocalItem.get_linear_id();
+                        const size_t logicalId =
+                            logicalLocalItem.get_linear_id();
+
+                        if (globalId < numPhysicalWorkItems) {
+                          global_acc[globalId] = globalId;
+                        } else {
+                          success = false;
+                        }
+
+                        if (physicalId < numPhysicalPerGroup) {
+                          physical_acc[physicalId] = physicalId;
+                        } else {
+                          success = false;
+                        }
+
+                        if (logicalId < numLogicalPerGroup) {
+                          logical_acc[logicalId] = logicalId;
+                        } else {
+                          success = false;
+                        }
+                      }
+
+                      // Get ranges
+                      cl::sycl::range<numDims> globalRange =
+                          item.get_global_range();
+                      cl::sycl::range<numDims> localRange =
+                          item.get_local_range();
+                      cl::sycl::range<numDims> logicalLocalRange =
+                          item.get_logical_local_range();
+                      cl::sycl::range<numDims> physicalLocalRange =
+                          item.get_physical_local_range();
+
+                      // Check ranges
+                      success &=
+                          check_equal(globalItem.get_range(), globalRange);
+                      success &= check_equal(localItem.get_range(), localRange);
+                      success &= check_equal(logicalLocalItem.get_range(),
+                                             logicalLocalRange);
+                      success &= check_equal(physicalLocalItem.get_range(),
+                                             physicalLocalRange);
+
+                      // Get IDs
+                      cl::sycl::id<numDims> globalId = item.get_global_id();
+                      cl::sycl::id<numDims> localId = item.get_local_id();
+                      cl::sycl::id<numDims> logicalLocalId =
+                          item.get_logical_local_id();
+                      cl::sycl::id<numDims> physicalLocalId =
+                          item.get_physical_local_id();
+
+                      // Check IDs
+                      success &= check_equal(globalItem.get_id(), globalId);
+                      success &= check_equal(localItem.get_id(), localId);
+                      success &= check_equal(logicalLocalItem.get_id(),
+                                             logicalLocalId);
+                      success &= check_equal(physicalLocalItem.get_id(),
+                                             physicalLocalId);
+
+                      if (!success) consistency_acc[0] = false;
+                    });
+              });
         });
-      }
-      if (numDims >= 2) {
-        testQueue.submit([&](cl::sycl::handler& cgh) {
-          cgh.parallel_for_work_group(
-              kernelGroupRange, kernelPhysicalLocalRange,
-              h_item_api_kernel_single<numDims, 1>{kernelLogicalLocalRange});
-        });
-      }
-      if (numDims >= 3) {
-        testQueue.submit([&](cl::sycl::handler& cgh) {
-          cgh.parallel_for_work_group(
-              kernelGroupRange, kernelPhysicalLocalRange,
-              h_item_api_kernel_single<numDims, 2>{kernelLogicalLocalRange});
-        });
+
+        if constexpr (numDims >= 1) {
+          testQueue.submit([&](cl::sycl::handler& cgh) {
+            auto consistency_acc =
+                consistency_buf.get_access<cl::sycl::access::mode::write>(cgh);
+            kernel_single<numDims, 0> functor{kernelLogicalLocalRange,
+                                              consistency_acc};
+            cgh.parallel_for_work_group(kernelGroupRange,
+                                        kernelPhysicalLocalRange, functor);
+          });
+        }
+        if constexpr (numDims >= 2) {
+          testQueue.submit([&](cl::sycl::handler& cgh) {
+            auto consistency_acc =
+                consistency_buf.get_access<cl::sycl::access::mode::write>(cgh);
+            kernel_single<numDims, 1> functor{kernelLogicalLocalRange,
+                                              consistency_acc};
+            cgh.parallel_for_work_group(kernelGroupRange,
+                                        kernelPhysicalLocalRange, functor);
+          });
+        }
+        if constexpr (numDims >= 3) {
+          testQueue.submit([&](cl::sycl::handler& cgh) {
+            auto consistency_acc =
+                consistency_buf.get_access<cl::sycl::access::mode::write>(cgh);
+            kernel_single<numDims, 2> functor{kernelLogicalLocalRange,
+                                              consistency_acc};
+            cgh.parallel_for_work_group(kernelGroupRange,
+                                        kernelPhysicalLocalRange, functor);
+          });
+        }
       }
 
+      // Check h_item API consistency
+      if (!isConsistent) {
+        FAIL(log, "h_item API consistency checks failed");
+      }
+      // Check all expected IDs are present
+      auto check = [&](size_t value, size_t index, const char* desc) {
+        if (value != index) {
+          std::string errorMessage(desc);
+          errorMessage += " with index ";
+          errorMessage += std::to_string(index);
+
+          if (value == initialValue) {
+            errorMessage += " was not present";
+          } else {
+            errorMessage += " has unexpected value: ";
+            errorMessage += std::to_string(value);
+          }
+          FAIL(log, errorMessage);
+        }
+      };
+      for (size_t i = 0; i < numPhysicalWorkItems; ++i) {
+        check(globalIdData[i], i, "global id");
+      }
+      for (size_t i = 0; i < numLogicalPerGroup; ++i) {
+        check(logicalLocalIdData[i], i, "logical local id");
+      }
+      for (size_t i = 0; i < numPhysicalPerGroup; ++i) {
+        check(physicalLocalIdData[i], i, "physical local id");
+      }
     } catch (const cl::sycl::exception& e) {
       log_exception(log, e);
-      cl::sycl::string_class errorMsg =
-          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
-      FAIL(log, errorMsg.c_str());
+      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
+      FAIL(log, errorMsg);
     }
   }
 
@@ -159,4 +324,4 @@ class TEST_NAME : public util::test_base {
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-}  // namespace TEST_NAME
+}  // namespace TEST_NAMESPACE

--- a/tests/h_item/h_item_api.cpp
+++ b/tests/h_item/h_item_api.cpp
@@ -13,292 +13,395 @@
 namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 
-template <int numDims>
+template <int dims>
 struct kernel_common;
 
-/**
- * @brief Kernel struct that tests retrieving a single value from a range or ID
- *        for different ranges and IDs obtained from an h_item
- * @tparam numDims Number of dimensions of the group used in the kernel
- * @tparam currentDim Current dimension to get the value for
+/** @brief Storage for linear ID values
  */
-template <int numDims, int currentDim>
-struct kernel_single {
-  using success_acc_t =
-      cl::sycl::accessor<bool, 1, cl::sycl::access::mode::write>;
+struct work_item_ids {
+  size_t global;
+  size_t physical;
+  size_t logical;
+};
 
-  cl::sycl::range<numDims> kernelLogicalLocalRange;
-  success_acc_t success_acc;
+/** @brief Wrapper for global ID support in generic code
+ */
+struct global_id {
+  static const auto& value(const work_item_ids& ids) { return ids.global; }
+  static std::string description() { return "global ID"; };
+};
 
-  void operator()(cl::sycl::group<numDims> group) const {
-    group.parallel_for_work_item(
-        kernelLogicalLocalRange, [&](cl::sycl::h_item<numDims> item) {
-          bool success = true;
-          {
-            auto value = item.get_global_range(currentDim);
-            auto expected = item.get_global_range()[currentDim];
-            success &= value == expected;
-          }
-          {
-            auto value = item.get_global_id(currentDim);
-            auto expected = item.get_global_id()[currentDim];
-            success &= value == expected;
-          }
-          {
-            auto value = item.get_local_range(currentDim);
-            auto expected = item.get_local_range()[currentDim];
-            success &= value == expected;
-          }
-          {
-            auto value = item.get_local_id(currentDim);
-            auto expected = item.get_local_id()[currentDim];
-            success &= value == expected;
-          }
-          {
-            auto value = item.get_logical_local_range(currentDim);
-            auto expected = item.get_logical_local_range()[currentDim];
-            success &= value == expected;
-          }
-          {
-            auto value = item.get_logical_local_id(currentDim);
-            auto expected = item.get_logical_local_id()[currentDim];
-            success &= value == expected;
-          }
-          {
-            auto value = item.get_physical_local_range(currentDim);
-            auto expected = item.get_physical_local_range()[currentDim];
-            success &= value == expected;
-          }
-          {
-            auto value = item.get_physical_local_id(currentDim);
-            auto expected = item.get_physical_local_id()[currentDim];
-            success &= value == expected;
-          }
+/** @brief Wrapper for physical local ID support in generic code
+ */
+struct physical_id {
+  static const auto& value(const work_item_ids& ids) { return ids.physical; }
+  static std::string description() { return "physical local ID"; };
+};
 
-          // Each work-item updates success flag only if it is needed to avoid
-          // data race
-          if (!success) success_acc[0] = false;
-        });
+/** @brief Wrapper for logical local ID support in generic code
+ */
+struct logical_id {
+  static const auto& value(const work_item_ids& ids) { return ids.logical; }
+  static std::string description() { return "logical local ID"; };
+};
+
+/** @brief Provides offset logic for the test
+ */
+class offset_helper {
+  const size_t numPerGroup;
+  const size_t numTotal;
+
+ public:
+  offset_helper(size_t numLogicalPerGroup, size_t numLogicalWorkItems)
+      : numPerGroup(numLogicalPerGroup), numTotal(numLogicalWorkItems) {}
+
+  size_t total() const { return numTotal; }
+  size_t max() const { return numTotal - 1; }
+
+  template <int dims>
+  size_t get(const sycl::group<dims>& group,
+             const sycl::h_item<dims>& item) const {
+    /**
+     * There is a data race in case any of these calls return same results for
+     * different work-items. As data race is UB, which has no formal guarantees
+     * according to the C++ sec, there is slight possibility of missing or
+     * broken output from test for such case.
+     *
+     * See PR#124 and 'How to Miscompile Programs with "Benign" Data Races' from
+     * Hans Boehm for more details.
+     */
+    return group.get_linear_id() * numPerGroup +
+           item.get_logical_local().get_linear_id();
+  }
+
+  size_t get_group_id(size_t offset) const { return offset / numPerGroup; }
+
+  size_t get_logical_local_id(size_t offset) const {
+    return offset % numPerGroup;
+  }
+
+  template <int dims>
+  std::string to_string(size_t offset) const {
+    std::string result;
+    result += std::to_string(dims) + " dimensions, group: ";
+    result += std::to_string(get_group_id(offset));
+    result += ", logical local id: ";
+    result += std::to_string(get_logical_local_id(offset));
+    return result;
   }
 };
 
-/** test cl::sycl::device initialization
+/** @brief Provides core test logic
+ */
+template <int dims>
+class api_tests {
+ public:
+  /** @brief Entry point for the test
+   */
+  static void run(util::logger& log);
+
+ private:
+  /** @brief Provides device-side checks for a single dimension
+   */
+  template <int currentDim>
+  static bool run_1d_checks(const sycl::h_item<dims>& item);
+
+  /** @brief Provides device-side checks applicable for all dimensions
+   *  @param ids Variable to store ID values into for later verification on the
+   *             host side
+   */
+  static bool run_nd_checks(const sycl::h_item<dims>& item, work_item_ids& ids);
+
+  /** @brief Counts unique id values and validates value ranges
+   */
+  template <typename id_descriptor_t>
+  static std::vector<size_t> count_ids(util::logger& log,
+                                       const offset_helper& offsets,
+                                       const std::vector<work_item_ids>& ids,
+                                       const work_item_ids& initialIds,
+                                       const work_item_ids& maxIds);
+
+  /** @brief Validates id count values
+   */
+  template <typename id_descriptor_t>
+  static void validate_id_count(util::logger& log,
+                                const std::vector<size_t>& count,
+                                const work_item_ids& expected);
+};
+
+template <int dims>
+void api_tests<dims>::run(util::logger& log) {
+  auto queue = util::get_cts_object::queue();
+
+  const auto kernelGroupRange = util::get_cts_object::range<dims>::get(3, 4, 2);
+  const auto kernelPhysicalLocalRange =
+      util::get_cts_object::range<dims>::get(4, 2, 1);
+  const auto kernelLogicalLocalRange =
+      util::get_cts_object::range<dims>::get(8, 4, 3);
+
+  const size_t numWorkGroups = kernelGroupRange.size();
+  const size_t numLogicalPerGroup = kernelLogicalLocalRange.size();
+  const size_t numPhysicalPerGroup = kernelPhysicalLocalRange.size();
+  const size_t numLogicalWorkItems = numWorkGroups * numLogicalPerGroup;
+  const size_t numPhysicalWorkItems = numWorkGroups * numPhysicalPerGroup;
+  const size_t numLogicalPerPhysical = numLogicalPerGroup / numPhysicalPerGroup;
+
+  const offset_helper offsets(numLogicalPerGroup, numLogicalWorkItems);
+
+  const work_item_ids initialValue = {43210, 43211, 43212};
+  std::vector<int> consistency(offsets.total(), false);
+  std::vector<work_item_ids> ids(offsets.total(), initialValue);
+
+  {
+    sycl::range<1> offsetsRange(offsets.total());
+    sycl::buffer<int> consistencyBuf(consistency.data(), offsetsRange);
+    sycl::buffer<work_item_ids> idsBuf(ids.data(), offsetsRange);
+
+    queue.submit([&](cl::sycl::handler& cgh) {
+      auto consistency_acc =
+          consistencyBuf.get_access<sycl::access::mode::write>(cgh);
+      auto id_acc = idsBuf.get_access<sycl::access::mode::write>(cgh);
+
+      cgh.parallel_for_work_group<kernel_common<dims>>(
+          kernelGroupRange, kernelPhysicalLocalRange,
+          [=](sycl::group<dims> group) {
+            group.parallel_for_work_item(
+                kernelLogicalLocalRange, [&](cl::sycl::h_item<dims> item) {
+                  bool success = true;
+                  const size_t offset = offsets.get(group, item);
+
+                  if (offset > offsets.max()) {
+                    /** There is no way to store result anyway, so just skip
+                     *  the check to preserve the initial values and fail.
+                     */
+                    return;
+                  }
+
+                  success &= run_nd_checks(item, id_acc[offset]);
+
+                  if constexpr (dims >= 1) {
+                    success &= run_1d_checks<0>(item);
+                  }
+                  if constexpr (dims >= 2) {
+                    success &= run_1d_checks<1>(item);
+                  }
+                  if constexpr (dims >= 3) {
+                    success &= run_1d_checks<2>(item);
+                  }
+
+                  consistency_acc[offset] = success;
+                });
+          });
+    });
+  }
+
+  // Validate consistency
+  for (size_t i = 0; i < ids.size(); ++i) {
+    const auto& id = ids[i];
+    const bool isConsistent = consistency[i];
+
+    if (!isConsistent) {
+      FAIL(log, "API consistency checks failed or not run for " +
+                    offsets.to_string<dims>(i));
+    }
+  }
+
+  // Count unique id values and validate value ranges
+  work_item_ids maxValue;
+  maxValue.global = numPhysicalWorkItems - 1;
+  maxValue.physical = numPhysicalPerGroup - 1;
+  maxValue.logical = numLogicalPerGroup - 1;
+
+  const auto global_count =
+      count_ids<global_id>(log, offsets, ids, initialValue, maxValue);
+  const auto physical_count =
+      count_ids<physical_id>(log, offsets, ids, initialValue, maxValue);
+  const auto logical_count =
+      count_ids<logical_id>(log, offsets, ids, initialValue, maxValue);
+
+  // Validate unique id values count
+  work_item_ids expectedCount;
+  expectedCount.global = numLogicalPerPhysical;
+  expectedCount.physical = numWorkGroups * numLogicalPerPhysical;
+  expectedCount.logical = numWorkGroups;
+
+  validate_id_count<global_id>(log, global_count, expectedCount);
+  validate_id_count<physical_id>(log, physical_count, expectedCount);
+  validate_id_count<logical_id>(log, logical_count, expectedCount);
+}
+
+template <int dims>
+template <typename id_descriptor_t>
+std::vector<size_t> api_tests<dims>::count_ids(
+    util::logger& log, const offset_helper& offsets,
+    const std::vector<work_item_ids>& ids, const work_item_ids& initialIds,
+    const work_item_ids& maxIds) {
+  const size_t max = id_descriptor_t::value(maxIds);
+  const size_t initial = id_descriptor_t::value(initialIds);
+
+  std::vector<size_t> count(max + 1, 0);
+
+  for (size_t i = 0; i < ids.size(); ++i) {
+    const size_t& value = id_descriptor_t::value(ids[i]);
+
+    if (value == initial) {
+      std::string message;
+      message += "No " + id_descriptor_t::description() + " stored for ";
+      message += offsets.to_string<dims>(i);
+      FAIL(log, message);
+    } else if (value > max) {
+      std::string message;
+      message += "Too big " + id_descriptor_t::description() + " value ";
+      message += std::to_string(value) + " for ";
+      message += offsets.to_string<dims>(i);
+      FAIL(log, message);
+    } else {
+      count[value] += 1;
+    }
+  }
+  return count;
+}
+
+template <int dims>
+template <typename id_descriptor_t>
+void api_tests<dims>::validate_id_count(util::logger& log,
+                                        const std::vector<size_t>& count,
+                                        const work_item_ids& expectedValues) {
+  for (size_t i = 0; i < count.size(); ++i) {
+    const auto& expected = id_descriptor_t::value(expectedValues);
+    if (count[i] != expected) {
+      std::string message("Unexpected number of occurences: ");
+      message += std::to_string(count[i]);
+      message += " for " + id_descriptor_t::description();
+      message += ", value " + std::to_string(i);
+      message += ", dimensions: " + std::to_string(dims);
+      message += "; expected: " + std::to_string(expected);
+      FAIL(log, message);
+    }
+  }
+}
+
+template <int dims>
+template <int currentDim>
+bool api_tests<dims>::run_1d_checks(const cl::sycl::h_item<dims>& item) {
+  bool success = true;
+  {
+    auto value = item.get_global_range(currentDim);
+    auto expected = item.get_global_range()[currentDim];
+    success &= value == expected;
+  }
+  {
+    auto value = item.get_global_id(currentDim);
+    auto expected = item.get_global_id()[currentDim];
+    success &= value == expected;
+  }
+  {
+    auto value = item.get_local_range(currentDim);
+    auto expected = item.get_local_range()[currentDim];
+    success &= value == expected;
+  }
+  {
+    auto value = item.get_local_id(currentDim);
+    auto expected = item.get_local_id()[currentDim];
+    success &= value == expected;
+  }
+  {
+    auto value = item.get_logical_local_range(currentDim);
+    auto expected = item.get_logical_local_range()[currentDim];
+    success &= value == expected;
+  }
+  {
+    auto value = item.get_logical_local_id(currentDim);
+    auto expected = item.get_logical_local_id()[currentDim];
+    success &= value == expected;
+  }
+  {
+    auto value = item.get_physical_local_range(currentDim);
+    auto expected = item.get_physical_local_range()[currentDim];
+    success &= value == expected;
+  }
+  {
+    auto value = item.get_physical_local_id(currentDim);
+    auto expected = item.get_physical_local_id()[currentDim];
+    success &= value == expected;
+  }
+  return success;
+}
+
+template <int dims>
+bool api_tests<dims>::run_nd_checks(const cl::sycl::h_item<dims>& item,
+                                    work_item_ids& ids) {
+  bool success = true;
+  static constexpr bool with_offset = false;
+
+  // Get items
+  sycl::item<dims, with_offset> globalItem = item.get_global();
+  sycl::item<dims, with_offset> localItem = item.get_local();
+  sycl::item<dims, with_offset> logicalLocalItem = item.get_logical_local();
+  sycl::item<dims, with_offset> physicalLocalItem = item.get_physical_local();
+
+  // Check items
+  success &= localItem == logicalLocalItem;
+
+  // Store item linear IDs to verify all are present
+  ids.global = globalItem.get_linear_id();
+  ids.physical = physicalLocalItem.get_linear_id();
+  ids.logical = logicalLocalItem.get_linear_id();
+
+  // Get ranges
+  using range_t = sycl::range<dims>;
+  range_t globalRange = item.get_global_range();
+  range_t localRange = item.get_local_range();
+  range_t logicalLocalRange = item.get_logical_local_range();
+  range_t physicalLocalRange = item.get_physical_local_range();
+
+  // Check ranges
+  success &= globalItem.get_range() == globalRange;
+  success &= localItem.get_range() == localRange;
+  success &= logicalLocalItem.get_range() == logicalLocalRange;
+  success &= physicalLocalItem.get_range() == physicalLocalRange;
+
+  // Get IDs
+  using id_t = sycl::id<dims>;
+  id_t globalId = item.get_global_id();
+  id_t localId = item.get_local_id();
+  id_t logicalLocalId = item.get_logical_local_id();
+  id_t physicalLocalId = item.get_physical_local_id();
+
+  // Check IDs
+  success &= globalItem.get_id() == globalId;
+  success &= localItem.get_id() == localId;
+  success &= logicalLocalItem.get_id() == logicalLocalId;
+  success &= physicalLocalItem.get_id() == physicalLocalId;
+
+  return success;
+}
+
+/** Test cl::sycl::device initialization
  */
 class TEST_NAME : public util::test_base {
  public:
-  /** return information about this test
+  /** Return information about this test
    */
   void get_info(test_base::info& out) const final {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
-  template <int numDims>
-  void test_api(util::logger& log) {
+  /** Execute the test
+   */
+  void run(util::logger& log) final {
     try {
-      auto testQueue = util::get_cts_object::queue();
-
-      const auto kernelGroupRange =
-          util::get_cts_object::range<numDims>::get(3, 4, 2);
-      const auto kernelPhysicalLocalRange =
-          util::get_cts_object::range<numDims>::get(4, 2, 1);
-      const auto kernelLogicalLocalRange =
-          util::get_cts_object::range<numDims>::get(8, 4, 3);
-
-      const auto numWorkGroups = kernelGroupRange.size();
-      const auto numPhysicalPerGroup = kernelPhysicalLocalRange.size();
-      const auto numLogicalPerGroup = kernelLogicalLocalRange.size();
-      const auto numPhysicalWorkItems = numWorkGroups * numPhysicalPerGroup;
-
-      bool isConsistent = true;  // stores result of API consistency check
-
-      using dataT = size_t;
-      const dataT initialValue = 12345;
-      std::vector<dataT> globalIdData(numPhysicalWorkItems, initialValue);
-      std::vector<dataT> physicalLocalIdData(numPhysicalPerGroup, initialValue);
-      std::vector<dataT> logicalLocalIdData(numLogicalPerGroup, initialValue);
-
-      {
-        cl::sycl::buffer<bool> consistency_buf(&isConsistent,
-                                               cl::sycl::range<1>(1));
-
-        cl::sycl::buffer<dataT> globalIdBuf(
-            globalIdData.data(), cl::sycl::range<1>(numPhysicalWorkItems));
-        cl::sycl::buffer<dataT> physicalLocalIdBuf(
-            physicalLocalIdData.data(),
-            cl::sycl::range<1>(numPhysicalPerGroup));
-        cl::sycl::buffer<dataT> logicalLocalIdBuf(
-            logicalLocalIdData.data(), cl::sycl::range<1>(numLogicalPerGroup));
-
-        testQueue.submit([&](cl::sycl::handler& cgh) {
-          auto consistency_acc =
-              consistency_buf.get_access<cl::sycl::access::mode::write>(cgh);
-
-          auto global_acc =
-              globalIdBuf.get_access<cl::sycl::access::mode::write>(cgh);
-          auto logical_acc =
-              logicalLocalIdBuf.get_access<cl::sycl::access::mode::write>(cgh);
-          auto physical_acc =
-              physicalLocalIdBuf.get_access<cl::sycl::access::mode::write>(cgh);
-
-          cgh.parallel_for_work_group<kernel_common<numDims>>(
-              kernelGroupRange, kernelPhysicalLocalRange,
-
-              [=](cl::sycl::group<numDims> group) {
-                group.parallel_for_work_item(
-                    kernelLogicalLocalRange,
-                    [&](cl::sycl::h_item<numDims> item) {
-                      bool success = true;
-                      static constexpr bool with_offset = false;
-
-                      // Get items
-                      cl::sycl::item<numDims, with_offset> globalItem =
-                          item.get_global();
-                      cl::sycl::item<numDims, with_offset> localItem =
-                          item.get_local();
-                      cl::sycl::item<numDims, with_offset> logicalLocalItem =
-                          item.get_logical_local();
-                      cl::sycl::item<numDims, with_offset> physicalLocalItem =
-                          item.get_physical_local();
-
-                      // Check items
-                      success &= localItem == logicalLocalItem;
-
-                      // Store item linear IDs to verify all are present
-                      {
-                        const size_t globalId = globalItem.get_linear_id();
-                        const size_t physicalId =
-                            physicalLocalItem.get_linear_id();
-                        const size_t logicalId =
-                            logicalLocalItem.get_linear_id();
-
-                        if (globalId < numPhysicalWorkItems) {
-                          global_acc[globalId] = globalId;
-                        } else {
-                          success = false;
-                        }
-
-                        if (physicalId < numPhysicalPerGroup) {
-                          physical_acc[physicalId] = physicalId;
-                        } else {
-                          success = false;
-                        }
-
-                        if (logicalId < numLogicalPerGroup) {
-                          logical_acc[logicalId] = logicalId;
-                        } else {
-                          success = false;
-                        }
-                      }
-
-                      // Get ranges
-                      cl::sycl::range<numDims> globalRange =
-                          item.get_global_range();
-                      cl::sycl::range<numDims> localRange =
-                          item.get_local_range();
-                      cl::sycl::range<numDims> logicalLocalRange =
-                          item.get_logical_local_range();
-                      cl::sycl::range<numDims> physicalLocalRange =
-                          item.get_physical_local_range();
-
-                      // Check ranges
-                      success &= globalItem.get_range() == globalRange;
-                      success &= localItem.get_range() == localRange;
-                      success &= logicalLocalItem.get_range() == logicalLocalRange;
-                      success &= physicalLocalItem.get_range() == physicalLocalRange;
-
-                      // Get IDs
-                      cl::sycl::id<numDims> globalId = item.get_global_id();
-                      cl::sycl::id<numDims> localId = item.get_local_id();
-                      cl::sycl::id<numDims> logicalLocalId =
-                          item.get_logical_local_id();
-                      cl::sycl::id<numDims> physicalLocalId =
-                          item.get_physical_local_id();
-
-                      // Check IDs
-                      success &= globalItem.get_id() == globalId;
-                      success &= localItem.get_id() == localId;
-                      success &= logicalLocalItem.get_id() == logicalLocalId;
-                      success &= physicalLocalItem.get_id() == physicalLocalId;
-
-                      if (!success) consistency_acc[0] = false;
-                    });
-              });
-        });
-
-        if constexpr (numDims >= 1) {
-          testQueue.submit([&](cl::sycl::handler& cgh) {
-            auto consistency_acc =
-                consistency_buf.get_access<cl::sycl::access::mode::write>(cgh);
-            kernel_single<numDims, 0> functor{kernelLogicalLocalRange,
-                                              consistency_acc};
-            cgh.parallel_for_work_group(kernelGroupRange,
-                                        kernelPhysicalLocalRange, functor);
-          });
-        }
-        if constexpr (numDims >= 2) {
-          testQueue.submit([&](cl::sycl::handler& cgh) {
-            auto consistency_acc =
-                consistency_buf.get_access<cl::sycl::access::mode::write>(cgh);
-            kernel_single<numDims, 1> functor{kernelLogicalLocalRange,
-                                              consistency_acc};
-            cgh.parallel_for_work_group(kernelGroupRange,
-                                        kernelPhysicalLocalRange, functor);
-          });
-        }
-        if constexpr (numDims >= 3) {
-          testQueue.submit([&](cl::sycl::handler& cgh) {
-            auto consistency_acc =
-                consistency_buf.get_access<cl::sycl::access::mode::write>(cgh);
-            kernel_single<numDims, 2> functor{kernelLogicalLocalRange,
-                                              consistency_acc};
-            cgh.parallel_for_work_group(kernelGroupRange,
-                                        kernelPhysicalLocalRange, functor);
-          });
-        }
-      }
-
-      // Check h_item API consistency
-      if (!isConsistent) {
-        FAIL(log, "h_item API consistency checks failed");
-      }
-      // Check all expected IDs are present
-      auto check = [&](size_t value, size_t index, const char* desc) {
-        if (value != index) {
-          std::string errorMessage(desc);
-          errorMessage += " with index ";
-          errorMessage += std::to_string(index);
-
-          if (value == initialValue) {
-            errorMessage += " was not present";
-          } else {
-            errorMessage += " has unexpected value: ";
-            errorMessage += std::to_string(value);
-          }
-          FAIL(log, errorMessage);
-        }
-      };
-      for (size_t i = 0; i < numPhysicalWorkItems; ++i) {
-        check(globalIdData[i], i, "global id");
-      }
-      for (size_t i = 0; i < numLogicalPerGroup; ++i) {
-        check(logicalLocalIdData[i], i, "logical local id");
-      }
-      for (size_t i = 0; i < numPhysicalPerGroup; ++i) {
-        check(physicalLocalIdData[i], i, "physical local id");
-      }
+      api_tests<1>::run(log);
+      api_tests<2>::run(log);
+      api_tests<3>::run(log);
     } catch (const cl::sycl::exception& e) {
       log_exception(log, e);
       auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
       FAIL(log, errorMsg);
+    } catch (const std::exception& e) {
+      auto errorMsg = std::string("an exception was caught: ") + e.what();
+      FAIL(log, errorMsg);
     }
-  }
-
-  /** execute the test
-   */
-  void run(util::logger& log) final {
-    test_api<1>(log);
-    test_api<2>(log);
-    test_api<3>(log);
   }
 };
 

--- a/tests/h_item/h_item_api.cpp
+++ b/tests/h_item/h_item_api.cpp
@@ -75,11 +75,16 @@ struct kernel_single {
             success &= value == expected;
           }
 
+          // Each work-item updates success flag only if it is needed to avoid
+          // data race
           if (!success) success_acc[0] = false;
         });
   }
 };
 
+/** @brief Explicit equality check to avoid usage of the common-by-value
+ *         semantics in this test
+ */
 template <template <int> class T, int numDims>
 bool check_equal(const T<numDims>& lhs, const T<numDims>& rhs) {
   bool result = true;
@@ -89,6 +94,8 @@ bool check_equal(const T<numDims>& lhs, const T<numDims>& rhs) {
   return result;
 }
 
+/** @brief Overload of explicit equality check for the item instances
+ */
 template <int numDims>
 bool check_equal(cl::sycl::item<numDims, false> id1,
                  cl::sycl::item<numDims, false> id2) {
@@ -112,7 +119,7 @@ class TEST_NAME : public util::test_base {
       auto testQueue = util::get_cts_object::queue();
 
       const auto kernelGroupRange =
-          util::get_cts_object::range<numDims>::get(2, 2, 2);
+          util::get_cts_object::range<numDims>::get(3, 4, 2);
       const auto kernelPhysicalLocalRange =
           util::get_cts_object::range<numDims>::get(4, 2, 1);
       const auto kernelLogicalLocalRange =

--- a/tests/h_item/h_item_api.cpp
+++ b/tests/h_item/h_item_api.cpp
@@ -82,27 +82,6 @@ struct kernel_single {
   }
 };
 
-/** @brief Explicit equality check to avoid usage of the common-by-value
- *         semantics in this test
- */
-template <template <int> class T, int numDims>
-bool check_equal(const T<numDims>& lhs, const T<numDims>& rhs) {
-  bool result = true;
-  for (size_t i = 0; i < numDims; ++i) {
-    result &= lhs[i] == rhs[i];
-  }
-  return result;
-}
-
-/** @brief Overload of explicit equality check for the item instances
- */
-template <int numDims>
-bool check_equal(cl::sycl::item<numDims, false> id1,
-                 cl::sycl::item<numDims, false> id2) {
-  return check_equal(id1.get_id(), id2.get_id()) &&
-         check_equal(id1.get_range(), id2.get_range());
-}
-
 /** test cl::sycl::device initialization
  */
 class TEST_NAME : public util::test_base {
@@ -222,13 +201,10 @@ class TEST_NAME : public util::test_base {
                           item.get_physical_local_range();
 
                       // Check ranges
-                      success &=
-                          check_equal(globalItem.get_range(), globalRange);
-                      success &= check_equal(localItem.get_range(), localRange);
-                      success &= check_equal(logicalLocalItem.get_range(),
-                                             logicalLocalRange);
-                      success &= check_equal(physicalLocalItem.get_range(),
-                                             physicalLocalRange);
+                      success &= globalItem.get_range() == globalRange;
+                      success &= localItem.get_range() == localRange;
+                      success &= logicalLocalItem.get_range() == logicalLocalRange;
+                      success &= physicalLocalItem.get_range() == physicalLocalRange;
 
                       // Get IDs
                       cl::sycl::id<numDims> globalId = item.get_global_id();
@@ -239,12 +215,10 @@ class TEST_NAME : public util::test_base {
                           item.get_physical_local_id();
 
                       // Check IDs
-                      success &= check_equal(globalItem.get_id(), globalId);
-                      success &= check_equal(localItem.get_id(), localId);
-                      success &= check_equal(logicalLocalItem.get_id(),
-                                             logicalLocalId);
-                      success &= check_equal(physicalLocalItem.get_id(),
-                                             physicalLocalId);
+                      success &= globalItem.get_id() == globalId;
+                      success &= localItem.get_id() == localId;
+                      success &= logicalLocalItem.get_id() == logicalLocalId;
+                      success &= physicalLocalItem.get_id() == physicalLocalId;
 
                       if (!success) consistency_acc[0] = false;
                     });

--- a/tests/h_item/h_item_constructors.cpp
+++ b/tests/h_item/h_item_constructors.cpp
@@ -9,6 +9,7 @@
 #include "../common/common.h"
 
 #include <array>
+#include <string>
 
 #define TEST_NAME h_item_constructors
 
@@ -30,7 +31,7 @@ enum class current_check {
 
 }  // namespace
 
-namespace TEST_NAME {
+namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 
 /**
@@ -187,9 +188,8 @@ class TEST_NAME : public util::test_base {
 
     } catch (const cl::sycl::exception& e) {
       log_exception(log, e);
-      cl::sycl::string_class errorMsg =
-          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
-      FAIL(log, errorMsg.c_str());
+      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
+      FAIL(log, errorMsg);
     }
   }
 
@@ -205,4 +205,4 @@ class TEST_NAME : public util::test_base {
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-}  // namespace TEST_NAME
+}  // namespace TEST_NAMESPACE

--- a/tests/h_item/h_item_equality.cpp
+++ b/tests/h_item/h_item_equality.cpp
@@ -10,6 +10,7 @@
 #include "../common/common_by_value.h"
 
 #include <array>
+#include <string>
 
 #define TEST_NAME h_item_equality
 
@@ -33,7 +34,7 @@ enum class current_check {
 
 }  // namespace
 
-namespace TEST_NAME {
+namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 
 /** test cl::sycl::device initialization
@@ -140,9 +141,8 @@ class TEST_NAME : public util::test_base {
 
     } catch (const cl::sycl::exception& e) {
       log_exception(log, e);
-      cl::sycl::string_class errorMsg =
-          "a SYCL exception was caught: " + cl::sycl::string_class(e.what());
-      FAIL(log, errorMsg.c_str());
+      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
+      FAIL(log, errorMsg);
     }
   }
 
@@ -158,4 +158,4 @@ class TEST_NAME : public util::test_base {
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-}  // namespace TEST_NAME
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
Local id values are stored from each work-group asynchronously.
We are using the fact that all bitwise-equal values go into the same memory to simplify the test logic.