### PR TITLE
Skip half and double builtin tests if not enabled [SYCL 2020]

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,12 +89,24 @@ add_custom_target(generate_test_sources)
 
 # Test generation routine
 function(generate_cts_test)
-  cmake_parse_arguments(GEN_TEST "" "TESTS;GENERATOR;OUTPUT;INPUT" "EXTRA_ARGS" ${ARGN})
+  cmake_parse_arguments(
+    GEN_TEST
+    ""
+    "TESTS;GENERATOR;OUTPUT;INPUT"
+    "EXTRA_ARGS;DEPENDS"
+    ${ARGN}
+  )
   message(STATUS "Setup test generation rules for: " ${GEN_TEST_OUTPUT})
 
   set(GEN_TEST_FILE_NAME ${GEN_TEST_OUTPUT})
   set(GEN_TEST_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${GEN_TEST_OUTPUT})
   set(GEN_TEST_INPUT ${CMAKE_CURRENT_SOURCE_DIR}/${GEN_TEST_INPUT})
+
+  set(extra_deps "")
+  foreach(filename ${GEN_TEST_DEPENDS})
+    list(APPEND extra_deps ${CMAKE_CURRENT_SOURCE_DIR}/${filename})
+  endforeach()
+
   # Add the file to the out test list
   set(${GEN_TEST_TESTS} ${${GEN_TEST_TESTS}} ${GEN_TEST_OUTPUT} PARENT_SCOPE)
 
@@ -111,6 +123,7 @@ function(generate_cts_test)
     DEPENDS
       ${GEN_TEST_GENERATOR}
       ${GEN_TEST_INPUT}
+      ${extra_deps}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     COMMENT "Generating test ${GEN_TEST_OUTPUT}..."
     )

--- a/tests/math_builtin_api/CMakeLists.txt
+++ b/tests/math_builtin_api/CMakeLists.txt
@@ -1,9 +1,16 @@
 set(TEST_CASES_LIST "")
 
 set(MATH_CAT_WITH_VARIANT common float relational geometric)
-set(MATH_VARIANT base double half)
+set(MATH_VARIANT base)
 
 set(MATH_CAT integer native half)
+
+if(SYCL_CTS_ENABLE_HALF_TESTS)
+  list(APPEND MATH_VARIANT half)
+endif()
+if(SYCL_CTS_ENABLE_DOUBLE_TESTS)
+  list(APPEND MATH_VARIANT double)
+endif()
 
 set(math_builtin_depends
   "modules/sycl_functions.py"

--- a/tests/math_builtin_api/CMakeLists.txt
+++ b/tests/math_builtin_api/CMakeLists.txt
@@ -5,6 +5,12 @@ set(MATH_VARIANT base double half)
 
 set(MATH_CAT integer native half)
 
+set(math_builtin_depends
+  "modules/sycl_functions.py"
+  "modules/sycl_types.py"
+  "modules/test_generator.py"
+)
+
 foreach(cat ${MATH_CAT_WITH_VARIANT})
   foreach(var ${MATH_VARIANT})
     if ("${cat}" STREQUAL geometric AND "${var}" STREQUAL half)
@@ -16,7 +22,9 @@ foreach(cat ${MATH_CAT_WITH_VARIANT})
       GENERATOR "generate_math_builtin.py"
       OUTPUT "math_builtin_${cat}_${var}.cpp"
       INPUT "math_builtin.template"
-      EXTRA_ARGS -test ${cat} -variante ${var})
+      EXTRA_ARGS -test ${cat} -variante ${var}
+      DEPENDS ${math_builtin_depends}
+    )
   endforeach()
 endforeach()
 
@@ -27,7 +35,9 @@ foreach(cat ${MATH_CAT})
     GENERATOR "generate_math_builtin.py"
     OUTPUT "math_builtin_${cat}.cpp"
     INPUT "math_builtin.template"
-    EXTRA_ARGS -test ${cat})
+    EXTRA_ARGS -test ${cat}
+    DEPENDS ${math_builtin_depends}
+  )
 endforeach()
 
 add_cts_test(${TEST_CASES_LIST})


### PR DESCRIPTION
Bringing https://github.com/KhronosGroup/SYCL-CTS/pull/71 and https://github.com/KhronosGroup/SYCL-CTS/pull/138 into the SYCL 2020 branch.