### PR TITLE
(Deprecated API) Remove has_extension() and replace it with .has() method

### DIFF
--- a/tests/atomic/atomic_api_64_base.cpp
+++ b/tests/atomic/atomic_api_64_base.cpp
@@ -105,7 +105,7 @@ class TEST_NAME : public util::test_base {
 
       /** Check atomics for supported types
        */
-      if (testDevice.has_extension("cl_khr_int64_base_atomics")) {
+      if (testDevice.has(sycl::aspect::atomic64)) {
         if constexpr (sizeof(long) * CHAR_BIT == 64 /*bits*/) {
           check_atomics_for_type<long>(log, testQueue);
           check_atomics_for_type<unsigned long>(log, testQueue);

--- a/tests/atomic/atomic_api_64_extended.cpp
+++ b/tests/atomic/atomic_api_64_extended.cpp
@@ -102,7 +102,7 @@ class TEST_NAME : public util::test_base {
 
       /** Check atomics for supported types
        */
-      if (testDevice.has_extension("cl_khr_int64_extended_atomics")) {
+      if (testDevice.has(sycl::aspect::atomic64)) {
         if constexpr (sizeof(long) * CHAR_BIT == 64 /*bits*/) {
           check_atomics_for_type<long>(log, testQueue);
           check_atomics_for_type<unsigned long>(log, testQueue);

--- a/tests/atomic/atomic_constructors_64.cpp
+++ b/tests/atomic/atomic_constructors_64.cpp
@@ -49,8 +49,7 @@ class TEST_NAME : public util::test_base {
 
       /** Check atomics for supported types
        */
-      if (testDevice.has_extension("cl_khr_int64_base_atomics") ||
-          testDevice.has_extension("cl_khr_int64_extended_atomics")) {
+      if (testDevice.has(sycl::aspect::atomic64)) {
         if constexpr (sizeof(long) * CHAR_BIT == 64 /*bits*/) {
           check_atomics_for_type<long>(log, testQueue);
           check_atomics_for_type<unsigned long>(log, testQueue);

--- a/tests/platform/platform_api.cpp
+++ b/tests/platform/platform_api.cpp
@@ -49,15 +49,14 @@ class TEST_NAME : public util::test_base {
         }
       }
 
-      /** check has_extensions() member function
+      /** check has() member function
       */
       {
         cts_selector selector;
         auto plt = util::get_cts_object::platform(selector);
-        auto extensionSupported =
-            plt.has_extension(std::string("cl_khr_icd"));
+        auto extensionSupported = plt.has(sycl::aspect::cpu);
         check_return_type<bool>(log, extensionSupported,
-                                "platform::has_extension(string_class)");
+                                "platform::has(sycl::aspect)");
       }
 
       /** check get_info() member function

--- a/util/extensions.h
+++ b/util/extensions.h
@@ -37,18 +37,18 @@ struct fp64 : generic {};
  * @brief Retrieve extension name by tag
  */
 template <typename tagT>
-inline const char* name();
+inline const sycl::aspect aspect();
 template <>
-inline const char* name<tag::atomic64>() {
-  return "cl_khr_int64_base_atomics";
+inline const sycl::aspect aspect<tag::atomic64>() {
+  return sycl::aspect::atomic64;
 }
 template <>
-inline const char* name<tag::fp16>() {
-  return "cl_khr_fp16";
+inline const sycl::aspect aspect<tag::fp16>() {
+  return sycl::aspect::fp16;
 }
 template <>
-inline const char* name<tag::fp64>() {
-  return "cl_khr_fp64";
+inline const sycl::aspect aspect<tag::fp64>() {
+  return sycl::aspect::fp64;
 }
 
 /**
@@ -58,7 +58,7 @@ template <typename tagT>
 inline std::string description();
 template <>
 inline std::string description<tag::atomic64>() {
-  return "64-bit base atomic operations";
+  return "64-bit atomic operations";
 }
 template <>
 inline std::string description<tag::fp16>() {
@@ -78,7 +78,7 @@ struct availability {
    *  @brief Verify extension availability without log messages
    */
   static inline bool check(const sycl::queue& queue) {
-    return queue.get_device().has_extension(name<tagT>());
+    return queue.get_device().has(aspect<tagT>());
   }
   /**
    *  @brief Verify extension availability with default log messages

--- a/util/test_manager.cpp
+++ b/util/test_manager.cpp
@@ -242,17 +242,10 @@ void test_manager::dump_device_info() {
     auto doesDeviceSupportDouble = chosenDevice.has(sycl::aspect::fp64)
                                        ? "Supported"
                                        : "Not Supported";
-    auto doesDeviceSupportBaseAtomics =
-        chosenDevice.has_extension("cl_khr_int64_base_atomics")
+    auto doesDeviceSupportAtomics =
+        chosenDevice.has(sycl::aspect::atomic64)
             ? "Supported"
             : "Not Supported";
-    auto doesDeviceSupportExtendedAtomics =
-        chosenDevice.has_extension("cl_khr_int64_extended_atomics")
-            ? "Supported"
-            : "Not Supported";
-    auto doesDeviceSupport3DImageWrites =
-        chosenDevice.has_extension("cl_khr_3d_image_writes") ? "Supported"
-                                                             : "Not Supported";
     auto platformNameStr =
         chosenPlatform.get_info<sycl::info::platform::name>();
     auto platformVendorStr =
@@ -266,10 +259,7 @@ void test_manager::dump_device_info() {
              << "\", \"device-version\": \"" << deviceVersionStr
              << "\", \"device-fp16\": \"" << doesDeviceSupportHalf
              << "\", \"device-fp64\": \"" << doesDeviceSupportDouble
-             << "\", \"device-int64-base\": \"" << doesDeviceSupportBaseAtomics
-             << "\", \"device-int64-extended\": \""
-             << doesDeviceSupportExtendedAtomics
-             << "\", \"device-3d-writes\": \"" << doesDeviceSupport3DImageWrites
+             << "\", \"device-atomic64\": \"" << doesDeviceSupportAtomics
              << "\", \"platform-name\": \"" << platformNameStr
              << "\", \"platform-vendor\": \"" << platformVendorStr
              << "\", \"platform-version\": \"" << platformVersionStr << "\"}";


### PR DESCRIPTION
- All has_extension(string) calls replaced with has(aspect)
- Removed has_extension(string) calls with extension without corresponding sycl::aspect (according to Table 189. "SYCL support for OpenCL 1.2 extensions" from the SYCL 2020 Spec)