### PR TITLE
Added host task test suite

### DIFF
--- a/tests/host_task/CMakeLists.txt
+++ b/tests/host_task/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB test_cases_list *.cpp)
+
+add_cts_test(${test_cases_list})

--- a/tests/host_task/host_task_interop_api.cpp
+++ b/tests/host_task/host_task_interop_api.cpp
@@ -9,6 +9,10 @@
 
 #include "../common/common.h"
 
+#ifdef SYCL_BACKEND_OPENCL
+#include <CL/sycl/backend/opencl.hpp>
+#endif  // SYCL_BACKEND_OPENCL
+
 #define TEST_NAME host_task_interop_api
 
 namespace TEST_NAMESPACE {
@@ -44,7 +48,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     try {
       sycl::queue q{util::get_cts_object::queue()};
       if (q.get_backend() != sycl::backend::opencl) {
-        log.note("Interop part is not supported on this backend type");
+        log.note("Interop part is not supported on OpenCL backend type");
         return;
       }
 
@@ -58,7 +62,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
         });
         q.wait_and_throw();
 
-        if (cl_native_queue != q.get())
+        if (cl_native_queue != sycl::get_native<sycl::backend::opencl>(q))
           FAIL(log, "get_native_queue query has failed.");
       }
 
@@ -72,7 +76,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
         });
         q.wait_and_throw();
 
-        if (cl_native_device_id != q.get_device().get())
+        if (cl_native_device_id !=
+            sycl::get_native<sycl::backend::opencl>(q.get_device()))
           FAIL(log, "get_native_device query has failed.");
       }
 
@@ -86,7 +91,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
         });
         q.wait_and_throw();
 
-        if (cl_native_context != q.get_context().get())
+        if (cl_native_context !=
+            sycl::get_native<sycl::backend::opencl>(q.get_context()))
           FAIL(log, "get_native_context query has failed.");
       }
 

