### PR TITLE
Fix reference values for sampled access with linear filtration

### DIFF
--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -945,7 +945,7 @@ class image_accessor_api_sampled_r {
       return get_expected_value_nearest(idx);
     }
     constexpr bool useUpper =
-        std::is_same<coordTag, acc_coord_tag::use_normalized_upper>::value;
+        std::is_same_v<coordTag, acc_coord_tag::use_normalized_upper>;
     if constexpr (!useUpper) {
       // Use simplified equation for lower coordinate values
       return get_expected_value_linear(idx);

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -407,7 +407,7 @@ T read_image_acc(const sycl::accessor<T, dims, mode,
 }
 
 template <typename T, int dims, sycl::target target,
-          sycl::access_mode mode, typename coordT = acc_coord_tag::use_int>
+          sycl::access_mode mode>
 T read_image_acc_sampled(const sycl::accessor<T, dims, mode, target> &acc,
                          const sycl::sampler& smpl,
                          sycl::id<dims> idx,
@@ -416,7 +416,7 @@ T read_image_acc_sampled(const sycl::accessor<T, dims, mode, target> &acc,
   return acc.read(image_access<dims>::get_int(idx), smpl);
 }
 template <typename T, int dims, sycl::target target,
-          sycl::access_mode mode, typename coordT = acc_coord_tag::use_float>
+          sycl::access_mode mode>
 T read_image_acc_sampled(const sycl::accessor<T, dims, mode, target> &acc,
                          const sycl::sampler& smpl,
                          sycl::id<dims> idx,
@@ -425,7 +425,7 @@ T read_image_acc_sampled(const sycl::accessor<T, dims, mode, target> &acc,
   return acc.read(image_access<dims>::get_float(idx), smpl);
 }
 template <typename T, int dims, sycl::target target,
-          sycl::access_mode mode, typename coordT = acc_coord_tag::use_float>
+          sycl::access_mode mode, typename coordT>
 T read_image_acc_sampled(const sycl::accessor<T, dims, mode, target> &acc,
                          const sycl::sampler& smpl,
                          sycl::id<dims> idx,


### PR DESCRIPTION
Upper coordinate in case of floating-point CoordT should use different texels for linear filtration.
See ["Filter Mode CLK_FILTER_LINEAR"](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#addressing-and-filter-modes) in OpenCL C Specification we are using according to the SYCL 1.2.1 par.3.