### PR TITLE
Specialization constants tests fixes

### DIFF
--- a/tests/specialization_constants/specialization_constants_defined_various_ways.h
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways.h
@@ -35,10 +35,10 @@ void perform_test(util::logger &log, const std::string &type_name,
     }
   }
   sycl::range<1> range(1);
-  T result = T(value_helper<T>(0));
-  T ref = T(value_helper<T>(0));
+  T result = T(get_init_value_helper<T>(0));
+  T ref = T(get_init_value_helper<T>(0));
   {
-    init_values(ref, case_num);
+    fill_init_values(ref, case_num);
     sycl::buffer<T, 1> result_buffer(&result, range);
     queue.submit([&](sycl::handler &cgh) {
       auto res_acc =

--- a/tests/specialization_constants/specialization_constants_defined_various_ways_helper.h
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways_helper.h
@@ -57,47 +57,47 @@ static std::string get_hint(sc_vw_id test_id) {
 
 // Defined in a non-global named namespace
 template <typename T, int case_num>
-constexpr sycl::specialization_id<T> sc_nonglob(gsc::value_helper<T>(case_num));
+constexpr sycl::specialization_id<T> sc_nonglob(gsc::get_init_value_helper<T>(case_num));
 
 // A static member variable of a struct in a non-global namespace
 struct struct_nonglob {
   constexpr struct_nonglob() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      gsc::value_helper<T>(case_num)};
+      gsc::get_init_value_helper<T>(case_num)};
 };
 }  // namespace spec_const_help
 
 namespace {
 // Defined in an unnamed namespace
 template <typename T, int case_num>
-constexpr sycl::specialization_id<T> sc_unnamed(gsc::value_helper<T>(case_num));
+constexpr sycl::specialization_id<T> sc_unnamed(gsc::get_init_value_helper<T>(case_num));
 
 // A static member variable of a struct in an unnamed namespace
 struct struct_unnamed {
   constexpr struct_unnamed() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      gsc::value_helper<T>(case_num)};
+      gsc::get_init_value_helper<T>(case_num)};
 };
 }  // unnamed namespace
 
 // Defined in the global namespace as inline constexpr
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> sc_glob_inl(
-    gsc::value_helper<T>(case_num));
+    gsc::get_init_value_helper<T>(case_num));
 
 // Defined in the global namespace as static constexpr
 template <typename T, int case_num>
 static constexpr sycl::specialization_id<T> sc_glob_static(
-    gsc::value_helper<T>(case_num));
+    gsc::get_init_value_helper<T>(case_num));
 
 // A static member variable of a struct in the global namespace
 struct struct_glob {
   constexpr struct_glob() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      gsc::value_helper<T>(case_num)};
+      gsc::get_init_value_helper<T>(case_num)};
 };
 
 // A static member variable declared inline constexpr of a struct in the global
@@ -106,7 +106,7 @@ struct struct_glob_inl {
   constexpr struct_glob_inl() {}
   template <typename T, int case_num>
   static inline constexpr sycl::specialization_id<T> sc{
-      gsc::value_helper<T>(case_num)};
+      gsc::get_init_value_helper<T>(case_num)};
 };
 
 // A static member variable of a templated struct in the global namespace
@@ -115,7 +115,7 @@ struct struct_glob_tmpl {
   constexpr struct_glob_tmpl() {}
   template <int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      gsc::value_helper<T>(case_num)};
+      gsc::get_init_value_helper<T>(case_num)};
 };
 
 #endif  // __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_HELPER_H

