### PR TITLE
add_device_compiler_definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,10 @@ include(AddSYCLExecutable)
 option(SYCL_CTS_ENABLE_DOUBLE_TESTS "Enable Double tests." ON)
 option(SYCL_CTS_ENABLE_HALF_TESTS "Enable Half tests." ON)
 if(SYCL_CTS_ENABLE_DOUBLE_TESTS)
-    add_definitions(-DSYCL_CTS_TEST_DOUBLE)
+    add_host_and_device_compiler_definitions(-DSYCL_CTS_TEST_DOUBLE)
 endif()
 if(SYCL_CTS_ENABLE_HALF_TESTS)
-    add_definitions(-DSYCL_CTS_TEST_HALF)
+    add_host_and_device_compiler_definitions(-DSYCL_CTS_TEST_HALF)
 endif()
 # ------------------
 
@@ -42,12 +42,12 @@ endif()
 option(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
        "Enable OpenCL interoperability tests." ON)
 if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS)
-    add_definitions(-DSYCL_CTS_TEST_OPENCL_INTEROP)
+    add_host_and_device_compiler_definitions(-DSYCL_CTS_TEST_OPENCL_INTEROP)
 endif()
 # ------------------
 
 if(${INTEL_SYCL_TRIPLE} MATCHES ".*-nvidia-cuda-.*")
-    add_definitions(-DSYCL_CTS_INTEL_PI_CUDA)
+    add_host_and_device_compiler_definitions(-DSYCL_CTS_INTEL_PI_CUDA)
 endif()
 
 enable_testing()

--- a/cmake/AddSYCLExecutable.cmake
+++ b/cmake/AddSYCLExecutable.cmake
@@ -58,3 +58,18 @@ function(add_sycl_executable)
         OBJECT_LIBRARY "${args_OBJECT_LIBRARY}"
         TESTS          "${args_TESTS}")
 endfunction()
+
+# Adds preprocessor definitions to the device compiler,
+# to mimic the add_definitions CMake function, but only for the device compiler
+# If the implementation uses a single compiler for host and device code,
+# then this function is expected to be a no-op
+# because add_definitions should take care of everything
+function(add_device_compiler_definitions)
+    add_device_compiler_definitions_implementation(${ARGN})
+endfunction()
+
+# Adds preprocessor definitions to both host and device compilers
+function(add_host_and_device_compiler_definitions)
+    add_definitions(${ARGN})
+    add_device_compiler_definitions(${ARGN})
+endfunction()

--- a/cmake/FindComputeCpp.cmake
+++ b/cmake/FindComputeCpp.cmake
@@ -54,6 +54,11 @@ set(COMPUTECPP_USER_FLAGS "" CACHE STRING "User flags for compute++")
 separate_arguments(COMPUTECPP_USER_FLAGS)
 mark_as_advanced(COMPUTECPP_USER_FLAGS)
 
+# Device compiler definitions, should not be set by the user on the command line
+# Must be a cache entry because that's the only way
+# it can be modified in a function
+set(computecpp_device_compiler_defs "" CACHE STRING "")
+
 # build_spir
 # Runs the device compiler on a single source file, creating the stub and the bc files.
 function(build_spir exe_name spir_target_name source_file output_path)
@@ -80,6 +85,7 @@ function(build_spir exe_name spir_target_name source_file output_path)
             -O2
             -mllvm -inline-threshold=1000
             -intelspirmetadata
+            ${computecpp_device_compiler_defs}
             ${COMPUTECPP_USER_FLAGS}
             ${platform_specific_args}
             $<$<BOOL:${include_directories}>:-I\"$<JOIN:${include_directories},\"\t-I\">\">
@@ -137,4 +143,12 @@ function(add_sycl_executable_implementation)
         FOLDER         "Tests/${exe_name}"
         LINK_LIBRARIES "ComputeCpp::Runtime;$<$<BOOL:${WIN32}>:-SAFESEH:NO>"
         BUILD_RPATH    "$<TARGET_FILE_DIR:ComputeCpp::Runtime>")
+endfunction()
+
+# Adds preprocessor definitions to the device compiler
+function(add_device_compiler_definitions_implementation)
+    set(computecpp_device_compiler_defs
+        ${computecpp_device_compiler_defs} ${ARGN}
+        CACHE STRING "" FORCE
+    )
 endfunction()

--- a/cmake/FindIntel_SYCL.cmake
+++ b/cmake/FindIntel_SYCL.cmake
@@ -74,3 +74,8 @@ function(add_sycl_executable_implementation)
             $<TARGET_PROPERTY:INTEL_SYCL::Runtime,INTERFACE_LINK_OPTIONS>)
     endif()
 endfunction()
+
+# Adds device compiler definitions
+# This functions is a no-op because add_definitions should take care of it
+function(add_device_compiler_definitions_implementation)
+endfunction()

--- a/cmake/FindhipSYCL.cmake
+++ b/cmake/FindhipSYCL.cmake
@@ -34,3 +34,8 @@ function(add_sycl_executable_implementation)
         POSITION_INDEPENDENT_CODE ON)
 
 endfunction()
+
+# Adds device compiler definitions
+# This functions is a no-op because add_definitions should take care of it
+function(add_device_compiler_definitions_implementation)
+endfunction()


### PR DESCRIPTION
The CTS sets some preprocessor definitions using `add_definitions`,
which causes host/device inconsistencies when using a split-compiler approach.

This patch adds `add_device_compiler_definitions`
and `add_host_and_device_compiler_definitions`
that are meant to unify preprocessor definitions between host and device compilers.
It is expected that this won't have an impact on single-compiler implementations
since only host definitions matter in that case.