### PR TITLE
Remove default platform selection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ The SYCL test suite can be launched via the following command::
     $ python runtests.py --help
 
     usage: runtests.py [-h] [-b BINPATH] [--csvpath CSVPATH] [--list]
-                       [-j JUNIT] [-p {host,intel,amd}]
+                       [-j JUNIT]
                        [-d {host,opencl_cpu,opencl_gpu,opencl_accelerator}]
 
     Khronos SYCL CTS
@@ -113,9 +113,6 @@ The SYCL test suite can be launched via the following command::
       --list                list all tests in a test binary
       -j JUNIT, --junit JUNIT
                             specify output path for a junit xml file
-      -p PLATFORM, --platform PLATFORM
-                            The platform to run on (where PLATFORM can be
-                            host, intel, amd)
       -d DEVICE, --device DEVICE
                             The device to run on (where DEVICE can be host,
                             opencl_cpu, opencl_gpu, opencl_accelerator)
@@ -149,9 +146,6 @@ stored in a test executable.  For instance::
 
 Passing the ``--junit`` option will output test results in `junit` format
 when the test suite has finished executing.
-
-The ``--platform`` argument can be used to specify which platform to run the
-tests on.
 
 The ``--device`` argument can be used to specify which device to run the
 tests on.

--- a/runtests.py
+++ b/runtests.py
@@ -406,9 +406,6 @@ def launch_cts_binary( list ):
     if g_csv_path:
         l_args = l_args + " --csv " + g_csv_path
 
-    if g_platform:
-        l_args += " --platform " + g_platform
-
     if g_device:
         l_args += " --device " + g_device
 
@@ -507,10 +504,12 @@ def parse_args( ):
     parser.add_argument( "--csvpath", help="specify path to csv file for filtering tests" )
     parser.add_argument( "--list", help="list all tests in a test binary", action="store_true" )
     parser.add_argument( "-j", "--junit", help="specify output path for a junit xml file" )
-    parser.add_argument( "-p", "--platform", choices=platforms, help="The platform to run on " )
     parser.add_argument( "-d", "--device", choices=devices, help="The device to run on " )
 
-    args = parser.parse_args()
+    (args, unknown_args) = parser.parse_known_args()
+    if unknown_args:
+        print("Unknown arguments:")
+        print(unknown_args)
 
     if 'binpath' in args:
         g_binary_path = args.binpath

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,12 +153,10 @@ function(add_cts_test)
   set(info_dump_dir "${CMAKE_BINARY_DIR}/Testing")
   add_test(NAME ${test_exe_name}_host
            COMMAND ${test_exe_name}
-                   --platform ${host_platform_name}
                    --device ${host_device_name}
                    --info-dump "${info_dump_dir}/${test_exe_name}_host.info")
   add_test(NAME ${test_exe_name}_opencl
            COMMAND ${test_exe_name}
-                   --platform ${opencl_platform_name}
                    --device ${opencl_device_name}
                    --info-dump "${info_dump_dir}/${test_exe_name}_opencl.info")
 

