### PR TITLE
Avoid use of sycl::get_kernel_bundle for CCPP & hipSYCL

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -599,9 +599,16 @@ inline bool kernel_supports_wg_size(sycl_cts::util::logger& log,
     return false;
   }
 
+// ComputeCpp and hipSYCL do not yet support sycl::get_kernel_bundle
+#if !defined(__COMPUTECPP__) && !defined(__HIPSYCL__)
   auto kb =
       sycl::get_kernel_bundle<kernelT, sycl::bundle_state::executable>(context);
   auto kernel = kb.get_kernel(sycl::get_kernel_id<kernelT>());
+#else
+  sycl::program program(context, devicesToCheck);
+  program.build_with_kernel_type<kernelT>("");
+  auto kernel = program.get_kernel<kernelT>();
+#endif
   auto maxKernelWorkGroupSize = kernel.template get_work_group_info<
       sycl::info::kernel_work_group::work_group_size>(device);
 

--- a/tests/common/get_cts_object.h
+++ b/tests/common/get_cts_object.h
@@ -96,10 +96,18 @@ struct get_cts_object {
     */
     template <class kernel_name>
     static sycl::kernel prebuilt(sycl::queue &queue) {
+// ComputeCpp and hipSYCL do not yet support sycl::get_kernel_bundle
+#if !defined(__COMPUTECPP__) && !defined(__HIPSYCL__)
       auto ctx = queue.get_context();
-      auto kb_exe = sycl::get_kernel_bundle<
-                      kernel_name, sycl::bundle_state::executable>(ctx);
+      auto kb_exe =
+          sycl::get_kernel_bundle<kernel_name, sycl::bundle_state::executable>(
+              ctx);
       return kb_exe.get_kernel(sycl::get_kernel_id<kernel_name>());
+#else
+      sycl::program program(queue.get_context());
+      program.build_with_kernel_type<kernel_name>();
+      return program.get_kernel<kernel_name>();
+#endif
     }
   };
 


### PR DESCRIPTION
Fix regression introduced in #179.