### PR TITLE
Update member function of various classes 'get_count' to 'size'

### DIFF
--- a/tests/accessor/accessor_api_buffer_common.h
+++ b/tests/accessor/accessor_api_buffer_common.h
@@ -89,10 +89,10 @@ class check_buffer_accessor_api_methods {
       }
     }
     {
-      /** check get_count() method
+      /** check size() method
        */
-      auto accessorCount = accessor.get_count();
-      check_acc_return_type<size_t>(log, accessorCount, "get_count()",
+      auto accessorCount = accessor.size();
+      check_acc_return_type<size_t>(log, accessorCount, "size()",
                                     typeName);
       if (accessorCount != accessedCount) {
         fail_for_accessor<T, dims, mode, target, placeholder>(log, typeName,

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -1154,10 +1154,10 @@ class check_image_accessor_api_methods {
                      image_range_t<dims, target> range,
                      const std::string& typeName) const {
     {
-      // check get_count() method
-      auto accessorCount = accessor.get_count();
+      // check size() method
+      auto accessorCount = accessor.size();
       check_acc_return_type<size_t>(
-          log, accessor.get_count(), "get_count", typeName);
+          log, accessor.size(), "size", typeName);
       if (accessorCount != count) {
         fail_for_accessor<T, dims, mode, target>(log, typeName,
             "accessor does not return the correct count");

--- a/tests/accessor/accessor_api_local_common.h
+++ b/tests/accessor/accessor_api_local_common.h
@@ -58,10 +58,10 @@ class check_local_accessor_api_methods {
       queue.submit([&](sycl::handler &h) {
         auto acc = make_local_accessor_generic<T, dims, mode>(range, h);
         {
-          /** check get_count() method
+          /** check size() method
           */
-          auto accessorCount = acc.get_count();
-          check_return_type<size_t>(log, accessorCount, "get_count()");
+          auto accessorCount = acc.size();
+          check_return_type<size_t>(log, accessorCount, "size()");
           const auto expectedCount = ((dims == 0) ? 1 : count);
           if (accessorCount != expectedCount) {
             fail_for_accessor<T, dims, mode, target>(log, typeName,

--- a/tests/accessor/accessor_constructors_buffer_utility.h
+++ b/tests/accessor/accessor_constructors_buffer_utility.h
@@ -47,8 +47,8 @@ public:
     // check the accessor
     check_accessor_members<accTag>::check(
         log, accessor, constructorName, typeName,
-        accessor_members::size{buffer.get_size()},
-        accessor_members::count{buffer.get_count()},
+        accessor_members::size{buffer.byte_size()},
+        accessor_members::count{buffer.size()},
         accessor_members::offset<accTag::dataDims>{offset},
         accessor_members::range<accTag::dataDims>{buffer.get_range()},
         accessor_members::placeholder{accTag::placeholder});

--- a/tests/accessor/accessor_constructors_utility.h
+++ b/tests/accessor/accessor_constructors_utility.h
@@ -185,7 +185,7 @@ namespace accessor_members {
     }
   };
 
-  /** @brief Helper struct to verify get_count() call for all accessors
+  /** @brief Helper struct to verify size() call for all accessors
    */
   class count {
   public:
@@ -196,17 +196,17 @@ namespace accessor_members {
      */
     template <typename accTag>
     static count from(const typename accTag::type& a) {
-      return count{a.get_count()};
+      return count{a.size()};
     }
 
-    /** @brief Test for get_count() call
+    /** @brief Test for size() call
      */
     template <typename accTag>
     void check(const typename accTag::type& a, sycl_cts::util::logger &log,
                const std::string& operation, const std::string& typeName) {
-      if (a.get_count() != value) {
+      if (a.size() != value) {
         fail_for_accessor<accTag>(log, typeName,
-                                  operation + " check(get_count)");
+                                  operation + " check(size)");
       }
     }
   };

--- a/tests/group/group_mem_fence_common.h
+++ b/tests/group/group_mem_fence_common.h
@@ -60,7 +60,7 @@ bool test_rw_mem_fence_global_space(sycl_cts::util::logger& log,
     // Initialize data state
     {
       auto ptr = data.get_access<sycl::access_mode::write>();
-      for (size_t i = 0; i < ptr.get_count(); ++i)
+      for (size_t i = 0; i < ptr.size(); ++i)
         ptr[i] = -1;
     }
     queue.submit([&](sycl::handler &cgh) {

--- a/tests/host_task/host_task_invoke_api.cpp
+++ b/tests/host_task/host_task_invoke_api.cpp
@@ -47,7 +47,7 @@ struct host_task_command_group {
   host_task_command_group(bufferT& buf, int a) : m_bufRef{buf}, m_add(a) {}
   void operator()(sycl::handler& cgh) {
     int a = m_add;
-    int container_size = m_bufRef.get().get_count();
+    int container_size = m_bufRef.get().size();
     auto acc_host =
         m_bufRef.get()
             .template get_access<sycl::access_mode::read_write,

--- a/tests/nd_item/nd_item_mem_fence_common.h
+++ b/tests/nd_item/nd_item_mem_fence_common.h
@@ -60,7 +60,7 @@ bool test_rw_mem_fence_global_space(sycl_cts::util::logger& log,
     // Initialize data state
     {
       auto ptr = data.get_access<sycl::access_mode::write>();
-      for (size_t i = 0; i < ptr.get_count(); ++i)
+      for (size_t i = 0; i < ptr.size(); ++i)
         ptr[i] = -1;
     }
     queue.submit([&](sycl::handler &cgh) {


### PR DESCRIPTION
get_count() is deprecated in SYCL 2020
Usage of it in buffer, vector and opencl_interop tests are changed in other patches