### PR TITLE
Do not rely on implementations to include <cmath>

### DIFF
--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -12,6 +12,8 @@
 #include "../tests/common/sycl.h"
 #include "./math_helper.h"
 
+#include <cmath>
+
 namespace reference {
 /* two argument relational reference */
 template <typename T>


### PR DESCRIPTION
Looks like implementations implicitly include `<cmath>` to implement builtins. However, that is not required by the spec.