### PR TITLE
Add test for specialization constants external

### DIFF
--- a/tests/specialization_constants/specialization_constants_external.h
+++ b/tests/specialization_constants/specialization_constants_external.h
@@ -1,0 +1,197 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common checks for specialization constants with SYCL_EXTERNAL function
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_SPEC_CONST_EXTERNAL_H
+#define __SYCLCTS_TESTS_SPEC_CONST_EXTERNAL_H
+
+#include "../common/common.h"
+#include "specialization_constants_common.h"
+
+using namespace get_spec_const;
+
+template <typename T, int case_num>
+inline constexpr sycl::specialization_id<T> spec_const_external(
+    value_helper<T>(default_val));
+
+#define FUNC_DECLARE(TYPE)                                               \
+  SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_handler( \
+      sycl::kernel_handler &h, TYPE);                                    \
+  SYCL_EXTERNAL bool check_kernel_handler_by_value_external_handler(     \
+      sycl::kernel_handler h, TYPE);                                     \
+  SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_bundle(  \
+      sycl::kernel_handler &h, TYPE);                                    \
+  SYCL_EXTERNAL bool check_kernel_handler_by_value_external_bundle(      \
+      sycl::kernel_handler h, TYPE);
+
+#ifdef TEST_CORE
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+CORE_TYPES(FUNC_DECLARE)
+#else
+CORE_TYPES_PARAM(SYCL_VECTORS_MARRAYS, FUNC_DECLARE)
+#endif
+FUNC_DECLARE(testing_types::no_cnstr)
+FUNC_DECLARE(testing_types::def_cnstr)
+FUNC_DECLARE(testing_types::no_def_cnstr)
+#endif  // TEST_CORE
+
+#ifdef TEST_FP64
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+FUNC_DECLARE(double)
+#else
+SYCL_VECTORS_MARRAYS(double, FUNC_DECLARE)
+#endif
+#endif  // TEST_FP64
+
+#ifdef TEST_FP16
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+FUNC_DECLARE(sycl::half)
+#else
+SYCL_VECTORS_MARRAYS(sycl::half, FUNC_DECLARE)
+#endif
+#endif  // TEST_FP16
+
+namespace specialization_constants_external {
+
+template <typename T, int num_case>
+class kernel;
+
+using namespace sycl_cts;
+
+template <typename T>
+class check_specialization_constants_external {
+ public:
+  void operator()(util::logger &log, const std::string &type_name) {
+    auto queue = util::get_cts_object::queue();
+    sycl::range<1> range(1);
+
+    // case 1: Pass kernel handler object by reference to external function via
+    // handler
+    bool func_result = false;
+    {
+      T ref = T(value_helper<T>(5));
+      const int case_num = by_reference_via_handler;
+      sycl::buffer<bool, 1> result_buffer(&func_result, range);
+      queue.submit([&](sycl::handler &cgh) {
+        auto res_acc =
+            result_buffer.template get_access<sycl::access_mode::write>(cgh);
+        cgh.set_specialization_constant<spec_const_external<T, case_num>>(ref);
+        cgh.single_task<kernel<T, case_num>>([=](sycl::kernel_handler h) {
+          res_acc[0] =
+              check_kernel_handler_by_reference_external_handler(h, ref);
+        });
+      });
+    }
+    if (!func_result)
+      FAIL(log,
+           "case 1: Pass kernel handler object by reference to external "
+           "function via handler failed for " +
+               type_name_string<T>::get(type_name));
+
+    // case 2: Pass kernel handler object by value to external function via
+    // handler
+    func_result = false;
+    {
+      T ref = T(value_helper<T>(10));
+      const int case_num = by_value_via_handler;
+      sycl::buffer<bool, 1> result_buffer(&func_result, range);
+      queue.submit([&](sycl::handler &cgh) {
+        auto res_acc =
+            result_buffer.template get_access<sycl::access_mode::write>(cgh);
+        cgh.set_specialization_constant<spec_const_external<T, case_num>>(ref);
+        cgh.single_task<kernel<T, case_num>>([=](sycl::kernel_handler h) {
+          res_acc[0] = check_kernel_handler_by_value_external_handler(h, ref);
+        });
+      });
+    }
+    if (!func_result)
+      FAIL(log,
+           "case 2: Pass kernel handler object by value to external function "
+           "via handler failed for " +
+               type_name_string<T>::get(type_name));
+
+    if (!queue.get_device().has(sycl::aspect::online_compiler))
+      log.note("Device does not support online compilation of device code");
+    else {
+      // case 3: Pass kernel handler object by reference to external function
+      // via kernel_bundle
+      func_result = false;
+      {
+        T ref = T(value_helper<T>(15));
+        const int case_num = by_reference_via_bundle;
+        sycl::buffer<bool, 1> result_buffer(&func_result, range);
+
+        auto context = queue.get_context();
+        sycl::kernel_id kernelID = sycl::get_kernel_id<kernel<T, case_num>>();
+        auto inputBundle = sycl::get_kernel_bundle<sycl::bundle_state::input>(
+            context, {kernelID});
+        if (!inputBundle.has_kernel(kernelID))
+          log.note("Input bundle misses kernel in question");
+        else {
+          inputBundle.template set_specialization_constant<
+              spec_const_external<T, case_num>>(ref);
+          auto exeBundle = sycl::build(inputBundle);
+
+          queue.submit([&](sycl::handler &cgh) {
+            auto res_acc =
+                result_buffer.template get_access<sycl::access_mode::write>(
+                    cgh);
+            cgh.use_kernel_bundle(exeBundle);
+            cgh.single_task<kernel<T, case_num>>([=](sycl::kernel_handler h) {
+              res_acc[0] =
+                  check_kernel_handler_by_reference_external_bundle(h, ref);
+            });
+          });
+        }
+      }
+      if (!func_result)
+        FAIL(log,
+             "case 3: Pass kernel handler object by reference to external "
+             "function via  kernel_bundle failed for " +
+                 type_name_string<T>::get(type_name));
+
+      // case 4: Pass kernel handler object by value to external function via
+      // kernel_bundle
+      func_result = false;
+      {
+        T ref = T(value_helper<T>(20));
+        const int case_num = by_value_via_bundle;
+        sycl::buffer<bool, 1> result_buffer(&func_result, range);
+
+        auto context = queue.get_context();
+        sycl::kernel_id kernelID = sycl::get_kernel_id<kernel<T, case_num>>();
+        auto inputBundle = sycl::get_kernel_bundle<sycl::bundle_state::input>(
+            context, {kernelID});
+        if (!inputBundle.has_kernel(kernelID))
+          log.note("Input bundle misses kernel in question");
+        else {
+          inputBundle.template set_specialization_constant<
+              spec_const_external<T, case_num>>(ref);
+          auto exeBundle = sycl::build(inputBundle);
+
+          queue.submit([&](sycl::handler &cgh) {
+            auto res_acc =
+                result_buffer.template get_access<sycl::access_mode::write>(
+                    cgh);
+            cgh.use_kernel_bundle(exeBundle);
+            cgh.single_task<kernel<T, case_num>>([=](sycl::kernel_handler h) {
+              res_acc[0] =
+                  check_kernel_handler_by_value_external_bundle(h, ref);
+            });
+          });
+        }
+      }
+      if (!func_result)
+        FAIL(log,
+             "case 4: Pass kernel handler object by value to external function "
+             "via kernel_bundle failed for " +
+                 type_name_string<T>::get(type_name));
+    }
+  }
+};
+} /* namespace specialization_constants_external */
+#endif  // __SYCLCTS_TESTS_SPEC_CONST_EXTERNAL_H

