### PR TITLE
Add test for specialization constants same command group

### DIFF
--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -118,6 +118,11 @@ inline constexpr auto get_init_value_helper(int x) {
 }
 
 template <>
+inline constexpr auto get_init_value_helper<bool>(int x) {
+  return (x%2 != 0);
+}
+
+template <>
 inline constexpr auto get_init_value_helper<testing_types::no_cnstr>(int x) {
   testing_types::no_cnstr instance{};
   instance.a = x;

--- a/tests/specialization_constants/specialization_constants_same_command_group_common.h
+++ b/tests/specialization_constants/specialization_constants_same_command_group_common.h
@@ -1,0 +1,96 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+// Common checks for specialization constants usage via handler
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_SAME_COMMAND_GROUP_COMMON_H
+#define __SYCLCTS_TESTS_SPEC_CONST_SAME_COMMAND_GROUP_COMMON_H
+
+#include "../common/common.h"
+#include "specialization_constants_common.h"
+
+namespace specialization_constants_same_command_group_common {
+using namespace sycl_cts;
+using namespace get_spec_const;
+
+template <typename T, int num_case> class kernel;
+
+template <typename T, int num_case> class command_group_object {
+  T *value; // to not initialize for struct with no default constructor
+  sycl::buffer<T, 1> *result_buffer;
+
+public:
+  bool set_const;
+  void set_value(T *value_) {
+    value = value_;
+    set_const = true;
+  }
+  void set_buffer(sycl::buffer<T, 1> *buffer) { result_buffer = buffer; }
+  void operator()(sycl::handler &cgh) {
+    if (set_const)
+      cgh.set_specialization_constant<spec_const<T, num_case>>(*value);
+    auto res_acc =
+        result_buffer->template get_access<sycl::access_mode::write>(cgh);
+    cgh.single_task<kernel<T, num_case>>([=](sycl::kernel_handler h) {
+      res_acc[0] = h.get_specialization_constant<spec_const<T, num_case>>();
+    });
+  }
+};
+
+template <typename T> class check_specialization_constants_same_command_group {
+public:
+  void operator()(util::logger &log, const std::string &type_name) {
+    T ref_A = T(value_helper<T>(5));
+    T ref_B = T(value_helper<T>(10));
+    auto queue = util::get_cts_object::queue();
+    sycl::range<1> range(1);
+    {
+      T result1 = T(value_helper<T>(0));
+      T result2 = T(value_helper<T>(0));
+      {
+        command_group_object<T, 1> cmo;
+        sycl::buffer<T> result_buffer1(&result1, range);
+        sycl::buffer<T> result_buffer2(&result2, range);
+
+        cmo.set_value(&ref_A);
+        cmo.set_buffer(&result_buffer1);
+        queue.submit(cmo);
+
+        cmo.set_value(&ref_B);
+        cmo.set_buffer(&result_buffer2);
+        queue.submit(cmo);
+      }
+      if (!check_equal_values(ref_A, result1))
+        FAIL(log, "case 1 failed for value A for " + type_name);
+      if (!check_equal_values(ref_B, result2))
+        FAIL(log, "case 1 failed for value B for " + type_name);
+    }
+
+    {
+      T result1 = T(value_helper<T>(0));
+      T result2 = T(value_helper<T>(0));
+      {
+        command_group_object<T, 2> cmo;
+        sycl::buffer<T> result_buffer1(&result1, range);
+        sycl::buffer<T> result_buffer2(&result2, range);
+
+        cmo.set_value(&ref_A);
+        cmo.set_buffer(&result_buffer1);
+        queue.submit(cmo);
+
+        cmo.set_const = false;
+        cmo.set_buffer(&result_buffer2);
+        queue.submit(cmo);
+      }
+      if (!check_equal_values(ref_A, result1))
+        FAIL(log, "case 2 failed for value A for " + type_name);
+      if (!check_equal_values(T(value_helper<T>(default_val)), result2))
+        FAIL(log, "case 2 failed for default value for " + type_name);
+    }
+  }
+};
+} /* namespace specialization_constants_same_command_group_common */
+#endif // __SYCLCTS_TESTS_SPEC_CONST_SAME_COMMAND_GROUP_COMMON_H

--- a/tests/specialization_constants/specialization_constants_same_command_group_common.h
+++ b/tests/specialization_constants/specialization_constants_same_command_group_common.h
@@ -43,13 +43,13 @@ public:
 template <typename T> class check_specialization_constants_same_command_group {
 public:
   void operator()(util::logger &log, const std::string &type_name) {
-    T ref_A = T(value_helper<T>(5));
-    T ref_B = T(value_helper<T>(10));
+    T ref_A { get_init_value_helper<T>(5) };
+    T ref_B { get_init_value_helper<T>(10) };
     auto queue = util::get_cts_object::queue();
     sycl::range<1> range(1);
     {
-      T result1 = T(value_helper<T>(0));
-      T result2 = T(value_helper<T>(0));
+      T result1 { get_init_value_helper<T>(0) };
+      T result2 = { get_init_value_helper<T>(0) };
       {
         command_group_object<T, 1> cmo;
         sycl::buffer<T> result_buffer1(&result1, range);
@@ -70,8 +70,8 @@ public:
     }
 
     {
-      T result1 = T(value_helper<T>(0));
-      T result2 = T(value_helper<T>(0));
+      T result1 = { get_init_value_helper<T>(0) };
+      T result2 = { get_init_value_helper<T>(0) };
       {
         command_group_object<T, 2> cmo;
         sycl::buffer<T> result_buffer1(&result1, range);
@@ -87,7 +87,7 @@ public:
       }
       if (!check_equal_values(ref_A, result1))
         FAIL(log, "case 2 failed for value A for " + type_name);
-      if (!check_equal_values(T(value_helper<T>(default_val)), result2))
+      if (!check_equal_values(T(get_init_value_helper<T>(default_val)), result2))
         FAIL(log, "case 2 failed for default value for " + type_name);
     }
   }

--- a/tests/specialization_constants/specialization_constants_same_command_group_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_core.cpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+// Provides tests for specialization constants usage with same command group
+// function
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_command_group_common.h"
+
+#define TEST_NAME specialization_constants_same_command_group_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_command_group_common;
+    try {
+
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+      for_all_types<
+          check_specialization_constants_same_command_group>(
+          get_spec_const::testing_types::types, log);
+#else
+      for_all_types_vectors_marray<
+          check_specialization_constants_same_command_group>(
+          get_spec_const::testing_types::types, log);
+#endif
+      for_all_types<check_specialization_constants_same_command_group>(
+          get_spec_const::testing_types::composite_types, log);
+
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg.c_str());
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg.c_str());
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+} /* namespace spec_const__ */

--- a/tests/specialization_constants/specialization_constants_same_command_group_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_fp16.cpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+// Provides tests for specialization constants usage with same command group
+// function for sycl::half
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_command_group_common.h"
+
+#define TEST_NAME specialization_constants_same_command_group_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_command_group_common;
+    try {
+      auto queue = util::get_cts_object::queue();
+      if (!queue.get_device().has(sycl::aspect::fp16)) {
+        log.note("Device does not support half precision floating point "
+                 "operations");
+        return;
+      }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+      check_specialization_constants_same_command_group<sycl::half> fp16_test{};
+      fp16_test(log, "sycl::half");
+#else
+      for_type_vectors_marray<check_specialization_constants_same_command_group,
+                              sycl::half>(log, "sycl::half");
+#endif
+
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg.c_str());
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg.c_str());
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+} /* namespace spec_const__ */

--- a/tests/specialization_constants/specialization_constants_same_command_group_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_fp64.cpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+// Provides tests for specialization constants usage with same command group
+// function for double
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+#include "specialization_constants_same_command_group_common.h"
+
+#define TEST_NAME specialization_constants_same_command_group_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using namespace specialization_constants_same_command_group_common;
+    try {
+      auto queue = util::get_cts_object::queue();
+      if (!queue.get_device().has(sycl::aspect::fp64)) {
+        log.note("Device does not support double precision floating point "
+                 "operations");
+        return;
+      }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+      check_specialization_constants_same_command_group<double> fp64_test{};
+      fp64_test(log, "double");
+#else
+      for_type_vectors_marray<check_specialization_constants_same_command_group,
+                              double>(log, "double");
+#endif
+
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg.c_str());
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg.c_str());
+    }
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+} /* namespace spec_const__ */


### PR DESCRIPTION
Provides tests for specialization constants with same command group

Based on #140  (got common code (tests/specialization_constants/specialization_constants_common.h) from this PR)

Please review from commit: 2249a311bcc2cbdc502bb694620818aa04b7786e