### PR TITLE
Add tests for usm allocate/free functions and usm_allocator

### DIFF
--- a/tests/usm/usm.h
+++ b/tests/usm/usm.h
@@ -1,0 +1,83 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common code for USM tests
+//
+*******************************************************************************/
+
+#ifndef __SYCL_CTS_TEST_USM_USM_H
+#define __SYCL_CTS_TEST_USM_USM_H
+
+#include "../common/common.h"
+#include <memory>
+#include <string_view>
+
+namespace usm {
+
+/** @brief Return std::unique_ptr with allocated USM object
+ *  @tparam USM allocation type
+ *  @param queue sycl::queue class object
+ */
+template <sycl::usm::alloc alloc, typename elems_typeT>
+auto allocate_usm_memory(const sycl::queue &queue, size_t num_elements = 1) {
+  const auto &device{queue.get_device()};
+  const auto &context{queue.get_context()};
+
+  auto deleter = [=](elems_typeT *ptr) { sycl::free(ptr, context); };
+
+  if constexpr (alloc == sycl::usm::alloc::shared) {
+    std::unique_ptr<elems_typeT, decltype(deleter)> usm_memory(
+        sycl::malloc_shared<elems_typeT>(num_elements, device, context),
+        deleter);
+    return usm_memory;
+  } else if constexpr (alloc == sycl::usm::alloc::device) {
+    std::unique_ptr<elems_typeT, decltype(deleter)> usm_memory(
+        sycl::malloc_device<elems_typeT>(num_elements, queue), deleter);
+    return usm_memory;
+  } else if constexpr (alloc == sycl::usm::alloc::host) {
+    std::unique_ptr<elems_typeT, decltype(deleter)> usm_memory(
+        sycl::malloc_host<elems_typeT>(num_elements, context), deleter);
+    return usm_memory;
+  } else {
+    static_assert(alloc != alloc, "Unknown USM allocation type");
+  }
+};
+
+/** @brief Returns an aspect depending on the type of allocated memory
+ *  @tparam alloc USM allocation type
+ *  @retval SYCL aspect that corresponds to allocated memory
+ */
+template <const sycl::usm::alloc alloc>
+auto get_aspect() {
+  if constexpr (alloc == sycl::usm::alloc::shared) {
+    return sycl::aspect::usm_shared_allocations;
+  } else if constexpr (alloc == sycl::usm::alloc::device) {
+    return sycl::aspect::usm_device_allocations;
+  } else if constexpr (alloc == sycl::usm::alloc::host) {
+    return sycl::aspect::usm_host_allocations;
+  } else {
+    static_assert(alloc != alloc, "Unknown USM allocation type");
+  }
+}
+
+/** @brief Return string's description depending on the type of allocated memory
+ *  @tparam alloc USM allocation type
+ *  @retval String description of allocated memory
+ */
+template <sycl::usm::alloc alloc>
+std::string_view get_allocation_decription() {
+  if constexpr (alloc == sycl::usm::alloc::shared) {
+    return "shared";
+  } else if constexpr (alloc == sycl::usm::alloc::device) {
+    return "device";
+  } else if constexpr (alloc == sycl::usm::alloc::host) {
+    return "host";
+  } else {
+    static_assert(alloc != alloc, "Unknown USM allocation type");
+  }
+}
+
+}  // namespace usm
+
+#endif  // __SYCL_CTS_TEST_USM_USM_H

--- a/tests/usm/usm.h
+++ b/tests/usm/usm.h
@@ -66,7 +66,7 @@ auto get_aspect() {
  *  @retval String description of allocated memory
  */
 template <sycl::usm::alloc alloc>
-std::string_view get_allocation_decription() {
+std::string_view get_allocation_description() {
   if constexpr (alloc == sycl::usm::alloc::shared) {
     return "shared";
   } else if constexpr (alloc == sycl::usm::alloc::device) {

--- a/tests/usm/usm_aligned_alloc.cpp
+++ b/tests/usm/usm_aligned_alloc.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::aligned_alloc with all usm::alloc kinds
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocate_free.h"
+
+#define TEST_NAME usm_aligned_alloc
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocate_free;
+    using TestType = int;
+    using op_aligned_alloc =
+        usm_operation<usm_op_name::malloc, usm_op_form::aligned>;
+    run_test<TestType, op_aligned_alloc>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_aligned_alloc.cpp
+++ b/tests/usm/usm_aligned_alloc.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using TestType = int;
     using op_aligned_alloc =
         usm_operation<usm_op_name::malloc, usm_op_form::aligned>;
-    run_test<TestType, op_aligned_alloc>(log);
+    run_usm_test<TestType, op_aligned_alloc>(log);
   }
 };
 

--- a/tests/usm/usm_aligned_alloc_device.cpp
+++ b/tests/usm/usm_aligned_alloc_device.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::aligned_alloc_device
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocate_free.h"
+
+#define TEST_NAME usm_aligned_alloc_device
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocate_free;
+    using TestType = int;
+    using op_aligned_alloc_device =
+        usm_operation<usm_op_name::malloc_device, usm_op_form::aligned>;
+    run_test<TestType, op_aligned_alloc_device>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_aligned_alloc_device.cpp
+++ b/tests/usm/usm_aligned_alloc_device.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using TestType = int;
     using op_aligned_alloc_device =
         usm_operation<usm_op_name::malloc_device, usm_op_form::aligned>;
-    run_test<TestType, op_aligned_alloc_device>(log);
+    run_usm_test<TestType, op_aligned_alloc_device>(log);
   }
 };
 

--- a/tests/usm/usm_aligned_alloc_host.cpp
+++ b/tests/usm/usm_aligned_alloc_host.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using TestType = int;
     using op_aligned_alloc_host =
         usm_operation<usm_op_name::malloc_host, usm_op_form::aligned>;
-    run_test<TestType, op_aligned_alloc_host>(log);
+    run_usm_test<TestType, op_aligned_alloc_host>(log);
   }
 };
 

--- a/tests/usm/usm_aligned_alloc_host.cpp
+++ b/tests/usm/usm_aligned_alloc_host.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::aligned_alloc_host
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocate_free.h"
+
+#define TEST_NAME usm_aligned_alloc_host
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocate_free;
+    using TestType = int;
+    using op_aligned_alloc_host =
+        usm_operation<usm_op_name::malloc_host, usm_op_form::aligned>;
+    run_test<TestType, op_aligned_alloc_host>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_aligned_alloc_shared.cpp
+++ b/tests/usm/usm_aligned_alloc_shared.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::aligned_alloc_shared
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocate_free.h"
+
+#define TEST_NAME usm_aligned_alloc_shared
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocate_free;
+    using TestType = int;
+    using op_aligned_alloc_shared =
+        usm_operation<usm_op_name::malloc_shared, usm_op_form::aligned>;
+    run_test<TestType, op_aligned_alloc_shared>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_aligned_alloc_shared.cpp
+++ b/tests/usm/usm_aligned_alloc_shared.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using TestType = int;
     using op_aligned_alloc_shared =
         usm_operation<usm_op_name::malloc_shared, usm_op_form::aligned>;
