### PR TITLE
Add test for specialization constants defined various ways

### DIFF
--- a/tests/specialization_constants/specialization_constants_defined_various_ways.h
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways.h
@@ -1,0 +1,256 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common checks for specialization constants defined in various ways
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_H
+#define __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_H
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "specialization_constants_common.h"
+#include "specialization_constants_defined_various_ways_helper.h"
+
+namespace specialization_constants_defined_various_ways {
+using namespace sycl_cts;
+using namespace get_spec_const;
+
+template <typename T, int num_case, typename via_kb>
+class kernel;
+
+template <typename T, int case_num, typename via_kb, auto &SpecConst>
+void perform_test(util::logger &log, const std::string &type_name,
+                  const std::string &case_hint) {
+  auto queue = util::get_cts_object::queue();
+  const sycl::context ctx = queue.get_context();
+  const sycl::device dev = queue.get_device();
+
+  if constexpr (via_kb::value) {
+    if (!dev.has(sycl::aspect::online_compiler)) {
+      once_per_unit::log(log, "Device does not support online compilation");
+      return;
+    }
+  }
+  sycl::range<1> range(1);
+  T result = T(value_helper<T>(0));
+  T ref = T(value_helper<T>(0));
+  {
+    init_values(ref, case_num);
+    sycl::buffer<T, 1> result_buffer(&result, range);
+    queue.submit([&](sycl::handler &cgh) {
+      auto res_acc =
+          result_buffer.template get_access<sycl::access_mode::write>(cgh);
+      // Via kernel_bundle
+      if constexpr (via_kb::value) {
+        auto kernelId = sycl::get_kernel_id<kernel<T, case_num, via_kb>>();
+        sycl::kernel_bundle k_bundle =
+            sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
+                                                               {kernelId});
+        if (!k_bundle.has_kernel(kernelId)) {
+          log.note("kernel_bundle doesn't contain target kernel in case (" +
+                   case_hint + ") for " + type_name_string<T>::get(type_name) +
+                   " (skipped)");
+          return;
+        }
+        k_bundle.template set_specialization_constant<SpecConst>(ref);
+        auto exec_bundle = sycl::build(k_bundle);
+        cgh.use_kernel_bundle(exec_bundle);
+        cgh.single_task<kernel<T, case_num, via_kb>>(
+            [=](sycl::kernel_handler h) {
+              res_acc[0] = h.get_specialization_constant<SpecConst>();
+            });
+      } else {
+        // No kernel_bundle
+        cgh.set_specialization_constant<SpecConst>(ref);
+        cgh.single_task<kernel<T, case_num, via_kb>>(
+            [=](sycl::kernel_handler h) {
+              res_acc[0] = h.get_specialization_constant<SpecConst>();
+            });
+      }
+    });
+  }
+  if (!check_equal_values(ref, result))
+    FAIL(log,
+         "case (" + case_hint + ") for " + type_name_string<T>::get(type_name));
+}
+
+template <typename T, typename via_kb>
+class check_specialization_constants_defined_various_ways_for_type {
+ public:
+  void operator()(util::logger &log, const std::string &type_name) {
+    namespace sch = spec_const_help;
+
+    // Case: defined in a non-global named namespace
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::nonglob;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb, sch::sc_nonglob<T, case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+
+    // Case: defined in an unnamed namespace
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::unnamed;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb, sc_unnamed<T, case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+
+    // Case: defined in the global namespace as inline constexpr
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::glob_inl;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb, sc_glob_inl<T, case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+
+    // Case: defined in the global namespace as static constexpr
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::glob_static;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb, sc_glob_static<T, case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+
+    // Case: a static member variable of a struct in the global namespace
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::str_glob;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb, struct_glob::sc<T, case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+
+    // Case: a static member variable of a struct in a non-global namespace
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::str_nonglob;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb, sch::struct_nonglob::sc<T, case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+
+    // Case: a static member variable of a struct in an unnamed namespace
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::str_unnamed;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb, struct_unnamed::sc<T, case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+
+    // Case: a static member variable declared inline constexpr of a struct in
+    // the global namespace
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::str_glob_inl;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb, struct_glob_inl::sc<T, case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+
+    // Case: a static member variable of a templated struct in the global
+    // namespace
+    {
+      constexpr sch::sc_vw_id test_id = sch::sc_vw_id::str_glob_tmpl;
+      constexpr int case_num = to_integral(test_id);
+      perform_test<T, case_num, via_kb,
+                   struct_glob_tmpl<T>::template sc<case_num>>(
+          log, type_name, get_hint(test_id));
+    }
+  }
+};
+
+template <typename via_kb>
+static void sc_run_test_core(util::logger &log) {
+  using namespace specialization_constants_defined_various_ways;
+  try {
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    for_all_types<check_specialization_constants_defined_various_ways_for_type,
+                  via_kb>(get_spec_const::testing_types::types, log);
+#else
+    for_all_types_vectors_marray<
+        check_specialization_constants_defined_various_ways_for_type, via_kb>(
+        get_spec_const::testing_types::types, log);
+#endif
+    for_all_types<check_specialization_constants_defined_various_ways_for_type,
+                  via_kb>(get_spec_const::testing_types::composite_types, log);
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+template <typename via_kb>
+static void sc_run_test_fp16(util::logger &log) {
+  using namespace specialization_constants_defined_various_ways;
+  try {
+    auto queue = util::get_cts_object::queue();
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      log.note(
+          "Device does not support half precision floating point "
+          "operations");
+      return;
+    }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    check_specialization_constants_defined_various_ways_for_type<sycl::half,
+                                                                 via_kb>
+        fp16_test{};
+    fp16_test(log, "sycl::half");
+#else
+    for_type_vectors_marray<
+        check_specialization_constants_defined_various_ways_for_type,
+        sycl::half, via_kb>(log, "sycl::half");
+#endif
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+template <typename via_kb>
+static void sc_run_test_fp64(util::logger &log) {
+  using namespace specialization_constants_defined_various_ways;
+  try {
+    auto queue = util::get_cts_object::queue();
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      log.note(
+          "Device does not support double precision floating point "
+          "operations");
+      return;
+    }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+    check_specialization_constants_defined_various_ways_for_type<double, via_kb>
+        fp64_test{};
+    fp64_test(log, "double");
+#else
+    for_type_vectors_marray<
+        check_specialization_constants_defined_various_ways_for_type, double,
+        via_kb>(log, "double");
+#endif
+
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    std::string errorMsg =
+        "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    std::string errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+}  // namespace specialization_constants_defined_various_ways
+
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_H

--- a/tests/specialization_constants/specialization_constants_defined_various_ways_core.cpp
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways_core.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants defined in various ways
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_defined_various_ways.h"
+
+#define TEST_NAME specialization_constants_defined_various_ways_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_defined_various_ways;
+    sc_run_test_core<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_defined_various_ways_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways_fp16.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants defined in various ways for
+//  sycl::half
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_defined_various_ways.h"
+
+#define TEST_NAME specialization_constants_defined_various_ways_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_defined_various_ways;
+    sc_run_test_fp16<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_defined_various_ways_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways_fp64.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants defined in various ways for
+//  double
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_defined_various_ways.h"
+
+#define TEST_NAME specialization_constants_defined_various_ways_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_defined_various_ways;
+    sc_run_test_fp64<get_spec_const::sc_no_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_defined_various_ways_helper.h
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways_helper.h
@@ -1,0 +1,121 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides sycl::specialization_id definitions for specialization constants
+//  defined various ways tests
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_HELPER_H
+#define __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_HELPER_H
+
+#include <map>
+
+#include "specialization_constants_common.h"
+
+namespace gsc = get_spec_const;
+
+namespace spec_const_help {
+
+enum class sc_vw_id : int {
+  nonglob = 1,
+  unnamed,
+  glob_inl,
+  glob_static,
+  str_glob,
+  str_nonglob,
+  str_unnamed,
+  str_glob_inl,
+  str_glob_tmpl
+};
+
+static std::string get_hint(sc_vw_id test_id) {
+  static const std::map<sc_vw_id, std::string> sc_vw_test_hints{
+      {sc_vw_id::nonglob,
+       "defined in a non-global named namespace"},
+      {sc_vw_id::unnamed,
+       "defined in an unnamed namespace"},
+      {sc_vw_id::glob_inl,
+       "defined in the global namespace as inline constexpr"},
+      {sc_vw_id::glob_static,
+       "defined in the global namespace as static constexpr"},
+      {sc_vw_id::str_glob,
+       "a static member variable of a struct in the global namespace"},
+      {sc_vw_id::str_nonglob,
+       "a static member variable of a struct in a non-global namespace"},
+      {sc_vw_id::str_unnamed,
+       "a static member variable of a struct in an unnamed namespace"},
+      {sc_vw_id::str_glob_inl,
+       "a static member variable declared inline constexpr of a struct in the "
+       "global namespace"},
+      {sc_vw_id::str_glob_tmpl,
+       "a static member variable of a templated struct in the global "
+       "namespace"}};
+  return sc_vw_test_hints.at(test_id);
+}
+
+// Defined in a non-global named namespace
+template <typename T, int case_num>
+constexpr sycl::specialization_id<T> sc_nonglob(gsc::value_helper<T>(case_num));
+
+// A static member variable of a struct in a non-global namespace
+struct struct_nonglob {
+  constexpr struct_nonglob() {}
+  template <typename T, int case_num>
+  static constexpr sycl::specialization_id<T> sc{
+      gsc::value_helper<T>(case_num)};
+};
+}  // namespace spec_const_help
+
+namespace {
+// Defined in an unnamed namespace
+template <typename T, int case_num>
+constexpr sycl::specialization_id<T> sc_unnamed(gsc::value_helper<T>(case_num));
+
+// A static member variable of a struct in an unnamed namespace
+struct struct_unnamed {
+  constexpr struct_unnamed() {}
+  template <typename T, int case_num>
+  static constexpr sycl::specialization_id<T> sc{
+      gsc::value_helper<T>(case_num)};
+};
+}  // unnamed namespace
+
+// Defined in the global namespace as inline constexpr
+template <typename T, int case_num>
+inline constexpr sycl::specialization_id<T> sc_glob_inl(
+    gsc::value_helper<T>(case_num));
+
+// Defined in the global namespace as static constexpr
+template <typename T, int case_num>
+static constexpr sycl::specialization_id<T> sc_glob_static(
+    gsc::value_helper<T>(case_num));
+
+// A static member variable of a struct in the global namespace
+struct struct_glob {
+  constexpr struct_glob() {}
+  template <typename T, int case_num>
+  static constexpr sycl::specialization_id<T> sc{
+      gsc::value_helper<T>(case_num)};
+};
+
+// A static member variable declared inline constexpr of a struct in the global
+// namespace
+struct struct_glob_inl {
+  constexpr struct_glob_inl() {}
+  template <typename T, int case_num>
+  static inline constexpr sycl::specialization_id<T> sc{
+      gsc::value_helper<T>(case_num)};
+};
+
+// A static member variable of a templated struct in the global namespace
+template <typename T>
+struct struct_glob_tmpl {
+  constexpr struct_glob_tmpl() {}
+  template <int case_num>
+  static constexpr sycl::specialization_id<T> sc{
+      gsc::value_helper<T>(case_num)};
+};
+
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_HELPER_H

--- a/tests/specialization_constants/specialization_constants_defined_various_ways_via_kb_core.cpp
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways_via_kb_core.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants defined in various ways via
+//  kernel_bundle
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_defined_various_ways.h"
+
+#define TEST_NAME specialization_constants_defined_various_ways_via_kb_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_defined_various_ways;
+    sc_run_test_core<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_defined_various_ways_via_kb_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways_via_kb_fp16.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants defined in various ways for
+//  sycl::half via kernel_bundle
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_defined_various_ways.h"
+
+#define TEST_NAME specialization_constants_defined_various_ways_via_kb_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_defined_various_ways;
+    sc_run_test_fp16<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/specialization_constants/specialization_constants_defined_various_ways_via_kb_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways_via_kb_fp64.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants defined in various ways for
+//  double via kernel_bundle
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#include "specialization_constants_defined_various_ways.h"
+
+#define TEST_NAME specialization_constants_defined_various_ways_via_kb_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_defined_various_ways;
+    sc_run_test_fp64<get_spec_const::sc_use_kernel_bundle>(log);
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
Provides tests for specialization constants defined various ways

Based on #140  (got common code (tests/specialization_constants/specialization_constants_common.h) from this PR)

Please review from commit: 9a6354a6fd0439433f928452250c5bfeb841b0af