### PR TITLE
Add tests for specialization constants part1

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -249,6 +249,18 @@ bool check_equal_values(const sycl::vec<T, numElements>& lhs,
   return result;
 }
 
+/**
+ * @brief Instantiation for marray with the same API as for scalar values
+ */
+template <typename T, std::size_t numElements>
+bool check_equal_values(const sycl::marray<T, numElements>& lhs,
+                        const sycl::marray<T, numElements>& rhs) {
+  auto perElement = lhs == rhs;
+  return std::all_of(perElement.begin(), perElement.end(), [](bool el){
+    return el;
+  });
+}
+
 /** helper function for retrieving an event from a submitted kernel
  */
 template <typename kernelT>

--- a/tests/common/once_per_unit.h
+++ b/tests/common/once_per_unit.h
@@ -12,40 +12,39 @@
 #include "../common/get_cts_object.h"
 
 namespace detail {
-  /**
-   * @brief Helper class for once_per_unit::log() function
-   */
-  struct log_notice {
-    log_notice(sycl_cts::util::logger &log, const std::string &message) {
-      log.note(message);
-    }
-  };
+/**
+ * @brief Helper class for once_per_unit::log() function
+ */
+struct log_notice {
+  log_notice(sycl_cts::util::logger &log, const std::string &message) {
+    log.note(message);
+  }
+};
 
-}
+}  // namespace detail
 
 namespace {
-  /**
-   * All symbols have internal linkage here;
-   * special attention to the ODR rules should be made
-   */
+/**
+ * All symbols have internal linkage here;
+ * special attention to the ODR rules should be made
+ */
 namespace once_per_unit {
-  /**
-   * @brief Factory method; provides unique queue instance per compilation unit
-   */
-  inline sycl::queue& get_queue() {
-    static auto q = sycl_cts::util::get_cts_object::queue();
-    return q;
-  }
+/**
+ * @brief Factory method; provides unique queue instance per compilation unit
+ */
+inline sycl::queue &get_queue() {
+  static auto q = sycl_cts::util::get_cts_object::queue();
+  return q;
+}
 
-  /**
-   * @brief Provide possibility to log message once per translation unit
-   */
-  static void log(sycl_cts::util::logger &log,
-                       const std::string &message) {
-    static const detail::log_notice log_just_once(log, message);
-    static_cast<void>(log_just_once);
-  }
-} // namespace once_per_unit
-} // namespace
+/**
+ * @brief Provide possibility to log message once per translation unit
+ */
+static void log(sycl_cts::util::logger &log, const std::string &message) {
+  static const detail::log_notice log_just_once(log, message);
+  static_cast<void>(log_just_once);
+}
+}  // namespace once_per_unit
+}  // namespace
 
-#endif // __SYCLCTS_TESTS_COMMON_ONCE_PER_UNIT_H
+#endif  // __SYCLCTS_TESTS_COMMON_ONCE_PER_UNIT_H

--- a/tests/common/once_per_unit.h
+++ b/tests/common/once_per_unit.h
@@ -42,8 +42,8 @@ namespace once_per_unit {
    */
   static void log(sycl_cts::util::logger &log,
                        const std::string &message) {
-    static const detail::log_notice once(log, message);
-    static_cast<void>(once);
+    static const detail::log_notice log_just_once(log, message);
+    static_cast<void>(log_just_once);
   }
 } // namespace once_per_unit
 } // namespace

--- a/tests/common/once_per_unit.h
+++ b/tests/common/once_per_unit.h
@@ -11,6 +11,18 @@
 
 #include "../common/get_cts_object.h"
 
+namespace detail {
+  /**
+   * @brief Helper class for once_per_unit::log() function
+   */
+  struct log_notice {
+    log_notice(sycl_cts::util::logger &log, const std::string &message) {
+      log.note(message);
+    }
+  };
+
+}
+
 namespace {
   /**
    * All symbols have internal linkage here;
@@ -23,6 +35,15 @@ namespace once_per_unit {
   inline sycl::queue& get_queue() {
     static auto q = sycl_cts::util::get_cts_object::queue();
     return q;
+  }
+
+  /**
+   * @brief Provide possibility to log message once per translation unit
+   */
+  static void log(sycl_cts::util::logger &log,
+                       const std::string &message) {
+    static const detail::log_notice once(log, message);
+    static_cast<void>(once);
   }
 } // namespace once_per_unit
 } // namespace

--- a/tests/common/once_per_unit.h
+++ b/tests/common/once_per_unit.h
@@ -42,7 +42,6 @@ inline sycl::queue &get_queue() {
  */
 static void log(sycl_cts::util::logger &log, const std::string &message) {
   static const detail::log_notice log_just_once(log, message);
-  static_cast<void>(log_just_once);
 }
 }  // namespace once_per_unit
 }  // namespace

--- a/tests/common/type_coverage.h
+++ b/tests/common/type_coverage.h
@@ -37,6 +37,19 @@ struct type_name_string<sycl::vec<T, nElements>> {
 };
 
 /**
+ * @brief Specialization of type name retrievement for cl::sycl::marray class
+ * @param T Type of the data stored in marray
+ * @param nElements Number of elements stored in marray
+ */
+template <typename T, size_t nElements>
+struct type_name_string<cl::sycl::marray<T, nElements>> {
+    static std::string get(const std::string &dataType) {
+      return "cl::sycl::marray<" + dataType + "," +
+             std::to_string(nElements) + ">";
+    }
+};
+
+/**
  * @brief Type pack to store types
  */
 template <typename ... T>
@@ -170,13 +183,13 @@ void for_all_types_and_vectors(const named_type_pack<types...>& typeList,
 template <template <typename, typename...> class action, typename T,
           typename... actionArgsT, typename... argsT>
 void for_type_vectors_marray(argsT&&... args) {
-  if constexpr (std::is_same<T, bool>::value)
+  if constexpr (std::is_same<T, bool>::value) {
     for_all_types<action, actionArgsT...>(
         type_pack<T, typename sycl::template marray<T, 2>,
                   typename sycl::template marray<T, 5>,
                   typename sycl::template marray<T, 10>>{},
         std::forward<argsT>(args)...);
-  else
+  } else {
     for_all_types<action, actionArgsT...>(
         type_pack<T, typename sycl::template vec<T, 1>,
                   typename sycl::template vec<T, 2>,
@@ -188,6 +201,7 @@ void for_type_vectors_marray(argsT&&... args) {
                   typename sycl::template marray<T, 5>,
                   typename sycl::template marray<T, 10>>{},
         std::forward<argsT>(args)...);
+  }
 }
 
 /**

--- a/tests/common/type_coverage.h
+++ b/tests/common/type_coverage.h
@@ -173,7 +173,7 @@ void for_all_types_and_vectors(const named_type_pack<types...>& typeList,
 
 
 /**
- * @brief Run action for type, vectors amd marrays of this type
+ * @brief Run action for type, vectors and marrays of this type
  * @tparam action Functor template for action to run
  * @tparam T Type to instantiate functor template with
  * @tparam actionArgsT Parameter pack to use for functor template instantiation
@@ -205,7 +205,7 @@ void for_type_vectors_marray(argsT&&... args) {
 }
 
 /**
- * @brief Run action for each of types, vectors amd marrays of types given by
+ * @brief Run action for each of types, vectors and marrays of types given by
  *        named_type_pack instance
  * @tparam action Functor template for action to run
  * @tparam actionArgsT Parameter pack to use for functor template instantiation

--- a/tests/common/type_coverage.h
+++ b/tests/common/type_coverage.h
@@ -158,4 +158,62 @@ void for_all_types_and_vectors(const named_type_pack<types...>& typeList,
   static_cast<void>(packExpansion);
 }
 
+
+/**
+ * @brief Run action for type, vectors amd marrays of this type
+ * @tparam action Functor template for action to run
+ * @tparam T Type to instantiate functor template with
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action, typename T,
+          typename... actionArgsT, typename... argsT>
+void for_type_vectors_marray(argsT&&... args) {
+  if constexpr (std::is_same<T, bool>::value)
+    for_all_types<action, actionArgsT...>(
+        type_pack<T, typename sycl::template marray<T, 2>,
+                  typename sycl::template marray<T, 5>,
+                  typename sycl::template marray<T, 10>>{},
+        std::forward<argsT>(args)...);
+  else
+    for_all_types<action, actionArgsT...>(
+        type_pack<T, typename sycl::template vec<T, 1>,
+                  typename sycl::template vec<T, 2>,
+                  typename sycl::template vec<T, 3>,
+                  typename sycl::template vec<T, 4>,
+                  typename sycl::template vec<T, 8>,
+                  typename sycl::template vec<T, 16>,
+                  typename sycl::template marray<T, 2>,
+                  typename sycl::template marray<T, 5>,
+                  typename sycl::template marray<T, 10>>{},
+        std::forward<argsT>(args)...);
+}
+
+/**
+ * @brief Run action for each of types, vectors amd marrays of types given by
+ *        named_type_pack instance
+ * @tparam action Functor template for action to run
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam types Deduced from type_pack parameter pack for list of types to use
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param typeList Named type pack instance with underlying type names stored
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
+void for_all_types_vectors_marray(const named_type_pack<types...>& typeList,
+                                  argsT&&... args) {
+  /** run action for each type from types... parameter pack
+   */
+  size_t typeNameIndex = 0;
+
+  int packExpansion[] = {(
+      for_type_vectors_marray<action, types, actionArgsT...>(
+          std::forward<argsT>(args)..., typeList.names[typeNameIndex]),
+      ++typeNameIndex,
+      0  // Dummy initialization value
+      )...};
+  static_cast<void>(packExpansion);
+}
 #endif  // __SYCLCTS_TESTS_COMMON_TYPE_COVERAGE_H

--- a/tests/specialization_constants/CMakeLists.txt
+++ b/tests/specialization_constants/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB test_cases_list *.cpp)
+
+add_cts_test(${test_cases_list})

