### PR TITLE
Update opencl_interop tests for SYCL 2020 style

### DIFF
--- a/tests/opencl_interop/opencl_interop_get.cpp
+++ b/tests/opencl_interop/opencl_interop_get.cpp
@@ -6,24 +6,28 @@
 //
 *******************************************************************************/
 
+#ifdef SYCL_BACKEND_OPENCL
 #include "../../util/opencl_helper.h"
 #include "../../util/test_base_opencl.h"
+#endif
 #include "../common/common.h"
 
 #define TEST_NAME opencl_interop_get
-
-struct program_get_kernel {
-  void operator()() const {}
-};
 
 namespace opencl_interop_get__ {
 using namespace sycl_cts;
 
 class event_kernel;
 
-/** tests the get() methods for OpenCL inter-op
+/** tests the get_native() methods for OpenCL inter-op
  */
-class TEST_NAME : public sycl_cts::util::test_base_opencl {
+class TEST_NAME :
+#ifdef SYCL_BACKEND_OPENCL
+    public sycl_cts::util::test_base_opencl
+#else
+    public util::test_base
+#endif
+{
  public:
   /** return information about this test
    */
@@ -34,83 +38,75 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
   /** execute this test
    */
   void run(util::logger &log) override {
+#ifdef SYCL_BACKEND_OPENCL
     try {
+      auto queue = util::get_cts_object::queue();
+      if (queue.get_backend() != sycl::backend::opencl) {
+        log.note("Interop part is not supported on non-OpenCL backend types");
+        return;
+      }
       cts_selector ctsSelector;
       const auto ctsContext = util::get_cts_object::context(ctsSelector);
       const auto ctsDevice = ctsContext.get_devices()[0];
 
-      if (ctsContext.is_host()) {
-        log.note("OpenCL interop doesn't work on host");
-        return;
-      }
-
-      /** check platform get() method
+      /** check get_native() for platform
        */
       {
         auto platform = util::get_cts_object::platform(ctsSelector);
-        if (!platform.is_host()) {
-          auto interopPlatformID = platform.get();
-          check_return_type<cl_platform_id>(log, interopPlatformID,
-                                            "sycl::platform::get()");
+        auto interopPlatformID =
+            sycl::get_native<sycl::backend::opencl>(platform);
+        check_return_type<cl_platform_id>(log, interopPlatformID,
+                                          "get_native(platform)");
 
-          if (interopPlatformID == 0) {
-            FAIL(log,
-                 "sycl::platform::get() did not return a valid "
-                 "cl_platform_id");
-          }
+        if (interopPlatformID == 0) {
+          FAIL(log,
+               "get_native(platform) did not return a valid "
+               "cl_platform_id");
         }
       }
 
-      /** check device get() method
+      /** check get_native() for device
        */
       {
         auto device = util::get_cts_object::device(ctsSelector);
-        if (!device.is_host()) {
-          auto interopDeviceID = device.get();
-          check_return_type<cl_device_id>(log, interopDeviceID,
-                                          "sycl::device::get()");
+        auto interopDeviceID = sycl::get_native<sycl::backend::opencl>(device);
+        check_return_type<cl_device_id>(log, interopDeviceID,
+                                        "get_native(device)");
 
-          if (interopDeviceID == 0) {
-            FAIL(log,
-                 "sycl::device::get() did not return a valid cl_device_id");
-          }
+        if (interopDeviceID == 0) {
+          FAIL(log, "get_native(device) did not return a valid cl_device_id");
         }
       }
 
-      /** check context get() method
+      /** check get_native() for context
        */
       {
         auto context = util::get_cts_object::context(ctsSelector);
-        if (!context.is_host()) {
-          auto interopContext = context.get();
-          check_return_type<cl_context>(log, interopContext,
-                                        "sycl::context::get()");
+        auto interopContext = sycl::get_native<sycl::backend::opencl>(context);
+        check_return_type<cl_context>(log, interopContext,
+                                      "get_native(context)");
 
-          if (interopContext == nullptr) {
-            FAIL(log,
-                 "sycl::context::get() did not return a valid cl_context");
-          }
+        if (interopContext == nullptr) {
+          FAIL(log, "get_native(context) did not return a valid cl_context");
         }
       }
 
-      /** check queue get() method
+      /** check get_native() for queue
        */
       {
         auto queue = util::get_cts_object::queue(ctsSelector);
-        if (!queue.is_host()) {
-          auto interopQueue = queue.get();
-          check_return_type<cl_command_queue>(log, interopQueue,
-                                              "sycl::queue::get()");
+        auto interopQueue = sycl::get_native<sycl::backend::opencl>(queue);
+        check_return_type<cl_command_queue>(log, interopQueue,
+                                            "get_native(queue)");
 
-          if (interopQueue == nullptr) {
-            FAIL(log,
-                 "sycl::queue::get() did not return a valid "
-                 "cl_command_queue");
-          }
+        if (interopQueue == nullptr) {
+          FAIL(log,
+               "get_native(queue) did not return a valid "
+               "cl_command_queue");
         }
       }
 
-      /** check program get() method
+      /** check get_native() for kernel_bundle
        */
       {
         if (!util::get_cts_object::queue(ctsSelector)
@@ -118,42 +114,49 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
                  .get_info<sycl::info::device::is_compiler_available>()) {
           log.note("online compiler not available -- skipping check");
         } else {
-          auto program =
-              util::get_cts_object::program::compiled<program_get_kernel>(
-                  ctsContext);
+          auto bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+              ctsContext);
           if (!program.is_host()) {
-            auto interopProgram = program.get();
+            auto interopProgram =
+                sycl::get_native<sycl::backend::opencl>(bundle);
             check_return_type<cl_program>(log, interopProgram,
-                                          "sycl::program::get()");
+                                          "get_native(kernel_bundle)");
 
             if (interopProgram == nullptr) {
-              FAIL(
-                  log,
-                  "sycl::program::get() did not return a valid cl_program");
+              FAIL(log,
+                   "get_native(kernel_bundle) did not return a valid "
+                   "cl_program");
             }
           }
         }
       }
 
-      /** check kernel get() method
+      /** check get_native() for kernel
        */
       {
         if (!ctsContext.is_host()) {
           cl_program clProgram{};
-          if (online_compiler_supported(ctsDevice.get(), log)) {
+          if (online_compiler_supported(
+                  sycl::get_native<sycl::backend::opencl>(ctsDevice), log)) {
             std::string kernelSource = R"(
             __kernel void opencl_interop_get_kernel() {}
             )";
 
-            if (!create_built_program(kernelSource, ctsContext.get(),
-                                      ctsDevice.get(), clProgram, log)) {
+            if (!create_built_program(
+                    kernelSource,
+                    sycl::get_native<sycl::backend::opencl>(ctsContext),
+                    sycl::get_native<sycl::backend::opencl>(ctsDevice),
+                    clProgram, log)) {
               FAIL(log, "create_built_program failed");
             }
           } else {
             std::string programBinaryFile = "opencl_interop_get.bin";
 
-            if (!create_program_with_binary(programBinaryFile, ctsContext.get(),
-                                            ctsDevice.get(), clProgram, log)) {
+            if (!create_program_with_binary(
+                    programBinaryFile,
+                    sycl::get_native<sycl::backend::opencl>(ctsContext),
+                    sycl::get_native<sycl::backend::opencl>(ctsDevice),
+                    clProgram, log)) {
               std::string errorMsg =
                   "create_program_with_binary failed.";
               errorMsg +=
@@ -169,20 +172,19 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
             FAIL(log, "create_kernel failed");
           }
 
-          sycl::kernel kernel(clKernel, ctsContext);
+          sycl::kernel kernel = sycl::make_kernel(clKernel, ctsContext);
 
-          auto interopKernel = kernel.get();
+          auto interopKernel = sycl::get_native<sycl::backend::opencl>(kernel);
           check_return_type<cl_kernel>(log, interopKernel,
-                                       "sycl::kernel::get()");
+                                       "get_native(kernel)");
 
           if (interopKernel == nullptr) {
-            FAIL(log,
-                 "sycl::kernel::get() did not return a valid cl_kernel");
+            FAIL(log, "get_native(kernel) did not return a valid cl_kernel");
           }
         }
       }
 
-      /** check event get() method
+      /** check get_native() for event
        */
       {
         auto ctsQueue = util::get_cts_object::queue(ctsSelector);
@@ -192,12 +194,11 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
         });
 
         if (!event.is_host()) {
-          auto interopEvent = event.get();
-          check_return_type<cl_event>(log, interopEvent,
-                                      "sycl::event::get()");
+          auto interopEvent = sycl::get_native<sycl::backend::opencl>(event);
+          check_return_type<cl_event>(log, interopEvent, "get_native(event)");
 
           if (interopEvent == nullptr) {
-            FAIL(log, "sycl::event::get() did not return a valid cl_event");
+            FAIL(log, "get_native(event) did not return a valid cl_event");
           }
         }
 
@@ -210,6 +211,9 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
           "a SYCL exception was caught: " + std::string(e.what());
       FAIL(log, errorMsg.c_str());
     }
+#else
+    log.note("The test is skipped because OpenCL back-end is not supported");
+#endif  // SYCL_BACKEND_OPENCL
   }
 };
 

--- a/tests/opencl_interop/opencl_interop_kernel.cpp
+++ b/tests/opencl_interop/opencl_interop_kernel.cpp
@@ -6,39 +6,16 @@
 //
 *******************************************************************************/
 
+#ifdef SYCL_BACKEND_OPENCL
 #include "../../util/opencl_helper.h"
 #include "../../util/test_base_opencl.h"
+#endif
 #include "../common/common.h"
 
 #define TEST_NAME opencl_interop_kernel
 
 namespace opencl_interop_kernel__ {
 using namespace sycl_cts;
-
-/** check inter-op types
- */
-template <typename T>
-using globalPtrType = typename sycl::global_ptr<T>::pointer;
-template <typename T>
-using constantPtrType = typename sycl::constant_ptr<T>::pointer;
-template <typename T>
-using localPtrType = typename sycl::local_ptr<T>::pointer;
-template <typename T>
-using privatePtrType = typename sycl::private_ptr<T>::pointer;
-template <typename T>
-using globalMultiPtrType = typename sycl::multi_ptr<
-    T, sycl::access::address_space::global_space>::pointer;
-template <typename T>
-using constantMultiPtrType = typename sycl::multi_ptr<
-    T, sycl::access::address_space::constant_space>::pointer;
-template <typename T>
-using localMultiPtrType = typename sycl::multi_ptr<
-    T, sycl::access::address_space::local_space>::pointer;
-template <typename T>
-using privateMultiPtrType = typename sycl::multi_ptr<
-    T, sycl::access::address_space::private_space>::pointer;
-template <typename T, int dims>
-using vectorType = typename sycl::vec<T, dims>::vector_t;
 
 /**
  * @brief Trivially-copyable standard layout custom type
@@ -48,25 +25,15 @@ struct simple_struct {
   float b;
 };
 
-// Forward declaration of the kernel
-template <int N>
-struct program_kernel_interop {
-  void operator()() const {}
-};
-
-/** simple OpenCL test kernel
- */
-const std::string kernelName = "sample";
-std::string kernel_source = R"(
-__kernel void sample(__global float * input)
-{
-    input[get_global_id(0)] = get_global_id(0);
-}
-)";
-
 /** tests the kernel execution for OpenCL inter-op
  */
-class TEST_NAME : public sycl_cts::util::test_base_opencl {
+class TEST_NAME :
+#ifdef SYCL_BACKEND_OPENCL
+    public sycl_cts::util::test_base_opencl
+#else
+    public util::test_base
+#endif
+{
  public:
   /** return information about this test
    */
@@ -77,14 +44,15 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
   /** execute this test
    */
   void run(util::logger &log) override {
+#ifdef SYCL_BACKEND_OPENCL
     try {
-      cts_selector ctsSelector;
-      const auto ctsContext = util::get_cts_object::context(ctsSelector);
-
-      if (ctsContext.is_host()) {
-        log.note("OpenCL interop doesn't work on host");
+      auto queue = util::get_cts_object::queue();
+      if (queue.get_backend() != sycl::backend::opencl) {
+        log.note("Interop part is not supported on non-OpenCL backend types");
         return;
       }
+      cts_selector ctsSelector;
+      const auto ctsContext = util::get_cts_object::context(ctsSelector);
 
       {
         const size_t bufferSize = 32;
@@ -98,7 +66,8 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
                                         sycl::range<1>(bufferSize));
 
         cl_program clProgram{};
-        if (online_compiler_supported(device.get(), log)) {
+        if (online_compiler_supported(
+                sycl::get_native<sycl::backend::opencl>(device), log)) {
           std::string kernelSource = R"(
             struct simple_struct {
               int a;
@@ -112,16 +81,22 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
             {}
             )";
 
-          if (!create_built_program(kernelSource, context.get(), device.get(),
-                                    clProgram, log)) {
+          if (!create_built_program(
+                  kernelSource,
+                  sycl::get_native<sycl::backend::opencl>(context),
+                  sycl::get_native<sycl::backend::opencl>(device), clProgram,
+                  log)) {
             FAIL(log, "create_built_program failed");
           }
         } else {
           std::string programBinaryFile =
               "opencl_interop_kernel.bin";
 
-          if (!create_program_with_binary(programBinaryFile, context.get(),
-                                          device.get(), clProgram, log)) {
+          if (!create_program_with_binary(
+                  programBinaryFile,
+                  sycl::get_native<sycl::backend::opencl>(context),
+                  sycl::get_native<sycl::backend::opencl>(device), clProgram,
+                  log)) {
             std::string errorMsg =
                 "create_program_with_binary failed.";
             errorMsg +=
@@ -137,7 +112,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
           FAIL(log, "create_kernel failed");
         }
 
-        sycl::kernel kernel(clKernel, context);
+        sycl::kernel kernel = sycl::make_kernel(clKernel, context);
 
         /** test single_task(kernel)
          */
@@ -185,336 +160,7 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
         queue.wait_and_throw();
       }
 
-      {
-        if (!util::get_cts_object::queue(ctsSelector)
-                 .get_device()
-                 .get_info<sycl::info::device::image_support>()) {
-          log.note("Device does not support images");
-        } else {
-          static constexpr size_t imageSideSize = 32;
-          static constexpr size_t imgAccElemSize = 4;  // rgba
-          static constexpr auto imageSize =
-              (imgAccElemSize * imageSideSize * imageSideSize);
-          float imageData[imageSize] = {0.0f};
-
-          auto queue = util::get_cts_object::queue(ctsSelector);
-          auto context = queue.get_context();
-          auto device = queue.get_device();
-
-          sycl::image<2> image(
-              imageData, sycl::image_channel_order::rgba,
-              sycl::image_channel_type::fp32,
-              sycl::range<2>(imageSideSize, imageSideSize));
-
-          cl_program clProgram{};
-          if (online_compiler_supported(device.get(), log)) {
-            std::string kernelSource = R"(
-              struct simple_struct {
-                int a;
-                float b;
-              };
-
-              __kernel void opencl_interop_image_kernel_kernel(read_only image2d_t arg0,
-                                                           sampler_t arg1)
-              {}
-              )";
-
-            if (!create_built_program(kernelSource, context.get(), device.get(),
-                                      clProgram, log)) {
-              FAIL(log, "create_built_program failed");
-            }
-          } else {
-            std::string programBinaryFile =
-                "opencl_interop_image_kernel.bin";
-
-            if (!create_program_with_binary(programBinaryFile, context.get(),
-                                            device.get(), clProgram, log)) {
-              std::string errorMsg =
-                  "create_program_with_binary failed.";
-              errorMsg +=
-                  " Since online compile is not supported, expecting to find " +
-                  programBinaryFile + " in same path as the executable binary";
-              FAIL(log, errorMsg.c_str());
-            }
-          }
-
-          cl_kernel clKernel{};
-          if (!create_kernel(clProgram, "opencl_interop_image_kernel_kernel",
-                             clKernel, log)) {
-            FAIL(log, "create_kernel failed");
-          }
-
-          sycl::kernel kernel(clKernel, context);
-
-          /** test single_task(kernel)
-           */
-          queue.submit([&](sycl::handler &handler) {
-            auto imageAccessor =
-                image
-                    .get_access<sycl::float4, sycl::access_mode::read>(
-                        handler);
-
-            sycl::sampler sampler(
-                sycl::coordinate_normalization_mode::unnormalized,
-                sycl::addressing_mode::none,
-                sycl::filtering_mode::nearest);
-
-            /** check the set_arg() methods
-             */
-
-            // set_args(int, image)
-            handler.set_arg(0, imageAccessor);
-            // set_args(int, sampler)
-            handler.set_arg(1, sampler);
-
-            handler.single_task(kernel);
-          });
-
-          /** test parallel_for(const nd range<dimensions>&, kernel)
-           */
-          queue.submit([&](sycl::handler &handler) {
-            auto imageAccessor =
-                image
-                    .get_access<sycl::float4, sycl::access_mode::read>(
-                        handler);
-
-            sycl::sampler sampler(
-                sycl::coordinate_normalization_mode::unnormalized,
-                sycl::addressing_mode::none,
-                sycl::filtering_mode::nearest);
-
-            /** check the set_args() method
-             */
-            handler.set_args(imageAccessor, sampler);
-
-            sycl::range<1> myRange(1024);
-            handler.parallel_for(myRange, kernel);
-          });
-
-          queue.wait_and_throw();
-        }
-      }
-
-      auto ctsQueue = util::get_cts_object::queue(ctsSelector);
-      auto context = ctsQueue.get_context();
-      auto deviceList = context.get_devices();
-
-      // Do ALL devices support online compiler / linker?
-      bool compiler_available = is_compiler_available(deviceList);
-      bool linker_available = is_linker_available(deviceList);
-
-      const std::string compileOptions = "-cl-opt-disable";
-      const std::string linkOptions = "-cl-fast-relaxed-math";
-
-      {
-        log.note(
-            "link an OpenCL and a SYCL program without compile and link "
-            "options");
-
-        if (!compiler_available) {
-          log.note("online compiler not available -- skipping check");
-        }
-
-        else {
-          // obtain an existing OpenCL C program object
-          cl_program myClProgram = nullptr;
-          if (!create_compiled_program(
-                  kernel_source, context.get(),
-                  ctsQueue.get_device().get(), myClProgram, log)) {
-            FAIL(log, "Didn't create the cl_program");
-          }
-
-          // Create a SYCL program object from a cl_program object
-          sycl::program myExternProgram(context,
-                                            myClProgram);
-
-          if (myExternProgram.get_state() !=
-              sycl::program_state::compiled) {
-            FAIL(log, "Compiled interop program should be in compiled state");
-          }
-
-          // Add in the SYCL program object for our kernel
-          sycl::program mySyclProgram(context);
-          mySyclProgram.compile_with_kernel_type<program_kernel_interop<0>>();
-
-          if (mySyclProgram.get_state() != sycl::program_state::compiled) {
-            FAIL(log, "Compiled SYCL program should be in compiled state");
-          }
-
-          // Link myClProgram with the SYCL program object
-          try {
-            sycl::program myLinkedProgram({myExternProgram, mySyclProgram});
-
-            if (myLinkedProgram.get_state() !=
-                sycl::program_state::linked) {
-              FAIL(log, "Program was not linked");
-            }
-
-            ctsQueue.submit([&](sycl::handler &cgh) {
-              cgh.single_task(program_kernel_interop<0>());
-            });
-            ctsQueue.wait_and_throw();
-
-          } catch (const sycl::feature_not_supported &fnse_link) {
-            if (!linker_available) {
-              log.note("online linker not available -- skipping check");
-            } else {
-              throw;
-            }
-          }
-        }
-      }
-
-      {
-        log.note(
-            "link an OpenCL and a SYCL program with compile and link options");
-
-        if (!compiler_available) {
-          log.note("online compiler not available -- skipping check");
-        }
-
-        else {
-          // obtain an existing OpenCL C program object
-          cl_program myClProgram = nullptr;
-          if (!create_compiled_program(
-                  kernel_source, context.get(),
-                  ctsQueue.get_device().get(), myClProgram, log)) {
-            FAIL(log, "Didn't create the cl_program");
-          }
-
-          // Create a SYCL program object from a cl_program object
-          sycl::program myExternProgram(context,
-                                            myClProgram);
-
-          if (myExternProgram.get_state() !=
-              sycl::program_state::compiled) {
-            FAIL(log, "Compiled interop program should be in compiled state");
-          }
-
-          // Add in the SYCL program object for our kernel
-          sycl::program mySyclProgram(context);
-          mySyclProgram.compile_with_kernel_type<program_kernel_interop<1>>(
-              compileOptions);
-
-          if (mySyclProgram.get_state() != sycl::program_state::compiled) {
-            FAIL(log, "Compiled SYCL program should be in compiled state");
-          }
-
-          if (mySyclProgram.get_compile_options() != compileOptions) {
-            FAIL(log,
-                 "Compiled SYCL program did not store the compile options");
-          }
-
-          // Link myClProgram with the SYCL program object
-          try {
-            sycl::program myLinkedProgram({myExternProgram, mySyclProgram},
-                                              linkOptions);
-
-            if (myLinkedProgram.get_state() !=
-                sycl::program_state::linked) {
-              FAIL(log, "Program was not linked");
-            }
-
-            if (myLinkedProgram.get_link_options() != linkOptions) {
-              FAIL(log, "Linked program did not store the link options");
-            }
-
-            ctsQueue.submit([&](sycl::handler &cgh) {
-              cgh.single_task(program_kernel_interop<1>());
-            });
-            ctsQueue.wait_and_throw();
-
-          } catch (const sycl::feature_not_supported &fnse_link) {
-            if (!linker_available) {
-              log.note("online linker not available -- skipping check");
-            } else {
-              throw;
-            }
-          }
-        }
-      }
-
-      if (!context.is_host()) {
-        log.note("check compiling and building from source");
-
-        {  // Check compile_with_source(source)
-          sycl::program prog(context);
-          try {
-            prog.compile_with_source(kernel_source);
-          } catch (const sycl::feature_not_supported &fnse_compile) {
-            if (!compiler_available) {
-              log.note("online compiler not available -- skipping check");
-            } else {
-              throw;
-            }
-          }
-        }
-        {  // Check compile_with_source(source, options)
-          sycl::program prog(context);
-          try {
-            prog.compile_with_source(kernel_source, compileOptions);
-          } catch (const sycl::feature_not_supported &fnse_compile) {
-            if (!compiler_available) {
-              log.note("online compiler not available -- skipping check");
-            } else {
-              throw;
-            }
-          }
-        }
-        {  // Check build_with_source(source)
-          sycl::program prog(context);
-          try {
-            prog.build_with_source(kernel_source);
-          } catch (const sycl::feature_not_supported &fnse_build) {
-            if (!compiler_available || !linker_available) {
-              log.note(
-                  "online compiler or linker not available -- skipping check");
-            } else {
-              throw;
-            }
-          }
-        }
-        {  // Check build_with_source(source, options)
-          sycl::program prog(context);
-
-          try {
-            prog.build_with_source(kernel_source, linkOptions);
-          } catch (const sycl::feature_not_supported &fnse_build) {
-            if (!compiler_available || !linker_available) {
-              log.note(
-                  "online compiler or linker not available -- skipping check");
-            } else {
-              throw;
-            }
-          }
-        }
-
-        {  // Check retrieving kernel
-          sycl::program prog(context);
-
-          try {
-            prog.build_with_source(kernel_source);
-
-            // Check has_kernel(string_class)
-            bool hasKernel = prog.has_kernel(kernelName);
-            if (!hasKernel) {
-              FAIL(log,
-                   "Program was not built properly (has_kernel(string_class))");
-            }
-
-            // Check get_kernel(string_class)
-            sycl::kernel k = prog.get_kernel(kernelName);
-
-          } catch (const sycl::feature_not_supported &fnse_build) {
-            if (!compiler_available || !linker_available) {
-              log.note(
-                  "online compiler or linker not available -- skipping check");
-            } else {
-              throw;
-            }
-          }
-        }
-      }
+      // TODO: add checks to sampled_image_accessor, unsampled_image_accessor
 
     } catch (const sycl::exception &e) {
       log_exception(log, e);
@@ -522,6 +168,9 @@ class TEST_NAME : public sycl_cts::util::test_base_opencl {
           "a SYCL exception was caught: " + std::string(e.what());
       FAIL(log, errorMsg.c_str());
     }
+#else
+    log.note("The test is skipped because OpenCL back-end is not supported");
+#endif  // SYCL_BACKEND_OPENCL
   }
 };
 

--- a/util/test_base_opencl.cpp
+++ b/util/test_base_opencl.cpp
@@ -17,7 +17,7 @@
 #else
 #include <unistd.h>
 #endif
-
+#ifdef SYCL_BACKEND_OPENCL
 // conformance test suite namespace
 namespace sycl_cts {
 namespace util {
@@ -52,11 +52,9 @@ bool test_base_opencl::setup(logger &log) {
   }
   const auto ctsDevice = ctsContext.get_devices()[0];
 
-  // There is nothing else to do for a host device
-  if (ctsDevice.is_host()) return true;
-
-  m_cl_platform_id = ctsDevice.get_platform().get();
-  m_cl_device_id = ctsDevice.get();
+  m_cl_platform_id =
+      sycl::get_native<sycl::backend::opencl>(ctsDevice.get_platform());
+  m_cl_device_id = sycl::get_native<sycl::backend::opencl>(ctsDevice);
 
   cl_context_properties properties[3] = {
       CL_CONTEXT_PLATFORM, (cl_context_properties)m_cl_platform_id, 0};
@@ -304,3 +302,4 @@ void test_base_opencl::cleanup() {
 
 }  // namespace util
 }  // namespace sycl_cts
+#endif


### PR DESCRIPTION
Added check if SYCL_BACKEND_OPENCL is defined
Replaced method get() with function get_native()
Replaced removed constructors with make_*()
Removed checks for program's get_compile_options and get_link_options in opencl_interop_kernel.cpp as program is removed and there are no clear counterparts in kernel_bundle for it.