### PR TITLE
Provide debug level for logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,14 @@ endif()
 # ------------------
 
 # ------------------
+# Debug-level verbose logging
+option(SYCL_CTS_ENABLE_VERBOSE_LOG "Enable debug-level logs" OFF)
+if(SYCL_CTS_ENABLE_VERBOSE_LOG)
+    add_definitions(-DSYCL_CTS_VERBOSE_LOG)
+endif()
+# ------------------
+
+# ------------------
 # Double and Half variables
 option(SYCL_CTS_ENABLE_DOUBLE_TESTS "Enable Double tests." ON)
 option(SYCL_CTS_ENABLE_HALF_TESTS "Enable Half tests." ON)

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,10 @@ When configuring CMake, it is possible to use these flags:
   Enable extensive coverage with huge compilation and execution time.
   This mode is switched off by default. Should be swithed on for conformance.
 
+``SYCL_CTS_VERBOSE_LOG``
+  Enable debug-level logs with the possibly oververbose output.
+  This mode is switched off by default.
+
 ``HOST_COMPILER_FLAGS``
   Flags that will be passed to the host compiler.
 


### PR DESCRIPTION
Sometimes it's important to have more detailed output from the tests up to the trace of actions made.

Providing such information on the regular basis would pull the performance down. Therefore compile-time switch is required to avoid all message construction routines entirely. Lambda usage makes possible to avoid heavy message construction in case compile-time switch is off. String, string view and string literal instances can be used without overhead.

As a side note, currently tests within `tests/accessors` are using undocumented `#ifdef VERBOSE_LOG` for the purpose of trace output.