--- a/tests/specialization_constants/specialization_constants_class_with_member_fun.cpp
+++ b/tests/specialization_constants/specialization_constants_class_with_member_fun.cpp
@@ -1,0 +1,93 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with class with a member
+//  function that accesses members
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+#define TEST_NAME specialization_constants_class_with_member_fun
+
+struct sc_class_with_memb {
+  int a, b;
+  constexpr sc_class_with_memb(int a, int b) : a(a), b(b) {}
+  int calculate(int c) const { return a * b * c; }
+};
+
+// spec const defined in global namespace
+constexpr sycl::specialization_id<sc_class_with_memb> sc_cl_w_mem_fn(
+    sc_class_with_memb(0, 0));
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    try {
+      auto queue = util::get_cts_object::queue();
+      sycl::range<1> range(1);
+      const int val_A = 3;
+      const int val_B = 4;
+      const int val_C = 2;
+      sc_class_with_memb result(0, 0);
+      sc_class_with_memb ref(val_A, val_B);
+      int kernel_result_val = 0;
+      {
+        sycl::buffer<sc_class_with_memb, 1> result_buffer(&result, range);
+        sycl::buffer<int, 1> kernel_result_val_buffer(&kernel_result_val,
+                                                      range);
+        queue.submit([&](sycl::handler &cgh) {
+          auto res_acc =
+              result_buffer.template get_access<sycl::access_mode::write>(cgh);
+          auto kernel_res_val_acc =
+              kernel_result_val_buffer
+                  .template get_access<sycl::access_mode::write>(cgh);
+          cgh.set_specialization_constant<sc_cl_w_mem_fn>(ref);
+          cgh.single_task<class sc_cl_w_mem_fn_kernel>(
+              [=](sycl::kernel_handler h) {
+                res_acc[0] = h.get_specialization_constant<sc_cl_w_mem_fn>();
+                kernel_res_val_acc[0] =
+                    h.get_specialization_constant<sc_cl_w_mem_fn>().calculate(
+                        val_C);
+              });
+        });
+      }
+      int ref_val = ref.calculate(val_C);
+      int result_val = result.calculate(val_C);
+      if (!check_equal_values(ref_val, result_val) ||
+          !check_equal_values(ref_val, kernel_result_val))
+        FAIL(log,
+             "case specialization constants with class with a member function "
+             "that accesses members");
+
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_class_with_member_fun.cpp
+++ b/tests/specialization_constants/specialization_constants_class_with_member_fun.cpp
@@ -76,11 +76,11 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
     } catch (const sycl::exception &e) {
       log_exception(log, e);
-      std::string errorMsg =
+      auto errorMsg =
           "a SYCL exception was caught: " + std::string(e.what());
       FAIL(log, errorMsg);
     } catch (const std::exception &e) {
-      std::string errorMsg =
+      auto errorMsg =
           "an exception was caught: " + std::string(e.what());
       FAIL(log, errorMsg);
     }

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -107,12 +107,8 @@ static const auto composite_types =
 
 }  // namespace testing_types
 
-struct sc_use_kernel_bundle {
-  static constexpr bool value = true;
-};
-struct sc_no_kernel_bundle {
-  static constexpr bool value = false;
-};
+struct sc_use_kernel_bundle = std::false_type;
+struct sc_no_kernel_bundle = std::false_type;
 
 template <typename T>
 inline constexpr auto get_init_value_helper(int x) {

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -23,11 +23,11 @@ struct no_cnstr {
   float a;
   int b;
   char c;
-};
 
-inline bool operator==(const no_cnstr &lhs, const no_cnstr &rhs) {
-  return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
-}
+  friend bool operator==(const no_cnstr &lhs, const no_cnstr &rhs) {
+    return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
+  }
+};
 
 // A user-defined class with several scalar member variables, a user-defined
 //  default constructor, and some member functions that modify the member
@@ -46,7 +46,7 @@ struct def_cnstr {
     c = val;
   }
 
-  friend bool operator==(const def_cnstr &lhs, const def_cnstr &rhs) {
+  inline friend bool operator==(const def_cnstr &lhs, const def_cnstr &rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
 };
@@ -86,8 +86,12 @@ static const auto composite_types =
 
 }  // namespace testing_types
 