--- a/tests/specialization_constants/specialization_constants_external_core.cpp
+++ b/tests/specialization_constants/specialization_constants_external_core.cpp
@@ -1,0 +1,67 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with SYCL_EXTERNAL function
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#define TEST_CORE
+
+#include "specialization_constants_external.h"
+
+#define TEST_NAME specialization_constants_external_core
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+#ifndef SYCL_EXTERNAL
+    log.note("SYCL_EXTERNAL is not defined");
+#else
+    using namespace specialization_constants_external;
+    try {
+
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+      for_all_types<check_specialization_constants_external>(
+          get_spec_const::testing_types::types, log);
+#else
+      for_all_types_vectors_marray<check_specialization_constants_external>(
+          get_spec_const::testing_types::types, log);
+#endif
+      for_all_types<check_specialization_constants_external>(
+          get_spec_const::testing_types::composite_types, log);
+
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    }
+#endif  // SYCL_EXTERNAL
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+} /* namespace TEST_NAMESPACE */

--- a/tests/specialization_constants/specialization_constants_external_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_external_fp16.cpp
@@ -1,0 +1,72 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with SYCL_EXTERNAL function
+//  for sycl::half
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#define TEST_FP16
+
+#include "specialization_constants_external.h"
+
+#define TEST_NAME specialization_constants_external_fp16
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for sycl::half
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+#ifndef SYCL_EXTERNAL
+    log.note("SYCL_EXTERNAL is not defined");
+#else
+    using namespace specialization_constants_external;
+    try {
+      auto queue = util::get_cts_object::queue();
+      if (!queue.get_device().has(sycl::aspect::fp16)) {
+        log.note(
+            "Device does not support half precision floating point "
+            "operations");
+        return;
+      }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+      check_specialization_constants_external<sycl::half> fp16_test{};
+      fp16_test(log, "sycl::half");
+#else
+      for_type_vectors_marray<check_specialization_constants_external,
+                              sycl::half>(log, "sycl::half");
+#endif
+
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    }
+#endif  // SYCL_EXTERNAL
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+} /* namespace TEST_NAMESPACE */

