### PR TITLE
Remove checks with offset for nd_range, nd_item and item classes

### DIFF
--- a/tests/item/item_1d.cpp
+++ b/tests/item/item_1d.cpp
@@ -29,7 +29,7 @@ class kernel_item_1d {
 
  public:
   kernel_item_1d(t_readAccess in_, t_writeAccess out_, sycl::range<1> r)
-      : m_x(in_), m_o(out_), r_exp(r), offset_exp(sycl::id<1>(0)) {}
+      : m_x(in_), m_o(out_), r_exp(r) {}
 
   void operator()(sycl::item<1> item) const {
     bool result = true;
@@ -42,10 +42,6 @@ class kernel_item_1d {
 
     sycl::range<1> localRange = item.get_range();
     result &= localRange == r_exp;
-
-    sycl::id<1> offset = item.get_offset();
-    (void)offset; // silent warning
-    result &= offset == offset_exp;
 
     /* get work item range */
     const size_t nWidth = item.get_range(0);

--- a/tests/item/item_2d.cpp
+++ b/tests/item/item_2d.cpp
@@ -25,11 +25,10 @@ class kernel_item_2d {
   t_readAccess m_x;
   t_writeAccess m_o;
   sycl::range<2> r_exp;
-  sycl::id<2> offset_exp;
 
  public:
   kernel_item_2d(t_readAccess in_, t_writeAccess out_, sycl::range<2> r)
-      : m_x(in_), m_o(out_), r_exp(r), offset_exp(sycl::id<2>(0, 0)) {}
+      : m_x(in_), m_o(out_), r_exp(r) {}
 
   void operator()(sycl::item<2> item) const {
     bool result = true;
@@ -43,9 +42,6 @@ class kernel_item_2d {
 
     sycl::range<2> localRange = item.get_range();
     result &= localRange == r_exp;
-
-    sycl::id<2> offset = item.get_offset();
-    result &= offset == offset_exp;
 
     /* get work item range */
     const size_t nWidth = item.get_range(0);

--- a/tests/item/item_3d.cpp
+++ b/tests/item/item_3d.cpp
@@ -24,11 +24,10 @@ class kernel_item_3d {
   t_readAccess m_x;
   t_writeAccess m_o;
   sycl::range<3> r_exp;
-  sycl::id<3> offset_exp;
 
  public:
   kernel_item_3d(t_readAccess in_, t_writeAccess out_, sycl::range<3> r)
-      : m_x(in_), m_o(out_), r_exp(r), offset_exp(sycl::id<3>(0, 0, 0)) {}
+      : m_x(in_), m_o(out_), r_exp(r) {}
 
   void operator()(sycl::item<3> item) const {
     bool result = true;
@@ -41,9 +40,6 @@ class kernel_item_3d {
 
     sycl::range<3> localRange = item.get_range();
     result &= localRange == r_exp;
-
-    sycl::id<3> offset = item.get_offset();
-    result &= offset == offset_exp;
 
     /* get work item range */
     const size_t nWidth = localRange.get(0);

--- a/tests/nd_item/nd_item_api.cpp
+++ b/tests/nd_item/nd_item_api.cpp
@@ -130,19 +130,16 @@ class kernel_nd_item {
       }
     }
 
-    /* test NDrange and offset*/
-    sycl::id<dimensions> offset = myitem.get_offset();
+    /* test NDrange*/
     sycl::nd_range<dimensions> NDRange = myitem.get_nd_range();
 
     sycl::range<dimensions> ndGlobal = NDRange.get_global_range();
     sycl::range<dimensions> ndLocal = NDRange.get_local_range();
-    sycl::id<dimensions> ndOffset = NDRange.get_offset();
 
     for (int i = 0; i < dimensions; ++i) {
       bool are_same = true;
       are_same &= globalRange.get(i) == ndGlobal.get(i);
       are_same &= localRange.get(i) == ndLocal.get(i);
-      are_same &= offset.get(i) == ndOffset.get(i);
 
       failed = !are_same ? true : failed;
     }

--- a/tests/nd_item/nd_item_constructors.cpp
+++ b/tests/nd_item/nd_item_constructors.cpp
@@ -57,7 +57,6 @@ private:
   sycl_cts::util::array<size_t, numDims> m_globalRange;
   sycl_cts::util::array<size_t, numDims> m_groupRange;
   sycl_cts::util::array<size_t, numDims> m_localRange;
-  sycl_cts::util::array<size_t, numDims> m_offset;
 public:
   state_storage(const sycl::nd_item<numDims>& state)
   {
@@ -71,7 +70,6 @@ public:
       m_globalRange[dim] = state.get_global_range(dim);
       m_groupRange[dim] = state.get_group_range(dim);
       m_localRange[dim] = state.get_local_range(dim);
-      m_offset[dim] = state.get_offset().get(dim);
     }
   }
 
@@ -111,9 +109,6 @@ public:
     return m_localRange[dim];
   }
 
-  size_t get_offset(int dim) const {
-    return m_offset[dim];
-  }
 };
 
 template <int index, int numDims, typename success_acc_t>
@@ -132,8 +127,6 @@ inline void check_equality_helper(success_acc_t& success,
                         expected.get_group_range(index));
   CHECK_EQUALITY_HELPER(success, actual.get_local_range(index),
                         expected.get_local_range(index));
-  CHECK_EQUALITY_HELPER(success, actual.get_offset().get(index),
-                        expected.get_offset(index));
 }
 
 template <int numDims, typename success_acc_t>

--- a/tests/nd_range/nd_range_api.cpp
+++ b/tests/nd_range/nd_range_api.cpp
@@ -17,51 +17,27 @@ static const size_t sizes[] = {16, 32, 64};
 
 template <int dim>
 void test_nd_range(util::logger &log, sycl::range<dim> gs,
-                   sycl::range<dim> ls, sycl::id<dim> offset) {
+                   sycl::range<dim> ls) {
   for (int i = 0; i < dim; i++) {
-    sycl::nd_range<dim> no_offset(gs, ls);
-    CHECK_TYPE(log, no_offset.get_global_range()[i], sizes[i]);
-    CHECK_VALUE(log, no_offset.get_global_range()[i], sizes[i], i);
-    CHECK_TYPE(log, no_offset.get_local_range()[i], sizes[i] / 4);
-    CHECK_VALUE(log, no_offset.get_local_range()[i], sizes[i] / 4, i);
+    sycl::nd_range<dim> nd_range(gs, ls);
+    CHECK_TYPE(log, nd_range.get_global_range()[i], sizes[i]);
+    CHECK_VALUE(log, nd_range.get_global_range()[i], sizes[i], i);
+    CHECK_TYPE(log, nd_range.get_local_range()[i], sizes[i] / 4);
+    CHECK_VALUE(log, nd_range.get_local_range()[i], sizes[i] / 4, i);
 
-    CHECK_TYPE(log, no_offset.get_offset()[i], (size_t)0);
-    CHECK_VALUE(log, no_offset.get_offset()[i], (size_t)0, i);
-    CHECK_TYPE(log, no_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4));
-    CHECK_VALUE(log, no_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
+    CHECK_TYPE(log, nd_range.get_group_range()[i], sizes[i] / (sizes[i] / 4));
+    CHECK_VALUE(log, nd_range.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
 
-    sycl::nd_range<dim> deep_copy(no_offset);
+    sycl::nd_range<dim> deep_copy(nd_range);
 
     CHECK_TYPE(log, deep_copy.get_global_range()[i], sizes[i]);
     CHECK_VALUE(log, deep_copy.get_global_range()[i], sizes[i], i);
     CHECK_TYPE(log, deep_copy.get_local_range()[i], sizes[i] / 4);
     CHECK_VALUE(log, deep_copy.get_local_range()[i], sizes[i] / 4, i);
 
-    CHECK_TYPE(log, deep_copy.get_offset()[i], (size_t)0);
-    CHECK_VALUE(log, deep_copy.get_offset()[i], (size_t)0, i);
     CHECK_TYPE(log, deep_copy.get_group_range()[i], sizes[i] / (sizes[i] / 4));
     CHECK_VALUE(log, deep_copy.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
 
-    sycl::nd_range<dim> with_offset(gs, ls, offset);
-    CHECK_TYPE(log, with_offset.get_global_range()[i], sizes[i]);
-    CHECK_VALUE(log, with_offset.get_global_range()[i], sizes[i], i);
-    CHECK_TYPE(log, with_offset.get_local_range()[i], sizes[i] / 4);
-    CHECK_VALUE(log, with_offset.get_local_range()[i], sizes[i] / 4, i);
-    CHECK_TYPE(log, with_offset.get_offset()[i], sizes[i] / 8);
-    CHECK_VALUE(log, with_offset.get_offset()[i], sizes[i] / 8, i);
-    CHECK_TYPE(log, with_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4));
-    CHECK_VALUE(log, with_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
-
-    sycl::nd_range<dim> deep_copy_offset(with_offset);
-    CHECK_TYPE(log, deep_copy_offset.get_global_range()[i], sizes[i]);
-    CHECK_VALUE(log, deep_copy_offset.get_global_range()[i], sizes[i], i);
-    CHECK_TYPE(log, deep_copy_offset.get_local_range()[i], sizes[i] / 4);
-    CHECK_VALUE(log, deep_copy_offset.get_local_range()[i], sizes[i] / 4, i);
-    CHECK_TYPE(log, deep_copy_offset.get_offset()[i], sizes[i] / 8);
-    CHECK_VALUE(log, deep_copy_offset.get_offset()[i], sizes[i] / 8, i);
-    CHECK_TYPE(log, deep_copy_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4));
-    CHECK_VALUE(log, deep_copy_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4),
-                i);
   }
 }
 
@@ -85,27 +61,19 @@ class TEST_NAME : public util::test_base {
       sycl::range<1> gs_1d(sizes[0]);
       // local size to be set to 1/4 of the sizes
       sycl::range<1> ls_1d(sizes[0] / 4);
-      // offset to be set to 1/8 of the sizes
-      sycl::id<1> offset_1d(sizes[0] / 8);
-      test_nd_range(log, gs_1d, ls_1d, offset_1d);
+      test_nd_range(log, gs_1d, ls_1d);
 
       // global size to be set to the size
       sycl::range<2> gs_2d(sizes[0], sizes[1]);
       // local size to be set to 1/4 of the sizes
       sycl::range<2> ls_2d(sizes[0] / 4, sizes[1] / 4);
-      // offset to be set to 1/8 of the sizes
-      sycl::range<2> range_2d(sizes[0] / 8u, sizes[1] / 8u);
-      sycl::id<2> offset_2d(range_2d);
-      test_nd_range(log, gs_2d, ls_2d, offset_2d);
+      test_nd_range(log, gs_2d, ls_2d);
 
       // global size to be set to the size
       sycl::range<3> gs_3d(sizes[0], sizes[1], sizes[2]);
       // local size to be set to 1/4 of the sizes
       sycl::range<3> ls_3d(sizes[0] / 4, sizes[1] / 4, sizes[2] / 4);
-      // offset to be set to 1/8 of the sizes
-      sycl::range<3> range_3d(sizes[0] / 8u, sizes[1] / 8u, sizes[2] / 8u);
-      sycl::id<3> offset_3d(range_3d);
-      test_nd_range(log, gs_3d, ls_3d, offset_3d);
+      test_nd_range(log, gs_3d, ls_3d);
     } catch (const sycl::exception &e) {
       log_exception(log, e);
       std::string errorMsg =

--- a/tests/nd_range/nd_range_constructors.cpp
+++ b/tests/nd_range/nd_range_constructors.cpp
@@ -26,54 +26,27 @@ inline sycl::nd_range<dim> get_default_nd_range() {
 
 template <int dim>
 void test_nd_range_constructors(util::logger &log, sycl::range<dim> gs,
-                                sycl::range<dim> ls,
-                                sycl::id<dim> offset) {
-  sycl::nd_range<dim> no_offset(gs, ls);
-  sycl::nd_range<dim> with_offset(gs, ls, offset);
+                                sycl::range<dim> ls) {
+  sycl::nd_range<dim> nd_range(gs, ls);
 
-  {  // Copy assignment, no offset
+  {  // Copy assignment
     auto defaultRange = get_default_nd_range<dim>();
-    defaultRange = no_offset;
+    defaultRange = nd_range;
 
     for (int i = 0; i < dim; i++) {
       CHECK_VALUE(log, defaultRange.get_global_range()[i], gs[i], i);
       CHECK_VALUE(log, defaultRange.get_local_range()[i], ls[i], i);
-      CHECK_VALUE(log, defaultRange.get_offset()[i], (size_t)0, i);
       CHECK_VALUE(log, defaultRange.get_group_range()[i],
                  gs[i] / ls[i], i);
     }
   }
-  {  // Copy assignment, with offset
+  {  // Move assignment
     auto defaultRange = get_default_nd_range<dim>();
-    defaultRange = with_offset;
+    defaultRange = std::move(nd_range);
     for (int i = 0; i < dim; i++) {
       CHECK_VALUE(log, defaultRange.get_global_range()[i], gs[i], i);
       CHECK_VALUE(log, defaultRange.get_local_range()[i], ls[i], i);
-      CHECK_VALUE(log, defaultRange.get_offset()[i], offset[i], i);
       CHECK_VALUE(log, defaultRange.get_group_range()[i],
-                 gs[i] / ls[i], i);
-    }
-  }
-  {  // Move assignment, no offset
-    auto defaultRange = get_default_nd_range<dim>();
-    defaultRange = std::move(no_offset);
-    for (int i = 0; i < dim; i++) {
-      CHECK_VALUE(log, defaultRange.get_global_range()[i], gs[i], i);
-      CHECK_VALUE(log, defaultRange.get_local_range()[i], ls[i], i);
-
-      CHECK_VALUE(log, defaultRange.get_offset()[i], (size_t)0, i);
-      CHECK_VALUE(log, defaultRange.get_group_range()[i],
-                 gs[i] / ls[i], i);
-    }
-  }
-  {  // Move assignment, with offset
-    auto defaultRange = get_default_nd_range<dim>();
-    defaultRange = std::move(with_offset);
-    for (int i = 0; i < dim; i++) {
-      CHECK_VALUE(log, with_offset.get_global_range()[i], gs[i], i);
-      CHECK_VALUE(log, with_offset.get_local_range()[i], ls[i], i);
-      CHECK_VALUE(log, with_offset.get_offset()[i], offset[i], i);
-      CHECK_VALUE(log, with_offset.get_group_range()[i],
                  gs[i] / ls[i], i);
     }
   }
@@ -99,27 +72,19 @@ class TEST_NAME : public util::test_base {
       sycl::range<1> gs_1d(sizes[0]);
       // local size to be set to 1/4 of the sizes
       sycl::range<1> ls_1d(sizes[0] / 4u);
-      // offset to be set to 1/8 of the sizes
-      sycl::id<1> offset_1d(sizes[0] / 8u);
-      test_nd_range_constructors(log, gs_1d, ls_1d, offset_1d);
+      test_nd_range_constructors(log, gs_1d, ls_1d);
 
       // global size to be set to the size
       sycl::range<2> gs_2d(sizes[0], sizes[1]);
       // local size to be set to 1/4 of the sizes
       sycl::range<2> ls_2d(sizes[0] / 4u, sizes[1] / 4u);
-      // offset to be set to 1/8 of the sizes
-      sycl::range<2> range_2d(sizes[0] / 8u, sizes[1] / 8u);
-      sycl::id<2> offset_2d(range_2d);
-      test_nd_range_constructors(log, gs_2d, ls_2d, offset_2d);
+      test_nd_range_constructors(log, gs_2d, ls_2d);
 
       // global size to be set to the size
       sycl::range<3> gs_3d(sizes[0], sizes[1], sizes[2]);
       // local size to be set to 1/4 of the sizes
       sycl::range<3> ls_3d(sizes[0] / 4, sizes[1] / 4, sizes[2] / 4);
-      // offset to be set to 1/8 of the sizes
-      sycl::range<3> range_3d(sizes[0] / 8u, sizes[1] / 8u, sizes[2] / 8u);
-      sycl::id<3> offset_3d(range_3d);
-      test_nd_range_constructors(log, gs_3d, ls_3d, offset_3d);
+      test_nd_range_constructors(log, gs_3d, ls_3d);
     } catch (const sycl::exception &e) {
       log_exception(log, e);
       std::string errorMsg =


### PR DESCRIPTION
Offsets to nd_range, nd_item and item classes have been deprecated in SYCL 2020.