--- a/tests/specialization_constants/specialization_constants_external.h
+++ b/tests/specialization_constants/specialization_constants_external.h
@@ -16,7 +16,7 @@ using namespace get_spec_const;
 
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> spec_const_external(
-    value_helper<T>(default_val));
+    get_init_value_helper<T>(default_val));
 
 #define FUNC_DECLARE(TYPE)                                               \
   SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_handler( \
@@ -73,7 +73,7 @@ class check_specialization_constants_external {
     // handler
     bool func_result = false;
     {
-      T ref = T(value_helper<T>(5));
+      T ref = T(get_init_value_helper<T>(5));
       const int case_num = (int)test_cases_external::by_reference_via_handler;
       sycl::buffer<bool, 1> result_buffer(&func_result, range);
       queue.submit([&](sycl::handler &cgh) {
@@ -96,7 +96,7 @@ class check_specialization_constants_external {
     // handler
     func_result = false;
     {
-      T ref = T(value_helper<T>(10));
+      T ref = T(get_init_value_helper<T>(10));
       const int case_num = (int)test_cases_external::by_value_via_handler;
       sycl::buffer<bool, 1> result_buffer(&func_result, range);
       queue.submit([&](sycl::handler &cgh) {
@@ -121,7 +121,7 @@ class check_specialization_constants_external {
       // via kernel_bundle
       func_result = false;
       {
-        T ref = T(value_helper<T>(15));
+        T ref = T(get_init_value_helper<T>(15));
         const int case_num = (int)test_cases_external::by_reference_via_bundle;
         sycl::buffer<bool, 1> result_buffer(&func_result, range);
 
@@ -158,7 +158,7 @@ class check_specialization_constants_external {
       // kernel_bundle
       func_result = false;
       {
-        T ref = T(value_helper<T>(20));
+        T ref = T(get_init_value_helper<T>(20));
         const int case_num = (int)test_cases_external::by_value_via_bundle;
         sycl::buffer<bool, 1> result_buffer(&func_result, range);
 

--- a/tests/specialization_constants/specialization_constants_external.h
+++ b/tests/specialization_constants/specialization_constants_external.h
@@ -74,7 +74,7 @@ class check_specialization_constants_external {
     bool func_result = false;
     {
       T ref = T(value_helper<T>(5));
-      const int case_num = by_reference_via_handler;
+      const int case_num = (int)test_cases_external::by_reference_via_handler;
       sycl::buffer<bool, 1> result_buffer(&func_result, range);
       queue.submit([&](sycl::handler &cgh) {
         auto res_acc =
@@ -97,7 +97,7 @@ class check_specialization_constants_external {
     func_result = false;
     {
       T ref = T(value_helper<T>(10));
-      const int case_num = by_value_via_handler;
+      const int case_num = (int)test_cases_external::by_value_via_handler;
       sycl::buffer<bool, 1> result_buffer(&func_result, range);
       queue.submit([&](sycl::handler &cgh) {
         auto res_acc =
@@ -122,7 +122,7 @@ class check_specialization_constants_external {
       func_result = false;
       {
         T ref = T(value_helper<T>(15));
-        const int case_num = by_reference_via_bundle;
+        const int case_num = (int)test_cases_external::by_reference_via_bundle;
         sycl::buffer<bool, 1> result_buffer(&func_result, range);
 
         auto context = queue.get_context();
@@ -159,7 +159,7 @@ class check_specialization_constants_external {
       func_result = false;
       {
         T ref = T(value_helper<T>(20));
-        const int case_num = by_value_via_bundle;
+        const int case_num = (int)test_cases_external::by_value_via_bundle;
         sycl::buffer<bool, 1> result_buffer(&func_result, range);
 
         auto context = queue.get_context();

--- a/tests/specialization_constants/specialization_constants_same_name_stress.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress.h
@@ -69,8 +69,8 @@ class check_specialization_constants_same_name_stress_for_type {
 
       // Initialize ref arrays
       for (int i = 0; i < size; ++i) {
-        fill_init_values(ref_def_values_arr[i], i);
-        fill_init_values(ref_arr[i], i + static_cast<int>(size));
+        fill_init_values(ref_def_values_arr[i].value, i);
+        fill_init_values(ref_arr[i].value, i + static_cast<int>(size));
       }
 
       {

--- a/tests/specialization_constants/specialization_constants_separate_unit.cpp
+++ b/tests/specialization_constants/specialization_constants_separate_unit.cpp
@@ -37,25 +37,25 @@ bool check_kernel_handler_by_value_external(sycl::kernel_handler h,
   SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_handler(       \
       sycl::kernel_handler &h, TYPE expected) {                                \
     return check_kernel_handler_by_reference_external<                         \
-        TYPE, by_reference_via_handler>(h, expected);                          \
+        TYPE, (int)test_cases_external::by_reference_via_handler>(h, expected);\
   }                                                                            \
                                                                                \
   SYCL_EXTERNAL bool check_kernel_handler_by_value_external_handler(           \
       sycl::kernel_handler h, TYPE expected) {                                 \
-    return check_kernel_handler_by_value_external<TYPE, by_value_via_handler>( \
-        h, expected);                                                          \
+    return check_kernel_handler_by_value_external<
+        TYPE, (int)test_cases_external::by_value_via_handler>(h, expected);    \
   }                                                                            \
                                                                                \
   SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_bundle(        \
       sycl::kernel_handler &h, TYPE expected) {                                \
     return check_kernel_handler_by_reference_external<                         \
-        TYPE, by_reference_via_bundle>(h, expected);                           \
+        TYPE, (int)test_cases_external::by_reference_via_bundle>(h, expected); \
   }                                                                            \
                                                                                \
   SYCL_EXTERNAL bool check_kernel_handler_by_value_external_bundle(            \
       sycl::kernel_handler h, TYPE expected) {                                 \
-    return check_kernel_handler_by_value_external<TYPE, by_value_via_bundle>(  \
-        h, expected);                                                          \
+    return check_kernel_handler_by_value_external<
+        TYPE, (int)test_cases_external::by_value_via_bundle>(h, expected);     \
   }
 
 #ifndef SYCL_CTS_FULL_CONFORMANCE

--- a/tests/specialization_constants/specialization_constants_separate_unit.cpp
+++ b/tests/specialization_constants/specialization_constants_separate_unit.cpp
@@ -42,7 +42,7 @@ bool check_kernel_handler_by_value_external(sycl::kernel_handler h,
                                                                                \
   SYCL_EXTERNAL bool check_kernel_handler_by_value_external_handler(           \
       sycl::kernel_handler h, TYPE expected) {                                 \
-    return check_kernel_handler_by_value_external<
+    return check_kernel_handler_by_value_external<                             \
         TYPE, (int)test_cases_external::by_value_via_handler>(h, expected);    \
   }                                                                            \
                                                                                \
@@ -54,7 +54,7 @@ bool check_kernel_handler_by_value_external(sycl::kernel_handler h,
                                                                                \
   SYCL_EXTERNAL bool check_kernel_handler_by_value_external_bundle(            \
       sycl::kernel_handler h, TYPE expected) {                                 \
-    return check_kernel_handler_by_value_external<
+    return check_kernel_handler_by_value_external<                             \
         TYPE, (int)test_cases_external::by_value_via_bundle>(h, expected);     \
   }
 

--- a/tests/specialization_constants/specialization_constants_separate_unit.cpp
+++ b/tests/specialization_constants/specialization_constants_separate_unit.cpp
@@ -14,7 +14,7 @@ using namespace get_spec_const;
 
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> spec_const_external(
-    value_helper<T>(default_val));
+    get_init_value_helper<T>(default_val));
 
 template <typename T, int case_num>
 bool check_kernel_handler_by_reference_external(sycl::kernel_handler &h,

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle.h
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle.h
@@ -136,7 +136,7 @@ struct values<containerT<bool, size>> : values<bool> {};
  */
 template <typename T, typename id>
 constexpr sycl::specialization_id<T> spec_const_by_kernel_bundle(
-    get_spec_const::value_helper<T>(
+    get_spec_const::get_init_value_helper<T>(
         specialization_constants_via_kernel_bundle::values<T>::initial));
 
 namespace specialization_constants_via_kernel_bundle {
@@ -300,8 +300,8 @@ void set_value(sycl::kernel_bundle<id::state>& bundle) {
                   " set_specialization_constant");
     for (int i = 0; i < id::n_set; ++i) {
       // Prepare value to store
-      T value = T(value_helper<T>(0));
-      init_values(value, values<T>::reference(i));
+      T value = T(get_init_value_helper<T>(0));
+      fill_init_values(value, values<T>::reference(i));
 
       bundle.template set_specialization_constant<
           spec_const_by_kernel_bundle<T, id>>(value);
@@ -323,16 +323,16 @@ bool check_value(specStorageT&& storage) {
   using namespace get_spec_const;
 
   // Prepare to read value
-  T value = T(value_helper<T>(0));
-  init_values(value, values<T>::empty);
+  T value = T(get_init_value_helper<T>(0));
+  fill_init_values(value, values<T>::empty);
 
   // Prepare to compare values
-  T expected = T(value_helper<T>(0));
+  T expected = T(get_init_value_helper<T>(0));
   if constexpr (id::n_set == 0) {
-    init_values(expected, values<T>::initial);
+    fill_init_values(expected, values<T>::initial);
   } else {
     const int effectiveSetIndex = id::n_set - 1;
-    init_values(expected, values<T>::reference(effectiveSetIndex));
+    fill_init_values(expected, values<T>::reference(effectiveSetIndex));
   }
 
   for (int i = 0; i < id::n_get; ++i) {

--- a/util/allocation.h
+++ b/util/allocation.h
@@ -9,6 +9,8 @@
 #ifndef __SYCL_UTIL_ALLOCATION_H
 #define __SYCL_UTIL_ALLOCATION_H
 
+#include "../tests/common/common.h"
+
 namespace sycl_cts {
 namespace util {
 
@@ -26,7 +28,7 @@ union remove_initialization {
 
   friend bool operator==(const remove_initialization &lhs,
                          const remove_initialization &rhs) {
-    return lhs.value == rhs.value;
+    return check_equal_values(lhs.value, rhs.value);
   }
 
   operator value_type &() { return value; }

--- a/util/allocation.h
+++ b/util/allocation.h
@@ -19,8 +19,8 @@ union remove_initialization {
   T value;
   remove_initialization() {}
 
-  template <typename T>
-  void operator=(const T &val) {
+  template <typename ValT>
+  void operator=(const ValT &val) {
     this->value = val;
   }
 


### PR DESCRIPTION
Provides following changes:
 - value_helper/init_values are renamed to get_init_value_helper/fill_init_values according to Khronos comments
 - small fix for specialization_constants_same_name_stress tests for bool type
 - fix of equality operator for remove_initialization class
 - fix enum class usage for specialization_constants_external tests
 - fix shadowing template T parameter for assignment operator of the remove_initialization class