--- a/tests/specialization_constants/specialization_constants_external_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_external_fp64.cpp
@@ -1,0 +1,72 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for specialization constants with SYCL_EXTERNAL function
+//  for double
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_coverage.h"
+
+#define TEST_FP64
+
+#include "specialization_constants_external.h"
+
+#define TEST_NAME specialization_constants_external_fp64
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+
+/** test specialization constants for double
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+#ifndef SYCL_EXTERNAL
+    log.note("SYCL_EXTERNAL is not defined");
+#else
+    using namespace specialization_constants_external;
+    try {
+      auto queue = util::get_cts_object::queue();
+      if (!queue.get_device().has(sycl::aspect::fp64)) {
+        log.note(
+            "Device does not support double precision floating point "
+            "operations");
+        return;
+      }
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+      check_specialization_constants_external<double> fp64_test{};
+      fp64_test(log, "double");
+#else
+      for_type_vectors_marray<check_specialization_constants_external, double>(
+          log, "double");
+#endif
+
+    } catch (const sycl::exception &e) {
+      log_exception(log, e);
+      std::string errorMsg =
+          "a SYCL exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    } catch (const std::exception &e) {
+      std::string errorMsg =
+          "an exception was caught: " + std::string(e.what());
+      FAIL(log, errorMsg);
+    }
+#endif  // SYCL_EXTERNAL
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+} /* namespace TEST_NAMESPACE */

--- a/tests/specialization_constants/specialization_constants_separate_unit.cpp
+++ b/tests/specialization_constants/specialization_constants_separate_unit.cpp
@@ -1,0 +1,85 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides separate unit for checks for specialization constants
+//  with SYCL_EXTERNAL function
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "specialization_constants_common.h"
+
+using namespace get_spec_const;
+
+template <typename T, int case_num>
+inline constexpr sycl::specialization_id<T> spec_const_external(
+    value_helper<T>(default_val));
+
+template <typename T, int case_num>
+bool check_kernel_handler_by_reference_external(sycl::kernel_handler &h,
+                                                T expected) {
+  return check_equal_values(
+      expected,
+      h.get_specialization_constant<spec_const_external<T, case_num>>());
+}
+
+template <typename T, int case_num>
+bool check_kernel_handler_by_value_external(sycl::kernel_handler h,
+                                            T expected) {
+  return check_equal_values(
+      expected,
+      h.get_specialization_constant<spec_const_external<T, case_num>>());
+}
+
+#define FUNC_DEFINE(TYPE)                                                      \
+                                                                               \
+  SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_handler(       \
+      sycl::kernel_handler &h, TYPE expected) {                                \
+    return check_kernel_handler_by_reference_external<                         \
+        TYPE, by_reference_via_handler>(h, expected);                          \
+  }                                                                            \
+                                                                               \
+  SYCL_EXTERNAL bool check_kernel_handler_by_value_external_handler(           \
+      sycl::kernel_handler h, TYPE expected) {                                 \
+    return check_kernel_handler_by_value_external<TYPE, by_value_via_handler>( \
+        h, expected);                                                          \
+  }                                                                            \
+                                                                               \
+  SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_bundle(        \
+      sycl::kernel_handler &h, TYPE expected) {                                \
+    return check_kernel_handler_by_reference_external<                         \
+        TYPE, by_reference_via_bundle>(h, expected);                           \
+  }                                                                            \
+                                                                               \
+  SYCL_EXTERNAL bool check_kernel_handler_by_value_external_bundle(            \
+      sycl::kernel_handler h, TYPE expected) {                                 \
+    return check_kernel_handler_by_value_external<TYPE, by_value_via_bundle>(  \
+        h, expected);                                                          \
+  }
+
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+CORE_TYPES(FUNC_DEFINE)
+#else
+CORE_TYPES_PARAM(SYCL_VECTORS_MARRAYS, FUNC_DEFINE)
+#endif
+
+FUNC_DEFINE(testing_types::no_cnstr)
+FUNC_DEFINE(testing_types::def_cnstr)
+FUNC_DEFINE(testing_types::no_def_cnstr)
+
+#ifdef SYCL_CTS_TEST_DOUBLE
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+FUNC_DEFINE(double)
+#else
+SYCL_VECTORS_MARRAYS(double, FUNC_DEFINE)
+#endif
+#endif  // SYCL_CTS_TEST_DOUBLE
+
+#ifdef SYCL_CTS_TEST_HALF
+#ifndef SYCL_CTS_FULL_CONFORMANCE
+FUNC_DEFINE(sycl::half)
+#else
+SYCL_VECTORS_MARRAYS(sycl::half, FUNC_DEFINE)
+#endif
+#endif  // SYCL_CTS_TEST_HALF


### PR DESCRIPTION
Provides tests for specialization constants external

Based on #140  (got common code (tests/specialization_constants/specialization_constants_common.h) from this PR)

Please review from commit: cfde845a30bc9af1c719d32257e6ab5af0e3a50a