### PR TITLE
Fix tests for accessors

### DIFF
--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -1231,7 +1231,7 @@ class check_image_accessor_api_reads {
   using failure_item_t = typename failure_storage_t::item_t;
 
   static constexpr bool supportsLinearFilering =
-      is_cl_float_type<typename T::value_type>::value;
+      is_cl_float_type<typename T::element_type>::value;
 
  public:
   static constexpr auto isImageArray =

--- a/tests/accessor/accessor_api_local_common.h
+++ b/tests/accessor/accessor_api_local_common.h
@@ -284,7 +284,7 @@ struct check_local_accessor_api_dim<generic_path_t> {
   }
 
   /**
-   *  @brief Check global buffer accessor api for all modes except atomic64 ones
+   *  @brief Check local accessor api for all modes except atomic64 ones
    */
   template <typename T, typename kernelName, int dims, typename accTagT,
             typename ... argsT>
@@ -304,8 +304,8 @@ struct check_local_accessor_api_dim<generic_path_t> {
   }
 
   /**
-   *  @brief Switch off local buffer accessor api check of atomic64 modes for
-   *         generic code path
+   *  @brief Switch off local accessor api check of atomic64 modes for generic
+   *         code path
    */
   template <typename T, typename kernelName, int dims, typename accTagT,
             typename ... argsT>
@@ -337,7 +337,7 @@ struct check_local_accessor_api_dim<atomic64_path_t> {
     // Run atomic64 checks only
   }
   /**
-   *  @brief Run accessor verification for atomic64 modes only
+   *  @brief Run local accessor verification for atomic64 modes only
    */
   template <typename T, typename kernelName, int dims, typename accTagT,
             typename ... argsT>
@@ -346,8 +346,7 @@ struct check_local_accessor_api_dim<atomic64_path_t> {
     // Run atomic64 checks only
     {
       constexpr auto mode = cl::sycl::access::mode::atomic;
-      check_buffer_accessor_api_mode<T, kernelName, dims, mode, target,
-                                     placeholder>(
+      check_local_accessor_api_mode<T, kernelName, dims, mode>(
           std::forward<argsT>(args)...);
     }
   }

--- a/tests/accessor/accessor_types_core.h
+++ b/tests/accessor/accessor_types_core.h
@@ -13,6 +13,7 @@
 #include "../common/common.h"
 #include "../common/type_coverage.h"
 #include "./../../util/extensions.h"
+#include "accessor_utility_common.h"
 
 #ifndef TEST_NAME
 #error Invalid test namespace
@@ -58,7 +59,7 @@ public:
     const auto scalar_types =
         named_type_pack<float,
                         std::size_t,
-                        user_struct>({
+                        accessor_utility::user_struct>({
                         "float",
                         "std::size_t",
                         "user struct"});
@@ -94,8 +95,8 @@ public:
                         "cl::sycl::cl_long", "cl::sycl::cl_ulong"});
     const auto scalar_types =
         named_type_pack<std::size_t,
-                        user_struct,
-                        user_namespace::user_alias>({
+                        accessor_utility::user_struct,
+                        accessor_utility::user_namespace::user_alias>({
                         "std::size_t",
                         "user struct",
                         "user alias"});
@@ -155,7 +156,7 @@ public:
 
     for_all_types<check_type>(scalar_types, log, queue);
 
-    check_type_on_kernel<user_namespace::nested::user_struct,
+    check_type_on_kernel<accessor_utility::user_namespace::nested::user_struct,
                          nested_struct_kernel>{}(
         log, queue, "nested user struct");
 


### PR DESCRIPTION
Fix three compilation issues within accessor tests:
  - use vec::element_type for image accessors
  - fix atomic64 code path for local accessors
  - fix user types verification