--- a/tests/host_task/host_task_interop_api.cpp
+++ b/tests/host_task/host_task_interop_api.cpp
@@ -43,8 +43,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger& log) override {
 #ifdef SYCL_BACKEND_OPENCL
-    for_type_and_vectors<check_buffer_ctors_for_type, sycl::cl_half>(
-        log, "sycl::cl_half");
     try {
       sycl::queue q{util::get_cts_object::queue()};
       if (q.get_backend() != sycl::backend::opencl) {

--- a/tests/host_task/host_task_interop_api.cpp
+++ b/tests/host_task/host_task_interop_api.cpp
@@ -1,0 +1,126 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provide verification for sycl::interop_handle::get_native functions
+//  this test check interop API with OpenCL back-end only.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+#define TEST_NAME host_task_interop_api
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+  /** return information about this test
+   */
+  void get_info(test_base::info& out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+#ifdef SYCL_BACKEND_OPENCL
+  cl_int call_opencl(cl_command_queue q, cl_mem mem, size_t size,
+                     size_t pattern) {
+    cl_event e{};
+    cl_int ret{clEnqueueFillBuffer(q, mem, &pattern, sizeof(size_t),
+                                   /*offset*/ 0, size * sizeof(size_t), 0,
+                                   nullptr, &e)};
+    if (ret == CL_SUCCESS) {
+      ret = clWaitForEvents(1, &e);
+    }
+    return ret;
+  }
+#endif  // SYCL_BACKEND_OPENCL
+
+  /** execute this test
+   */
+  void run(util::logger& log) override {
+#ifdef SYCL_BACKEND_OPENCL
+    for_type_and_vectors<check_buffer_ctors_for_type, sycl::cl_half>(
+        log, "sycl::cl_half");
+    try {
+      sycl::queue q{util::get_cts_object::queue()};
+      if (q.get_backend() != sycl::backend::opencl) {
+        log.note("Interop part is not supported on this backend type");
+        return;
+      }
+
+      // check get_native_queue
+      {
+        cl_command_queue cl_native_queue{nullptr};
+        q.submit([&](sycl::handler& cgh) {
+          cgh.host_task([=, &cl_native_queue](sycl::interop_handle ih) {
+            cl_native_queue = ih.get_native_queue();
+          });
+        });
+        q.wait_and_throw();
+
+        if (cl_native_queue != q.get())
+          FAIL(log, "get_native_queue query has failed.");
+      }
+
+      // check get_native_device
+      {
+        cl_device_id cl_native_device_id{nullptr};
+        q.submit([&](sycl::handler& cgh) {
+          cgh.host_task([=, &cl_native_device_id](sycl::interop_handle ih) {
+            cl_native_device_id = ih.get_native_device();
+          });
+        });
+        q.wait_and_throw();
+
+        if (cl_native_device_id != q.get_device().get())
+          FAIL(log, "get_native_device query has failed.");
+      }
+
+      // check get_native_context
+      {
+        cl_context cl_native_context{nullptr};
+        q.submit([&](sycl::handler& cgh) {
+          cgh.host_task([=, &cl_native_context](sycl::interop_handle ih) {
+            cl_native_context = ih.get_native_context();
+          });
+        });
+        q.wait_and_throw();
+
+        if (cl_native_context != q.get_context().get())
+          FAIL(log, "get_native_context query has failed.");
+      }
+
+      // execute OpenCL function
+      {
+        const size_t size{16};
+        const size_t pattern{13};
+        sycl::buffer<size_t, 1> buf(sycl::range<1>{size});
+        q.submit([&](sycl::handler& cgh) {
+          auto buf_acc_dev{buf.get_access<sycl::access::mode::read_write>(cgh)};
+          cgh.host_task([=](sycl::interop_handle ih) {
+            cl_command_queue native_queue = ih.get_native_queue();
+            cl_mem native_mem = ih.get_native_mem(buf_acc_dev);
+            call_opencl(native_queue, native_mem, size, pattern);
+          });
+        });
+
+        {
+          auto buf_acc_host{buf.get_access<sycl::access::mode::read>()};
+          for (int i = 0; i < size; ++i) {
+            if (buf_acc_host[i] != pattern)
+              FAIL(log, "OpenCL invocation has failed.");
+          }
+        }
+      }
+    } catch (const sycl::exception& e) {
+      log_exception(log, e);
+      FAIL(log, "An unexpected SYCL exception was caught");
+    }
+#else
+    log.note("The test is skipped because OpenCL back-end is not supported");
+#endif  // SYCL_BACKEND_OPENCL
+  }
+};
+
+util::test_proxy<TEST_NAME> proxy;
+}  // namespace TEST_NAMESPACE

--- a/tests/host_task/host_task_invoke_api.cpp
+++ b/tests/host_task/host_task_invoke_api.cpp
@@ -1,0 +1,256 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provide verification for invoking a native C++ callable.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+#define TEST_NAME host_task_invoke_api
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+template <typename T>
+class kernel;
+
+/** This functor object represents a command group that will be executed
+ *  on a device. It performs a multiplication of every buffers` element by
+ *  specified constant by calling parallel_for method.
+ */
+template <typename bufferT>
+struct kernel_command_group {
+  kernel_command_group() = delete;
+  kernel_command_group(bufferT& buf, int mul)
+      : m_bufRef{buf}, m_multiplier(mul) {}
+  void operator()(sycl::handler& cgh) {
+    int m = m_multiplier;
+    auto acc_dev =
+        m_bufRef.get().template get_access<sycl::access::mode::read_write>(cgh);
+    cgh.parallel_for<kernel<bufferT>>(m_bufRef.get().get_range(),
+                                      [=](sycl::id<1> i) { acc_dev[i] *= m; });
+  }
+
+  std::reference_wrapper<bufferT> m_bufRef;
+  int m_multiplier;
+};
+
+/** This functor object represents a command group that will be executed
+ *  on host. It performs an addition of a constant to every buffers` element by
+ *  calling host_task method.
+ */
+template <typename bufferT>
+struct host_task_command_group {
+  host_task_command_group() = delete;
+  host_task_command_group(bufferT& buf, int a) : m_bufRef{buf}, m_add(a) {}
+  void operator()(sycl::handler& cgh) {
+    int a = m_add;
+    int container_size = m_bufRef.get().get_count();
+    auto acc_host =
+        m_bufRef.get()
+            .template get_access<sycl::access::mode::read_write,
+                                 sycl::access::target::host_buffer>(cgh);
+    cgh.host_task([=]() {
+      for (int i = 0; i < container_size; ++i) {
+        acc_host[i] += a;
+      }
+    });
+  }
+
+  std::reference_wrapper<bufferT> m_bufRef{};
+  int m_add{};
+};
+
+template <typename T>
+void verify_results(sycl::vector_class<T>& data, T expected,
+                    util::logger& log) {
+  for (T& d : data) {
+    if (d != expected) {
+      FAIL(log, "Data verification failed. Expected: " +
+                    std::to_string(expected) + " got: " + std::to_string(d));
+    }
+  }
+}
+
+class TEST_NAME : public sycl_cts::util::test_base {
+  /** return information about this test
+   */
+  void get_info(test_base::info& out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  static constexpr int container_size{2};
+  static constexpr int init_value{13};
+  static constexpr int multiplier{3};
+  static constexpr int add{3};
+
+  void check_execution_kernel_host(sycl::queue& q, util::logger& log) {
+    log.note("Checking device_task -> host_task execution");
+    constexpr int expected{init_value * multiplier + add};
+    sycl::vector_class<int> data(container_size, init_value);
+
+    {
+      sycl::buffer<int, 1> buffer(data.data(), sycl::range<1>{container_size});
+
+      kernel_command_group<sycl::buffer<int, 1>> kernel(buffer, multiplier);
+      host_task_command_group<sycl::buffer<int, 1>> host_task(buffer, add);
+
+      q.submit(kernel);
+      q.submit(host_task);
+    }
+
+    verify_results(data, expected, log);
+  }
+
+  void check_execution_host_kernel(sycl::queue& q, util::logger& log) {
+    log.note("Checking host_task -> device_task execution");
+    constexpr int expected = (init_value + add) * multiplier;
+    sycl::vector_class<int> data(container_size, init_value);
+
+    {
+      sycl::buffer<int, 1> buffer(data.data(), sycl::range<1>{container_size});
+
+      kernel_command_group<sycl::buffer<int, 1>> kernel(buffer, multiplier);
+      host_task_command_group<sycl::buffer<int, 1>> host_task(buffer, add);
+
+      q.submit(host_task);
+      q.submit(kernel);
+    }
+
+    verify_results(data, expected, log);
+  }
+
+  void check_execution_kernel_host_kernel(sycl::queue& q, util::logger& log) {
+    log.note("Checking device_task -> host_task -> device_task execution");
+
+    constexpr int expected = (init_value * multiplier + add) * multiplier;
+    sycl::vector_class<int> data(container_size, init_value);
+
+    {
+      sycl::buffer<int, 1> buffer(data.data(), sycl::range<1>{container_size});
+
+      kernel_command_group<sycl::buffer<int, 1>> kernel_1(buffer, multiplier);
+      kernel_command_group<sycl::buffer<int, 1>> kernel_2(buffer, multiplier);
+      host_task_command_group<sycl::buffer<int, 1>> host_task(buffer, add);
+
+      q.submit(kernel_1);
+      q.submit(host_task);
+      q.submit(kernel_2);
+    }
+
+    verify_results(data, expected, log);
+  }
+
+  void check_execution_order(sycl::queue& q, util::logger& log) {
+    log.note("Checking execution order");
+    check_execution_host_kernel(q, log);
+    check_execution_kernel_host(q, log);
+    check_execution_kernel_host_kernel(q, log);
+  }
+
+  void check_data_update(sycl::queue& q, util::logger& log) {
+    constexpr int multiplier{10};
+    constexpr int expected{init_value * multiplier};
+    sycl::vector_class<int> data(container_size, init_value);
+    {
+      sycl::buffer<int, 1> buffer(data.data(), sycl::range<1>{container_size});
+
+      q.submit([&](sycl::handler& cgh) {
+        auto acc_host{
+            buffer.get_access<sycl::access::mode::read,
+                              sycl::access::target::host_buffer>(cgh)};
+        auto acc_dev = buffer.get_access<sycl::access::mode::write>(cgh);
+        cgh.host_task([=]() {
+          for (int i = 0; i < container_size; ++i) {
+            acc_dev[i] = acc_host[i] * multiplier;
+          }
+        });
+      });
+
+      {
+        auto acc_host = buffer.get_access<sycl::access::mode::read>();
+        for (int i = 0; i < container_size; ++i) {
+          if (acc_host[i] != expected) {
+            auto errorMessage = "Data verification failed. Expected: " +
+                                std::to_string(expected) +
+                                " got: " + std::to_string(acc_host[i]);
+            FAIL(log, errorMessage);
+          }
+        }
+      }
+    }
+  }
+
+  void check_two_host_tasks_in_different_contexts(sycl::queue& q1,
+                                                  sycl::queue& q2,
+                                                  util::logger& log) {
+    log.note("Checking execution of host_task in different contexts");
+    constexpr int add_1{3};
+    constexpr int add_2{4};
+    constexpr int expected{init_value + (add_1 + add_2) * 2};
+    sycl::vector_class<int> data(container_size, init_value);
+
+    {
+      sycl::buffer<int, 1> buffer(data.data(), sycl::range<1>{container_size});
+
+      host_task_command_group<sycl::buffer<int, 1>> host_task_1(buffer, add_1);
+      host_task_command_group<sycl::buffer<int, 1>> host_task_2(buffer, add_2);
+
+      q1.submit(host_task_1);
+      q2.submit(host_task_2);
+      q2.submit(host_task_1);
+      q1.submit(host_task_2);
+    }
+
+    verify_results(data, expected, log);
+  }
+
+  void check_host_task_and_two_kernels_in_different_contexts(
+      sycl::queue& q1, sycl::queue& q2, util::logger& log) {
+    log.note(
+        "Checking execution of host_task and kernel in different contexts");
+    constexpr int add{3};
+    constexpr int expected{(init_value * multiplier + add) * multiplier + add};
+    sycl::vector_class<int> data(container_size, init_value);
+
+    {
+      sycl::buffer<int, 1> buffer(data.data(), sycl::range<1>{container_size});
+
+      kernel_command_group<sycl::buffer<int, 1>> kernel(buffer, multiplier);
+      host_task_command_group<sycl::buffer<int, 1>> host_task(buffer, add);
+
+      q1.submit(kernel);
+      q2.submit(host_task);
+      q2.submit(kernel);
+      q1.submit(host_task);
+    }
+
+    verify_results(data, expected, log);
+  }
+
+  void check_different_contexts(sycl::queue& q1, util::logger& log) {
+    sycl::queue q2{util::get_cts_object::queue()};
+    check_two_host_tasks_in_different_contexts(q1, q2, log);
+    check_host_task_and_two_kernels_in_different_contexts(q1, q2, log);
+  }
+
+  /** execute this test
+   */
+  void run(util::logger& log) override {
+    try {
+      sycl::queue q{util::get_cts_object::queue()};
+      check_execution_order(q, log);
+      check_different_contexts(q, log);
+      check_data_update(q, log);
+    } catch (const sycl::exception& e) {
+      log_exception(log, e);
+      FAIL(log, "An unexpected SYCL exception was caught");
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
Provide testing host tasks and sycl::interop_handle::get_native function.

Test for sycl::interop_handle::get_native function can be launched only if OpenCL back-end supported.