-struct sc_use_kernel_bundle { static constexpr bool value = true; };
-struct sc_no_kernel_bundle { static constexpr bool value = false; };
+struct sc_use_kernel_bundle {
+  static constexpr bool value = true;
+};
+struct sc_no_kernel_bundle {
+  static constexpr bool value = false;
+};
 
 template <typename T>
 inline constexpr auto value_helper(int x) {

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -96,12 +96,12 @@ struct sc_no_kernel_bundle {
 };
 
 template <typename T>
-inline constexpr auto value_helper(int x) {
+inline constexpr auto get_init_value_helper(int x) {
   return x;
 }
 
 template <>
-inline constexpr auto value_helper<testing_types::no_cnstr>(int x) {
+inline constexpr auto get_init_value_helper<testing_types::no_cnstr>(int x) {
   testing_types::no_cnstr instance{};
   instance.a = x;
   instance.b = x;
@@ -110,7 +110,7 @@ inline constexpr auto value_helper<testing_types::no_cnstr>(int x) {
 }
 
 template <>
-inline constexpr auto value_helper<testing_types::def_cnstr>(int x) {
+inline constexpr auto get_init_value_helper<testing_types::def_cnstr>(int x) {
   testing_types::def_cnstr instance;
   instance.assign(x);
   return instance;
@@ -119,15 +119,16 @@ inline constexpr auto value_helper<testing_types::def_cnstr>(int x) {
 constexpr int default_val = 20;
 
 template <typename T, int case_num>
-constexpr sycl::specialization_id<T> spec_const(value_helper<T>(default_val));
+constexpr sycl::specialization_id<T> spec_const(
+    get_init_value_helper<T>(default_val));
 
 template <typename T>
-void init_values(T &result, int val) {
-  result = value_helper<T>(val);
+void fill_init_values(T &result, int val) {
+  result = get_init_value_helper<T>(val);
 }
 
 template <typename T, int numElements>
-void init_values(sycl::vec<T, numElements> &result, int val) {
+void fill_init_values(sycl::vec<T, numElements> &result, int val) {
   // Fill manually because sycl::vec does not have iterators
   for (int i = 0; i < numElements; ++i) {
     result[i] = val + i;
@@ -135,7 +136,7 @@ void init_values(sycl::vec<T, numElements> &result, int val) {
 }
 
 template <typename T, std::size_t numElements>
-void init_values(sycl::marray<T, numElements> &result, int val) {
+void fill_init_values(sycl::marray<T, numElements> &result, int val) {
   std::iota(result.begin(), result.end(), val);
 }
 

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -109,8 +109,8 @@ static const auto composite_types =
 
 // Flags that used to specify test type (test with kernel bundle or without
 // kernel bundle)
-struct sc_use_kernel_bundle = std::false_type;
-struct sc_no_kernel_bundle = std::false_type;
+using sc_use_kernel_bundle = std::true_type;
+using sc_no_kernel_bundle = std::false_type;
 
 template <typename T>
 inline constexpr auto get_init_value_helper(int x) {

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -1,0 +1,188 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides common type list for specialization constants type coverage
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_COMMON_H
+#define __SYCLCTS_TESTS_SPEC_CONST_COMMON_H
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include <numeric>
+
+namespace get_spec_const {
+namespace testing_types {
+
+// A user-defined struct with several scalar member variables, no constructor,
+//  destructor or member functions.
+struct no_cnstr {
+  float a;
+  int b;
+  char c;
+};
+
+inline bool operator==(const no_cnstr &lhs, const no_cnstr &rhs) {
+  return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
+}
+
+// A user-defined class with several scalar member variables, a user-defined
+//  default constructor, and some member functions that modify the member
+//  variables.
+struct def_cnstr {
+  float a;
+  int b;
+  char c;
+
+ public:
+  constexpr def_cnstr() : a(3.0), b(2), c('c') {}
+
+  constexpr void assign(int val) {
+    a = val * 3.0;
+    b = val * 2;
+    c = val;
+  }
+
+  friend bool operator==(const def_cnstr &lhs, const def_cnstr &rhs) {
+    return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
+  }
+};
+
+// A user-defined class with several scalar member variables, a deleted default
+// constructor, and a user-defined (non-default) constructor.
+class no_def_cnstr {
+  float a;
+  int b;
+  char c;
+
+ public:
+  no_def_cnstr() = delete;
+
+  constexpr no_def_cnstr(int val) : a(val * 3.0), b(val * 2), c(val) {}
+
+  friend bool operator==(const no_def_cnstr &lhs, const no_def_cnstr &rhs) {
+    return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
+  }
+};
+
+static const auto types = named_type_pack<
+    bool, char, signed char, unsigned char, short, unsigned short, int,
+    unsigned int, long, unsigned long, long long, unsigned long long, float,
+    sycl::byte, std::int8_t, std::uint8_t, std::int16_t, std::uint16_t,
+    std::int32_t, std::uint32_t, std::int64_t, std::uint64_t, std::size_t>{
+    "bool",         "char",           "signed char",  "unsigned char",
+    "short",        "unsigned short", "int",          "unsigned int",
+    "long",         "unsigned long",  "long long",    "unsigned long long",
+    "float",        "sycl::byte",     "std::int8_t",  "std::uint8_t",
+    "std::int16_t", "std::uint16_t",  "std::int32_t", "std::uint32_t",
+    "std::int64_t", "std::uint64_t",  "std::size_t"};
+
+static const auto composite_types =
+    named_type_pack<no_cnstr, def_cnstr, no_def_cnstr>(
+        {"no_cnstr", "def_cnstr", "no_def_cnstr"});
+
+}  // namespace testing_types
+
+struct sc_use_kernel_bundle { static constexpr bool value = true; };
+struct sc_no_kernel_bundle { static constexpr bool value = false; };
+
+template <typename T>
+inline constexpr auto value_helper(int x) {
+  return x;
+}
+
+template <>
+inline constexpr auto value_helper<testing_types::no_cnstr>(int x) {
+  testing_types::no_cnstr instance{};
+  instance.a = x;
+  instance.b = x;
+  instance.c = x;
+  return instance;
+}
+
+template <>
+inline constexpr auto value_helper<testing_types::def_cnstr>(int x) {
+  testing_types::def_cnstr instance;
+  instance.assign(x);
+  return instance;
+}
+
+constexpr int default_val = 20;
+
+template <typename T, int case_num>
+constexpr sycl::specialization_id<T> spec_const(value_helper<T>(default_val));
+
+template <typename T>
+void init_values(T &result, int val) {
+  result = value_helper<T>(val);
+}
+
+template <typename T, int numElements>
+void init_values(sycl::vec<T, numElements> &result, int val) {
+  // Fill manually because sycl::vec does not have iterators
+  for (int i = 0; i < numElements; ++i) {
+    result[i] = val + i;
+  }
+}
+
+template <typename T, std::size_t numElements>
+void init_values(sycl::marray<T, numElements> &result, int val) {
+  std::iota(result.begin(), result.end(), val);
+}
+
+enum test_cases_external {
+  by_reference_via_handler = 1,
+  by_value_via_handler = 2,
+  by_reference_via_bundle = 3,
+  by_value_via_bundle = 4
+};
+
+}  // namespace get_spec_const
+
+#define SINGLE_ARG(...) __VA_ARGS__
+#define SYCL_VECTORS_MARRAYS(TYPE, FUNC)  \
+  FUNC(TYPE)                              \
+  FUNC(SINGLE_ARG(sycl::vec<TYPE, 1>))    \
+  FUNC(SINGLE_ARG(sycl::vec<TYPE, 2>))    \
+  FUNC(SINGLE_ARG(sycl::vec<TYPE, 3>))    \
+  FUNC(SINGLE_ARG(sycl::vec<TYPE, 4>))    \
+  FUNC(SINGLE_ARG(sycl::vec<TYPE, 8>))    \
+  FUNC(SINGLE_ARG(sycl::vec<TYPE, 16>))   \
+  FUNC(SINGLE_ARG(sycl::marray<TYPE, 2>)) \
+  FUNC(SINGLE_ARG(sycl::marray<TYPE, 5>)) \
+  FUNC(SINGLE_ARG(sycl::marray<TYPE, 10>))
+
+#define CORE_TYPES(FUNC)   \
+  FUNC(bool)               \
+  FUNC(char)               \
+  FUNC(signed char)        \
+  FUNC(unsigned char)      \
+  FUNC(short)              \
+  FUNC(unsigned short)     \
+  FUNC(int)                \
+  FUNC(unsigned int)       \
+  FUNC(long)               \
+  FUNC(unsigned long)      \
+  FUNC(long long)          \
+  FUNC(unsigned long long) \
+  FUNC(float)
+
+#define CORE_TYPES_PARAM(FUNC, X) \
+  FUNC(bool, X)                   \
+  FUNC(char, X)                   \
+  FUNC(signed char, X)            \
+  FUNC(unsigned char, X)          \
+  FUNC(short, X)                  \
+  FUNC(unsigned short, X)         \
+  FUNC(int, X)                    \
+  FUNC(unsigned int, X)           \
+  FUNC(long, X)                   \
+  FUNC(unsigned long, X)          \
+  FUNC(long long, X)              \
+  FUNC(unsigned long long, X)     \
+  FUNC(float, X)
+
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_COMMON_H

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -107,6 +107,8 @@ static const auto composite_types =
 
 }  // namespace testing_types
 
+// Flags that used to specify test type (test with kernel bundle or without
+// kernel bundle)
 struct sc_use_kernel_bundle = std::false_type;
 struct sc_no_kernel_bundle = std::false_type;
 

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -140,7 +140,7 @@ void fill_init_values(sycl::marray<T, numElements> &result, int val) {
   std::iota(result.begin(), result.end(), val);
 }
 
-enum test_cases_external {
+enum class test_cases_external {
   by_reference_via_handler = 1,
   by_value_via_handler = 2,
   by_reference_via_bundle = 3,

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -24,6 +24,12 @@ struct no_cnstr {
   int b;
   char c;
 
+  void operator=(const int &v) {
+    this->a = v;
+    this->b = v;
+    this->c = v;
+  }
+
   friend bool operator==(const no_cnstr &lhs, const no_cnstr &rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
@@ -46,6 +52,12 @@ struct def_cnstr {
     c = val;
   }
 
+  void operator=(const int &v) {
+    this->a = v * 3.0;
+    this->b = v * 2;
+    this->c = v;
+  }
+
   inline friend bool operator==(const def_cnstr &lhs, const def_cnstr &rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
@@ -66,6 +78,13 @@ class no_def_cnstr {
   friend bool operator==(const no_def_cnstr &lhs, const no_def_cnstr &rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
+
+  void operator=(const int &v) {
+    no_def_cnstr temp(v);
+    this->a = temp.a;
+    this->b = temp.b;
+    this->c = temp.c;
+  }
 };
 
 template <typename T>
@@ -79,6 +98,10 @@ union remove_initialization {
   template <typename T>
   void operator=(const T &v) {
     this->value = v;
+  }
+
+  friend bool operator==(const remove_initialization &lhs, const remove_initialization &rhs) {
+    return lhs.value == rhs.value;
   }
 
   value_type *data() { return &value; }

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -68,6 +68,7 @@ class no_def_cnstr {
   }
 };
 
+// C++ fundamental types that will be used in type coverage
 static const auto types = named_type_pack<
     bool, char, signed char, unsigned char, short, unsigned short, int,
     unsigned int, long, unsigned long, long long, unsigned long long, float,
@@ -80,6 +81,7 @@ static const auto types = named_type_pack<
     "std::int16_t", "std::uint16_t",  "std::int32_t", "std::uint32_t",
     "std::int64_t", "std::uint64_t",  "std::size_t"};
 
+// custom data types that will be used in type coverage
 static const auto composite_types =
     named_type_pack<no_cnstr, def_cnstr, no_def_cnstr>(
         {"no_cnstr", "def_cnstr", "no_def_cnstr"});

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -87,27 +87,6 @@ class no_def_cnstr {
   }
 };
 
-template <typename T>
-union remove_initialization {
-  using value_type = T;
-  T value;
-  remove_initialization() {}
-
-  operator value_type &() { return value; }
-  operator const value_type &() const { return value; }
-  template <typename T>
-  void operator=(const T &v) {
-    this->value = v;
-  }
-
-  friend bool operator==(const remove_initialization &lhs, const remove_initialization &rhs) {
-    return lhs.value == rhs.value;
-  }
-
-  value_type *data() { return &value; }
-  const value_type *data() const { return &value; }
-};
-
 // C++ fundamental types that will be used in type coverage
 static const auto types = named_type_pack<
     bool, char, signed char, unsigned char, short, unsigned short, int,

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -68,6 +68,23 @@ class no_def_cnstr {
   }
 };
 
+template <typename T>
+union remove_initialization {
+  using value_type = T;
+  T value;
+  remove_initialization() {}
+
+  operator value_type &() { return value; }
+  operator const value_type &() const { return value; }
+  template <typename T>
+  void operator=(const T &v) {
+    this->value = v;
+  }
+
+  value_type *data() { return &value; }
+  const value_type *data() const { return &value; }
+};
+
 // C++ fundamental types that will be used in type coverage
 static const auto types = named_type_pack<
     bool, char, signed char, unsigned char, short, unsigned short, int,

--- a/tests/specialization_constants/specialization_constants_multiple.h
+++ b/tests/specialization_constants/specialization_constants_multiple.h
@@ -15,7 +15,7 @@
 
 template <typename T, int def_val>
 constexpr sycl::specialization_id<T> sc_multiple(
-    get_spec_const::value_helper<T>(def_val));
+    get_spec_const::get_init_value_helper<T>(def_val));
 
 namespace specialization_constants_multiple {
 using namespace sycl_cts;
@@ -56,12 +56,12 @@ class check_specialization_constants_multiple_for_type {
     int val_A = 5;
     int val_B = 10;
     int val_C = 30;
-    T ref1 = T(value_helper<T>(0));
-    T ref2 = T(value_helper<T>(0));
-    T ref3 = T(value_helper<T>(0));
-    init_values(ref1, val_A);
-    init_values(ref2, val_B);
-    init_values(ref3, val_C);
+    T ref1 = T(get_init_value_helper<T>(0));
+    T ref2 = T(get_init_value_helper<T>(0));
+    T ref3 = T(get_init_value_helper<T>(0));
+    fill_init_values(ref1, val_A);
+    fill_init_values(ref2, val_B);
+    fill_init_values(ref3, val_C);
     // to not initialize for struct with no default constructor
     T *result_vec = (T *)malloc(size * sizeof(T));
     {
@@ -74,11 +74,12 @@ class check_specialization_constants_multiple_for_type {
           auto kernelId = sycl::get_kernel_id<sc_kernel_multiple<T, via_kb>>();
           sycl::kernel_bundle k_bundle =
               sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
-                                                                {kernelId});
-            if (!k_bundle.has_kernel(kernelId)) {
-            log.note("kernel_bundle doesn't contain target kernel;"
-                    "multiple spec const for " +
-                    type_name_string<T>::get(type_name) + "(skipped)");
+                                                                 {kernelId});
+          if (!k_bundle.has_kernel(kernelId)) {
+            log.note(
+                "kernel_bundle doesn't contain target kernel;"
+                "multiple spec const for " +
+                type_name_string<T>::get(type_name) + "(skipped)");
             return;
           }
 
@@ -112,9 +113,12 @@ class check_specialization_constants_multiple_for_type {
     if (!check_equal_values(ref1, result_vec[0]) ||
         !check_equal_values(ref2, result_vec[1]) ||
         !check_equal_values(ref3, result_vec[2]) ||
-        !check_equal_values(T(value_helper<T>(def_values[3])), result_vec[3]) ||
-        !check_equal_values(T(value_helper<T>(def_values[4])), result_vec[4]) ||
-        !check_equal_values(T(value_helper<T>(def_values[5])), result_vec[5]))
+        !check_equal_values(T(get_init_value_helper<T>(def_values[3])),
+                            result_vec[3]) ||
+        !check_equal_values(T(get_init_value_helper<T>(def_values[4])),
+                            result_vec[4]) ||
+        !check_equal_values(T(get_init_value_helper<T>(def_values[5])),
+                            result_vec[5]))
       FAIL(log,
            "multiple spec const for " + type_name_string<T>::get(type_name));
 

--- a/tests/specialization_constants/specialization_constants_multiple.h
+++ b/tests/specialization_constants/specialization_constants_multiple.h
@@ -1,0 +1,215 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common checks for multiple specialization constants via kernel_bundle
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_MULTIPLE_H
+#define __SYCLCTS_TESTS_SPEC_CONST_MULTIPLE_H
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "specialization_constants_common.h"
+
+template <typename T, int def_val>
+constexpr sycl::specialization_id<T> sc_multiple(
+    get_spec_const::value_helper<T>(def_val));
+
+namespace specialization_constants_multiple {
+using namespace sycl_cts;
+using namespace get_spec_const;
+
+template <typename T, typename via_kb>
+class sc_kernel_multiple;
+
+constexpr int size = 6;
+constexpr std::array<int, size> def_values{11, 22, 33, 44, 55, 66};
+
+template <typename T, typename ResAccType>
+void get_values_from_handler(ResAccType &res_acc, sycl::kernel_handler &h) {
+  res_acc[0] = h.get_specialization_constant<sc_multiple<T, def_values[0]>>();
+  res_acc[1] = h.get_specialization_constant<sc_multiple<T, def_values[1]>>();
+  res_acc[2] = h.get_specialization_constant<sc_multiple<T, def_values[2]>>();
+  res_acc[3] = h.get_specialization_constant<sc_multiple<T, def_values[3]>>();
+  res_acc[4] = h.get_specialization_constant<sc_multiple<T, def_values[4]>>();
+  res_acc[5] = h.get_specialization_constant<sc_multiple<T, def_values[5]>>();
+}
+
+template <typename T, typename via_kb>
+class check_specialization_constants_multiple_for_type {
+ public:
+  void operator()(util::logger &log, const std::string &type_name) {
+    // Set several values via kernel_bundle, launch a kernel, and read
+    // these values and some default values from the kernel.
+    auto queue = util::get_cts_object::queue();
+    const sycl::context ctx = queue.get_context();
+    const sycl::device dev = queue.get_device();
+
+    if constexpr (via_kb::value) {
+      if (!dev.has(sycl::aspect::online_compiler)) {
+        once_per_unit::log(log, "Device does not support online compilation");
+        return;
+      }
+    }
+    int val_A = 5;
+    int val_B = 10;
+    int val_C = 30;
+    T ref1 = T(value_helper<T>(0));
+    T ref2 = T(value_helper<T>(0));
+    T ref3 = T(value_helper<T>(0));
+    init_values(ref1, val_A);
+    init_values(ref2, val_B);
+    init_values(ref3, val_C);
+    // to not initialize for struct with no default constructor
+    T *result_vec = (T *)malloc(size * sizeof(T));
+    {
+      sycl::buffer<T, 1> result_buffer(result_vec, sycl::range<1>(size));
+      queue.submit([&](sycl::handler &cgh) {
+        auto res_acc =
+            result_buffer.template get_access<sycl::access_mode::write>(cgh);
+        // Via kernel_bundle
+        if constexpr (via_kb::value) {
+          auto kernelId = sycl::get_kernel_id<sc_kernel_multiple<T, via_kb>>();
+          sycl::kernel_bundle k_bundle =
+              sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
+                                                                {kernelId});
+            if (!k_bundle.has_kernel(kernelId)) {
+            log.note("kernel_bundle doesn't contain target kernel;"
+                    "multiple spec const for " +
+                    type_name_string<T>::get(type_name) + "(skipped)");
+            return;
+          }
+
+          k_bundle.template set_specialization_constant<
+              sc_multiple<T, def_values[0]>>(ref1);
+          k_bundle.template set_specialization_constant<
+              sc_multiple<T, def_values[1]>>(ref2);
+          k_bundle.template set_specialization_constant<
+              sc_multiple<T, def_values[2]>>(ref3);
+
+          auto exec_bundle = sycl::build(k_bundle);
+          cgh.use_kernel_bundle(exec_bundle);
+
+          cgh.single_task<sc_kernel_multiple<T, via_kb>>(
+              [=](sycl::kernel_handler h) {
+                get_values_from_handler<T>(res_acc, h);
+              });
+        } else {
+          // No kernel_bundle
+          cgh.set_specialization_constant<sc_multiple<T, def_values[0]>>(ref1);
+          cgh.set_specialization_constant<sc_multiple<T, def_values[1]>>(ref2);
+          cgh.set_specialization_constant<sc_multiple<T, def_values[2]>>(ref3);
+
+          cgh.single_task<sc_kernel_multiple<T, via_kb>>(
+              [=](sycl::kernel_handler h) {
+                get_values_from_handler<T>(res_acc, h);
+              });
+        }
+      });
+    }
+    if (!check_equal_values(ref1, result_vec[0]) ||
+        !check_equal_values(ref2, result_vec[1]) ||
+        !check_equal_values(ref3, result_vec[2]) ||
+        !check_equal_values(T(value_helper<T>(def_values[3])), result_vec[3]) ||
+        !check_equal_values(T(value_helper<T>(def_values[4])), result_vec[4]) ||
+        !check_equal_values(T(value_helper<T>(def_values[5])), result_vec[5]))
+      FAIL(log,
+           "multiple spec const for " + type_name_string<T>::get(type_name));
+
+    free(result_vec);
+  }
+};
+
+template <typename via_kb>
+static void sc_run_test_core(util::logger &log) {
+  using namespace specialization_constants_multiple;
+  try {
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    for_all_types<check_specialization_constants_multiple_for_type, via_kb>(
+        get_spec_const::testing_types::types, log);
+#else
+    for_all_types_vectors_marray<
+        check_specialization_constants_multiple_for_type, via_kb>(
+        get_spec_const::testing_types::types, log);
+#endif
+    for_all_types<check_specialization_constants_multiple_for_type, via_kb>(
+        get_spec_const::testing_types::composite_types, log);
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+template <typename via_kb>
+static void sc_run_test_fp16(util::logger &log) {
+  using namespace specialization_constants_multiple;
+  try {
+    auto queue = util::get_cts_object::queue();
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      log.note(
+          "Device does not support half precision floating point "
+          "operations");
+      return;
+    }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    check_specialization_constants_multiple_for_type<sycl::half, via_kb>
+        fp16_test{};
+    fp16_test(log, "sycl::half");
+#else
+    for_type_vectors_marray<check_specialization_constants_multiple_for_type,
+                            sycl::half, via_kb>(log, "sycl::half");
+#endif
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+template <typename via_kb>
+static void sc_run_test_fp64(util::logger &log) {
+  using namespace specialization_constants_multiple;
+  try {
+    auto queue = util::get_cts_object::queue();
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      log.note(
+          "Device does not support double precision floating point "
+          "operations");
+      return;
+    }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    check_specialization_constants_multiple_for_type<double, via_kb>
+        fp64_test{};
+    fp64_test(log, "double");
+#else
+    for_type_vectors_marray<check_specialization_constants_multiple_for_type,
+                            double, via_kb>(log, "double");
+#endif
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+}  // namespace specialization_constants_multiple
+
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_MULTIPLE_H

--- a/tests/specialization_constants/specialization_constants_multiple.h
+++ b/tests/specialization_constants/specialization_constants_multiple.h
@@ -56,9 +56,9 @@ class check_specialization_constants_multiple_for_type {
     int val_A = 5;
     int val_B = 10;
     int val_C = 30;
-    T ref1 = T(get_init_value_helper<T>(0));
-    T ref2 = T(get_init_value_helper<T>(0));
-    T ref3 = T(get_init_value_helper<T>(0));
+    T ref1{get_init_value_helper<T>(0)};
+    T ref2{get_init_value_helper<T>(0)};
+    T ref3{get_init_value_helper<T>(0)};
     fill_init_values(ref1, val_A);
     fill_init_values(ref2, val_B);
     fill_init_values(ref3, val_C);

--- a/tests/specialization_constants/specialization_constants_multiple.h
+++ b/tests/specialization_constants/specialization_constants_multiple.h
@@ -12,6 +12,7 @@
 #include "../common/common.h"
 #include "../common/once_per_unit.h"
 #include "specialization_constants_common.h"
+#include "../../util/allocation.h"
 #include <memory>
 
 template <typename T, int def_val>
@@ -64,7 +65,7 @@ class check_specialization_constants_multiple_for_type {
     fill_init_values(ref2, val_B);
     fill_init_values(ref3, val_C);
     auto tested_data_smart_storage = std::make_unique<
-        get_spec_const::testing_types::remove_initialization<T>[]>(size);
+        util::remove_initialization<T>[]>(size);
     auto result_vec = tested_data_smart_storage.get();
     {
       sycl::buffer<T, 1> result_buffer(result_vec->data(),

--- a/tests/specialization_constants/specialization_constants_multiple.h
+++ b/tests/specialization_constants/specialization_constants_multiple.h
@@ -13,7 +13,6 @@
 #include "../common/once_per_unit.h"
 #include "specialization_constants_common.h"
 #include "../../util/allocation.h"
-#include <memory>
 
 template <typename T, int def_val>
 constexpr sycl::specialization_id<T> sc_multiple(
@@ -64,9 +63,7 @@ class check_specialization_constants_multiple_for_type {
     fill_init_values(ref1, val_A);
     fill_init_values(ref2, val_B);
     fill_init_values(ref3, val_C);
-    auto tested_data_smart_storage = std::make_unique<
-        util::remove_initialization<T>[]>(size);
-    auto result_vec = tested_data_smart_storage.get();
+    util::remove_initialization<T> result_vec[size] {};
     {
       sycl::buffer<T, 1> result_buffer(result_vec->data(),
                                        sycl::range<1>(size));

--- a/tests/specialization_constants/specialization_constants_multiple_core.cpp
+++ b/tests/specialization_constants/specialization_constants_multiple_core.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multiple specialization constants
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_multiple.h"
+
+#define TEST_NAME specialization_constants_multiple_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_multiple;
+    sc_run_test_core<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_multiple_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_multiple_fp16.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multiple specialization constants for sycl::half
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_multiple.h"
+
+#define TEST_NAME specialization_constants_multiple_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_multiple;
+    sc_run_test_fp16<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_multiple_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_multiple_fp64.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multiple specialization constants for double
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_multiple.h"
+
+#define TEST_NAME specialization_constants_multiple_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_multiple;
+    sc_run_test_fp64<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_multiple_via_kb_core.cpp
+++ b/tests/specialization_constants/specialization_constants_multiple_via_kb_core.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multiple specialization constants via kernel_bundle
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_multiple.h"
+
+#define TEST_NAME specialization_constants_multiple_via_kb_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_multiple;
+    sc_run_test_core<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_multiple_via_kb_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_multiple_via_kb_fp16.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multiple specialization constants via kernel_bundle
+//  for sycl::half
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_multiple.h"
+
+#define TEST_NAME specialization_constants_multiple_via_kb_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_multiple;
+    sc_run_test_fp16<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_multiple_via_kb_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_multiple_via_kb_fp64.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multiple specialization constants via kernel_bundle
+//  for double
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_multiple.h"
+
+#define TEST_NAME specialization_constants_multiple_via_kb_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_multiple;
+    sc_run_test_fp64<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link.h
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link.h
@@ -48,10 +48,10 @@ class check_specialization_constants_same_name_inter_link_for_type {
         }
       }
       sycl::range<1> range(1);
-      T def_value = T(get_init_value_helper<T>(0));
-      T ref_def_value = T(get_init_value_helper<T>(0));
-      T result = T(get_init_value_helper<T>(0));
-      T ref = T(get_init_value_helper<T>(0));
+      T def_value{get_init_value_helper<T>(0)};
+      T ref_def_value{get_init_value_helper<T>(0)};
+      T result{get_init_value_helper<T>(0)};
+      T ref{get_init_value_helper<T>(0)};
       {
         // Setting ref values according to TU number
         fill_init_values(ref_def_value, TestConfig::tu);

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link.h
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link.h
@@ -48,14 +48,14 @@ class check_specialization_constants_same_name_inter_link_for_type {
         }
       }
       sycl::range<1> range(1);
-      T def_value = T(value_helper<T>(0));
-      T ref_def_value = T(value_helper<T>(0));
-      T result = T(value_helper<T>(0));
-      T ref = T(value_helper<T>(0));
+      T def_value = T(get_init_value_helper<T>(0));
+      T ref_def_value = T(get_init_value_helper<T>(0));
+      T result = T(get_init_value_helper<T>(0));
+      T ref = T(get_init_value_helper<T>(0));
       {
         // Setting ref values according to TU number
-        init_values(ref_def_value, TestConfig::tu);
-        init_values(ref, TestConfig::ref_val);
+        fill_init_values(ref_def_value, TestConfig::tu);
+        fill_init_values(ref, TestConfig::ref_val);
         sycl::buffer<T, 1> result_buffer(&result, range);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -68,8 +68,7 @@ class check_specialization_constants_same_name_inter_link_for_type {
                                                                    {kernelId});
             if (!k_bundle.has_kernel(kernelId)) {
               log.note("kernel_bundle doesn't contain target kernel for " +
-                       type_name_string<T>::get(type_name) +
-                       " (skipped)");
+                       type_name_string<T>::get(type_name) + " (skipped)");
               return;
             }
             // Get default value to make sure the spec const is valid

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link.h
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link.h
@@ -1,0 +1,214 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_INTER_LINK_H
+#define __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_INTER_LINK_H
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "specialization_constants_common.h"
+#include "specialization_constants_same_name_inter_link_helper.h"
+
+namespace specialization_constants_same_name_inter_link {
+using namespace sycl_cts;
+using namespace get_spec_const;
+
+template <typename T, int tu_num, typename via_kb>
+struct sc_sn_il_kernel;
+
+/** @brief Test suite for specialization constants with same name and internal
+ *         linkage
+ *  @tparam T Underlying data type, required to specify an actual instance of
+ *            the specialization constant
+ *  @tparam TestConfig helper class with default values depending on TU number
+ *  @tparam via_kb std::true(false)_type like helper type to separate tests
+ *                 with or without a kernel_bundle
+ */
+template <typename T, typename TestConfig, typename via_kb>
+class check_specialization_constants_same_name_inter_link_for_type {
+ public:
+  void operator()(util::logger &log, const std::string &type_name) try {
+    {
+      using kernel_name = sc_sn_il_kernel<T, TestConfig::tu, via_kb>;
+      constexpr auto &spec_const_il = sc_same_name_inter_link<T, via_kb>;
+      auto queue = util::get_cts_object::queue();
+      const sycl::context ctx = queue.get_context();
+      const sycl::device dev = queue.get_device();
+
+      if constexpr (via_kb::value) {
+        if (!dev.has(sycl::aspect::online_compiler)) {
+          once_per_unit::log(log, "Device does not support online compilation");
+          return;
+        }
+      }
+      sycl::range<1> range(1);
+      T def_value = T(value_helper<T>(0));
+      T ref_def_value = T(value_helper<T>(0));
+      T result = T(value_helper<T>(0));
+      T ref = T(value_helper<T>(0));
+      {
+        // Setting ref values according to TU number
+        init_values(ref_def_value, TestConfig::tu);
+        init_values(ref, TestConfig::ref_val);
+        sycl::buffer<T, 1> result_buffer(&result, range);
+        queue.submit([&](sycl::handler &cgh) {
+          auto res_acc =
+              result_buffer.template get_access<sycl::access_mode::write>(cgh);
+          // Via kernel_bundle
+          if constexpr (via_kb::value) {
+            auto kernelId = sycl::get_kernel_id<kernel_name>();
+            sycl::kernel_bundle k_bundle =
+                sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
+                                                                   {kernelId});
+            if (!k_bundle.has_kernel(kernelId)) {
+              log.note("kernel_bundle doesn't contain target kernel for " +
+                       type_name_string<T>::get(type_name) +
+                       " (skipped)");
+              return;
+            }
+            // Get default value to make sure the spec const is valid
+            def_value =
+                k_bundle.template get_specialization_constant<spec_const_il>();
+
+            k_bundle.template set_specialization_constant<spec_const_il>(ref);
+            auto exec_bundle = sycl::build(k_bundle);
+            cgh.use_kernel_bundle(exec_bundle);
+            cgh.single_task<kernel_name>([=](sycl::kernel_handler h) {
+              res_acc[0] = h.get_specialization_constant<spec_const_il>();
+            });
+          } else {
+            // No kernel_bundle
+            // Get default value to make sure the spec const is valid
+            def_value = cgh.get_specialization_constant<spec_const_il>();
+
+            cgh.set_specialization_constant<spec_const_il>(ref);
+            cgh.single_task<kernel_name>([=](sycl::kernel_handler h) {
+              res_acc[0] = h.get_specialization_constant<spec_const_il>();
+            });
+          }
+        });
+      }
+      if (!check_equal_values(ref_def_value, def_value))
+        FAIL(log, "Wrong linked spec const; (translation unit " +
+                      std::to_string(TestConfig::tu) + ") for " +
+                      type_name_string<T>::get(type_name));
+      if (!check_equal_values(ref, result))
+        FAIL(log, "Wrong returned value; (translation unit " +
+                      std::to_string(TestConfig::tu) + ") for " +
+                      type_name_string<T>::get(type_name));
+    }
+  } catch (...) {
+    std::string message{"translation unit " + std::to_string(TestConfig::tu) +
+                        " for " + type_name_string<T>::get(type_name)};
+    log.note(message);
+    throw;
+  }
+};
+
+// Test function for core tests
+template <int tu_num, typename via_kb>
+static void sc_run_test_core(util::logger &log) {
+  using namespace spec_const_help;
+  try {
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    for_all_types<check_specialization_constants_same_name_inter_link_for_type,
+                  sc_sn_il_config<tu_num>, via_kb>(
+        get_spec_const::testing_types::types, log);
+#else
+    for_all_types_vectors_marray<
+        check_specialization_constants_same_name_inter_link_for_type,
+        sc_sn_il_config<tu_num>, via_kb>(get_spec_const::testing_types::types,
+                                         log);
+#endif
+    for_all_types<check_specialization_constants_same_name_inter_link_for_type,
+                  sc_sn_il_config<tu_num>, via_kb>(
+        get_spec_const::testing_types::composite_types, log);
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+// Test function for fp16 tests
+template <int tu_num, typename via_kb>
+static void sc_run_test_fp16(util::logger &log) {
+  using namespace spec_const_help;
+  try {
+    auto queue = util::get_cts_object::queue();
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      log.note(
+          "Device does not support half precision floating point "
+          "operations");
+      return;
+    }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    check_specialization_constants_same_name_inter_link_for_type<
+        sycl::half, sc_sn_il_config<tu_num>, via_kb>
+        fp16_test{};
+    fp16_test(log, "sycl::half");
+#else
+    for_type_vectors_marray<
+        check_specialization_constants_same_name_inter_link_for_type,
+        sycl::half, sc_sn_il_config<tu_num>, via_kb>(log, "sycl::half");
+#endif
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+// Test function for fp64 tests
+template <int tu_num, typename via_kb>
+static void sc_run_test_fp64(util::logger &log) {
+  using namespace spec_const_help;
+  try {
+    auto queue = util::get_cts_object::queue();
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      log.note(
+          "Device does not support double precision floating point "
+          "operations");
+      return;
+    }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    check_specialization_constants_same_name_inter_link_for_type<
+        double, sc_sn_il_config<tu_num>, via_kb>
+        fp64_test{};
+    fp64_test(log, "double");
+#else
+    for_type_vectors_marray<
+        check_specialization_constants_same_name_inter_link_for_type, double,
+        sc_sn_il_config<tu_num>, via_kb>(log, "double");
+#endif
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+}  // namespace specialization_constants_same_name_inter_link
+
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_INTER_LINK_H

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_core.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage (1st translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 1
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME specialization_constants_same_name_inter_link_1st_tu_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_core<SC_SN_IL_TU_NUM, sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage for sycl::half (1st translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 1
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME specialization_constants_same_name_inter_link_1st_tu_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_fp16<SC_SN_IL_TU_NUM, sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage for double (1st translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 1
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME specialization_constants_same_name_inter_link_1st_tu_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_fp64<SC_SN_IL_TU_NUM, sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_via_kb_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_via_kb_core.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage via kernel_bundle (1st translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 1
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME \
+  specialization_constants_same_name_inter_link_1st_tu_via_kb_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_core<SC_SN_IL_TU_NUM, sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_via_kb_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_via_kb_fp16.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage for sycl::half via kernel_bundle (1st translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 1
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME \
+  specialization_constants_same_name_inter_link_1st_tu_via_kb_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_fp16<SC_SN_IL_TU_NUM, sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_via_kb_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_1st_tu_via_kb_fp64.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage for double via kernel_bundle (1st translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 1
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME \
+  specialization_constants_same_name_inter_link_1st_tu_via_kb_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_fp64<SC_SN_IL_TU_NUM, sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_core.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage (2nd translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 2
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME specialization_constants_same_name_inter_link_2nd_tu_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_core<SC_SN_IL_TU_NUM, sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage for sycl::half (2nd translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 2
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME specialization_constants_same_name_inter_link_2nd_tu_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_fp16<SC_SN_IL_TU_NUM, sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage for double (2nd translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 2
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME specialization_constants_same_name_inter_link_2nd_tu_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_fp64<SC_SN_IL_TU_NUM, sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_via_kb_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_via_kb_core.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage via kernel_bundle (2nd translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 2
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME \
+  specialization_constants_same_name_inter_link_2nd_tu_via_kb_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_core<SC_SN_IL_TU_NUM, sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_via_kb_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_via_kb_fp16.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage for sycl::half via kernel_bundle (2nd translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 2
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME \
+  specialization_constants_same_name_inter_link_2nd_tu_via_kb_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_fp16<SC_SN_IL_TU_NUM, sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_via_kb_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_2nd_tu_via_kb_fp64.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with same name and internal
+//  linkage for double via kernel_bundle (2nd translation unit)
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+// Index of TU
+#define SC_SN_IL_TU_NUM 2
+
+#include "specialization_constants_same_name_inter_link.h"
+
+#define TEST_NAME \
+  specialization_constants_same_name_inter_link_2nd_tu_via_kb_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_inter_link;
+    using namespace get_spec_const;
+    sc_run_test_fp64<SC_SN_IL_TU_NUM, sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_helper.h
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_helper.h
@@ -30,7 +30,7 @@ namespace {
 // SC_SN_IL_TU_NUM is defined in every TU
 template <typename T, typename via_kb>
 constexpr sycl::specialization_id<T> sc_same_name_inter_link(
-    get_spec_const::value_helper<T>(SC_SN_IL_TU_NUM));
+    get_spec_const::get_init_value_helper<T>(SC_SN_IL_TU_NUM));
 
 }  // namespace
 

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link_helper.h
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link_helper.h
@@ -1,0 +1,37 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides sycl::specialization_id definitions for specialization constants
+//  with same name and internal linkage
+//
+*******************************************************************************/
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_INTERNAL_LINK_HELPER_H
+#define __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_INTERNAL_LINK_HELPER_H
+
+#include "../common/common.h"
+#include "specialization_constants_common.h"
+
+namespace spec_const_help {
+
+template <int tu_num>
+struct sc_sn_il_config {
+  static constexpr int tu = tu_num;
+  static constexpr int ref_val = tu_num + 1;
+};
+
+}  // namespace spec_const_help
+
+//  Using unnamed namespace to make it static and enforce internal linkage in
+//  accordance with the test plan, taking into account that it is necessary
+//  to perform a test for several types
+namespace {
+
+// SC_SN_IL_TU_NUM is defined in every TU
+template <typename T, typename via_kb>
+constexpr sycl::specialization_id<T> sc_same_name_inter_link(
+    get_spec_const::value_helper<T>(SC_SN_IL_TU_NUM));
+
+}  // namespace
+
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_INTERNAL_LINK_HELPER_H

--- a/tests/specialization_constants/specialization_constants_same_name_stress.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress.h
@@ -1,0 +1,275 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common checks for specialization constants same name stress test
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_STRESS_H
+#define __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_STRESS_H
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "specialization_constants_common.h"
+#include "specialization_constants_same_name_stress_helper.h"
+
+namespace specialization_constants_same_name_stress {
+using namespace sycl_cts;
+using namespace get_spec_const;
+
+template <typename T, typename via_kb>
+class kernel;
+
+template <typename T, typename via_kb>
+class check_specialization_constants_same_name_stress_for_type {
+  // Aliases for spec constants
+  static constexpr auto &sc_glob = ::sc_same_name<T>;
+  static constexpr auto &sc_out = g_outer::sc_same_name<T>;
+  static constexpr auto &sc_out_in = g_outer::g_inner::sc_same_name<T>;
+  static constexpr auto &sc_out_unn = g_outer::sc_ref_outer_unnamed<T>;
+  static constexpr auto &sc_out_unn_in =
+      g_outer::g_u_inner::sc_ref_outer_unnamed_inner<T>;
+  static constexpr auto &sc_out_unn_in_unn =
+      g_outer::g_u_inner::sc_ref_outer_unnamed_inner_unnamed<T>;
+  static constexpr auto &sc_unn = sc_ref_unnamed<T>;
+  static constexpr auto &sc_unn_out = u_outer::sc_ref_unnamed_outer<T>;
+  static constexpr auto &sc_unn_out_unn =
+      u_outer::sc_ref_unnamed_outer_unnamed<T>;
+  static constexpr auto &sc_unn_out_unn_in =
+      u_outer::u_inner::sc_ref_unnamed_out_unnamed_inner<T>;
+
+ public:
+  void operator()(util::logger &log, const std::string &type_name) {
+    using namespace spec_const_help;
+    try {
+      auto queue = util::get_cts_object::queue();
+      const sycl::context ctx = queue.get_context();
+      const sycl::device dev = queue.get_device();
+
+      if constexpr (via_kb::value) {
+        if (!dev.has(sycl::aspect::online_compiler)) {
+          once_per_unit::log(log, "Device does not support online compilation");
+          return;
+        }
+      }
+      // Size for result arrays
+      std::size_t size = to_integral(sc_st_id::SIZE);
+      sycl::range<1> range(size);
+      // Using malloc to not initialize for struct with no default constructor
+      // Array of expected default values
+      T *ref_def_values_arr = (T *)malloc(size * sizeof(T));
+      // Array of expected values
+      T *ref_arr = (T *)malloc(size * sizeof(T));
+      // Array for real default values
+      T *def_values_arr = (T *)malloc(size * sizeof(T));
+      // Array for real values
+      T *result_arr = (T *)malloc(size * sizeof(T));
+      // Initialize ref arrays
+      for (int i = 0; i < size; ++i) {
+        init_values(ref_def_values_arr[i], i);
+        init_values(ref_arr[i], i + static_cast<int>(size));
+      }
+
+      {
+        sycl::buffer<T, 1> result_buffer(result_arr, range);
+        queue.submit([&](sycl::handler &cgh) {
+          // Kernel name
+          using kernel_name = kernel<T, via_kb>;
+          using TargetT = typename std::conditional<
+              via_kb::value, sycl::kernel_bundle<sycl::bundle_state::input>,
+              sycl::handler>::type;
+
+          // Get default values and set new ones for spec consts
+          auto get_default_and_set = [&](TargetT &tgt) {
+            // Getting default values of all spec constants
+            def_values_arr[0] =
+                tgt.template get_specialization_constant<sc_glob>();
+            def_values_arr[1] =
+                tgt.template get_specialization_constant<sc_out>();
+            def_values_arr[2] =
+                tgt.template get_specialization_constant<sc_out_in>();
+            def_values_arr[3] =
+                tgt.template get_specialization_constant<sc_out_unn>();
+            def_values_arr[4] =
+                tgt.template get_specialization_constant<sc_out_unn_in>();
+            def_values_arr[5] =
+                tgt.template get_specialization_constant<sc_out_unn_in_unn>();
+            def_values_arr[6] =
+                tgt.template get_specialization_constant<sc_unn>();
+            def_values_arr[7] =
+                tgt.template get_specialization_constant<sc_unn_out>();
+            def_values_arr[8] =
+                tgt.template get_specialization_constant<sc_unn_out_unn>();
+            def_values_arr[9] =
+                tgt.template get_specialization_constant<sc_unn_out_unn_in>();
+
+            // Setting values to all spec constants
+            tgt.template set_specialization_constant<sc_glob>(ref_arr[0]);
+            tgt.template set_specialization_constant<sc_out>(ref_arr[1]);
+            tgt.template set_specialization_constant<sc_out_in>(ref_arr[2]);
+            tgt.template set_specialization_constant<sc_out_unn>(ref_arr[3]);
+            tgt.template set_specialization_constant<sc_out_unn_in>(ref_arr[4]);
+            tgt.template set_specialization_constant<sc_out_unn_in_unn>(
+                ref_arr[5]);
+            tgt.template set_specialization_constant<sc_unn>(ref_arr[6]);
+            tgt.template set_specialization_constant<sc_unn_out>(ref_arr[7]);
+            tgt.template set_specialization_constant<sc_unn_out_unn>(
+                ref_arr[8]);
+            tgt.template set_specialization_constant<sc_unn_out_unn_in>(
+                ref_arr[9]);
+          };
+
+          auto res_acc =
+              result_buffer.template get_access<sycl::access_mode::write>(cgh);
+          // Read all spec consts values from kernel_handler
+          auto read_from_kernel_handler = [&]() {
+            cgh.single_task<kernel_name>([=](sycl::kernel_handler h) {
+              res_acc[0] = h.get_specialization_constant<sc_glob>();
+              res_acc[1] = h.get_specialization_constant<sc_out>();
+              res_acc[2] = h.get_specialization_constant<sc_out_in>();
+              res_acc[3] = h.get_specialization_constant<sc_out_unn>();
+              res_acc[4] = h.get_specialization_constant<sc_out_unn_in>();
+              res_acc[5] = h.get_specialization_constant<sc_out_unn_in_unn>();
+              res_acc[6] = h.get_specialization_constant<sc_unn>();
+              res_acc[7] = h.get_specialization_constant<sc_unn_out>();
+              res_acc[8] = h.get_specialization_constant<sc_unn_out_unn>();
+              res_acc[9] = h.get_specialization_constant<sc_unn_out_unn_in>();
+            });
+          };
+          // No kernel_bundle
+          if constexpr (!via_kb::value) {
+            get_default_and_set(cgh);
+            read_from_kernel_handler();
+          } else {
+          // Via kernel_bundle
+            auto kernelId = sycl::get_kernel_id<kernel_name>();
+            auto k_bundle = sycl::get_kernel_bundle<sycl::bundle_state::input>(
+                ctx, {dev}, {kernelId});
+            if (!k_bundle.has_kernel(kernelId)) {
+              log.note("kernel_bundle doesn't contain target kernel for " +
+                       type_name_string<T>::get(type_name) + " (skipped)");
+              return;
+            }
+            get_default_and_set(k_bundle);
+            auto exec_bundle = sycl::build(k_bundle);
+            cgh.use_kernel_bundle(exec_bundle);
+            read_from_kernel_handler();
+          }
+        });
+      }
+      for (int i = 0; i < size; ++i) {
+        if (!check_equal_values(def_values_arr[i], ref_def_values_arr[i])) {
+          FAIL(log, "Wrong default value for spec const defined in " +
+                        get_hint(i) + " for type " + type_name);
+        }
+        if (!check_equal_values(result_arr[i], ref_arr[i])) {
+          FAIL(log, "Wrong result value for spec const defined in " +
+                        get_hint(i) + "for type " + type_name);
+        }
+      }
+      free(ref_def_values_arr);
+      free(ref_arr);
+      free(def_values_arr);
+      free(result_arr);
+    } catch (...) {
+      std::string message{"for type " + type_name_string<T>::get(type_name)};
+      log.note(message);
+      throw;
+    }
+  }
+};
+
+template <typename via_kb>
+static void sc_run_test_core(util::logger &log) {
+  using namespace specialization_constants_same_name_stress;
+  try {
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    for_all_types<check_specialization_constants_same_name_stress_for_type,
+                  via_kb>(get_spec_const::testing_types::types, log);
+#else
+    for_all_types_vectors_marray<
+        check_specialization_constants_same_name_stress_for_type, via_kb>(
+        get_spec_const::testing_types::types, log);
+#endif
+    for_all_types<check_specialization_constants_same_name_stress_for_type,
+                  via_kb>(get_spec_const::testing_types::composite_types, log);
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+template <typename via_kb>
+static void sc_run_test_fp16(util::logger &log) {
+  using namespace specialization_constants_same_name_stress;
+  try {
+    auto queue = util::get_cts_object::queue();
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      log.note(
+          "Device does not support half precision floating point "
+          "operations");
+      return;
+    }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    check_specialization_constants_same_name_stress_for_type<sycl::half, via_kb>
+        fp16_test{};
+    fp16_test(log, "sycl::half");
+#else
+    for_type_vectors_marray<
+        check_specialization_constants_same_name_stress_for_type, sycl::half,
+        via_kb>(log, "sycl::half");
+#endif
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+template <typename via_kb>
+static void sc_run_test_fp64(util::logger &log) {
+  using namespace specialization_constants_same_name_stress;
+  try {
+    auto queue = util::get_cts_object::queue();
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      log.note(
+          "Device does not support double precision floating point "
+          "operations");
+      return;
+    }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    check_specialization_constants_same_name_stress_for_type<double, via_kb>
+        fp64_test{};
+    fp64_test(log, "double");
+#else
+    for_type_vectors_marray<
+        check_specialization_constants_same_name_stress_for_type, double,
+        via_kb>(log, "double");
+#endif
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+}  // namespace specialization_constants_same_name_stress
+
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_STRESS_H

--- a/tests/specialization_constants/specialization_constants_same_name_stress.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress.h
@@ -55,25 +55,18 @@ class check_specialization_constants_same_name_stress_for_type {
         }
       }
       // Size for result arrays
-      std::size_t size = to_integral(sc_st_id::SIZE);
+      constexpr auto size = static_cast<size_t>(sc_st_id::SIZE);
       sycl::range<1> range(size);
       // Using malloc to not initialize for struct with no default constructor
       // Array of expected default values
-      auto ref_def_smart_storage = std::make_unique<
-          util::remove_initialization<T>[]>(size);
-      auto ref_def_values_arr = ref_def_smart_storage.get();
+      util::remove_initialization<T> ref_def_values_arr[size] {};
       // Array of expected values
-      auto ref_arr_smart_storage = std::make_unique<
-          util::remove_initialization<T>[]>(size);
-      auto ref_arr = ref_arr_smart_storage.get();
+      util::remove_initialization<T> ref_arr[size] {};
       // Array for real default values
-      auto def_values_arr_smart_storage = std::make_unique<
-          util::remove_initialization<T>[]>(size);
-      auto def_values_arr = def_values_arr_smart_storage.get();
+      util::remove_initialization<T> def_values_arr[size] {};
       // Array for real values
-      auto result_arr_smart_storage = std::make_unique<
-          util::remove_initialization<T>[]>(size);
-      auto result_arr = result_arr_smart_storage.get();
+      util::remove_initialization<T> result_arr[size] {};
+
       // Initialize ref arrays
       for (int i = 0; i < size; ++i) {
         fill_init_values(ref_def_values_arr[i], i);

--- a/tests/specialization_constants/specialization_constants_same_name_stress.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress.h
@@ -11,6 +11,7 @@
 
 #include "../common/common.h"
 #include "../common/once_per_unit.h"
+#include "../../util/allocation.h"
 #include "specialization_constants_common.h"
 #include "specialization_constants_same_name_stress_helper.h"
 
@@ -59,19 +60,19 @@ class check_specialization_constants_same_name_stress_for_type {
       // Using malloc to not initialize for struct with no default constructor
       // Array of expected default values
       auto ref_def_smart_storage = std::make_unique<
-          get_spec_const::testing_types::remove_initialization<T>[]>(size);
+          util::remove_initialization<T>[]>(size);
       auto ref_def_values_arr = ref_def_smart_storage.get();
       // Array of expected values
       auto ref_arr_smart_storage = std::make_unique<
-          get_spec_const::testing_types::remove_initialization<T>[]>(size);
+          util::remove_initialization<T>[]>(size);
       auto ref_arr = ref_arr_smart_storage.get();
       // Array for real default values
       auto def_values_arr_smart_storage = std::make_unique<
-          get_spec_const::testing_types::remove_initialization<T>[]>(size);
+          util::remove_initialization<T>[]>(size);
       auto def_values_arr = def_values_arr_smart_storage.get();
       // Array for real values
       auto result_arr_smart_storage = std::make_unique<
-          get_spec_const::testing_types::remove_initialization<T>[]>(size);
+          util::remove_initialization<T>[]>(size);
       auto result_arr = result_arr_smart_storage.get();
       // Initialize ref arrays
       for (int i = 0; i < size; ++i) {

--- a/tests/specialization_constants/specialization_constants_same_name_stress.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress.h
@@ -67,8 +67,8 @@ class check_specialization_constants_same_name_stress_for_type {
       T *result_arr = (T *)malloc(size * sizeof(T));
       // Initialize ref arrays
       for (int i = 0; i < size; ++i) {
-        init_values(ref_def_values_arr[i], i);
-        init_values(ref_arr[i], i + static_cast<int>(size));
+        fill_init_values(ref_def_values_arr[i], i);
+        fill_init_values(ref_arr[i], i + static_cast<int>(size));
       }
 
       {
@@ -142,7 +142,7 @@ class check_specialization_constants_same_name_stress_for_type {
             get_default_and_set(cgh);
             read_from_kernel_handler();
           } else {
-          // Via kernel_bundle
+            // Via kernel_bundle
             auto kernelId = sycl::get_kernel_id<kernel_name>();
             auto k_bundle = sycl::get_kernel_bundle<sycl::bundle_state::input>(
                 ctx, {dev}, {kernelId});

--- a/tests/specialization_constants/specialization_constants_same_name_stress_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_core.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants same name stress test
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_name_stress.h"
+
+#define TEST_NAME specialization_constants_same_name_stress_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_stress;
+    sc_run_test_core<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_stress_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_fp16.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants same name stress test for
+//  sycl::half
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_name_stress.h"
+
+#define TEST_NAME specialization_constants_same_name_stress_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_stress;
+    sc_run_test_fp16<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_stress_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_fp64.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants same name stress test for
+//  double
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_name_stress.h"
+
+#define TEST_NAME specialization_constants_same_name_stress_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_stress;
+    sc_run_test_fp64<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_stress_helper.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_helper.h
@@ -18,7 +18,7 @@ namespace gsc = get_spec_const;
 namespace spec_const_help {
 
 enum class sc_st_id : int {
-  glob,
+  glob = 0,
   outer,
   outer_inner,
   outer_unnamed,

--- a/tests/specialization_constants/specialization_constants_same_name_stress_helper.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_helper.h
@@ -1,0 +1,153 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides sycl::specialization_id definitions for specialization constants
+//  same name stress tests
+//
+*******************************************************************************/
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_STRESS_HELPER_H
+#define __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_STRESS_HELPER_H
+
+#include <map>
+
+#include "specialization_constants_common.h"
+
+namespace gsc = get_spec_const;
+
+namespace spec_const_help {
+
+enum class sc_st_id : int {
+  glob,
+  outer,
+  outer_inner,
+  outer_unnamed,
+  outer_unnamed_inner,
+  outer_unnamed_inner_unnamed,
+  unnamed,
+  unnamed_outer,
+  unnamed_outer_unnamed,
+  unnamed_outer_unnamed_inner,
+  SIZE  // This should be last
+};
+
+static std::string get_hint(int test_id) {
+  static const std::map<int, std::string> sc_st_tests_hints{
+      {to_integral(sc_st_id::glob),
+       "global namespace"},
+      {to_integral(sc_st_id::outer),
+       "outer namespace"},
+      {to_integral(sc_st_id::outer_inner),
+       "outer::inner namespace"},
+      {to_integral(sc_st_id::outer_unnamed),
+       "outer::unnamed namespace"},
+      {to_integral(sc_st_id::outer_unnamed_inner),
+       "outer::unnamed::inner namespace"},
+      {to_integral(sc_st_id::outer_unnamed_inner_unnamed),
+       "outer::unnamed::inner::unnamed namespace"},
+      {to_integral(sc_st_id::unnamed),
+       "unnamed namespace"},
+      {to_integral(sc_st_id::unnamed_outer),
+       "unnamed::outer namespace"},
+      {to_integral(sc_st_id::unnamed_outer_unnamed),
+       "unnamed::outer::unnamed namespace"},
+      {to_integral(sc_st_id::unnamed_outer_unnamed_inner),
+       "unnamed::outer::unnamed::inner namespace"}};
+
+  return sc_st_tests_hints.at(test_id);
+}
+
+}  // namespace spec_const_help
+
+// Specialization constant defined in global namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(
+    gsc::value_helper<T>(to_integral(spec_const_help::sc_st_id::glob)));
+
+namespace g_outer {
+// Specialization constant defined in outer namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(
+    gsc::value_helper<T>(to_integral(spec_const_help::sc_st_id::outer)));
+
+namespace g_inner {
+// Specialization constant defined in outer::inner namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(
+    gsc::value_helper<T>(to_integral(spec_const_help::sc_st_id::outer_inner)));
+}  // namespace g_inner
+
+namespace {
+// Specialization constant defined in outer::unnamed namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::outer_unnamed)));
+
+template <typename T>
+constexpr auto& sc_ref_outer_unnamed = sc_same_name<T>;
+
+namespace g_u_inner {
+// Specialization constant defined in outer::unnamed::inner namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::outer_unnamed_inner)));
+
+template <typename T>
+constexpr auto& sc_ref_outer_unnamed_inner = sc_same_name<T>;
+
+namespace {
+// Specialization constant defined in outer::unnamed::inner::unnamed
+// namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::outer_unnamed_inner_unnamed)));
+
+template <typename T>
+constexpr auto& sc_ref_outer_unnamed_inner_unnamed = sc_same_name<T>;
+}  // unnamed namespace
+}  // namespace g_u_inner
+}  // unnamed namespace
+}  // namespace g_outer
+
+namespace {
+// Specialization constant defined in unnamed namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(
+    gsc::value_helper<T>(to_integral(spec_const_help::sc_st_id::unnamed)));
+
+template <typename T>
+constexpr auto& sc_ref_unnamed = sc_same_name<T>;
+
+namespace u_outer {
+// Specialization constant defined in unnamed::outer namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::unnamed_outer)));
+
+template <typename T>
+constexpr auto& sc_ref_unnamed_outer = sc_same_name<T>;
+
+namespace {
+// Specialization constant defined in unnamed::outer::unnamed namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::unnamed_outer_unnamed)));
+
+template <typename T>
+constexpr auto& sc_ref_unnamed_outer_unnamed = sc_same_name<T>;
+
+namespace u_inner {
+// Specialization constant defined in unnamed::outer::unnamed::inner
+// namespace
+template <typename T>
+constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::unnamed_outer_unnamed_inner)));
+
+template <typename T>
+constexpr auto& sc_ref_unnamed_out_unnamed_inner = sc_same_name<T>;
+}  // namespace u_inner
+}  // unnamed namespace
+}  // namespace u_outer
+}  // unnamed namespace
+
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_SAME_NAME_STRESS_HELPER_H

--- a/tests/specialization_constants/specialization_constants_same_name_stress_helper.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_helper.h
@@ -33,22 +33,16 @@ enum class sc_st_id : int {
 
 static std::string get_hint(int test_id) {
   static const std::map<int, std::string> sc_st_tests_hints{
-      {to_integral(sc_st_id::glob),
-       "global namespace"},
-      {to_integral(sc_st_id::outer),
-       "outer namespace"},
-      {to_integral(sc_st_id::outer_inner),
-       "outer::inner namespace"},
-      {to_integral(sc_st_id::outer_unnamed),
-       "outer::unnamed namespace"},
+      {to_integral(sc_st_id::glob), "global namespace"},
+      {to_integral(sc_st_id::outer), "outer namespace"},
+      {to_integral(sc_st_id::outer_inner), "outer::inner namespace"},
+      {to_integral(sc_st_id::outer_unnamed), "outer::unnamed namespace"},
       {to_integral(sc_st_id::outer_unnamed_inner),
        "outer::unnamed::inner namespace"},
       {to_integral(sc_st_id::outer_unnamed_inner_unnamed),
        "outer::unnamed::inner::unnamed namespace"},
-      {to_integral(sc_st_id::unnamed),
-       "unnamed namespace"},
-      {to_integral(sc_st_id::unnamed_outer),
-       "unnamed::outer namespace"},
+      {to_integral(sc_st_id::unnamed), "unnamed namespace"},
+      {to_integral(sc_st_id::unnamed_outer), "unnamed::outer namespace"},
       {to_integral(sc_st_id::unnamed_outer_unnamed),
        "unnamed::outer::unnamed namespace"},
       {to_integral(sc_st_id::unnamed_outer_unnamed_inner),
@@ -61,26 +55,26 @@ static std::string get_hint(int test_id) {
 
 // Specialization constant defined in global namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(
-    gsc::value_helper<T>(to_integral(spec_const_help::sc_st_id::glob)));
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::glob)));
 
 namespace g_outer {
 // Specialization constant defined in outer namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(
-    gsc::value_helper<T>(to_integral(spec_const_help::sc_st_id::outer)));
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::outer)));
 
 namespace g_inner {
 // Specialization constant defined in outer::inner namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(
-    gsc::value_helper<T>(to_integral(spec_const_help::sc_st_id::outer_inner)));
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::outer_inner)));
 }  // namespace g_inner
 
 namespace {
 // Specialization constant defined in outer::unnamed namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
     to_integral(spec_const_help::sc_st_id::outer_unnamed)));
 
 template <typename T>
@@ -89,7 +83,7 @@ constexpr auto& sc_ref_outer_unnamed = sc_same_name<T>;
 namespace g_u_inner {
 // Specialization constant defined in outer::unnamed::inner namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
     to_integral(spec_const_help::sc_st_id::outer_unnamed_inner)));
 
 template <typename T>
@@ -99,8 +93,9 @@ namespace {
 // Specialization constant defined in outer::unnamed::inner::unnamed
 // namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
-    to_integral(spec_const_help::sc_st_id::outer_unnamed_inner_unnamed)));
+constexpr sycl::specialization_id<T> sc_same_name(
+    gsc::get_init_value_helperue_helper<T>(
+        to_integral(spec_const_help::sc_st_id::outer_unnamed_inner_unnamed)));
 
 template <typename T>
 constexpr auto& sc_ref_outer_unnamed_inner_unnamed = sc_same_name<T>;
@@ -112,8 +107,8 @@ constexpr auto& sc_ref_outer_unnamed_inner_unnamed = sc_same_name<T>;
 namespace {
 // Specialization constant defined in unnamed namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(
-    gsc::value_helper<T>(to_integral(spec_const_help::sc_st_id::unnamed)));
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
+    to_integral(spec_const_help::sc_st_id::unnamed)));
 
 template <typename T>
 constexpr auto& sc_ref_unnamed = sc_same_name<T>;
@@ -121,7 +116,7 @@ constexpr auto& sc_ref_unnamed = sc_same_name<T>;
 namespace u_outer {
 // Specialization constant defined in unnamed::outer namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
     to_integral(spec_const_help::sc_st_id::unnamed_outer)));
 
 template <typename T>
@@ -130,7 +125,7 @@ constexpr auto& sc_ref_unnamed_outer = sc_same_name<T>;
 namespace {
 // Specialization constant defined in unnamed::outer::unnamed namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
     to_integral(spec_const_help::sc_st_id::unnamed_outer_unnamed)));
 
 template <typename T>
@@ -140,7 +135,7 @@ namespace u_inner {
 // Specialization constant defined in unnamed::outer::unnamed::inner
 // namespace
 template <typename T>
-constexpr sycl::specialization_id<T> sc_same_name(gsc::value_helper<T>(
+constexpr sycl::specialization_id<T> sc_same_name(gsc::get_init_value_helper<T>(
     to_integral(spec_const_help::sc_st_id::unnamed_outer_unnamed_inner)));
 
 template <typename T>

--- a/tests/specialization_constants/specialization_constants_same_name_stress_helper.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_helper.h
@@ -94,7 +94,7 @@ namespace {
 // namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    gsc::get_init_value_helperue_helper<T>(
+    gsc::get_init_value_helper<T>(
         to_integral(spec_const_help::sc_st_id::outer_unnamed_inner_unnamed)));
 
 template <typename T>

--- a/tests/specialization_constants/specialization_constants_same_name_stress_via_kb_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_via_kb_core.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants same name stress test via
+//  kernel_bundle
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_name_stress.h"
+
+#define TEST_NAME specialization_constants_same_name_stress_via_kb_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_stress;
+    sc_run_test_core<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_stress_via_kb_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_via_kb_fp16.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants same name stress test for
+//  sycl::half via kernel_bundle
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_name_stress.h"
+
+#define TEST_NAME specialization_constants_same_name_stress_via_kb_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_stress;
+    sc_run_test_fp16<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_same_name_stress_via_kb_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_name_stress_via_kb_fp64.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants same name stress test for
+//  double via kernel_bundle
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_name_stress.h"
+
+#define TEST_NAME specialization_constants_same_name_stress_via_kb_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_name_stress;
+    sc_run_test_fp64<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/util/allocation.h
+++ b/util/allocation.h
@@ -1,0 +1,41 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provide union that let allocate memory without default constructor calling
+//
+*******************************************************************************/
+
+#ifndef __SYCL_UTIL_ALLOCATION_H
+#define __SYCL_UTIL_ALLOCATION_H
+
+namespace sycl_cts {
+namespace util {
+
+template <typename T>
+union remove_initialization {
+  using value_type = T;
+  T value;
+  remove_initialization() {}
+
+  template <typename T>
+  void operator=(const T &val) {
+    this->value = val;
+  }
+
+  friend bool operator==(const remove_initialization &lhs,
+                         const remove_initialization &rhs) {
+    return lhs.value == rhs.value;
+  }
+
+  operator value_type &() { return value; }
+  operator const value_type &() const { return value; }
+
+  value_type *data() { return &value; }
+  const value_type *data() const { return &value; }
+};
+
+}  // namespace util
+}  // namespace sycl_cts
+
+#endif  // __SYCLCTS_UTIL_ACCURACY_H

--- a/util/allocation.h
+++ b/util/allocation.h
@@ -12,6 +12,7 @@
 namespace sycl_cts {
 namespace util {
 
+// Use a union to avoid calling variable ​"value"'s default constructor
 template <typename T>
 union remove_initialization {
   using value_type = T;


### PR DESCRIPTION
Provide common code for all spec const tests

Contains following tests via kernel_bundle and without it:
 - spec const with class member function that accesses members (no kb)
 - spec consts with same name and internal linkage
 - spec consts with same name (stress test)
 - multiple spec consts