-    run_test<TestType, op_aligned_alloc_shared>(log);
+    run_usm_test<TestType, op_aligned_alloc_shared>(log);
   }
 };
 

--- a/tests/usm/usm_allocate_free.h
+++ b/tests/usm/usm_allocate_free.h
@@ -418,7 +418,7 @@ class check_usm_allocate_free {
  *  @tparam op Defines name and form of usm allocation function
  */
 template <typename T, typename op>
-static void run_test(util::logger &log) {
+static void run_usm_test(util::logger &log) {
   try {
     check_usm_allocate_free<T, op>{}(log);
   } catch (const sycl::exception &e) {

--- a/tests/usm/usm_allocate_free.h
+++ b/tests/usm/usm_allocate_free.h
@@ -1,0 +1,437 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common checks for usm allocation/free functions
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_USM_ALLOC_FREE_H
+#define __SYCLCTS_TESTS_USM_ALLOC_FREE_H
+
+#include "../common/common.h"
+#include "usm.h"
+#include "usm_allocations_helper.h"
+
+namespace usm_allocate_free {
+using namespace sycl_cts;
+
+struct templated : std::true_type {};
+struct non_templated : std::false_type {};
+struct by_context : std::true_type {};
+struct by_queue : std::false_type {};
+
+template <typename T, typename id, usm_alloc_help::memb_func_index index>
+class usm_kernel_name;
+
+enum class usm_op_name : int {
+  malloc = 0,
+  malloc_device,
+  malloc_host,
+  malloc_shared
+};
+
+enum class usm_op_form : int { general = 0, aligned };
+
+/** @brief Defines an usm allocation function to test
+ *  @tparam usm_op_name Name of usm allocation function
+ *  @tparam usm_op_form Form of usm allocation function (general/aligned)
+ */
+template <usm_op_name opName, usm_op_form opForm>
+struct usm_operation {
+  static constexpr usm_op_name name = opName;
+  static constexpr usm_op_form form = opForm;
+
+  static constexpr sycl::usm::alloc extract_kind() {
+    if constexpr (name == usm_op_name::malloc_device) {
+      return sycl::usm::alloc::device;
+    } else if constexpr (name == usm_op_name::malloc_host) {
+      return sycl::usm::alloc::host;
+    } else if constexpr (name == usm_op_name::malloc_shared) {
+      return sycl::usm::alloc::shared;
+    } else {
+      static_assert(name != name, "Unknown name");
+    }
+  }
+};
+
+/** @brief Defines a case and used to make unique kernel name
+ *  @tparam op Defines name and form of usm allocation function
+ *  @tparam caseNum Index of test case
+ *  @tparam alKind usm::alloc kind of usm allocation
+ *  @tparam templatedT Points to use a templated variant of usm function or not
+ */
+template <typename op, int caseNum, sycl::usm::alloc alKind,
+          typename templatedT>
+struct case_id {
+  using operation = op;
+  static constexpr int case_num = caseNum;
+  static constexpr sycl::usm::alloc kind = alKind;
+
+  static constexpr bool templated() { return templatedT::value; }
+
+  static std::string get_description() {
+    std::string result{"case " + std::to_string(caseNum)};
+    if constexpr (op::name == usm_op_name::malloc) {
+      result += " with kind:";
+      if constexpr (kind == sycl::usm::alloc::device) {
+        result += " usm::alloc::device";
+      }
+      if constexpr (kind == sycl::usm::alloc::host) {
+        result += " usm::alloc::host";
+      }
+      if constexpr (kind == sycl::usm::alloc::shared) {
+        result += " usm::alloc::shared";
+      }
+    }
+    if constexpr (templatedT::value) {
+      result += " (templated form)";
+    }
+    return result;
+  }
+};
+
+/** @brief Defines calls to all overloads of usm allocation functions and
+ *         different checks based on usm::alloc kind
+ *  @tparam T Testing type
+ *  @tparam count Count of elements to allocate
+ */
+template <typename T, std::size_t count>
+class usm_allocations_test_helper {
+  sycl::queue &q;
+  std::size_t align;
+
+ public:
+  usm_allocations_test_helper(sycl::queue &queue, std::size_t al)
+      : q(queue), align(al) {}
+
+  /** @brief Overload to call general form of usm allocation functions
+   *  @tparam c_id Id of test
+   *  @param cnt Count of elements to allocate
+   *  @param args Manualy passed parameters depending on the tested overload
+   *  @retval Pointer to memory allocated with required usm allocation function
+   */
+  template <typename c_id, typename... argsT>
+  T *allocate(std::size_t cnt, argsT &&... args) {
+    using op = typename c_id::operation;
+    if constexpr (c_id::templated()) {
+      // Templated
+      if constexpr (op::name == usm_op_name::malloc) {
+        return sycl::malloc<T>(cnt, std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_device) {
+        return sycl::malloc_device<T>(cnt, std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_host) {
+        return sycl::malloc_host<T>(cnt, std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_shared) {
+        return sycl::malloc_shared<T>(cnt, std::forward<argsT>(args)...);
+      } else {
+        static_assert(op::name != op::name, "Unknown op::name passed");
+      }
+    } else {
+      // Non-templated
+      std::size_t n_bytes = sizeof(T) * cnt;
+      if constexpr (op::name == usm_op_name::malloc) {
+        return (T *)sycl::malloc(n_bytes, std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_device) {
+        return (T *)sycl::malloc_device(n_bytes, std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_host) {
+        return (T *)sycl::malloc_host(n_bytes, std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_shared) {
+        return (T *)sycl::malloc_shared(n_bytes, std::forward<argsT>(args)...);
+      } else {
+        static_assert(op::name != op::name, "Unknown op::name passed");
+      }
+    }
+  }
+
+  /** @brief Overload to call aligned form of usm allocation functions
+   *  @tparam c_id Id of test
+   *  @param al Requred alignment
+   *  @param cnt Count of elements to allocate
+   *  @param args Manualy passed parameters depending on the tested overload
+   *  @retval Pointer to memory allocated with required usm allocation function
+   */
+  template <typename c_id, typename... argsT>
+  T *allocate(std::size_t al, std::size_t cnt, argsT &&... args) {
+    using op = typename c_id::operation;
+    if constexpr (c_id::templated()) {
+      // Templated
+      if constexpr (op::name == usm_op_name::malloc) {
+        return sycl::aligned_alloc<T>(al, cnt, std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_device) {
+        return sycl::aligned_alloc_device<T>(al, cnt,
+                                             std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_host) {
+        return sycl::aligned_alloc_host<T>(al, cnt,
+                                           std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_shared) {
+        return sycl::aligned_alloc_shared<T>(al, cnt,
+                                             std::forward<argsT>(args)...);
+      } else {
+        static_assert(op::name != op::name, "Unknown op::name passed");
+      }
+    } else {
+      // Non-templated
+      std::size_t n_bytes = sizeof(T) * cnt;
+      if constexpr (op::name == usm_op_name::malloc) {
+        return (T *)sycl::aligned_alloc(al, n_bytes,
+                                        std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_device) {
+        return (T *)sycl::aligned_alloc_device(al, n_bytes,
+                                               std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_host) {
+        return (T *)sycl::aligned_alloc_host(al, n_bytes,
+                                             std::forward<argsT>(args)...);
+      } else if constexpr (op::name == usm_op_name::malloc_shared) {
+        return (T *)sycl::aligned_alloc_shared(al, n_bytes,
+                                               std::forward<argsT>(args)...);
+      } else {
+        static_assert(op::name != op::name, "Unknown op::name passed");
+      }
+    }
+  }
+
+  /** @brief Perform required allocations and checks
+   */
+  template <typename c_id>
+  void fill_and_check(util::logger &log, T *ptr) {
+    using namespace usm_alloc_help;
+    // Create unique kernel names
+    using fill_kernel = usm_kernel_name<T, c_id, memb_func_index::fill>;
+    using simple_kernel = usm_kernel_name<T, c_id, memb_func_index::simple>;
+    using device_kernel = usm_kernel_name<T, c_id, memb_func_index::device>;
+    using host_kernel = usm_kernel_name<T, c_id, memb_func_index::host>;
+
+    fill<T, count, fill_kernel>(ptr, q);
+
+    if (!check_simple<T, count, simple_kernel>(log, ptr, q))
+      FAIL(log, "Default check " + c_id::get_description());
+
+    // Memory allocated on 'host' or as 'shared' should be accessible to memory
+    // allocated on 'device'
+    if constexpr (c_id::kind == sycl::usm::alloc::host ||
+                  c_id::kind == sycl::usm::alloc::shared) {
+      if (allocation_supported<sycl::usm::alloc::device>(log, q)) {
+        if (!check_by_index<T, memb_func_index::device, count, device_kernel>(
+                log, ptr, q))
+          FAIL(log, "Check on device " + c_id::get_description());
+      } else {
+        log.note("(skipped check on device)");
+      }
+    }
+    // Memory allocated as 'shared' should be accessible to memory allocated
+    // on 'host'
+    if constexpr (c_id::kind == sycl::usm::alloc::shared) {
+      if (allocation_supported<sycl::usm::alloc::host>(log, q)) {
+        if (!check_by_index<T, memb_func_index::host, count, host_kernel>(
+                log, ptr, q))
+          FAIL(log, "Check on host " + c_id::get_description());
+      } else {
+        log.note("(skipped check on host)");
+      }
+    }
+  }
+
+  /** @brief Run an actual check for given case id
+   *  @tparam c_id Id of current test case
+   *  @tparam byQueue Defines the sycl::free strategy
+   *  @param args Manualy passed parameters depending on the tested overload
+   */
+  template <typename c_id, typename byQueue, typename... argsT>
+  void run(util::logger &log, argsT &&... args) {
+    using namespace usm_alloc_help;
+    T *ptr = nullptr;
+    if (c_id::operation::form == usm_op_form::general) {
+      ptr = allocate<c_id>(count, std::forward<argsT>(args)...);
+    } else {
+      ptr = allocate<c_id>(align, count, std::forward<argsT>(args)...);
+    }
+    if (ptr == nullptr) {
+      FAIL(log, "allocation returned 'nullptr' in " + c_id::get_description());
+      return;
+    }
+    // Custom deleter
+    auto deleter = [&](T *ptr) { sycl::free(ptr, q); };
+    std::unique_ptr<T, decltype(deleter)> free_ptr(ptr, deleter);
+
+    // Check alignment
+    if constexpr (c_id::operation::form == usm_op_form::aligned) {
+      if (!check_alignment(ptr, align)) {
+        FAIL(log, "wrong aligned pointer in " + c_id::get_description());
+      }
+    }
+
+    fill_and_check<c_id>(log, ptr);
+  }
+};
+
+/** @brief Run checks for 'malloc' or 'aligned_alloc' with given usm::alloc
+ *         'kind'
+ *  @tparam T Testing type
+ *  @tparam op Defines name and form of usm allocation function
+ *  @tparam count Count of elements to allocate
+ *  @tparam kind usm::alloc kind of usm allocation
+ *  @tparam templatedT Points to use a templated variant of usm function or not
+ */
+template <typename T, typename op, std::size_t count, sycl::usm::alloc kind,
+          typename templatedT>
+static void do_malloc_by_kind(util::logger &log, std::size_t align,
+                              sycl::queue &q, const sycl::property_list pl) {
+  using namespace usm_alloc_help;
+  if (!allocation_supported<kind>(log, q)) {
+    log.note("(skipped)");
+    return;
+  }
+  auto dev = q.get_device();
+  auto ctx = q.get_context();
+  usm_allocations_test_helper<T, count> test(q, align);
+
+  {
+    /** Passing 'queue' as parameter
+     */
+    constexpr int case_num = 1;
+    using id = case_id<op, case_num, kind, templatedT>;
+    test.template run<id, by_queue>(log, q, kind);
+  }
+  {
+    /** Passing 'context' as parameter
+     */
+    constexpr int case_num = 2;
+    using id = case_id<op, case_num, kind, templatedT>;
+    test.template run<id, by_context>(log, dev, ctx, kind);
+  }
+  // Cases for overloads with sycl::property_list will be added here
+}
+
+/** @brief Run checks for 'malloc_host' or 'aligned_alloc_host'
+ *  @tparam T Testing type
+ *  @tparam op Defines name and form of usm allocation function
+ *  @tparam count Count of elements to allocate
+ *  @tparam templatedT Points to use a templated variant of usm function or not
+ */
+template <typename T, typename op, std::size_t count, typename templatedT>
+static void do_malloc_host(util::logger &log, std::size_t align, sycl::queue &q,
+                           const sycl::property_list pl) {
+  using namespace usm_alloc_help;
+  constexpr sycl::usm::alloc kind = op::extract_kind();
+  if (!allocation_supported<kind>(log, q)) {
+    log.note("(skipped)");
+    return;
+  }
+  auto ctx = q.get_context();
+  usm_allocations_test_helper<T, count> test(q, align);
+
+  {
+    /** Passing 'queue' as parameter
+     */
+    constexpr int case_num = 1;
+    using id = case_id<op, case_num, kind, templatedT>;
+    test.template run<id, by_queue>(log, q);
+  }
+  {
+    /** Passing 'context' as parameter
+     */
+    constexpr int case_num = 2;
+    using id = case_id<op, case_num, kind, templatedT>;
+    test.template run<id, by_context>(log, ctx);
+  }
+  // Cases for overloads with sycl::property_list will be added here
+}
+
+/** @brief Run checks for 'malloc_...' or 'aligned_alloc_...' (host/device)
+ *  @tparam T Testing type
+ *  @tparam op Defines name and form of usm allocation function
+ *  @tparam count Count of elements to allocate
+ *  @tparam templatedT Points to use a templated variant of usm function or not
+ */
+template <typename T, typename op, std::size_t count, typename templatedT>
+static void do_malloc_by_operation(util::logger &log, std::size_t align,
+                                   sycl::queue &q,
+                                   const sycl::property_list pl) {
+  using namespace usm_alloc_help;
+  constexpr sycl::usm::alloc kind = op::extract_kind();
+  if (!allocation_supported<kind>(log, q)) {
+    log.note("(skipped)");
+    return;
+  }
+  auto dev = q.get_device();
+  auto ctx = q.get_context();
+  usm_allocations_test_helper<T, count> test(q, align);
+
+  {
+    /** Passing 'queue' as parameter
+     */
+    constexpr int case_num = 1;
+    using id = case_id<op, case_num, kind, templatedT>;
+    test.template run<id, by_queue>(log, q);
+  }
+  {
+    /** Passing 'context' as parameter
+     */
+    constexpr int case_num = 2;
+    using id = case_id<op, case_num, kind, templatedT>;
+    test.template run<id, by_context>(log, dev, ctx);
+  }
+  // Cases for overloads with sycl::property_list will be added here
+}
+
+/** @brief Main test-suite
+ *  @tparam T Testing type
+ *  @tparam op Defines name and form of usm allocation function
+ */
+template <typename T, typename op>
+class check_usm_allocate_free {
+ public:
+  void operator()(util::logger &log) {
+    constexpr auto device = sycl::usm::alloc::device;
+    constexpr auto host = sycl::usm::alloc::host;
+    constexpr auto shared = sycl::usm::alloc::shared;
+    constexpr std::size_t count = 10;
+    /** Possible universal values for alignment are powers of two (8, 16, etc)
+     *  Behaviour is backend-specific if incorrect alignment passed
+     */
+    constexpr std::size_t align = 8;
+
+    auto q = util::get_cts_object::queue();
+    const sycl::property_list pl{};
+
+    if constexpr (op::name == usm_op_name::malloc) {
+      do_malloc_by_kind<T, op, count, device, non_templated>(log, align, q, pl);
+      do_malloc_by_kind<T, op, count, host, non_templated>(log, align, q, pl);
+      do_malloc_by_kind<T, op, count, shared, non_templated>(log, align, q, pl);
+
+      do_malloc_by_kind<T, op, count, device, templated>(log, align, q, pl);
+      do_malloc_by_kind<T, op, count, host, templated>(log, align, q, pl);
+      do_malloc_by_kind<T, op, count, shared, templated>(log, align, q, pl);
+    } else if constexpr (op::name == usm_op_name::malloc_host) {
+      do_malloc_host<T, op, count, non_templated>(log, align, q, pl);
+      do_malloc_host<T, op, count, templated>(log, align, q, pl);
+    } else {
+      do_malloc_by_operation<T, op, count, non_templated>(log, align, q, pl);
+      do_malloc_by_operation<T, op, count, templated>(log, align, q, pl);
+    }
+  }
+};
+
+/** @brief Execute test for type defined by operation
+ *  @tparam T Testing type
+ *  @tparam op Defines name and form of usm allocation function
+ */
+template <typename T, typename op>
+static void run_test(util::logger &log) {
+  try {
+    check_usm_allocate_free<T, op>{}(log);
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+}  // namespace usm_allocate_free
+
+#endif  // __SYCLCTS_TESTS_USM_ALLOC_FREE_H

--- a/tests/usm/usm_allocations_helper.h
+++ b/tests/usm/usm_allocations_helper.h
@@ -1,0 +1,204 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides different tools for usm allocation/free/usm_allocator tests
+//
+*******************************************************************************/
+#include "../common/common.h"
+#include "usm.h"
+#include <cstddef>
+
+namespace usm_alloc_help {
+using namespace sycl_cts;
+
+/** @brief Custom type to create usm_allocator with other T type
+ */
+struct custom_type {
+  int value;
+};
+
+/** @brief Kernel index to differentiate kernel names in methods
+ */
+enum class memb_func_index : int { fill = 0, simple, device, host };
+
+/** @brief Get description of index given
+ */
+template <memb_func_index index>
+static std::string get_index_name() {
+  if constexpr (index == memb_func_index::fill) {
+    return "fill";
+  } else if constexpr (index == memb_func_index::simple) {
+    return "simple";
+  } else if constexpr (index == memb_func_index::device) {
+    return "device";
+  } else if constexpr (index == memb_func_index::host) {
+    return "host";
+  } else {
+    static_assert(index != index, "Wrong memb_func_index value!");
+  }
+}
+
+/** @brief Get usm::alloc kind which differs from current (only used by tests
+ *         for usm_allocator)
+ */
+template <sycl::usm::alloc kind>
+inline constexpr sycl::usm::alloc other_kind() {
+  if constexpr (kind == sycl::usm::alloc::host) {
+    return sycl::usm::alloc::shared;
+  } else if constexpr (kind == sycl::usm::alloc::shared) {
+    return sycl::usm::alloc::host;
+  } else {
+    static_assert(kind != kind, "'kind' is supposed to be 'host' or 'shared'");
+  }
+}
+
+/** @brief Check usm::alloc kind of allocated memory
+ *  @tparam UPtr Expecting std::unique_ptr type
+ */
+template <typename UPtr>
+static bool check_ptr_kind(const UPtr &ptr, sycl::context &ctx,
+                           sycl::usm::alloc ref_kind) {
+  return sycl::get_pointer_type(ptr.get(), ctx) == ref_kind;
+}
+
+/** @brief Check that two memory allocations have the same usm::alloc kind
+ *  @tparam UPtrT Expecting std::unique_ptr type
+ *  @tparam UPtrU Expecting other std::unique_ptr type
+ */
+template <typename UPtrT, typename UPtrU>
+static bool compare_ptrs_kind(const UPtrT &lhs, const UPtrU &rhs,
+                              sycl::context ctx) {
+  return sycl::get_pointer_type(lhs.get(), ctx) ==
+         sycl::get_pointer_type(rhs.get(), ctx);
+}
+
+/** @brief Checks if allocation of this usm::alloc kind is supported
+ */
+template <sycl::usm::alloc kind>
+static bool allocation_supported(util::logger &log, sycl::queue &q) {
+  if (!q.get_device().has(usm::get_aspect<kind>())) {
+    log.note("Device does not support " +
+             std::string(usm::get_allocation_description<kind>()) +
+             " allocations");
+    return false;
+  }
+  return true;
+}
+
+/** @brief Fills allocated memory
+ *  @tparam T Testing type
+ *  @tparam count Count of allocated elements
+ *  @tparam kernel_name Unique kernel name
+ */
+template <typename T, std::size_t count, typename kernel_name>
+void fill(T *ptr, sycl::queue &q) {
+  sycl::range<1> ndRng{count};
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for<kernel_name>(ndRng, [=](sycl::id<1> idx) {
+      ptr[idx] = idx[0];
+    });
+  });
+  q.wait_and_throw();
+}
+
+/** @brief Checks that allocated memory is accessible
+ *  @tparam T Testing type
+ *  @tparam count Count of allocated elements
+ *  @tparam kernel_name Unique kernel name
+ */
+template <typename T, std::size_t count, typename kernel_name>
+bool check_simple(util::logger &log, T *ptr, sycl::queue &q) {
+  sycl::range<1> ndRng{count};
+  T result_arr[count]{};
+  {
+    sycl::buffer<T, 1> buf(result_arr, ndRng);
+    q.submit([&](sycl::handler &cgh) {
+      auto acc = buf.template get_access<sycl::access_mode::write>(cgh);
+      cgh.parallel_for<kernel_name>(ndRng, [=](sycl::id<1> idx) {
+        acc[idx] = ptr[idx];
+      });
+    });
+  }
+  bool result = true;
+  for (int i = 0; i < count; ++i) {
+    result = result && (result_arr[i] == i);
+  }
+  return result;
+}
+
+/** @brief Allocate memory of requred usm::alloc kind and store it in
+ *         std::unique_ptr
+ *  @brief T Testing type
+ *  @brief index Defines the allocation type
+ */
+template <typename T, memb_func_index index>
+auto allocate_by_index(sycl::queue &q, std::size_t count) {
+  if constexpr (index == memb_func_index::device) {
+    return usm::allocate_usm_memory<sycl::usm::alloc::device, T>(q, count);
+  } else if constexpr (index == memb_func_index::host) {
+    return usm::allocate_usm_memory<sycl::usm::alloc::host, T>(q, count);
+  } else {
+    static_assert(index != index,
+                  "'index' is supposed to be 'host' or 'device'");
+  }
+}
+
+/** @brief Checks that memory is accessible for memory allocated with another
+ *         usm::alloc kind
+ *  @tparam T Testing type
+ *  @tparam index Defines the allocation type
+ *  @tparam count Count of elements to allocate
+ *  @tparam kernel_name Unique kernel name
+ */
+template <typename T, memb_func_index index, std::size_t count,
+          typename kernel_name>
+bool check_by_index(util::logger &log, T *ptr, sycl::queue &q) {
+  sycl::range<1> ndRng{count};
+  // Save input values
+  T ref_arr[count]{};
+  for (int i = 0; i < count; ++i) ref_arr[i] = ptr[i];
+
+  auto check_ptr = allocate_by_index<T, index>(q, count);
+  if (!check_ptr) {
+    log.note("allocation returned nullptr (check skipped)");
+    return true;
+  }
+  T *check_raw_ptr = check_ptr.get();
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for<kernel_name>(ndRng, [=](sycl::id<1> idx) {
+      const int i = idx[0];
+      check_raw_ptr[i] = ptr[i] * 2;
+      ptr[i] = check_raw_ptr[i];
+    });
+  });
+  q.wait_and_throw();
+  bool result = true;
+  for (int i = 0; i < count; ++i) {
+    result = result && (ptr[i] == ref_arr[i] * 2);
+  }
+  return result;
+}
+
+/** @brief Check that pointer address aligned with given value
+ */
+template <typename T>
+bool check_alignment(T *ptr, std::size_t align) {
+  return (reinterpret_cast<std::size_t>(ptr) % align) == 0;
+}
+
+/** @brief Custom deleter for automatical deallocation of memory allocated by
+ *         usm_allocator
+ */
+template <typename T, typename Allocator, std::size_t count>
+class usm_custom_deleter {
+  Allocator& allocator;
+ public:
+  usm_custom_deleter(Allocator& allctr) : allocator(allctr) {}
+
+  void operator()(T* ptr) {
+    allocator.deallocate(ptr, count);
+  }
+};
+
+}  // namespace usm_alloc_help

--- a/tests/usm/usm_allocations_helper.h
+++ b/tests/usm/usm_allocations_helper.h
@@ -18,7 +18,7 @@ struct custom_type {
   int value;
 };
 
-/** @brief Kernel index to differentiate kernel names in methods
+/** @brief Kernel index to differentiate kernel names in member functions
  */
 enum class memb_func_index : int { fill = 0, simple, device, host };
 

--- a/tests/usm/usm_allocator_api.cpp
+++ b/tests/usm/usm_allocator_api.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::usm_allocator api
+//
+*******************************************************************************/
+
+#include "usm_allocator_api.h"
+#include "../common/common.h"
+
+#define TEST_NAME usm_allocator_api
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocator_api;
+    using TestType = int;
+    try {
+      check_usm_allocator_api<TestType, allocate_general>{}(log);
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_allocator_api.h
+++ b/tests/usm/usm_allocator_api.h
@@ -1,0 +1,240 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common checks for sycl::usm_allocator api
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_USM_ALLOCATOR_API_H
+#define __SYCLCTS_TESTS_USM_ALLOCATOR_API_H
+
+#include "../common/common.h"
+#include "usm.h"
+#include "usm_allocations_helper.h"
+
+namespace usm_allocator_api {
+using namespace sycl_cts;
+
+using allocate_aligned = std::true_type;
+using allocate_general = std::false_type;
+
+template <typename c_id, usm_alloc_help::memb_func_index index>
+struct usm_allctr_krnl_name;
+
+/** @brief Represents the way the allocator was created
+ */
+enum class creation_way : int {
+  by_context_device = 0,
+  by_context_device_prop_list,
+  by_queue,
+  by_queue_prop_list,
+  copy_ctor,
+  move_ctor,
+  copy_ctor_diff_type,
+  move_assign
+};
+
+template <creation_way way>
+std::string_view creation_way_hint() {
+  if constexpr (way == creation_way::by_context_device) {
+    return "constructed by context and device";
+  } else if constexpr (way == creation_way::by_context_device_prop_list) {
+    return "constructed by context, device and property_list";
+  } else if constexpr (way == creation_way::by_queue) {
+    return "constructed by queue";
+  } else if constexpr (way == creation_way::by_queue_prop_list) {
+    return "constructed by queue and property_list";
+  } else if constexpr (way == creation_way::copy_ctor) {
+    return "copy constructed";
+  } else if constexpr (way == creation_way::move_ctor) {
+    return "move constructed";
+  } else if constexpr (way == creation_way::copy_ctor_diff_type) {
+    return "copy constructed from allocator with different type";
+  } else if constexpr (way == creation_way::move_assign) {
+    return "move assigned";
+  } else {
+    static_assert(way != way, "Unknown creation way");
+  }
+}
+
+/** @brief Defines a case and used to make unique kernel name
+ *  @tparam T Testing type
+ *  @tparam alKind sycl::usm::alloc
+ *  @tparam crWay Creation way of usm_allocator
+ */
+template <typename T, sycl::usm::alloc alKind, creation_way crWay,
+          typename Aligned>
+struct case_id {
+  using Type = T;
+  static constexpr sycl::usm::alloc kind = alKind;
+  static constexpr creation_way way = crWay;
+  using aligned = Aligned;
+};
+
+template <typename c_id>
+std::string log_message(const char *check) {
+  return "case for 'allocate' (usm_allocator is " +
+         std::string(creation_way_hint<c_id::way>()) + ") - " +
+         std::string(check) + " for kind: " +
+         std::string(usm::get_allocation_description<c_id::kind>());
+}
+
+/** @brief Perform check for allocated memory
+ */
+template <typename c_id, std::size_t count, std::size_t align, typename UPtr>
+static void fill_and_check(util::logger &log, const UPtr &u_ptr,
+                           sycl::queue &q) {
+  using namespace usm_alloc_help;
+  using T = typename c_id::Type;
+  using Aligned = typename c_id::aligned;
+  // Prepare unique kernel names
+  using fill_kernel = usm_allctr_krnl_name<c_id, memb_func_index::fill>;
+  using simple_kernel = usm_allctr_krnl_name<c_id, memb_func_index::simple>;
+  using host_kernel = usm_allctr_krnl_name<c_id, memb_func_index::host>;
+
+  T *ptr = u_ptr.get();
+
+  // Check alignment
+  if constexpr (Aligned::value) {
+    if (!check_alignment(ptr, align)) {
+      FAIL(log,
+           "Wrong aligned pointer in " + log_message<c_id>("alignment check"));
+    }
+  }
+
+  fill<T, count, fill_kernel>(ptr, q);
+
+  // Regular check
+  if (!check_simple<T, count, simple_kernel>(log, ptr, q)) {
+    FAIL(log, log_message<c_id>("default check"));
+  }
+
+  // Memory allocated as 'shared' should be accessible to memory allocated
+  // on 'host'
+  if constexpr (c_id::kind == sycl::usm::alloc::shared) {
+    if (allocation_supported<sycl::usm::alloc::host>(log, q)) {
+      if (!check_by_index<T, memb_func_index::host, count, host_kernel>(
+              log, ptr, q)) {
+        FAIL(log, log_message<c_id>("check on host"));
+      }
+    } else {
+      log.note(log_message<c_id>("(skipped check on host)"));
+    }
+  }
+}
+
+/** @brief Run tests for given usm::alloc
+ */
+template <typename T, sycl::usm::alloc kind, typename Aligned>
+static void run_api_test_for_kind(util::logger &log) {
+  using namespace usm_alloc_help;
+  auto queue = util::get_cts_object::queue();
+
+  if (!usm_alloc_help::allocation_supported<kind>(log, queue)) {
+    log.note(" (test skipped) for kind: " +
+             std::string(usm::get_allocation_description<kind>()));
+    return;
+  }
+  auto ctx = queue.get_context();
+  auto dev = queue.get_device();
+  sycl::property_list pl{};
+  constexpr std::size_t count = 10;
+  /** Possible universal values for alignment are powers of two (8, 16, etc)
+   *  Behaviour is backend-specific if incorrect alignment passed
+   */
+  constexpr std::size_t align = 8;
+
+  using AllocatorT =
+      typename std::conditional<Aligned::value,
+                                sycl::usm_allocator<T, kind, align>,
+                                sycl::usm_allocator<T, kind>>::type;
+  // Custom deleter
+  using DeleterT = usm_custom_deleter<T, AllocatorT, count>;
+  using PtrType = std::unique_ptr<T, DeleterT>;
+
+  /** Check (context, device) constructor
+   */
+  {
+    using c_id = case_id<T, kind, creation_way::by_context_device, Aligned>;
+    AllocatorT allctr(ctx, dev);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+    fill_and_check<c_id, count, align>(log, ptr, queue);
+  }
+
+  // TODO: Case for (context, device, property_list) constructor will be added
+  // here
+
+  /** Check (queue) constructor
+   */
+  {
+    using c_id = case_id<T, kind, creation_way::by_queue, Aligned>;
+    AllocatorT allctr(queue);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+    fill_and_check<c_id, count, align>(log, ptr, queue);
+  }
+
+  // TODO: Case for (queue, property_list) constructor will be added here
+
+  /** Check copy constructor
+   */
+  {
+    using c_id = case_id<T, kind, creation_way::copy_ctor, Aligned>;
+    AllocatorT other(ctx, dev);
+    AllocatorT allctr(other);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+    fill_and_check<c_id, count, align>(log, ptr, queue);
+  }
+
+  /** Check move constructor
+   */
+  {
+    using c_id = case_id<T, kind, creation_way::move_ctor, Aligned>;
+    AllocatorT other(ctx, dev);
+    AllocatorT allctr(std::move(other));
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+    fill_and_check<c_id, count, align>(log, ptr, queue);
+  }
+
+  /** Check copy constructor for allocator with different T type
+   */
+  {
+    using c_id = case_id<T, kind, creation_way::copy_ctor_diff_type, Aligned>;
+    using U = custom_type;
+    using AllocDiffTType =
+        typename std::conditional<Aligned::value,
+                                  sycl::usm_allocator<U, kind, align>,
+                                  sycl::usm_allocator<U, kind>>::type;
+    AllocDiffTType other(ctx, dev);
+    AllocatorT allctr(other);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+    fill_and_check<c_id, count, align>(log, ptr, queue);
+  }
+
+  /** Check move assignment
+   */
+  {
+    using c_id = case_id<T, kind, creation_way::move_assign, Aligned>;
+    AllocatorT other(queue);
+    AllocatorT allctr(ctx, dev);
+    allctr = std::move(other);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+    fill_and_check<c_id, count, align>(log, ptr, queue);
+  }
+}
+
+/** @brief Main test-suite
+ *  @tparam T Testing type
+ */
+template <typename T, typename Aligned>
+class check_usm_allocator_api {
+ public:
+  void operator()(util::logger &log) {
+    run_api_test_for_kind<T, sycl::usm::alloc::host, Aligned>(log);
+    run_api_test_for_kind<T, sycl::usm::alloc::shared, Aligned>(log);
+  }
+};
+
+}  // namespace usm_allocator_api
+
+#endif  // __SYCLCTS_TESTS_USM_ALLOCATOR_API_H

--- a/tests/usm/usm_allocator_api_aligned.cpp
+++ b/tests/usm/usm_allocator_api_aligned.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::usm_allocator api with alignment
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocator_api.h"
+
+#define TEST_NAME usm_allocator_api_aligned
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocator_api;
+    using TestType = int;
+    try {
+      check_usm_allocator_api<TestType, allocate_aligned>{}(log);
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_allocator_constructors.cpp
+++ b/tests/usm/usm_allocator_constructors.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::usm_allocator constructors
+//
+*******************************************************************************/
+
+#include "usm_allocator_constructors.h"
+#include "../common/common.h"
+
+#define TEST_NAME usm_allocator_constructors
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocator_constructors;
+    using TestType = int;
+    try {
+      check_usm_allocator_constructors<TestType>{}(log);
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_allocator_constructors.h
+++ b/tests/usm/usm_allocator_constructors.h
@@ -1,0 +1,206 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common checks for sycl::usm_allocator constructors
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_USM_ALLOCATOR_CONSTRUCTORS_H
+#define __SYCLCTS_TESTS_USM_ALLOCATOR_CONSTRUCTORS_H
+
+#include "../common/common.h"
+#include "usm.h"
+#include "usm_allocations_helper.h"
+#include <memory>
+
+namespace usm_allocator_constructors {
+using namespace sycl_cts;
+
+/** @brief Run tests for given usm::alloc
+ */
+template <typename T, sycl::usm::alloc kind>
+static void run_ctors_test_for_kind(util::logger &log) {
+  using namespace usm_alloc_help;
+  auto queue = util::get_cts_object::queue();
+
+  if (!usm_alloc_help::allocation_supported<kind>(log, queue)) {
+    log.note(" (test skipped) for kind: " +
+             std::string(usm::get_allocation_description<kind>()));
+    return;
+  }
+  auto ctx = queue.get_context();
+  auto dev = queue.get_device();
+  sycl::property_list pl{};
+  constexpr std::size_t count = 10;
+  /** Possible universal values for alignment are powers of two (8, 16, etc)
+   *  Behaviour is backend-specific if incorrect alignment passed
+   */
+  constexpr std::size_t align = 8;
+
+  using AllocatorT = sycl::usm_allocator<T, kind, align>;
+  // Custom deleter
+  using DeleterT = usm_custom_deleter<T, AllocatorT, count>;
+  using PtrType = std::unique_ptr<T, DeleterT>;
+
+  /** Check (context, device) constructor
+   */
+  {
+    AllocatorT allctr(ctx, dev);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+    if (!check_ptr_kind(ptr, ctx, kind)) {
+      FAIL(log, "Constructor (context, device) for kind: " +
+                std::string(usm::get_allocation_description<kind>()));
+    }
+  }
+
+  // TODO: Case for (context, device, property_list) ctor will be added here
+
+  /** Check (queue) constructor
+   */
+  {
+    AllocatorT allctr(queue);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+    if (!check_ptr_kind(ptr, ctx, kind)) {
+      FAIL(log, "Constructor (queue) for kind: " +
+                std::string(usm::get_allocation_description<kind>()));
+    }
+  }
+
+  // TODO: Case for (queue, property_list) ctor will be added here
+
+  /** Check copy constructor
+   */
+  {
+    AllocatorT other(ctx, dev);
+    PtrType ptr_other(other.allocate(count), DeleterT{other});
+
+    AllocatorT allctr(other);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+
+    if (!compare_ptrs_kind(ptr, ptr_other, ctx)) {
+      FAIL(log, "Copy constructor for kind: " +
+                std::string(usm::get_allocation_description<kind>()));
+    }
+  }
+
+  /** Check move constructor
+   */
+  {
+    AllocatorT other(ctx, dev);
+    T* other_ptr = other.allocate(count);
+
+    AllocatorT allctr(std::move(other));
+    // Both pointers should be deleted by 'allctr' because 'other' was moved
+    PtrType ptr_other(other_ptr, DeleterT{allctr});
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+
+    if (!compare_ptrs_kind(ptr, ptr_other, ctx)) {
+      FAIL(log, "Move constructor for kind: " +
+                std::string(usm::get_allocation_description<kind>()));
+    }
+  }
+
+  /** Check copy constructor for allocator with different T type
+   */
+  {
+    using U = custom_type;
+    using AllocDiffTType = sycl::usm_allocator<U, kind, align>;
+    using DeleterDiffTType = usm_custom_deleter<U, AllocDiffTType, count>;
+    using OtherPtrType = std::unique_ptr<U, DeleterDiffTType>;
+
+    AllocDiffTType other(ctx, dev);
+    OtherPtrType ptr_other(other.allocate(count), DeleterDiffTType{other});
+
+    AllocatorT allctr(other);
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+
+    if (!compare_ptrs_kind(ptr, ptr_other, ctx)) {
+      FAIL(log, "Copy constructor (usm_allocator<U,...>) for kind: " +
+                std::string(usm::get_allocation_description<kind>()));
+    }
+  }
+
+  /** Check move assignment
+   */
+  {
+    AllocatorT other(queue);
+    T* other_ptr = other.allocate(count);
+
+    AllocatorT allctr(ctx, dev);
+    allctr = std::move(other);
+    // Both pointers should be deleted by 'allctr' because 'other' was moved
+    PtrType ptr_other(other_ptr, DeleterT{allctr});
+    PtrType ptr(allctr.allocate(count), DeleterT{allctr});
+
+    if (!compare_ptrs_kind(ptr, ptr_other, ctx)) {
+      FAIL(log, "Move assignment for kind: " +
+                std::string(usm::get_allocation_description<kind>()));
+    }
+  }
+
+  /** Check equality operator
+   */
+  {
+    using AllocatorDiffT = sycl::usm_allocator<T, other_kind<kind>(), align>;
+    AllocatorT allctrA(ctx, dev);
+    AllocatorT allctrB(allctrA);
+    AllocatorT allctrC(queue);
+    allctrC = allctrA;
+    AllocatorDiffT allctrD(ctx, dev);
+    std::string kind_hint{usm::get_allocation_description<kind>()};
+
+    if (!(allctrA == allctrB)) {
+      FAIL(log,
+           "usm_allocator equality operator does not work correctly"
+           "(copy constructed) for kind: " +
+               kind_hint);
+    }
+    if (!(allctrA == allctrC)) {
+      FAIL(log,
+           "usm_allocator equality operator does not work correctly"
+           "(copy assigned) for kind: " +
+               kind_hint);
+    }
+    if (allctrA != allctrB) {
+      FAIL(log,
+           "usm_allocator non-equality operator does not work correctly"
+           "(copy constructed) for kind: " +
+               kind_hint);
+    }
+    if (allctrA != allctrC) {
+      FAIL(log,
+           "usm_allocator non-equality operator does not work correctly"
+           "(copy constructed) for kind: " +
+               kind_hint);
+    }
+    if (allctrC == allctrD) {
+      FAIL(log,
+           "usm_allocator equality operator does not work correctly"
+           "(comparing with different) for kind: " +
+               kind_hint);
+    }
+    if (!(allctrC != allctrD)) {
+      FAIL(log,
+           "usm_allocator non-equality operator does not work correctly"
+           "(comparing with different) for kind: " +
+               kind_hint);
+    }
+  }
+}
+
+/** @brief Main test-suite
+ *  @tparam T Testing type
+ */
+template <typename T>
+class check_usm_allocator_constructors {
+ public:
+  void operator()(util::logger &log) {
+    run_ctors_test_for_kind<T, sycl::usm::alloc::host>(log);
+    run_ctors_test_for_kind<T, sycl::usm::alloc::shared>(log);
+  }
+};
+
+}  // namespace usm_allocator_constructors
+
+#endif  // __SYCLCTS_TESTS_USM_ALLOCATOR_CONSTRUCTORS_H

--- a/tests/usm/usm_fill_memset_memcpy.cpp
+++ b/tests/usm/usm_fill_memset_memcpy.cpp
@@ -6,7 +6,7 @@
 //
 *******************************************************************************/
 
-#include "../common/common.h"
+#include "usm.h"
 #include <cstring>
 
 #define TEST_NAME usm_fill_memset_memcpy
@@ -41,13 +41,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
       constexpr auto value_for_filling{1};
       constexpr auto value_for_first_element_overwriting{10};
 
-      auto deleter = [&q](int *data) { sycl::free(data, q.get_context()); };
-      std::unique_ptr<int, decltype(deleter)> src(
-          sycl::malloc_shared<int>(size, q.get_device(), q.get_context()),
-          deleter);
-      std::unique_ptr<int, decltype(deleter)> output(
-          sycl::malloc_shared<int>(size, q.get_device(), q.get_context()),
-          deleter);
+      auto src {usm::allocate_usm_memory<sycl::usm::alloc::shared, int>(q, count)};
+      auto output {usm::allocate_usm_memory<sycl::usm::alloc::shared, int>(q, count)};
 
       sycl::event init_fill = q.submit([&](sycl::handler &cgh) {
         cgh.fill(src.get(), value_for_filling, count);

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -21,7 +21,7 @@ void run_check(const sycl::queue &queue, sycl_cts::util::logger &log) {
   const auto &device{queue.get_device()};
   const auto &context{queue.get_context()};
 
-  auto str_usm_alloc_type{usm::get_allocation_decription<alloc>()};
+  auto str_usm_alloc_type{usm::get_allocation_description<alloc>()};
 
   if (device.has(usm::get_aspect<alloc>())) {
     auto allocated_memory = usm::allocate_usm_memory<alloc, int>(queue);

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provide verification to cooperation USM functions get_pointer_type and
+//  get_pointer_device with four memory allocation types: host, device, shared
+//  and non USM allocation.
+//
+*******************************************************************************/
+
+#include "usm.h"
+#include <cstring>
+
+#define TEST_NAME usm_get_pointer_queries
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+template <sycl::usm::alloc alloc>
+void run_check(const sycl::queue &queue, sycl_cts::util::logger &log) {
+  const auto &device{queue.get_device()};
+  const auto &context{queue.get_context()};
+
+  auto str_usm_alloc_type{usm::get_allocation_decription<alloc>()};
+
+  if (device.has(usm::get_aspect<alloc>())) {
+    auto allocated_memory = usm::allocate_usm_memory<alloc, int>(queue);
+    const auto value = sycl::get_pointer_type(allocated_memory.get(), context);
+
+    if (alloc != value) {
+      FAIL(log, "sycl::get_pointer_type return " +
+                    std::to_string(to_integral(value)) +
+                    " type, expected sycl::usm::alloc::" +
+                    std::string(str_usm_alloc_type) + " type");
+    }
+    if (sycl::get_pointer_device(allocated_memory.get(), context) != device) {
+      FAIL(log, "sycl::get_pointer_device return invalid device for " +
+                    std::string(str_usm_alloc_type) + " type");
+    }
+  } else {
+    log.note("Device does not support " + std::string(str_usm_alloc_type) +
+             " allocation. Tests were skipped.");
+  }
+}
+
+/** Test instance
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    try {
+      auto queue{util::get_cts_object::queue()};
+
+      {
+        int non_usm_allocated_memory{};
+        if (sycl::usm::alloc::unknown !=
+            sycl::get_pointer_type(&non_usm_allocated_memory,
+                                   queue.get_context())) {
+          FAIL(log,
+               "sycl::get_pointer_type return not sycl::usm::alloc::unknown "
+               "type");
+        }
+      }
+
+      run_check<sycl::usm::alloc::shared>(queue, log);
+      run_check<sycl::usm::alloc::device>(queue, log);
+      run_check<sycl::usm::alloc::host>(queue, log);
+
+    } catch (const cl::sycl::exception &e) {
+      log_exception(log, e);
+      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_malloc.cpp
+++ b/tests/usm/usm_malloc.cpp
@@ -28,7 +28,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using namespace usm_allocate_free;
     using TestType = int;
     using op_malloc = usm_operation<usm_op_name::malloc, usm_op_form::general>;
-    run_test<TestType, op_malloc>(log);
+    run_usm_test<TestType, op_malloc>(log);
   }
 };
 

--- a/tests/usm/usm_malloc.cpp
+++ b/tests/usm/usm_malloc.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::malloc with all usm::alloc kinds
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocate_free.h"
+
+#define TEST_NAME usm_malloc
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocate_free;
+    using TestType = int;
+    using op_malloc = usm_operation<usm_op_name::malloc, usm_op_form::general>;
+    run_test<TestType, op_malloc>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_malloc_device.cpp
+++ b/tests/usm/usm_malloc_device.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::malloc_device
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocate_free.h"
+
+#define TEST_NAME usm_malloc_device
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocate_free;
+    using TestType = int;
+    using op_malloc_device =
+        usm_operation<usm_op_name::malloc_device, usm_op_form::general>;
+    run_test<TestType, op_malloc_device>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_malloc_device.cpp
+++ b/tests/usm/usm_malloc_device.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using TestType = int;
     using op_malloc_device =
         usm_operation<usm_op_name::malloc_device, usm_op_form::general>;
-    run_test<TestType, op_malloc_device>(log);
+    run_usm_test<TestType, op_malloc_device>(log);
   }
 };
 

--- a/tests/usm/usm_malloc_host.cpp
+++ b/tests/usm/usm_malloc_host.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using TestType = int;
     using op_malloc_host =
         usm_operation<usm_op_name::malloc_host, usm_op_form::general>;
-    run_test<TestType, op_malloc_host>(log);
+    run_usm_test<TestType, op_malloc_host>(log);
   }
 };
 

--- a/tests/usm/usm_malloc_host.cpp
+++ b/tests/usm/usm_malloc_host.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::malloc_host
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocate_free.h"
+
+#define TEST_NAME usm_malloc_host
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocate_free;
+    using TestType = int;
+    using op_malloc_host =
+        usm_operation<usm_op_name::malloc_host, usm_op_form::general>;
+    run_test<TestType, op_malloc_host>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_malloc_shared.cpp
+++ b/tests/usm/usm_malloc_shared.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::malloc_shared
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "usm_allocate_free.h"
+
+#define TEST_NAME usm_malloc_shared
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace usm_allocate_free;
+    using TestType = int;
+    using op_malloc_shared =
+        usm_operation<usm_op_name::malloc_shared, usm_op_form::general>;
+    run_test<TestType, op_malloc_shared>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/usm/usm_malloc_shared.cpp
+++ b/tests/usm/usm_malloc_shared.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using TestType = int;
     using op_malloc_shared =
         usm_operation<usm_op_name::malloc_shared, usm_op_form::general>;
-    run_test<TestType, op_malloc_shared>(log);
+    run_usm_test<TestType, op_malloc_shared>(log);
   }
 };
 


### PR DESCRIPTION
Provide tests for:
- usm::malloc and usm::aligned_alloc overloads for all sycl::usm::alloc kinds
- usm::malloc_(device/host/shared) overloads
- usm::aligned_alloc_(device/host/shared) overloads
- usm::free
- usm_allocator constructors
- usm_allocator api

This PR relies on #131 to use common file: tests/usm/usm.h
**Please review from this commit:** https://github.com/KhronosGroup/SYCL-CTS/commit/ef0f0f98cb39306d2e61d2b53dccaf3ba36a80ae