### PR TITLE
Update tests for buffer for SYCL2020

### DIFF
--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -81,7 +81,7 @@ class test_buffer_reinterpret {
     sycl::buffer<TIn, dims> a(data, rangeIn);
     auto r = a.template reinterpret<TOut, dims>(rangeOut);
 
-    if (r.get_size() != (elementsCount * sizeof(TOut))) {
+    if (r.byte_size() != (elementsCount * sizeof(TOut))) {
       FAIL(log, "Reinterpretation failed! The buffers have different size");
     }
   }
@@ -111,16 +111,16 @@ class test_buffer_reinterpret_no_range {
 
     auto buf2 = buf1.template reinterpret<TOut>();
 
-    if (buf2.get_count() != buf1.get_count()) {
+    if (buf2.size() != buf1.size()) {
       const auto msg = "Reinterpret buffer has wrong count: " +
-                       std::to_string(buf2.get_count()) +
-                       " != " + std::to_string(buf1.get_count());
+                       std::to_string(buf2.size()) +
+                       " != " + std::to_string(buf1.size());
       FAIL(log, msg);
     }
-    if (buf2.get_size() != buf1.get_size()) {
+    if (buf2.byte_size() != buf1.byte_size()) {
       const auto msg = "Reinterpret buffer has wrong size: " +
-                       std::to_string(buf2.get_size()) +
-                       " != " + std::to_string(buf1.get_size());
+                       std::to_string(buf2.byte_size()) +
+                       " != " + std::to_string(buf1.byte_size());
       FAIL(log, msg);
     }
     if (buf2.get_range() != buf1.get_range()) {
@@ -145,20 +145,20 @@ class test_buffer_reinterpret_no_range<TIn, TOut, inputDim, 1> {
     sycl::range<inputDim> rangeIn =
         sycl_cts::util::get_cts_object::range<inputDim>::get(size, size, size);
     sycl::buffer<TIn, inputDim> buf1{data, rangeIn};
-    const auto expectedOutputCount = buf1.get_size() / sizeof(TOut);
+    const auto expectedOutputCount = buf1.byte_size() / sizeof(TOut);
 
     auto buf2 = buf1.template reinterpret<TOut, 1>();
 
-    if (buf2.get_count() != expectedOutputCount) {
+    if (buf2.size() != expectedOutputCount) {
       const auto msg = "Reinterpret buffer has wrong count: " +
-                       std::to_string(buf2.get_count()) +
+                       std::to_string(buf2.size()) +
                        " != " + std::to_string(expectedOutputCount);
       FAIL(log, msg);
     }
-    if (buf2.get_size() != buf1.get_size()) {
+    if (buf2.byte_size() != buf1.byte_size()) {
       const auto msg = "Reinterpret buffer has wrong size: " +
-                       std::to_string(buf2.get_size()) +
-                       " != " + std::to_string(buf1.get_size());
+                       std::to_string(buf2.byte_size()) +
+                       " != " + std::to_string(buf1.byte_size());
       FAIL(log, msg);
     }
     if (buf2.get_range() != sycl::range<1>{expectedOutputCount}) {
@@ -246,7 +246,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
       }
       {
         check_type_existence<typename sycl::buffer<
-            T, dims, sycl::buffer_allocator>::allocator_type>
+            T, dims, sycl::buffer_allocator<T>>::allocator_type>
             typeCheck;
         (void)typeCheck;
       }
@@ -262,22 +262,22 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     }
 
     /* check the buffer returns the correct element count */
-    auto count = buf.get_count();
-    check_return_type<size_t>(log, count, "sycl::buffer::get_count()");
+    auto count = buf.size();
+    check_return_type<size_t>(log, count, "sycl::buffer::size()");
 
     if (count != size) {
       FAIL(log,
-           "sycl::buffer::get_count() does not return "
+           "sycl::buffer::size() does not return "
            "the correct number of elements");
     }
 
     /* check the buffer returns the correct byte size */
-    auto ret_size = buf.get_size();
-    check_return_type<size_t>(log, ret_size, "sycl::buffer::get_size()");
+    auto ret_size = buf.byte_size();
+    check_return_type<size_t>(log, ret_size, "sycl::buffer::byte_size()");
 
     if (ret_size != size * sizeof(T)) {
       FAIL(log,
-           "sycl::buffer::get_size() does not return "
+           "sycl::buffer::byte_size() does not return "
            "the correct size of the buffer");
     }
 
@@ -481,7 +481,7 @@ template <typename T> class check_buffer_api_for_type {
 public:
   void operator()(util::logger &log, const std::string &typeName) {
     log.note("testing: " + type_name_string<T>::get(typeName));
-    check_with_alloc<sycl::buffer_allocator>(log);
+    check_with_alloc<sycl::buffer_allocator<T>>(log);
     check_with_alloc<std::allocator<T>>(log);
   }
 };

--- a/tests/buffer/buffer_constructors_common.h
+++ b/tests/buffer/buffer_constructors_common.h
@@ -210,7 +210,7 @@ class buffer_ctors {
 
     /* Check (range, allocator) constructor */
     {
-      sycl::buffer_allocator buf_alloc;
+      sycl::buffer_allocator<T> buf_alloc;
       sycl::buffer<T, dims> buf(r, buf_alloc, propList);
       sycl::buffer<T, dims> buf1(r, buf_alloc);
       if (!check_buffer_constructor(buf, r) ||
@@ -222,7 +222,7 @@ class buffer_ctors {
 
     /* check (data pointer, range, allocator) constructor*/
     {
-      sycl::buffer_allocator buf_alloc;
+      sycl::buffer_allocator<T> buf_alloc;
       T data[size];
       std::fill(data, (data + size), 0);
       sycl::buffer<T, dims> buf(data, r, buf_alloc, propList);
@@ -237,7 +237,7 @@ class buffer_ctors {
 
     /* check (const data pointer, range, allocator) constructor*/
     {
-      sycl::buffer_allocator buf_alloc;
+      sycl::buffer_allocator<T> buf_alloc;
       const T data[size] = {static_cast<T>(0)};
       sycl::buffer<T, dims> buf(data, r, buf_alloc, propList);
       sycl::buffer<T, dims> buf1(data, r, buf_alloc);
@@ -252,7 +252,7 @@ class buffer_ctors {
 
     /* check (shared pointer, range, allocator) constructor*/
     {
-      sycl::buffer_allocator buf_alloc;
+      sycl::buffer_allocator<T> buf_alloc;
       std::shared_ptr<T> data(new T[size]);
       std::fill(data.get(), (data.get() + size), 0);
       sycl::buffer<T, dims> buf(data, r, buf_alloc, propList);
@@ -268,7 +268,7 @@ class buffer_ctors {
 
     /* Check buffer (iterator, allocator) constructor */
     if (dims == 1) {
-      sycl::buffer_allocator buf_alloc;
+      sycl::buffer_allocator<T> buf_alloc;
       T data[size];
       std::fill(data, (data + size), 0);
       sycl::buffer<T, 1> buf_iter(data, data + size, buf_alloc, propList);

--- a/tests/buffer/buffer_storage_common.h
+++ b/tests/buffer/buffer_storage_common.h
@@ -131,7 +131,7 @@ public:
   void operator()(util::logger &log, const std::string &typeName) {
     log.note("testing: " + typeName);
     check_with_alloc<custom_alloc<T>>(log);
-    check_with_alloc<sycl::buffer_allocator>(log);
+    check_with_alloc<sycl::buffer_allocator<T>>(log);
   }
 };
 


### PR DESCRIPTION
Update buffer_allocator to have templates
Rename deprecated functions get_count() and get_size() to size() and byte_size()