--- a/tests/common/cts_selector.h
+++ b/tests/common/cts_selector.h
@@ -17,12 +17,13 @@
  */
 class cts_selector : public cl::sycl::device_selector {
  public:
-  /** Returns true if the default platform of the selector is host.
-   * @return boolean specifying whether the default platform is host. */
+  /** Checks whether the default device is a host device
+   * @return True if the default device is host
+   */
   bool is_host() const {
     using namespace sycl_cts::util;
 
-    return (get<selector>().get_default_platform() == selector::ctsplat::host);
+    return (get<selector>().get_default_device() == selector::ctsdevice::host);
   }
 
   /**
@@ -86,48 +87,11 @@ class cts_selector : public cl::sycl::device_selector {
     using namespace sycl_cts::util;
 
     selector::ctsdevice ctsDevType = get<selector>().get_default_device();
-    selector::ctsplat ctsPlatform = get<selector>().get_default_platform();
 
-    // Early exit for host device
-    if (dev.is_host()) {
-      if (ctsDevType == selector::ctsdevice::host) {
-        return 1000;
-      } else {
-        return -1;
-      }
-    }
-
-    cl::sycl::string_class vendor =
-        dev.get_platform().get_info<cl::sycl::info::platform::vendor>();
     cl::sycl::info::device_type type =
         dev.get_info<cl::sycl::info::device::device_type>();
 
-    int result = -1;
-
-    switch (ctsPlatform) {
-      case selector::ctsplat::amd:
-        if (vendor.find("AMD") != std::string::npos) {
-          result = score(type, ctsDevType);
-        }
-        break;
-      case selector::ctsplat::arm:
-        if (vendor.find("ARM") != std::string::npos) {
-          result = score(type, ctsDevType);
-        }
-        break;
-      case selector::ctsplat::intel:
-        if (vendor.find("Intel") != std::string::npos) {
-          result = score(type, ctsDevType);
-        }
-        break;
-      case selector::ctsplat::nvidia:
-        if (vendor.find("NVIDIA") != std::string::npos) {
-          result = score(type, ctsDevType);
-        }
-        break;
-      default:
-        result = -1;
-    }
+    int result = score(type, ctsDevType);
 
     return result;
   }

--- a/util/selector.cpp
+++ b/util/selector.cpp
@@ -14,21 +14,7 @@ namespace util {
 
 /** constructor
  */
-selector::selector()
-    : m_platform(ctsplat::unknown), m_device(ctsdevice::unknown) {}
-
-void selector::set_default_platform(const std::string &name) {
-  if (name == "host")
-    m_platform = ctsplat::host;
-  else if (name == "amd")
-    m_platform = ctsplat::amd;
-  else if (name == "arm")
-    m_platform = ctsplat::arm;
-  else if (name == "intel")
-    m_platform = ctsplat::intel;
-  else if (name == "nvidia")
-    m_platform = ctsplat::nvidia;
-}
+selector::selector() : m_device(ctsdevice::unknown) {}
 
 /** set the default device to use for the SYCL CTS
  *  @param name, the name of the device to use.
@@ -53,21 +39,10 @@ void selector::set_default_device(const std::string &name) {
   }
 }
 
-/** set the default platform via enum
- */
-void selector::set_default_platform(ctsplat platform) { m_platform = platform; }
-
 /** set the default device type via enum
  */
 void selector::set_default_device(ctsdevice deviceType) {
   m_device = deviceType;
-}
-
-/** return the default platform of choice for this cts run
- */
-selector::ctsplat selector::get_default_platform() const {
-  // return the cached device type
-  return m_platform;
 }
 
 /** return the default device of choice for this cts run

--- a/util/selector.h
+++ b/util/selector.h
@@ -20,10 +20,6 @@ namespace util {
  */
 class selector : public singleton<selector> {
  public:
-  /** SYCL platforms
-   */
-  enum class ctsplat { unknown = 0, host, amd, arm, intel, nvidia };
-
   /** SYCL device types
    */
   enum class ctsdevice {
@@ -39,17 +35,6 @@ class selector : public singleton<selector> {
    */
   selector();
 
-  /**
-   * @param name, the name of the platform to select.
-   * valid values are:
-   *    'amd'
-   *    'arm'
-   *    'host'
-   *    'intel'
-   *    'nvidia'
-   */
-  void set_default_platform(const std::string &name);
-
   /** set the default device to use for the SYCL CTS
    *  @param name, the name of the device to use.
    *  valid options are:
@@ -64,23 +49,12 @@ class selector : public singleton<selector> {
    */
   void set_default_device(ctsdevice deviceType);
 
-  /** set the default device type via enum
-   */
-  void set_default_platform(ctsplat platform);
-
   /** return a enum of cts_device type specifying the
    *  requested default device type for this run of the cts
    */
   ctsdevice get_default_device() const;
 
-  /** return a enum of ctsplat type specifying the
-   *  requested default platform type for this run of the cts
-   */
-  ctsplat get_default_platform() const;
-
  protected:
-  // default platform to select
-  ctsplat m_platform;
   // default SYCL device type to use
   ctsdevice m_device;
 };

--- a/util/test_manager.cpp
+++ b/util/test_manager.cpp
@@ -25,8 +25,11 @@ namespace util {
 
 /**
  */
-test_manager::test_manager() : m_willExecute(false), m_wimpyMode(false),
-  m_infoDump(false), m_infoDumpFile{""} {}
+test_manager::test_manager()
+    : m_willExecute(false),
+      m_wimpyMode(false),
+      m_infoDump(false),
+      m_infoDumpFile{""} {}
 
 /**
  */
@@ -110,13 +113,6 @@ bool test_manager::parse(const int argc, const char **args) {
     printer.set_format(sycl_cts::util::printer::etext);
   }
 
-  // set the default sycl cts platform
-  std::string platformName;
-  if (cmdarg.get_value("--platform", platformName) ||
-      cmdarg.get_value("-p", platformName)) {
-    selector.set_default_platform(platformName);
-  }
-
   // set the default sycl cts device
   std::string deviceName;
   if (cmdarg.get_value("--device", deviceName) ||
@@ -167,12 +163,6 @@ Usage:
     --csv       -c         CSV file for specifying tests to run
     --list      -l         List the tests compiled in this executable
     --wimpy     -w         Run with reduced test complexity (faster)
-    --platform  -p [name]  Set a platform to target:
-                   'host'
-                   'amd'
-                   'arm'
-                   'intel'
-                   'nvidia'
     --device    -d [name]  Select a device to target:
                    'host'
                    'opencl_cpu'


### PR DESCRIPTION
Hardcoding vendor names makes it difficult to run the CTS on custom devices.
This patch removes default platform selection code altogether.
It's still possible to specify the device type to run on,
but implementations should provide their own ways
of performing selection between multiple platforms.

This includes completely removing the `--platform` argument,
the `ctsplat` enum value, and the `get/set_default_platform` functions.

Changed argument parsing to `parse_known_args`
to allow existing script calls to still work.