### PR TITLE
Return previously removed checks for deprecated APIs

### DIFF
--- a/tests/accessor/accessor_api_buffer_common.h
+++ b/tests/accessor/accessor_api_buffer_common.h
@@ -100,6 +100,17 @@ class check_buffer_accessor_api_methods {
       }
     }
     {
+      /** check get_count() method
+       */
+      auto accessorCount = accessor.get_count();
+      check_acc_return_type<size_t>(log, accessorCount, "get_count()",
+                                    typeName);
+      if (accessorCount != accessedCount) {
+        fail_for_accessor<T, dims, mode, target, placeholder>(
+            log, typeName, "accessor does not return the correct count");
+      }
+    }
+    {
       /** check get_size() method
        */
       auto accessorSize = accessor.get_size();

--- a/tests/accessor/accessor_api_buffer_common.h
+++ b/tests/accessor/accessor_api_buffer_common.h
@@ -102,6 +102,7 @@ class check_buffer_accessor_api_methods {
     {
       /** check get_count() method
        */
+      // TODO: mark this check as testing deprecated functionality
       auto accessorCount = accessor.get_count();
       check_acc_return_type<size_t>(log, accessorCount, "get_count()",
                                     typeName);

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -1164,6 +1164,16 @@ class check_image_accessor_api_methods {
       }
     }
     {
+      // check get_count() method
+      auto accessorCount = accessor.get_count();
+      check_acc_return_type<size_t>(log, accessor.get_count(), "get_count",
+                                    typeName);
+      if (accessorCount != count) {
+        fail_for_accessor<T, dims, mode, target>(
+            log, typeName, "accessor does not return the correct count");
+      }
+    }
+    {
       // check get_range() method
       auto accessorRange = accessor.get_range();
 #ifdef VERBOSE_LOG

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -1165,6 +1165,7 @@ class check_image_accessor_api_methods {
     }
     {
       // check get_count() method
+      // TODO: mark this check as testing deprecated functionality
       auto accessorCount = accessor.get_count();
       check_acc_return_type<size_t>(log, accessor.get_count(), "get_count",
                                     typeName);

--- a/tests/accessor/accessor_api_local_common.h
+++ b/tests/accessor/accessor_api_local_common.h
@@ -71,6 +71,7 @@ class check_local_accessor_api_methods {
         {
           /** check get_count() method
            */
+          // TODO: mark this check as testing deprecated functionality
           auto accessorCount = acc.get_count();
           check_return_type<size_t>(log, accessorCount, "get_count()");
           const auto expectedCount = ((dims == 0) ? 1 : count);

--- a/tests/accessor/accessor_api_local_common.h
+++ b/tests/accessor/accessor_api_local_common.h
@@ -69,6 +69,17 @@ class check_local_accessor_api_methods {
           }
         }
         {
+          /** check get_count() method
+           */
+          auto accessorCount = acc.get_count();
+          check_return_type<size_t>(log, accessorCount, "get_count()");
+          const auto expectedCount = ((dims == 0) ? 1 : count);
+          if (accessorCount != expectedCount) {
+            fail_for_accessor<T, dims, mode, target>(
+                log, typeName, "accessor does not return the correct count");
+          }
+        }
+        {
           /** check get_size() method
           */
           auto accessorSize = acc.get_size();

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -263,6 +263,17 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
            "the correct number of elements");
     }
 
+    /* check the buffer returns the correct element count
+       with deprecated get_count */
+    auto count_depr = buf.get_count();
+    check_return_type<size_t>(log, count_depr, "sycl::buffer::get_count()");
+
+    if (count_depr != size) {
+      FAIL(log,
+           "sycl::buffer::get_count() does not return "
+           "the correct number of elements");
+    }
+
     /* check the buffer returns the correct byte size */
     auto ret_size = buf.byte_size();
     check_return_type<size_t>(log, ret_size, "sycl::buffer::byte_size()");
@@ -270,6 +281,17 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     if (ret_size != size * sizeof(T)) {
       FAIL(log,
            "sycl::buffer::byte_size() does not return "
+           "the correct size of the buffer");
+    }
+
+    /* check the buffer returns the correct byte size
+     with deprecated get_size*/
+    auto ret_size_depr = buf.get_size();
+    check_return_type<size_t>(log, ret_size_depr, "sycl::buffer::get_size()");
+
+    if (ret_size_depr != size * sizeof(T)) {
+      FAIL(log,
+           "sycl::buffer::get_size() does not return "
            "the correct size of the buffer");
     }
 

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -265,6 +265,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
 
     /* check the buffer returns the correct element count
        with deprecated get_count */
+    // TODO: mark this check as testing deprecated functionality
     auto count_depr = buf.get_count();
     check_return_type<size_t>(log, count_depr, "sycl::buffer::get_count()");
 
@@ -286,6 +287,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
 
     /* check the buffer returns the correct byte size
      with deprecated get_size*/
+    // TODO: mark this check as testing deprecated functionality
     auto ret_size_depr = buf.get_size();
     check_return_type<size_t>(log, ret_size_depr, "sycl::buffer::get_size()");
 

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -358,6 +358,8 @@ struct vector_swizzle_check<T, 16> {
  * @brief Helper function to test the following functions of a vec
  * size()
  * byte_size()
+ * get_count()
+ * get_size()
  */
 template <typename vecType, int N>
 bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
@@ -371,6 +373,17 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
     return false;
   }
 
+  // get_count()
+  size_t count_depr = inputVec.get_count();
+  if (count_depr != N) {
+    return false;
+  }
+  count_depr =
+      vector_swizzle_check<vecType, N>::get_swizzle(inputVec).get_count();
+  if (count_depr != N) {
+    return false;
+  }
+
   // byte_size()
   size_t size = inputVec.byte_size();
   size_t M = (N == 3) ? 4 : N;
@@ -379,6 +392,17 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   }
   size = vector_swizzle_check<vecType, N>::get_swizzle(inputVec).byte_size();
   if (size != sizeof(vecType) * M) {
+    return false;
+  }
+
+  // get_size()
+  size_t size_depr = inputVec.get_size();
+  if (size_depr != sizeof(vecType) * M) {
+    return false;
+  }
+  size_depr =
+      vector_swizzle_check<vecType, N>::get_swizzle(inputVec).get_size();
+  if (size_depr != sizeof(vecType) * M) {
     return false;
   }
   return true;

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -374,6 +374,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   }
 
   // get_count()
+  // TODO: mark this check as testing deprecated functionality
   size_t count_depr = inputVec.get_count();
   if (count_depr != N) {
     return false;
@@ -396,6 +397,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   }
 
   // get_size()
+  // TODO: mark this check as testing deprecated functionality
   size_t size_depr = inputVec.get_size();
   if (size_depr != sizeof(vecType) * M) {
     return false;

--- a/tests/item/item_1d.cpp
+++ b/tests/item/item_1d.cpp
@@ -29,7 +29,7 @@ class kernel_item_1d {
 
  public:
   kernel_item_1d(t_readAccess in_, t_writeAccess out_, sycl::range<1> r)
-      : m_x(in_), m_o(out_), r_exp(r) {}
+      : m_x(in_), m_o(out_), r_exp(r), offset_exp(sycl::id<1>(0)) {}
 
   void operator()(sycl::item<1> item) const {
     bool result = true;
@@ -42,6 +42,10 @@ class kernel_item_1d {
 
     sycl::range<1> localRange = item.get_range();
     result &= localRange == r_exp;
+
+    sycl::id<1> offset = item.get_offset();
+    (void)offset; // silent warning
+    result &= offset == offset_exp;
 
     /* get work item range */
     const size_t nWidth = item.get_range(0);

--- a/tests/item/item_1d.cpp
+++ b/tests/item/item_1d.cpp
@@ -43,6 +43,7 @@ class kernel_item_1d {
     sycl::range<1> localRange = item.get_range();
     result &= localRange == r_exp;
 
+    // TODO: mark this check as testing deprecated functionality
     sycl::id<1> offset = item.get_offset();
     (void)offset; // silent warning
     result &= offset == offset_exp;

--- a/tests/item/item_2d.cpp
+++ b/tests/item/item_2d.cpp
@@ -25,10 +25,11 @@ class kernel_item_2d {
   t_readAccess m_x;
   t_writeAccess m_o;
   sycl::range<2> r_exp;
+  sycl::id<2> offset_exp;
 
  public:
   kernel_item_2d(t_readAccess in_, t_writeAccess out_, sycl::range<2> r)
-      : m_x(in_), m_o(out_), r_exp(r) {}
+      : m_x(in_), m_o(out_), r_exp(r), offset_exp(sycl::id<2>(0, 0)) {}
 
   void operator()(sycl::item<2> item) const {
     bool result = true;
@@ -42,6 +43,9 @@ class kernel_item_2d {
 
     sycl::range<2> localRange = item.get_range();
     result &= localRange == r_exp;
+
+    sycl::id<2> offset = item.get_offset();
+    result &= offset == offset_exp;
 
     /* get work item range */
     const size_t nWidth = item.get_range(0);

--- a/tests/item/item_2d.cpp
+++ b/tests/item/item_2d.cpp
@@ -44,6 +44,7 @@ class kernel_item_2d {
     sycl::range<2> localRange = item.get_range();
     result &= localRange == r_exp;
 
+    // TODO: mark this check as testing deprecated functionality
     sycl::id<2> offset = item.get_offset();
     result &= offset == offset_exp;
 

--- a/tests/item/item_3d.cpp
+++ b/tests/item/item_3d.cpp
@@ -42,6 +42,7 @@ class kernel_item_3d {
     sycl::range<3> localRange = item.get_range();
     result &= localRange == r_exp;
 
+    // TODO: mark this check as testing deprecated functionality
     sycl::id<3> offset = item.get_offset();
     result &= offset == offset_exp;
 

--- a/tests/item/item_3d.cpp
+++ b/tests/item/item_3d.cpp
@@ -24,10 +24,11 @@ class kernel_item_3d {
   t_readAccess m_x;
   t_writeAccess m_o;
   sycl::range<3> r_exp;
+  sycl::id<3> offset_exp;
 
  public:
   kernel_item_3d(t_readAccess in_, t_writeAccess out_, sycl::range<3> r)
-      : m_x(in_), m_o(out_), r_exp(r) {}
+      : m_x(in_), m_o(out_), r_exp(r), offset_exp(sycl::id<3>(0, 0, 0)) {}
 
   void operator()(sycl::item<3> item) const {
     bool result = true;
@@ -40,6 +41,9 @@ class kernel_item_3d {
 
     sycl::range<3> localRange = item.get_range();
     result &= localRange == r_exp;
+
+    sycl::id<3> offset = item.get_offset();
+    result &= offset == offset_exp;
 
     /* get work item range */
     const size_t nWidth = localRange.get(0);

--- a/tests/nd_item/nd_item_api.cpp
+++ b/tests/nd_item/nd_item_api.cpp
@@ -131,6 +131,7 @@ class kernel_nd_item {
     }
 
     /* test NDrange and offset*/
+    // TODO: mark this check as testing deprecated functionality
     sycl::id<dimensions> offset = myitem.get_offset();
     sycl::nd_range<dimensions> NDRange = myitem.get_nd_range();
 
@@ -142,6 +143,7 @@ class kernel_nd_item {
       bool are_same = true;
       are_same &= globalRange.get(i) == ndGlobal.get(i);
       are_same &= localRange.get(i) == ndLocal.get(i);
+      // TODO: mark this check as testing deprecated functionality
       are_same &= offset.get(i) == ndOffset.get(i);
 
       failed = !are_same ? true : failed;

--- a/tests/nd_item/nd_item_api.cpp
+++ b/tests/nd_item/nd_item_api.cpp
@@ -130,16 +130,19 @@ class kernel_nd_item {
       }
     }
 
-    /* test NDrange*/
+    /* test NDrange and offset*/
+    sycl::id<dimensions> offset = myitem.get_offset();
     sycl::nd_range<dimensions> NDRange = myitem.get_nd_range();
 
     sycl::range<dimensions> ndGlobal = NDRange.get_global_range();
     sycl::range<dimensions> ndLocal = NDRange.get_local_range();
+    sycl::id<dimensions> ndOffset = NDRange.get_offset();
 
     for (int i = 0; i < dimensions; ++i) {
       bool are_same = true;
       are_same &= globalRange.get(i) == ndGlobal.get(i);
       are_same &= localRange.get(i) == ndLocal.get(i);
+      are_same &= offset.get(i) == ndOffset.get(i);
 
       failed = !are_same ? true : failed;
     }

--- a/tests/nd_item/nd_item_constructors.cpp
+++ b/tests/nd_item/nd_item_constructors.cpp
@@ -132,6 +132,7 @@ inline void check_equality_helper(success_acc_t& success,
                         expected.get_group_range(index));
   CHECK_EQUALITY_HELPER(success, actual.get_local_range(index),
                         expected.get_local_range(index));
+  // TODO: mark this check as testing deprecated functionality
   CHECK_EQUALITY_HELPER(success, actual.get_offset().get(index),
                         expected.get_offset(index));
 }

--- a/tests/nd_item/nd_item_constructors.cpp
+++ b/tests/nd_item/nd_item_constructors.cpp
@@ -57,6 +57,7 @@ private:
   sycl_cts::util::array<size_t, numDims> m_globalRange;
   sycl_cts::util::array<size_t, numDims> m_groupRange;
   sycl_cts::util::array<size_t, numDims> m_localRange;
+  sycl_cts::util::array<size_t, numDims> m_offset;
 public:
   state_storage(const sycl::nd_item<numDims>& state)
   {
@@ -70,6 +71,7 @@ public:
       m_globalRange[dim] = state.get_global_range(dim);
       m_groupRange[dim] = state.get_group_range(dim);
       m_localRange[dim] = state.get_local_range(dim);
+      m_offset[dim] = state.get_offset().get(dim);
     }
   }
 
@@ -109,6 +111,9 @@ public:
     return m_localRange[dim];
   }
 
+  size_t get_offset(int dim) const {
+    return m_offset[dim];
+  }
 };
 
 template <int index, int numDims, typename success_acc_t>
@@ -127,6 +132,8 @@ inline void check_equality_helper(success_acc_t& success,
                         expected.get_group_range(index));
   CHECK_EQUALITY_HELPER(success, actual.get_local_range(index),
                         expected.get_local_range(index));
+  CHECK_EQUALITY_HELPER(success, actual.get_offset().get(index),
+                        expected.get_offset(index));
 }
 
 template <int numDims, typename success_acc_t>

--- a/tests/nd_range/nd_range_api.cpp
+++ b/tests/nd_range/nd_range_api.cpp
@@ -17,27 +17,51 @@ static const size_t sizes[] = {16, 32, 64};
 
 template <int dim>
 void test_nd_range(util::logger &log, sycl::range<dim> gs,
-                   sycl::range<dim> ls) {
+                   sycl::range<dim> ls, sycl::id<dim> offset) {
   for (int i = 0; i < dim; i++) {
-    sycl::nd_range<dim> nd_range(gs, ls);
-    CHECK_TYPE(log, nd_range.get_global_range()[i], sizes[i]);
-    CHECK_VALUE(log, nd_range.get_global_range()[i], sizes[i], i);
-    CHECK_TYPE(log, nd_range.get_local_range()[i], sizes[i] / 4);
-    CHECK_VALUE(log, nd_range.get_local_range()[i], sizes[i] / 4, i);
+    sycl::nd_range<dim> no_offset(gs, ls);
+    CHECK_TYPE(log, no_offset.get_global_range()[i], sizes[i]);
+    CHECK_VALUE(log, no_offset.get_global_range()[i], sizes[i], i);
+    CHECK_TYPE(log, no_offset.get_local_range()[i], sizes[i] / 4);
+    CHECK_VALUE(log, no_offset.get_local_range()[i], sizes[i] / 4, i);
 
-    CHECK_TYPE(log, nd_range.get_group_range()[i], sizes[i] / (sizes[i] / 4));
-    CHECK_VALUE(log, nd_range.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
+    CHECK_TYPE(log, no_offset.get_offset()[i], (size_t)0);
+    CHECK_VALUE(log, no_offset.get_offset()[i], (size_t)0, i);
+    CHECK_TYPE(log, no_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4));
+    CHECK_VALUE(log, no_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
 
-    sycl::nd_range<dim> deep_copy(nd_range);
+    sycl::nd_range<dim> deep_copy(no_offset);
 
     CHECK_TYPE(log, deep_copy.get_global_range()[i], sizes[i]);
     CHECK_VALUE(log, deep_copy.get_global_range()[i], sizes[i], i);
     CHECK_TYPE(log, deep_copy.get_local_range()[i], sizes[i] / 4);
     CHECK_VALUE(log, deep_copy.get_local_range()[i], sizes[i] / 4, i);
 
+    CHECK_TYPE(log, deep_copy.get_offset()[i], (size_t)0);
+    CHECK_VALUE(log, deep_copy.get_offset()[i], (size_t)0, i);
     CHECK_TYPE(log, deep_copy.get_group_range()[i], sizes[i] / (sizes[i] / 4));
     CHECK_VALUE(log, deep_copy.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
 
+    sycl::nd_range<dim> with_offset(gs, ls, offset);
+    CHECK_TYPE(log, with_offset.get_global_range()[i], sizes[i]);
+    CHECK_VALUE(log, with_offset.get_global_range()[i], sizes[i], i);
+    CHECK_TYPE(log, with_offset.get_local_range()[i], sizes[i] / 4);
+    CHECK_VALUE(log, with_offset.get_local_range()[i], sizes[i] / 4, i);
+    CHECK_TYPE(log, with_offset.get_offset()[i], sizes[i] / 8);
+    CHECK_VALUE(log, with_offset.get_offset()[i], sizes[i] / 8, i);
+    CHECK_TYPE(log, with_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4));
+    CHECK_VALUE(log, with_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
+
+    sycl::nd_range<dim> deep_copy_offset(with_offset);
+    CHECK_TYPE(log, deep_copy_offset.get_global_range()[i], sizes[i]);
+    CHECK_VALUE(log, deep_copy_offset.get_global_range()[i], sizes[i], i);
+    CHECK_TYPE(log, deep_copy_offset.get_local_range()[i], sizes[i] / 4);
+    CHECK_VALUE(log, deep_copy_offset.get_local_range()[i], sizes[i] / 4, i);
+    CHECK_TYPE(log, deep_copy_offset.get_offset()[i], sizes[i] / 8);
+    CHECK_VALUE(log, deep_copy_offset.get_offset()[i], sizes[i] / 8, i);
+    CHECK_TYPE(log, deep_copy_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4));
+    CHECK_VALUE(log, deep_copy_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4),
+                i);
   }
 }
 
@@ -61,19 +85,27 @@ class TEST_NAME : public util::test_base {
       sycl::range<1> gs_1d(sizes[0]);
       // local size to be set to 1/4 of the sizes
       sycl::range<1> ls_1d(sizes[0] / 4);
-      test_nd_range(log, gs_1d, ls_1d);
+      // offset to be set to 1/8 of the sizes
+      sycl::id<1> offset_1d(sizes[0] / 8);
+      test_nd_range(log, gs_1d, ls_1d, offset_1d);
 
       // global size to be set to the size
       sycl::range<2> gs_2d(sizes[0], sizes[1]);
       // local size to be set to 1/4 of the sizes
       sycl::range<2> ls_2d(sizes[0] / 4, sizes[1] / 4);
-      test_nd_range(log, gs_2d, ls_2d);
+      // offset to be set to 1/8 of the sizes
+      sycl::range<2> range_2d(sizes[0] / 8u, sizes[1] / 8u);
+      sycl::id<2> offset_2d(range_2d);
+      test_nd_range(log, gs_2d, ls_2d, offset_2d);
 
       // global size to be set to the size
       sycl::range<3> gs_3d(sizes[0], sizes[1], sizes[2]);
       // local size to be set to 1/4 of the sizes
       sycl::range<3> ls_3d(sizes[0] / 4, sizes[1] / 4, sizes[2] / 4);
-      test_nd_range(log, gs_3d, ls_3d);
+      // offset to be set to 1/8 of the sizes
+      sycl::range<3> range_3d(sizes[0] / 8u, sizes[1] / 8u, sizes[2] / 8u);
+      sycl::id<3> offset_3d(range_3d);
+      test_nd_range(log, gs_3d, ls_3d, offset_3d);
     } catch (const sycl::exception &e) {
       log_exception(log, e);
       std::string errorMsg =

--- a/tests/nd_range/nd_range_api.cpp
+++ b/tests/nd_range/nd_range_api.cpp
@@ -25,8 +25,10 @@ void test_nd_range(util::logger &log, sycl::range<dim> gs,
     CHECK_TYPE(log, no_offset.get_local_range()[i], sizes[i] / 4);
     CHECK_VALUE(log, no_offset.get_local_range()[i], sizes[i] / 4, i);
 
+    // TODO: mark this check as testing deprecated functionality
     CHECK_TYPE(log, no_offset.get_offset()[i], (size_t)0);
     CHECK_VALUE(log, no_offset.get_offset()[i], (size_t)0, i);
+
     CHECK_TYPE(log, no_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4));
     CHECK_VALUE(log, no_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
 
@@ -37,11 +39,14 @@ void test_nd_range(util::logger &log, sycl::range<dim> gs,
     CHECK_TYPE(log, deep_copy.get_local_range()[i], sizes[i] / 4);
     CHECK_VALUE(log, deep_copy.get_local_range()[i], sizes[i] / 4, i);
 
+    // TODO: mark this check as testing deprecated functionality
     CHECK_TYPE(log, deep_copy.get_offset()[i], (size_t)0);
     CHECK_VALUE(log, deep_copy.get_offset()[i], (size_t)0, i);
+
     CHECK_TYPE(log, deep_copy.get_group_range()[i], sizes[i] / (sizes[i] / 4));
     CHECK_VALUE(log, deep_copy.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
 
+    // TODO: mark this check as testing deprecated functionality
     sycl::nd_range<dim> with_offset(gs, ls, offset);
     CHECK_TYPE(log, with_offset.get_global_range()[i], sizes[i]);
     CHECK_VALUE(log, with_offset.get_global_range()[i], sizes[i], i);
@@ -52,6 +57,7 @@ void test_nd_range(util::logger &log, sycl::range<dim> gs,
     CHECK_TYPE(log, with_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4));
     CHECK_VALUE(log, with_offset.get_group_range()[i], sizes[i] / (sizes[i] / 4), i);
 
+    // TODO: mark this check as testing deprecated functionality
     sycl::nd_range<dim> deep_copy_offset(with_offset);
     CHECK_TYPE(log, deep_copy_offset.get_global_range()[i], sizes[i]);
     CHECK_VALUE(log, deep_copy_offset.get_global_range()[i], sizes[i], i);

--- a/tests/nd_range/nd_range_constructors.cpp
+++ b/tests/nd_range/nd_range_constructors.cpp
@@ -38,12 +38,14 @@ void test_nd_range_constructors(util::logger &log, sycl::range<dim> gs,
     for (int i = 0; i < dim; i++) {
       CHECK_VALUE(log, defaultRange.get_global_range()[i], gs[i], i);
       CHECK_VALUE(log, defaultRange.get_local_range()[i], ls[i], i);
+      // TODO: mark this check as testing deprecated functionality
       CHECK_VALUE(log, defaultRange.get_offset()[i], (size_t)0, i);
       CHECK_VALUE(log, defaultRange.get_group_range()[i],
                  gs[i] / ls[i], i);
     }
   }
   {  // Copy assignment, with offset
+     // TODO: mark this check as testing deprecated functionality
     auto defaultRange = get_default_nd_range<dim>();
     defaultRange = with_offset;
     for (int i = 0; i < dim; i++) {
@@ -60,13 +62,14 @@ void test_nd_range_constructors(util::logger &log, sycl::range<dim> gs,
     for (int i = 0; i < dim; i++) {
       CHECK_VALUE(log, defaultRange.get_global_range()[i], gs[i], i);
       CHECK_VALUE(log, defaultRange.get_local_range()[i], ls[i], i);
-
+      // TODO: mark this check as testing deprecated functionality
       CHECK_VALUE(log, defaultRange.get_offset()[i], (size_t)0, i);
       CHECK_VALUE(log, defaultRange.get_group_range()[i],
                  gs[i] / ls[i], i);
     }
   }
   {  // Move assignment, with offset
+     // TODO: mark this check as testing deprecated functionality
     auto defaultRange = get_default_nd_range<dim>();
     defaultRange = std::move(with_offset);
     for (int i = 0; i < dim; i++) {

--- a/tests/nd_range/nd_range_constructors.cpp
+++ b/tests/nd_range/nd_range_constructors.cpp
@@ -26,27 +26,54 @@ inline sycl::nd_range<dim> get_default_nd_range() {
 
 template <int dim>
 void test_nd_range_constructors(util::logger &log, sycl::range<dim> gs,
-                                sycl::range<dim> ls) {
-  sycl::nd_range<dim> nd_range(gs, ls);
+                                sycl::range<dim> ls,
+                                sycl::id<dim> offset) {
+  sycl::nd_range<dim> no_offset(gs, ls);
+  sycl::nd_range<dim> with_offset(gs, ls, offset);
 
-  {  // Copy assignment
+  {  // Copy assignment, no offset
     auto defaultRange = get_default_nd_range<dim>();
-    defaultRange = nd_range;
+    defaultRange = no_offset;
 
     for (int i = 0; i < dim; i++) {
       CHECK_VALUE(log, defaultRange.get_global_range()[i], gs[i], i);
       CHECK_VALUE(log, defaultRange.get_local_range()[i], ls[i], i);
+      CHECK_VALUE(log, defaultRange.get_offset()[i], (size_t)0, i);
       CHECK_VALUE(log, defaultRange.get_group_range()[i],
                  gs[i] / ls[i], i);
     }
   }
-  {  // Move assignment
+  {  // Copy assignment, with offset
     auto defaultRange = get_default_nd_range<dim>();
-    defaultRange = std::move(nd_range);
+    defaultRange = with_offset;
     for (int i = 0; i < dim; i++) {
       CHECK_VALUE(log, defaultRange.get_global_range()[i], gs[i], i);
       CHECK_VALUE(log, defaultRange.get_local_range()[i], ls[i], i);
+      CHECK_VALUE(log, defaultRange.get_offset()[i], offset[i], i);
       CHECK_VALUE(log, defaultRange.get_group_range()[i],
+                 gs[i] / ls[i], i);
+    }
+  }
+  {  // Move assignment, no offset
+    auto defaultRange = get_default_nd_range<dim>();
+    defaultRange = std::move(no_offset);
+    for (int i = 0; i < dim; i++) {
+      CHECK_VALUE(log, defaultRange.get_global_range()[i], gs[i], i);
+      CHECK_VALUE(log, defaultRange.get_local_range()[i], ls[i], i);
+
+      CHECK_VALUE(log, defaultRange.get_offset()[i], (size_t)0, i);
+      CHECK_VALUE(log, defaultRange.get_group_range()[i],
+                 gs[i] / ls[i], i);
+    }
+  }
+  {  // Move assignment, with offset
+    auto defaultRange = get_default_nd_range<dim>();
+    defaultRange = std::move(with_offset);
+    for (int i = 0; i < dim; i++) {
+      CHECK_VALUE(log, with_offset.get_global_range()[i], gs[i], i);
+      CHECK_VALUE(log, with_offset.get_local_range()[i], ls[i], i);
+      CHECK_VALUE(log, with_offset.get_offset()[i], offset[i], i);
+      CHECK_VALUE(log, with_offset.get_group_range()[i],
                  gs[i] / ls[i], i);
     }
   }
@@ -72,19 +99,27 @@ class TEST_NAME : public util::test_base {
       sycl::range<1> gs_1d(sizes[0]);
       // local size to be set to 1/4 of the sizes
       sycl::range<1> ls_1d(sizes[0] / 4u);
-      test_nd_range_constructors(log, gs_1d, ls_1d);
+      // offset to be set to 1/8 of the sizes
+      sycl::id<1> offset_1d(sizes[0] / 8u);
+      test_nd_range_constructors(log, gs_1d, ls_1d, offset_1d);
 
       // global size to be set to the size
       sycl::range<2> gs_2d(sizes[0], sizes[1]);
       // local size to be set to 1/4 of the sizes
       sycl::range<2> ls_2d(sizes[0] / 4u, sizes[1] / 4u);
-      test_nd_range_constructors(log, gs_2d, ls_2d);
+      // offset to be set to 1/8 of the sizes
+      sycl::range<2> range_2d(sizes[0] / 8u, sizes[1] / 8u);
+      sycl::id<2> offset_2d(range_2d);
+      test_nd_range_constructors(log, gs_2d, ls_2d, offset_2d);
 
       // global size to be set to the size
       sycl::range<3> gs_3d(sizes[0], sizes[1], sizes[2]);
       // local size to be set to 1/4 of the sizes
       sycl::range<3> ls_3d(sizes[0] / 4, sizes[1] / 4, sizes[2] / 4);
-      test_nd_range_constructors(log, gs_3d, ls_3d);
+      // offset to be set to 1/8 of the sizes
+      sycl::range<3> range_3d(sizes[0] / 8u, sizes[1] / 8u, sizes[2] / 8u);
+      sycl::id<3> offset_3d(range_3d);
+      test_nd_range_constructors(log, gs_3d, ls_3d, offset_3d);
     } catch (const sycl::exception &e) {
       log_exception(log, e);
       std::string errorMsg =

--- a/tests/platform/platform_api.cpp
+++ b/tests/platform/platform_api.cpp
@@ -59,6 +59,17 @@ class TEST_NAME : public util::test_base {
                                 "platform::has(sycl::aspect)");
       }
 
+      /** check has_extensions() member function
+      */
+      {
+        cts_selector selector;
+        auto plt = util::get_cts_object::platform(selector);
+        auto extensionSupported =
+            plt.has_extension(std::string("cl_khr_icd"));
+        check_return_type<bool>(log, extensionSupported,
+                                "platform::has_extension(string_class)");
+      }
+
       /** check get_info() member function
       */
       {

--- a/tests/platform/platform_api.cpp
+++ b/tests/platform/platform_api.cpp
@@ -61,6 +61,7 @@ class TEST_NAME : public util::test_base {
 
       /** check has_extensions() member function
       */
+      // TODO: mark this check as testing deprecated functionality
       {
         cts_selector selector;
         auto plt = util::get_cts_object::platform(selector);


### PR DESCRIPTION
Return checks for deprecated APIs that were removed in following PRs: https://github.com/KhronosGroup/SYCL-CTS/pull/168, https://github.com/KhronosGroup/SYCL-CTS/pull/163, https://github.com/KhronosGroup/SYCL-CTS/pull/156, https://github.com/KhronosGroup/SYCL-CTS/pull/164, https://github.com/KhronosGroup/SYCL-CTS/pull/159 