### PR TITLE
Remove use of half from global namespace

### DIFF
--- a/tests/multi_ptr/multi_ptr_api_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_api_fp16.cpp
@@ -39,8 +39,8 @@ class TEST_NAME : public util::test_base {
         return;
       }
 
-      check_void_pointer_api<half>{}(log, queue, "half");
-      check_pointer_api<half>{}(log, queue, "half");
+      check_void_pointer_api<sycl::half>{}(log, queue, "sycl::half");
+      check_pointer_api<sycl::half>{}(log, queue, "sycl::half");
 
       queue.wait_and_throw();
     } catch (const sycl::exception &e) {

--- a/tests/multi_ptr/multi_ptr_constructors_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_constructors_fp16.cpp
@@ -39,8 +39,8 @@ class TEST_NAME : public util::test_base {
         return;
       }
 
-      check_void_pointer_ctors<half>{}(queue, "half");
-      check_pointer_ctors<half>{}(queue, "half");
+      check_void_pointer_ctors<sycl::half>{}(queue, "sycl::half");
+      check_pointer_ctors<sycl::half>{}(queue, "sycl::half");
 
       queue.wait_and_throw();
     } catch (const sycl::exception &e) {


### PR DESCRIPTION
Recent SYCL 1.2.1 and SYCL 2020 specification put half type to sycl
namespace. This change replaces use of the half type from global
namespace with sycl::half.