### PR TITLE
Move try-catch to test_base w/o formatting changes

### DIFF
--- a/tests/accessor/accessor_api_buffer_atomic64.cpp
+++ b/tests/accessor/accessor_api_buffer_atomic64.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::atomic64;
@@ -38,11 +38,6 @@ class TEST_NAME : public util::test_base {
                            extension_tag>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_buffer_core.cpp
+++ b/tests/accessor/accessor_api_buffer_core.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::core;
@@ -38,11 +38,6 @@ class TEST_NAME : public util::test_base {
                            extension_tag>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_buffer_fp16.cpp
+++ b/tests/accessor/accessor_api_buffer_fp16.cpp
@@ -29,17 +29,12 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_types_fp16<check_buffer_accessor_api_type>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_buffer_fp64.cpp
+++ b/tests/accessor/accessor_api_buffer_fp64.cpp
@@ -29,17 +29,12 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_types_fp64<check_buffer_accessor_api_type>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_image_core.cpp
+++ b/tests/accessor/accessor_api_image_core.cpp
@@ -35,7 +35,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::core;
@@ -44,11 +44,6 @@ class TEST_NAME : public util::test_base {
                                  extension_tag>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_image_fp16.cpp
+++ b/tests/accessor/accessor_api_image_fp16.cpp
@@ -35,18 +35,13 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_types_image_fp16<check_image_accessor_api_type>::run(
           queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_local_atomic64.cpp
+++ b/tests/accessor/accessor_api_local_atomic64.cpp
@@ -29,19 +29,13 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::atomic64;
 
       check_all_types_core<check_local_accessor_api_type,
                            extension_tag>::run(queue, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_local_core.cpp
+++ b/tests/accessor/accessor_api_local_core.cpp
@@ -29,19 +29,13 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::core;
 
       check_all_types_core<check_local_accessor_api_type,
                            extension_tag>::run(queue, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_local_fp16.cpp
+++ b/tests/accessor/accessor_api_local_fp16.cpp
@@ -30,16 +30,10 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_types_fp16<check_local_accessor_api_type>::run(queue, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_api_local_fp64.cpp
+++ b/tests/accessor/accessor_api_local_fp64.cpp
@@ -29,16 +29,10 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_types_fp64<check_local_accessor_api_type>::run(queue, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_constructors_buffer.cpp
+++ b/tests/accessor/accessor_constructors_buffer.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::core;
@@ -38,11 +38,6 @@ class TEST_NAME : public util::test_base {
                            extension_tag>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_constructors_buffer_placeholder.cpp
+++ b/tests/accessor/accessor_constructors_buffer_placeholder.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::core;
@@ -38,11 +38,6 @@ class TEST_NAME : public util::test_base {
                            extension_tag>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_constructors_fp16.cpp
+++ b/tests/accessor/accessor_constructors_fp16.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_types_fp16<buffer_accessor_type>::run(queue, log);
@@ -41,11 +41,6 @@ class TEST_NAME : public util::test_base {
       check_all_types_image_fp16<image_accessor_type>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_constructors_fp64.cpp
+++ b/tests/accessor/accessor_constructors_fp64.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_types_fp64<buffer_accessor_type>::run(queue, log);
@@ -37,11 +37,6 @@ class TEST_NAME : public util::test_base {
       check_all_types_fp64<local_accessor_all_dims>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_constructors_image.cpp
+++ b/tests/accessor/accessor_constructors_image.cpp
@@ -27,7 +27,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::core;
@@ -36,11 +36,6 @@ class TEST_NAME : public util::test_base {
           queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/accessor/accessor_constructors_local.cpp
+++ b/tests/accessor/accessor_constructors_local.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       using extension_tag = sycl_cts::util::extensions::tag::core;
@@ -38,11 +38,6 @@ class TEST_NAME : public util::test_base {
                            extension_tag>::run(queue, log);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/address_space/address_space_common.h
+++ b/tests/address_space/address_space_common.h
@@ -199,13 +199,9 @@ class check_types {
 
 template <typename T>
 void test_types(util::logger &log) {
-  try {
+  {
     check_types<T> verifier;
     if (!verifier()) FAIL(log, "Device compiler failed address space tests");
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-    FAIL(log, errorMsg);
   }
   return;
 }

--- a/tests/atomic/atomic_api_32.cpp
+++ b/tests/atomic/atomic_api_32.cpp
@@ -160,7 +160,7 @@ class TEST_NAME : public util::test_base {
   /** Execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto testQueue = util::get_cts_object::queue();
       auto testDevice = testQueue.get_device();
 
@@ -180,11 +180,6 @@ class TEST_NAME : public util::test_base {
       }
 
       testQueue.wait_and_throw();
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/atomic/atomic_api_64_base.cpp
+++ b/tests/atomic/atomic_api_64_base.cpp
@@ -95,7 +95,7 @@ class TEST_NAME : public util::test_base {
   /** Execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto testQueue = util::get_cts_object::queue();
       auto testDevice = testQueue.get_device();
 
@@ -115,11 +115,6 @@ class TEST_NAME : public util::test_base {
       }
 
       testQueue.wait_and_throw();
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/atomic/atomic_api_64_extended.cpp
+++ b/tests/atomic/atomic_api_64_extended.cpp
@@ -92,7 +92,7 @@ class TEST_NAME : public util::test_base {
   /** Execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto testQueue = util::get_cts_object::queue();
       auto testDevice = testQueue.get_device();
 
@@ -112,11 +112,6 @@ class TEST_NAME : public util::test_base {
       }
 
       testQueue.wait_and_throw();
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/atomic/atomic_constructors_32.cpp
+++ b/tests/atomic/atomic_constructors_32.cpp
@@ -43,7 +43,7 @@ class TEST_NAME : public util::test_base {
   /** Execute the test
    */
   virtual void run(util::logger &log) override {
-    try {
+    {
       auto testQueue = util::get_cts_object::queue();
 
       /** Check atomics for supported types
@@ -58,11 +58,6 @@ class TEST_NAME : public util::test_base {
       }
 
       testQueue.wait_and_throw();
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/atomic/atomic_constructors_64.cpp
+++ b/tests/atomic/atomic_constructors_64.cpp
@@ -43,7 +43,7 @@ class TEST_NAME : public util::test_base {
   /** Execute the test
    */
   virtual void run(util::logger &log) override {
-    try {
+    {
       auto testQueue = util::get_cts_object::queue();
       auto testDevice = testQueue.get_device();
 
@@ -59,11 +59,6 @@ class TEST_NAME : public util::test_base {
       }
 
       testQueue.wait_and_throw();
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -211,7 +211,7 @@ using flip_signedness_t =
 template <typename T, int size, int dims, typename alloc>
 void test_buffer(util::logger &log, sycl::range<dims> &r,
                  sycl::id<dims> &i) {
-  try {
+  {
     std::unique_ptr<T[]> data(new T[size]);
     std::fill(data.get(), (data.get() + size), 0);
 
@@ -435,11 +435,6 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     }
 
     q.wait_and_throw();
-  } catch (const sycl::exception& e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
   }
 }
 

--- a/tests/buffer/buffer_constructors_core.cpp
+++ b/tests/buffer/buffer_constructors_core.cpp
@@ -30,7 +30,7 @@ public:
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
 #ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types_and_vectors<
           buffer_constructors_common::check_buffer_ctors_for_type>(
@@ -82,11 +82,6 @@ public:
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<buffer_constructors_common::check_buffer_ctors_for_type>(
           get_buffer_types::scalar_types, log);
-    } catch (sycl::exception e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/buffer/buffer_destructors.cpp
+++ b/tests/buffer/buffer_destructors.cpp
@@ -61,15 +61,10 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       test_buffers<int>(log);
       test_buffers<float>(log);
       test_buffers<double>(log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/buffer/buffer_storage_core.cpp
+++ b/tests/buffer/buffer_storage_core.cpp
@@ -31,7 +31,7 @@ public:
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
 #ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types_and_vectors<
           buffer_storage_common::check_buffer_storage_for_type>(
@@ -75,11 +75,6 @@ public:
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<buffer_storage_common::check_buffer_storage_for_type>(
           get_buffer_types::scalar_types, log);
-    } catch (sycl::exception e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/common/async_work_group_copy.h
+++ b/tests/common/async_work_group_copy.h
@@ -495,15 +495,11 @@ void check_all_dims(sycl::queue &queue, sycl_cts::util::logger &log,
 template<template<int, typename...> class action,
          typename ... actionArgsT, typename ... argsT>
 void check_all_dims(sycl_cts::util::logger &log, argsT&& ... args) {
-  try {
+  {
     auto queue = once_per_unit::get_queue();
 
     check_all_dims<action, actionArgsT...>(queue, log,
                                            std::forward<argsT>(args)...);
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-    FAIL(log, errorMsg);
   }
 }
 

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -599,9 +599,16 @@ inline bool kernel_supports_wg_size(sycl_cts::util::logger& log,
     return false;
   }
 
+// ComputeCpp and hipSYCL do not yet support sycl::get_kernel_bundle
+#if !defined(__COMPUTECPP__) && !defined(__HIPSYCL__)
   auto kb =
       sycl::get_kernel_bundle<kernelT, sycl::bundle_state::executable>(context);
   auto kernel = kb.get_kernel(sycl::get_kernel_id<kernelT>());
+#else
+  sycl::program program(context, devicesToCheck);
+  program.build_with_kernel_type<kernelT>("");
+  auto kernel = program.get_kernel<kernelT>();
+#endif
   auto maxKernelWorkGroupSize = kernel.template get_work_group_info<
       sycl::info::kernel_work_group::work_group_size>(device);
 

--- a/tests/common/common_python_vec.py
+++ b/tests/common/common_python_vec.py
@@ -171,17 +171,12 @@ kernel_template = Template("""  bool resArray[1] = {true};
 test_func_template = Template("""
 void ${func_name}(util::logger &log) {
 
-  try {
+  {
     auto testQueue = util::get_cts_object::queue();
     {
       auto testDevice = testQueue.get_device();
       ${test}
     }
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
   }
 }
 """)

--- a/tests/common/get_cts_object.h
+++ b/tests/common/get_cts_object.h
@@ -96,10 +96,18 @@ struct get_cts_object {
     */
     template <class kernel_name>
     static sycl::kernel prebuilt(sycl::queue &queue) {
+// ComputeCpp and hipSYCL do not yet support sycl::get_kernel_bundle
+#if !defined(__COMPUTECPP__) && !defined(__HIPSYCL__)
       auto ctx = queue.get_context();
-      auto kb_exe = sycl::get_kernel_bundle<
-                      kernel_name, sycl::bundle_state::executable>(ctx);
+      auto kb_exe =
+          sycl::get_kernel_bundle<kernel_name, sycl::bundle_state::executable>(
+              ctx);
       return kb_exe.get_kernel(sycl::get_kernel_id<kernel_name>());
+#else
+      sycl::program program(queue.get_context());
+      program.build_with_kernel_type<kernel_name>();
+      return program.get_kernel<kernel_name>();
+#endif
     }
   };
 

--- a/tests/common/vector_swizzles.template
+++ b/tests/common/vector_swizzles.template
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto testQueue = util::get_cts_object::queue();
       {
         auto testDevice = testQueue.get_device();
@@ -57,11 +57,6 @@ class TEST_NAME : public util::test_base {
       }
 
       testQueue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/context/context_api.cpp
+++ b/tests/context/context_api.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto context = util::get_cts_object::context();
 
       /** check is_host() method
@@ -50,12 +50,6 @@ class TEST_NAME : public util::test_base {
         auto platform = context.get_platform();
         check_return_type<sycl::platform>(log, platform, "get_platform()");
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/context/context_constructors.cpp
+++ b/tests/context/context_constructors.cpp
@@ -27,7 +27,7 @@ class TEST_NAME : public util::test_base {
   void run(util::logger &log) override {
     cts_async_handler asyncHandler;
 
-    try {
+    {
       /** check default constructor and destructor
       */
       {
@@ -233,11 +233,6 @@ class TEST_NAME : public util::test_base {
                "failed)");
         }
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/context/context_info.cpp
+++ b/tests/context/context_info.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto context = util::get_cts_object::context();
 
       /** check get_info for info::context::reference_count
@@ -57,12 +57,6 @@ class TEST_NAME : public util::test_base {
             log, devs, "get_info<sycl::info::context::devices>()");
         TEST_TYPE_TRAIT(context, devices, context);
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/device/device_api.cpp
+++ b/tests/device/device_api.cpp
@@ -62,7 +62,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check get_platform() member function
        */
       {
@@ -221,11 +221,6 @@ class TEST_NAME : public util::test_base {
         check_return_type<std::vector<sycl::device>>(
             log, devs, "device::get_devices(info::device_type::all)");
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check default constructor and destructor
        */
       {
@@ -154,11 +154,6 @@ class TEST_NAME : public util::test_base {
                "device hash_class does not work correctly (copy assigned)");
         }
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/device/device_info.cpp
+++ b/tests/device/device_info.cpp
@@ -27,7 +27,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check info::device
        */
       check_enum_class_value(sycl::info::device::device_type);
@@ -415,12 +415,6 @@ class TEST_NAME : public util::test_base {
         check_get_info_param<sycl::info::device, sycl::cl_uint,
                              sycl::info::device::reference_count>(log, dev);
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/device_event/device_event_api.cpp
+++ b/tests/device_event/device_event_api.cpp
@@ -32,7 +32,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check wait() member function
        */
       auto testQueue = util::get_cts_object::queue();
@@ -80,11 +80,6 @@ class TEST_NAME : public util::test_base {
       if (error) {
         FAIL(log, "sycl::device_event async_work_group_copy failed");
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      const auto errorMsg =
-          std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/device_selector/device_selector_api.cpp
+++ b/tests/device_selector/device_selector_api.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check select_device() method
        */
       {
@@ -44,12 +44,6 @@ class TEST_NAME : public util::test_base {
         auto score = selector(device);
         check_return_type<int>(log, score, "selector(sycl::device)");
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/device_selector/device_selector_constructors.cpp
+++ b/tests/device_selector/device_selector_constructors.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check default constructor and destructor
       */
       { cts_selector selector; }
@@ -44,11 +44,6 @@ class TEST_NAME : public util::test_base {
         cts_selector selectorA;
         cts_selector selectorB = selectorA;
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/device_selector/device_selector_custom.cpp
+++ b/tests/device_selector/device_selector_custom.cpp
@@ -55,7 +55,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check a custom selector for a device
       */
       {
@@ -103,11 +103,6 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "custom selector selected a device with a negative score");
         }
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/device_selector/device_selector_predefined.cpp
+++ b/tests/device_selector/device_selector_predefined.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       bool gpuAvailable = false;
       bool cpuAvailable = false;
       bool acceleratorAvailable = false;
@@ -101,12 +101,6 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "accelerator_selector failed to select an appropriate device");
         }
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/event/event_api.cpp
+++ b/tests/event/event_api.cpp
@@ -35,8 +35,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
-
+    {
 #ifdef SYCL_CTS_TEST_OPENCL_INTEROP
       /** check get()
       */
@@ -112,12 +111,6 @@ class TEST_NAME : public util::test_base {
 
         sycl::event::wait_and_throw(eventList);
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/event/event_constructors.cpp
+++ b/tests/event/event_constructors.cpp
@@ -37,7 +37,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check default constructor and destructor
       */
       {
@@ -171,11 +171,6 @@ class TEST_NAME : public util::test_base {
 
         queue.wait_and_throw();
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/event/event_info.cpp
+++ b/tests/event/event_info.cpp
@@ -28,7 +28,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check sycl::info::event_command_status
        */
       check_enum_class_value(sycl::info::event_command_status::complete);
@@ -112,11 +112,6 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "command start time > end time");
         }
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/event/event_wait.cpp
+++ b/tests/event/event_wait.cpp
@@ -101,7 +101,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(sycl_cts::util::logger &log) override {
-    try {
+    {
       auto queueA = util::get_cts_object::queue();
       auto queueB = util::get_cts_object::queue();
 
@@ -111,11 +111,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
       queueA.wait_and_throw();
       queueB.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/exception_handling/synchronous_exceptions.cpp
+++ b/tests/exception_handling/synchronous_exceptions.cpp
@@ -109,13 +109,9 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       check_exception_api(log);
       check_exception_usage(log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/exceptions/exceptions_error_code.cpp
+++ b/tests/exceptions/exceptions_error_code.cpp
@@ -44,7 +44,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       for (const auto &err_c : get_err_codes()) {
         check_unique_enum_values(err_c, log);
       }
@@ -54,14 +54,6 @@ class TEST_NAME : public util::test_base {
       if (std::is_error_condition_enum<sycl::errc>::value) {
         FAIL(log, "sycl::errc is a error condition enumeration");
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg{"a SYCL exception was caught: " +
-                           std::string(e.what())};
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg{"an exception was caught: " + std::string(e.what())};
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/exceptions/exceptions_make_error_code.cpp
+++ b/tests/exceptions/exceptions_make_error_code.cpp
@@ -95,19 +95,11 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       for (const auto &err_c : get_err_codes()) {
         compare_sycl_and_std_working(err_c, log);
         check_sycl_working(err_c, log);
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg{"a SYCL exception was caught: " +
-                           std::string(e.what())};
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg{"an exception was caught: " + std::string(e.what())};
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/exceptions/exceptions_sycl_category.cpp
+++ b/tests/exceptions/exceptions_sycl_category.cpp
@@ -28,7 +28,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       const auto &error_category_local_usage{sycl::sycl_category()};
       const test_result_checker test_result_checker_local_usage(
           error_category_local_usage);
@@ -51,14 +51,6 @@ class TEST_NAME : public util::test_base {
              "sycl::sycl_category function's return type are not equal to "
              "const std::error_category");
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg{"a SYCL exception was caught: " +
-                           std::string(e.what())};
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg{"an exception was caught: " + std::string(e.what())};
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/exceptions/exceptions_sycl_category_try_order_fiasco.cpp
+++ b/tests/exceptions/exceptions_sycl_category_try_order_fiasco.cpp
@@ -36,17 +36,9 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       static_instance.check_results(
           "while trying to provoke static initialization order fiasco", log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg{"a SYCL exception was caught: " +
-                           std::string(e.what())};
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg{"an exception was caught: " + std::string(e.what())};
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/group/group_api.cpp
+++ b/tests/group/group_api.cpp
@@ -405,7 +405,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       // Validate for each dimension possible
@@ -444,11 +444,6 @@ class TEST_NAME : public util::test_base {
         validator.collect_group_indicies(queue);
         validator.validate_group_indicies(log);
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/group/group_async_work_group_copy_fp16.cpp
+++ b/tests/group/group_async_work_group_copy_fp16.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp16)) {
@@ -39,11 +39,6 @@ class TEST_NAME : public util::test_base {
           "sycl::half");
       for_type_and_vectors<check_type, sycl::cl_half>(queue, log,
           "sycl::cl_half");
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/group/group_async_work_group_copy_fp64.cpp
+++ b/tests/group/group_async_work_group_copy_fp64.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp64)) {
@@ -39,11 +39,6 @@ class TEST_NAME : public util::test_base {
           "double");
       for_type_and_vectors<check_type, sycl::cl_double>(queue, log,
           "sycl::cl_double");
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/group/group_combined_mem_fence.cpp
+++ b/tests/group/group_combined_mem_fence.cpp
@@ -88,7 +88,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       test_mem_fence<access_group::useDefault, 1>(log, queue);
@@ -96,11 +96,6 @@ class TEST_NAME : public util::test_base {
       test_mem_fence<access_group::useSeparate, 1>(log, queue);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/group/group_constructors.cpp
+++ b/tests/group/group_constructors.cpp
@@ -138,7 +138,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_constructors(util::logger& log) {
-    try {
+    {
       success_array_t success;
       std::fill(std::begin(success), std::end(success), true);
 
@@ -250,11 +250,6 @@ class TEST_NAME : public util::test_base {
       CHECK_VALUE(log,
                   success[to_integral(current_check::move_assignment)],
                   true, numDims);
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 

--- a/tests/group/group_default_mem_fence.cpp
+++ b/tests/group/group_default_mem_fence.cpp
@@ -87,7 +87,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       test_mem_fence<access_group::useDefault, 1>(log, queue);
@@ -95,11 +95,6 @@ class TEST_NAME : public util::test_base {
       test_mem_fence<access_group::useSeparate, 1>(log, queue);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/group/group_equality.cpp
+++ b/tests/group/group_equality.cpp
@@ -33,7 +33,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_equality(util::logger& log) {
-    try {
+    {
       using item_t = sycl::group<numDims>;
 
       // group is not default constructible, store two objects into the array
@@ -51,11 +51,6 @@ class TEST_NAME : public util::test_base {
       check_equality_comparable_generic(log, items[0],
                                         "group " + std::to_string(numDims) +
                                         " (host)");
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 

--- a/tests/group/group_global_mem_fence.cpp
+++ b/tests/group/group_global_mem_fence.cpp
@@ -75,7 +75,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       test_mem_fence<access_group::useDefault, 1>(log, queue);
@@ -83,11 +83,6 @@ class TEST_NAME : public util::test_base {
       test_mem_fence<access_group::useSeparate, 1>(log, queue);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/group/group_local_mem_fence.cpp
+++ b/tests/group/group_local_mem_fence.cpp
@@ -75,7 +75,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       test_mem_fence<access_group::useDefault, 1>(log, queue);
@@ -83,11 +83,6 @@ class TEST_NAME : public util::test_base {
       test_mem_fence<access_group::useSeparate, 1>(log, queue);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/group/group_wait_for.cpp
+++ b/tests/group/group_wait_for.cpp
@@ -45,15 +45,10 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_dims<check_dim>(queue, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/h_item/h_item_api.cpp
+++ b/tests/h_item/h_item_api.cpp
@@ -390,17 +390,10 @@ class TEST_NAME : public util::test_base {
   /** Execute the test
    */
   void run(util::logger& log) final {
-    try {
+    {
       api_tests<1>::run(log);
       api_tests<2>::run(log);
       api_tests<3>::run(log);
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
-    } catch (const std::exception& e) {
-      auto errorMsg = std::string("an exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/h_item/h_item_constructors.cpp
+++ b/tests/h_item/h_item_constructors.cpp
@@ -126,7 +126,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_constructors(util::logger& log) {
-    try {
+    {
       success_array_t success;
       std::fill(std::begin(success), std::end(success), true);
 
@@ -185,11 +185,6 @@ class TEST_NAME : public util::test_base {
       CHECK_VALUE(log,
                   success[static_cast<size_t>(current_check::move_assignment)],
                   true, numDims);
-
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 

--- a/tests/h_item/h_item_equality.cpp
+++ b/tests/h_item/h_item_equality.cpp
@@ -49,7 +49,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_equality(util::logger& log) {
-    try {
+    {
       using item_t = sycl::h_item<numDims>;
 
       // h_item is not default constructible, store two objects
@@ -138,11 +138,6 @@ class TEST_NAME : public util::test_base {
       CHECK_VALUE(log,
                   success[static_cast<size_t>(current_check::not_equal_other)],
                   true, numDims);
-
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 

--- a/tests/handler/handler_api.cpp
+++ b/tests/handler/handler_api.cpp
@@ -33,7 +33,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       const auto range = sycl::range<1>(1);
       int data[1]{0};
@@ -63,11 +63,6 @@ class TEST_NAME : public util::test_base {
       }
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/handler/handler_copy.cpp
+++ b/tests/handler/handler_copy.cpp
@@ -938,7 +938,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       log_helper lh(&log);
@@ -959,12 +959,6 @@ class TEST_NAME : public util::test_base {
       test_all_variants<sycl::long8>(lh, queue);
       test_all_variants<sycl::float8>(lh, queue);
 #endif
-
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/handler/handler_invoke_api.cpp
+++ b/tests/handler/handler_invoke_api.cpp
@@ -475,7 +475,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
            "A SYCL exception was "
            "caught");
     }
-  };
+  }
 };
 
 // register this test with the test_collection

--- a/tests/handler/handler_invoke_api.cpp
+++ b/tests/handler/handler_invoke_api.cpp
@@ -190,7 +190,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       using handler = sycl::handler;
 
       auto queue = util::get_cts_object::queue();
@@ -468,12 +468,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
                          });
         }
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      FAIL(log,
-           "A SYCL exception was "
-           "caught");
     }
   }
 };

--- a/tests/hierarchical/hierarchical_functor.cpp
+++ b/tests/hierarchical/hierarchical_functor.cpp
@@ -83,15 +83,10 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       check_dim<1>(log);
       check_dim<2>(log);
       check_dim<3>(log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/hierarchical/hierarchical_id.cpp
+++ b/tests/hierarchical/hierarchical_id.cpp
@@ -41,7 +41,7 @@ template <int dim> void check_dim(util::logger &log) {
   const int check_gr_range_2d = (check_g_items_2d / check_l_items_2d);
   const int check_gr_range_3d = (check_g_items_3d / check_l_items_3d);
 
-  try {
+  {
     sycl::int4 localIdData[gl_items_total];
     sycl::int4 localSizeData[gl_items_total];
     sycl::int4 globalIdData[gl_items_total];
@@ -231,11 +231,6 @@ template <int dim> void check_dim(util::logger &log) {
         }
       }
     }
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
   }
 }
 

--- a/tests/hierarchical/hierarchical_implicit_barriers.cpp
+++ b/tests/hierarchical/hierarchical_implicit_barriers.cpp
@@ -31,7 +31,7 @@ static const size_t groupRangeTotal = (groupItemsTotal / localItemsTotal);
 using namespace sycl_cts;
 
 template <int dim> void check_dim(util::logger &log) {
-  try {
+  {
     size_t inputData[groupItemsTotal];
 
     auto testQueue = util::get_cts_object::queue();
@@ -90,12 +90,6 @@ template <int dim> void check_dim(util::logger &log) {
         FAIL(log, "Values not equal.");
       }
     }
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
   }
 }
 

--- a/tests/hierarchical/hierarchical_implicit_conditional.cpp
+++ b/tests/hierarchical/hierarchical_implicit_conditional.cpp
@@ -30,7 +30,7 @@ static const int groupRangeTotal = (groupItemsTotal / localItemsTotal);
 using namespace sycl_cts;
 
 template <int dim> void check_dim(util::logger &log) {
-  try {
+  {
     int outputData[groupItemsTotal];
     for (int i = 0; i < groupItemsTotal; i++) {
       outputData[i] = 0;
@@ -87,12 +87,6 @@ template <int dim> void check_dim(util::logger &log) {
         FAIL(log, "Result not as expected.");
       }
     }
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
   }
 }
 

--- a/tests/hierarchical/hierarchical_implicit_reduce.cpp
+++ b/tests/hierarchical/hierarchical_implicit_reduce.cpp
@@ -147,7 +147,7 @@ class Multiplier {
 };
 
 template <int dim> void check_dim(util::logger &log) {
-  try {
+  {
       cts_selector sel;
       {
         Adder data[inputSize];
@@ -180,11 +180,6 @@ template <int dim> void check_dim(util::logger &log) {
           FAIL(log, msg);
         }
       }
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
 }
 

--- a/tests/hierarchical/hierarchical_lambda.cpp
+++ b/tests/hierarchical/hierarchical_lambda.cpp
@@ -17,7 +17,7 @@ template <int dim> class kernel;
 using namespace sycl_cts;
 
 template <int dim> void check_dim(util::logger &log) {
-  try {
+  {
     constexpr size_t globalRange1d = 6;
     constexpr size_t globalRange2d = 2;
     constexpr size_t globalRangeTotal = 24;
@@ -62,12 +62,6 @@ template <int dim> void check_dim(util::logger &log) {
         FAIL(log, errorMessage);
       }
     }
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
   }
 }
 

--- a/tests/hierarchical/hierarchical_non_uniform_local_range.cpp
+++ b/tests/hierarchical/hierarchical_non_uniform_local_range.cpp
@@ -57,7 +57,7 @@ template <int dim> void check_dim(util::logger &log) {
       (dim > 1) ? ((dim > 2) ? local_range : local_range_total / local_range)
                 : 1;
   const unsigned local_range_3d = (dim > 2) ? local_range : 1;
-  try {
+  {
     // Set element of the vector with -1 to represent unset data.
     std::fill(data.begin(), data.end(), sycl::int3(-1, -1, -1));
 
@@ -134,11 +134,6 @@ template <int dim> void check_dim(util::logger &log) {
                 }
                 idx++;
               }
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
   }
 }
 

--- a/tests/hierarchical/hierarchical_private_memory.cpp
+++ b/tests/hierarchical/hierarchical_private_memory.cpp
@@ -17,7 +17,7 @@ template <int dim> class kernel;
 using namespace sycl_cts;
 
 template <int dim> void check_dim(util::logger &log) {
-  try {
+  {
     constexpr size_t globalRange1d = 6;
     constexpr size_t globalRange2d = 2;
     constexpr size_t globalRangeTotal = 24;
@@ -69,12 +69,6 @@ template <int dim> void check_dim(util::logger &log) {
         FAIL(log, errorMessage);
       }
     }
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
   }
 }
 /** test sycl::range::get(int index) return size_t

--- a/tests/host_task/host_task_interop_api.cpp
+++ b/tests/host_task/host_task_interop_api.cpp
@@ -43,7 +43,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger& log) override {
 #ifdef SYCL_BACKEND_OPENCL
-    try {
+    {
       sycl::queue q{util::get_cts_object::queue()};
       if (q.get_backend() != sycl::backend::opencl) {
         log.note("Interop part is not supported on OpenCL backend type");
@@ -116,9 +116,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
           }
         }
       }
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      FAIL(log, "An unexpected SYCL exception was caught");
     }
 #else
     log.note("The test is skipped because OpenCL back-end is not supported");

--- a/tests/host_task/host_task_invoke_api.cpp
+++ b/tests/host_task/host_task_invoke_api.cpp
@@ -239,14 +239,11 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute this test
    */
   void run(util::logger& log) override {
-    try {
+    {
       sycl::queue q{util::get_cts_object::queue()};
       check_execution_order(q, log);
       check_different_contexts(q, log);
       check_data_update(q, log);
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      FAIL(log, "An unexpected SYCL exception was caught");
     }
   }
 };

--- a/tests/id/id_api.cpp
+++ b/tests/id/id_api.cpp
@@ -273,7 +273,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // use across all the dimensions
       auto my_queue = util::get_cts_object::queue();
       // templated approach
@@ -295,11 +295,6 @@ class TEST_NAME : public util::test_base {
         test_id<3> test3d;
         test3d(log, range_3d_g, range_3d_l, my_queue);
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/id/id_constructors.cpp
+++ b/tests/id/id_constructors.cpp
@@ -31,7 +31,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // check default constructors
 
       // dim 1
@@ -285,11 +285,6 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "id with item was not constructed correctly for dim = 3");
         }
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/image/image_api.cpp
+++ b/tests/image/image_api.cpp
@@ -28,7 +28,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // Ensure the image always has 64 elements
       const int elemsPerDim1 = 64;
       const int elemsPerDim2 = 8;
@@ -94,11 +94,6 @@ class TEST_NAME : public util::test_base {
         check_enum_class_value(sycl::image_channel_type::fp16);
         check_enum_class_value(sycl::image_channel_type::fp32);
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/image/image_api_fp16.cpp
+++ b/tests/image/image_api_fp16.cpp
@@ -41,7 +41,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp16)) {
@@ -79,11 +79,6 @@ class TEST_NAME : public util::test_base {
         check_allocs(log, img_2d, range_2d, &pitch_1d);
         check_allocs(log, img_3d, range_3d, &pitch_2d);
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/image/image_constructors.cpp
+++ b/tests/image/image_constructors.cpp
@@ -661,7 +661,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // Ensure the image always has 64 elements
       const int elemsPerDim1 = 64;
       const int elemsPerDim2 = 8;
@@ -697,11 +697,6 @@ class TEST_NAME : public util::test_base {
       img_1d_with_properties(log, range_1d, propList);
       img_2d_with_properties(log, range_2d, propList, &pitch_1d);
       img_3d_with_properties(log, range_3d, propList, &pitch_2d);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/invoke/invoke_kernel_param_sizes.cpp
+++ b/tests/invoke/invoke_kernel_param_sizes.cpp
@@ -70,7 +70,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto sycl_queue = util::get_cts_object::queue();
 
       bool pass = true;
@@ -190,11 +190,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       if (!pass) FAIL(log, "one or more type size mismatches");
 
       sycl_queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/invoke/invoke_kernel_params.cpp
+++ b/tests/invoke/invoke_kernel_params.cpp
@@ -87,7 +87,7 @@ class TEST_NAME : public util::test_base {
     {
       uint32_t result = 0;
 
-      try {
+      {
         auto my_queue = util::get_cts_object::queue();
 
         sycl::buffer<uint32_t> buf_result(&result, sycl::range<1>(1));
@@ -122,11 +122,6 @@ class TEST_NAME : public util::test_base {
         });
 
         my_queue.wait_and_throw();
-      } catch (const sycl::exception &e) {
-        log_exception(log, e);
-        std::string errorMsg =
-            "a SYCL exception was caught: " + std::string(e.what());
-        FAIL(log, errorMsg.c_str());
       }
 
       if (!CHECK_VALUE_SCALAR(log, result, static_cast<decltype(result)>(1))) {
@@ -137,7 +132,7 @@ class TEST_NAME : public util::test_base {
     {
       uint32_t result = 0;
 
-      try {
+      {
         auto my_queue = util::get_cts_object::queue();
 
         sycl::buffer<uint32_t> buf_result(&result, sycl::range<1>(1));
@@ -165,11 +160,6 @@ class TEST_NAME : public util::test_base {
         });
 
         my_queue.wait_and_throw();
-      } catch (const sycl::exception &e) {
-        log_exception(log, e);
-        std::string errorMsg =
-            "a SYCL exception was caught: " + std::string(e.what());
-        FAIL(log, errorMsg.c_str());
       }
 
       if (!CHECK_VALUE_SCALAR(log, result, static_cast<decltype(result)>(1))) {

--- a/tests/invoke/invoke_template_kernels.cpp
+++ b/tests/invoke/invoke_template_kernels.cpp
@@ -63,7 +63,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto sycl_queue = util::get_cts_object::queue();
 
       static const float test_float_value = 10;
@@ -118,11 +118,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       }
 
       sycl_queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/item/item_1d.cpp
+++ b/tests/item/item_1d.cpp
@@ -88,7 +88,7 @@ bool test_item_1d(util::logger &log) {
   /*  */
   buffer_fill(dataIn.get(), nWidth);
 
-  try {
+  {
     sycl::range<1> dataRange(nWidth);
 
     sycl::buffer<int, 1> bufIn(dataIn.get(), dataRange);
@@ -106,12 +106,6 @@ bool test_item_1d(util::logger &log) {
     });
 
     cmdQueue.wait_and_throw();
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
-    return false;
   }
 
   /*  */

--- a/tests/item/item_2d.cpp
+++ b/tests/item/item_2d.cpp
@@ -100,7 +100,7 @@ bool test_item_2d(util::logger &log) {
   /*  */
   buffer_fill(dataIn.get(), nWidth, nHeight);
 
-  try {
+  {
     sycl::range<2> dataRange_i(nWidth, nHeight);
     sycl::range<2> dataRange_o(nWidth, nHeight);
 
@@ -121,12 +121,6 @@ bool test_item_2d(util::logger &log) {
     });
 
     cmdQueue.wait_and_throw();
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
-    return false;
   }
 
   if (buffer_verify(dataOut.get(), nWidth, nHeight)) {

--- a/tests/item/item_3d.cpp
+++ b/tests/item/item_3d.cpp
@@ -105,7 +105,7 @@ bool test_item_3d(util::logger &log) {
 
   buffer_fill(dataIn.get(), nWidth, nHeight, nDepth);
 
-  try {
+  {
     sycl::range<3> dataRange(nWidth, nHeight, nDepth);
 
     sycl::buffer<int, 3> bufIn(dataIn.get(), dataRange);
@@ -125,12 +125,6 @@ bool test_item_3d(util::logger &log) {
     });
 
     cmdQueue.wait_and_throw();
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg.c_str());
-    return false;
   }
 
   if (buffer_verify(dataOut.get(), nWidth, nHeight, nDepth)) {

--- a/tests/item/item_constructors.cpp
+++ b/tests/item/item_constructors.cpp
@@ -87,7 +87,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_constructors(util::logger& log) {
-    try {
+    {
       success_array_t success;
       std::fill(std::begin(success), std::end(success), true);
 
@@ -141,11 +141,6 @@ class TEST_NAME : public util::test_base {
       CHECK_VALUE(log,
                   success[static_cast<size_t>(current_check::move_assignment)],
                   true, numDims);
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 

--- a/tests/item/item_equality.cpp
+++ b/tests/item/item_equality.cpp
@@ -48,7 +48,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_equality(util::logger& log) {
-    try {
+    {
       using item_t = sycl::item<numDims>;
 
       // item is not default constructible, store two objects
@@ -134,12 +134,6 @@ class TEST_NAME : public util::test_base {
       CHECK_VALUE(log,
                   success[static_cast<size_t>(current_check::not_equal_other)],
                   true, numDims);
-
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 

--- a/tests/kernel/kernel_api.cpp
+++ b/tests/kernel/kernel_api.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto ctsQueue = util::get_cts_object::queue();
       const auto isHostCtx = ctsQueue.is_host();
       auto deviceList = ctsQueue.get_context().get_devices();
@@ -51,11 +51,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       // Check get_context()
       auto cxt = kernel.get_context();
       check_return_type<sycl::context>(log, cxt, "sycl::kernel::get_context()");
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/kernel/kernel_constructors.cpp
+++ b/tests/kernel/kernel_constructors.cpp
@@ -35,7 +35,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /* Test copy constructor
        */
       {
@@ -273,11 +273,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
         ctsQueue.wait_and_throw();
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -28,7 +28,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       auto deviceList = queue.get_context().get_devices();
       auto ctx = queue.get_context();
@@ -91,11 +91,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       TEST_TYPE_TRAIT(kernel, attributes, kernel);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/kernel_args/kernel_args.cpp
+++ b/tests/kernel_args/kernel_args.cpp
@@ -44,7 +44,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // Test values
       int testScalar = 1;
       auto testVec = sycl::vec<int, 4>(1, 2, 3, 4);
@@ -124,11 +124,6 @@ class TEST_NAME : public util::test_base {
           }
         }
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/multi_ptr/multi_ptr_api.cpp
+++ b/tests/multi_ptr/multi_ptr_api.cpp
@@ -32,7 +32,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       auto types = named_type_pack<bool, float, double, char,   // types grouped
@@ -55,10 +55,6 @@ class TEST_NAME : public util::test_base {
       check_pointer_api<user_struct>{}(log, queue, "user_struct");
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/multi_ptr/multi_ptr_api_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_api_fp16.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp16)) {
@@ -43,10 +43,6 @@ class TEST_NAME : public util::test_base {
       check_pointer_api<sycl::half>{}(log, queue, "sycl::half");
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/multi_ptr/multi_ptr_constructors.cpp
+++ b/tests/multi_ptr/multi_ptr_constructors.cpp
@@ -32,7 +32,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       auto types = named_type_pack<bool, float, double, char,   // types grouped
@@ -55,10 +55,6 @@ class TEST_NAME : public util::test_base {
       check_pointer_ctors<user_struct>{}(queue, "user_struct");
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/multi_ptr/multi_ptr_constructors_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_constructors_fp16.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp16)) {
@@ -43,10 +43,6 @@ class TEST_NAME : public util::test_base {
       check_pointer_ctors<sycl::half>{}(queue, "sycl::half");
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/nd_item/nd_item_api.cpp
+++ b/tests/nd_item/nd_item_api.cpp
@@ -320,17 +320,12 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto cmd_queue = util::get_cts_object::queue();
 
       test_item(log, cmd_queue);
 
       cmd_queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp16)) {
@@ -39,11 +39,6 @@ class TEST_NAME : public util::test_base {
           "sycl::half");
       for_type_and_vectors<check_type, sycl::cl_half>(queue, log,
           "sycl::cl_half");
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp64)) {
@@ -39,11 +39,6 @@ class TEST_NAME : public util::test_base {
           "double");
       for_type_and_vectors<check_type, sycl::cl_double>(queue, log,
           "sycl::cl_double");
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/nd_item/nd_item_combined_barrier.cpp
+++ b/tests/nd_item/nd_item_combined_barrier.cpp
@@ -42,7 +42,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto cmdQueue = util::get_cts_object::queue();
 
       // Verify global_and_local barrier works for local address space
@@ -66,11 +66,6 @@ class TEST_NAME : public util::test_base {
           log, cmdQueue, barrierCall<3>(), errorMsg);
 
       cmdQueue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_combined_mem_fence.cpp
+++ b/tests/nd_item/nd_item_combined_mem_fence.cpp
@@ -88,7 +88,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       test_mem_fence<access_group::useDefault, 1>(log, queue);
@@ -96,11 +96,6 @@ class TEST_NAME : public util::test_base {
       test_mem_fence<access_group::useSeparate, 1>(log, queue);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_constructors.cpp
+++ b/tests/nd_item/nd_item_constructors.cpp
@@ -174,7 +174,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_constructors(util::logger& log) {
-    try {
+    {
       success_array_t success;
       std::fill(std::begin(success), std::end(success), true);
 
@@ -287,11 +287,6 @@ class TEST_NAME : public util::test_base {
       CHECK_VALUE(log,
                   success[to_integral(current_check::move_assignment)],
                   true, numDims);
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 

--- a/tests/nd_item/nd_item_default_barrier.cpp
+++ b/tests/nd_item/nd_item_default_barrier.cpp
@@ -42,7 +42,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto cmdQueue = util::get_cts_object::queue();
 
       // Verify default barrier works as fence for local address space
@@ -66,11 +66,6 @@ class TEST_NAME : public util::test_base {
           log, cmdQueue, barrierCall<3>(), errorMsg);
 
       cmdQueue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_default_mem_fence.cpp
+++ b/tests/nd_item/nd_item_default_mem_fence.cpp
@@ -87,7 +87,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       test_mem_fence<access_group::useDefault, 1>(log, queue);
@@ -95,11 +95,6 @@ class TEST_NAME : public util::test_base {
       test_mem_fence<access_group::useSeparate, 1>(log, queue);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_equality.cpp
+++ b/tests/nd_item/nd_item_equality.cpp
@@ -33,7 +33,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_equality(util::logger& log) {
-    try {
+    {
       using item_t = sycl::nd_item<numDims>;
 
       // nd_item is not default constructible, store two objects into the array
@@ -51,11 +51,6 @@ class TEST_NAME : public util::test_base {
       check_equality_comparable_generic(log, items[0],
                                         "nd_item " + std::to_string(numDims) +
                                         " (host)");
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 

--- a/tests/nd_item/nd_item_global_barrier.cpp
+++ b/tests/nd_item/nd_item_global_barrier.cpp
@@ -39,7 +39,7 @@ class TEST_NAME : public util::test_base {
    *  @param log, test transcript logging class
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto cmdQueue = util::get_cts_object::queue();
 
       // Verify global barrier works as fence for global address space
@@ -53,11 +53,6 @@ class TEST_NAME : public util::test_base {
           log, cmdQueue, barrierCall<3>(), errorMsg);
 
       cmdQueue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_global_mem_fence.cpp
+++ b/tests/nd_item/nd_item_global_mem_fence.cpp
@@ -75,7 +75,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       test_mem_fence<access_group::useDefault, 1>(log, queue);
@@ -83,11 +83,6 @@ class TEST_NAME : public util::test_base {
       test_mem_fence<access_group::useSeparate, 1>(log, queue);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_local_barrier.cpp
+++ b/tests/nd_item/nd_item_local_barrier.cpp
@@ -44,7 +44,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto cmdQueue = util::get_cts_object::queue();
 
       // Verify local barrier works as fence for local address space
@@ -58,11 +58,6 @@ class TEST_NAME : public util::test_base {
           log, cmdQueue, barrierCall<3>(), errorMsg);
 
       cmdQueue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_local_mem_fence.cpp
+++ b/tests/nd_item/nd_item_local_mem_fence.cpp
@@ -75,7 +75,7 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       test_mem_fence<access_group::useDefault, 1>(log, queue);
@@ -83,11 +83,6 @@ class TEST_NAME : public util::test_base {
       test_mem_fence<access_group::useSeparate, 1>(log, queue);
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_item/nd_item_wait_for.cpp
+++ b/tests/nd_item/nd_item_wait_for.cpp
@@ -45,15 +45,10 @@ class TEST_NAME : public util::test_base {
   *  @param log, test transcript logging class
   */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       check_all_dims<check_dim>(queue, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = std::string("a SYCL exception was caught: ") + e.what();
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/nd_range/nd_range_api.cpp
+++ b/tests/nd_range/nd_range_api.cpp
@@ -86,7 +86,7 @@ class TEST_NAME : public util::test_base {
    *  @param log, test transcript logging class
    */
   void run(util::logger &log) override {
-    try {
+    {
       // global size to be set to the size
       sycl::range<1> gs_1d(sizes[0]);
       // local size to be set to 1/4 of the sizes
@@ -112,11 +112,6 @@ class TEST_NAME : public util::test_base {
       sycl::range<3> range_3d(sizes[0] / 8u, sizes[1] / 8u, sizes[2] / 8u);
       sycl::id<3> offset_3d(range_3d);
       test_nd_range(log, gs_3d, ls_3d, offset_3d);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_range/nd_range_constructors.cpp
+++ b/tests/nd_range/nd_range_constructors.cpp
@@ -97,7 +97,7 @@ class TEST_NAME : public util::test_base {
   void run(util::logger &log) override {
     constexpr size_t sizes[] = {16, 32, 64};
 
-    try {
+    {
       // global size to be set to the size
       sycl::range<1> gs_1d(sizes[0]);
       // local size to be set to 1/4 of the sizes
@@ -123,11 +123,6 @@ class TEST_NAME : public util::test_base {
       sycl::range<3> range_3d(sizes[0] / 8u, sizes[1] / 8u, sizes[2] / 8u);
       sycl::id<3> offset_3d(range_3d);
       test_nd_range_constructors(log, gs_3d, ls_3d, offset_3d);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/nd_range/nd_range_equality.cpp
+++ b/tests/nd_range/nd_range_equality.cpp
@@ -63,7 +63,7 @@ class TEST_NAME : public util::test_base {
 
   template <int numDims>
   void test_equality(util::logger& log) {
-    try {
+    {
       // Prepare ranges
       const auto range2 = util::get_cts_object::range<numDims>::get(2, 1, 1);
       const auto range4 = util::get_cts_object::range<numDims>::get(4, 1, 1);
@@ -135,12 +135,6 @@ class TEST_NAME : public util::test_base {
                   numDims);
       CHECK_VALUE(log, success[current_check::not_equal_other_same_local], true,
                   numDims);
-
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 

--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -39,7 +39,7 @@ class TEST_NAME :
    */
   void run(util::logger &log) override {
 #ifdef SYCL_BACKEND_OPENCL
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (queue.get_backend() != sycl::backend::opencl) {
         log.note("Interop part is not supported on non-OpenCL backend types");
@@ -393,12 +393,6 @@ class TEST_NAME :
           FAIL(log, "event was not constructed correctly");
         }
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
 #else
     log.note("The test is skipped because OpenCL back-end is not supported");

--- a/tests/opencl_interop/opencl_interop_get.cpp
+++ b/tests/opencl_interop/opencl_interop_get.cpp
@@ -39,7 +39,7 @@ class TEST_NAME :
    */
   void run(util::logger &log) override {
 #ifdef SYCL_BACKEND_OPENCL
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (queue.get_backend() != sycl::backend::opencl) {
         log.note("Interop part is not supported on non-OpenCL backend types");
@@ -204,12 +204,6 @@ class TEST_NAME :
 
         ctsQueue.wait_and_throw();
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
 #else
     log.note("The test is skipped because OpenCL back-end is not supported");

--- a/tests/opencl_interop/opencl_interop_kernel.cpp
+++ b/tests/opencl_interop/opencl_interop_kernel.cpp
@@ -45,7 +45,7 @@ class TEST_NAME :
    */
   void run(util::logger &log) override {
 #ifdef SYCL_BACKEND_OPENCL
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (queue.get_backend() != sycl::backend::opencl) {
         log.note("Interop part is not supported on non-OpenCL backend types");
@@ -161,12 +161,6 @@ class TEST_NAME :
       }
 
       // TODO: add checks to sampled_image_accessor, unsampled_image_accessor
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
 #else
     log.note("The test is skipped because OpenCL back-end is not supported");

--- a/tests/platform/platform_api.cpp
+++ b/tests/platform/platform_api.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       /** check get_devices() member function
       */
       {
@@ -97,11 +97,6 @@ class TEST_NAME : public util::test_base {
         check_return_type<std::vector<sycl::platform>>(
             log, plt, "platform::get_platform()");
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/platform/platform_constructors.cpp
+++ b/tests/platform/platform_constructors.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       /** check default constructor and destructor
       */
       {
@@ -157,12 +157,6 @@ class TEST_NAME : public util::test_base {
                "platform hash_class does not work correctly (copy assigned)");
         }
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/platform/platform_info.cpp
+++ b/tests/platform/platform_info.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check info::platform
        */
       check_enum_class_value(sycl::info::platform::profile);
@@ -52,12 +52,6 @@ class TEST_NAME : public util::test_base {
                              std::vector<std::string>,
                              sycl::info::platform::extensions>(log, plt);
       }
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/pointers/kernel_pointers.cpp
+++ b/tests/pointers/kernel_pointers.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto my_queue = util::get_cts_object::queue();
 
       typedef int res_type;
@@ -58,11 +58,6 @@ class TEST_NAME : public util::test_base {
       }
 
       my_queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/queue/queue_api.cpp
+++ b/tests/queue/queue_api.cpp
@@ -31,7 +31,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check is_host() member function
        */
       {
@@ -133,11 +133,6 @@ class TEST_NAME : public util::test_base {
 
         queue.throw_asynchronous();
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/queue/queue_constructors.cpp
+++ b/tests/queue/queue_constructors.cpp
@@ -27,7 +27,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check default constructor and destructor
       */
       { sycl::queue queue; }
@@ -415,11 +415,6 @@ class TEST_NAME : public util::test_base {
                "failed)");
         }
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/queue/queue_info.cpp
+++ b/tests/queue/queue_info.cpp
@@ -27,7 +27,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       /** check sycl::info::queue
       */
       check_enum_class_value(sycl::info::queue::reference_count);
@@ -47,11 +47,6 @@ class TEST_NAME : public util::test_base {
         check_get_info_param<sycl::info::queue, sycl::device,
                              sycl::info::queue::device>(log, queue);
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/queue/queue_properties.cpp
+++ b/tests/queue/queue_properties.cpp
@@ -27,7 +27,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   virtual void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       /** check property::queue::enable_profiling
@@ -52,11 +52,6 @@ class TEST_NAME : public util::test_base {
             "sycl::queue::has_property<sycl::property::queue::"
             "enable_profiling>()");
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/range/range_api.cpp
+++ b/tests/range/range_api.cpp
@@ -293,7 +293,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // use across all the dimensions
       auto my_queue = util::get_cts_object::queue();
       // templated approach
@@ -317,11 +317,6 @@ class TEST_NAME : public util::test_base {
         test_range<3> test3d;
         test3d(log, range_3d_g, range_3d_l, my_queue);
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/range/range_constructors.cpp
+++ b/tests/range/range_constructors.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
    *  @param log, test transcript logging class
    */
   void run(util::logger &log) override {
-    try {
+    {
       // use across all the dimensions
       size_t sizes[] = {16, 8, 4};
 
@@ -164,11 +164,6 @@ class TEST_NAME : public util::test_base {
         check_equality_comparable_generic(log, range_explicit,
                                           std::string("range"));
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/reduction/reduction_with_identity_param_core.cpp
+++ b/tests/reduction/reduction_with_identity_param_core.cpp
@@ -27,15 +27,11 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
 
       for_all_types<reduction_with_identity::run_test_for_type>(
           reduction_common::scalar_types, queue, log);
-    } catch (const sycl::exception& e) {
-      log_exception(log, e);
-      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/reduction/reduction_with_identity_param_fp16.cpp
+++ b/tests/reduction/reduction_with_identity_param_fp16.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp16)) {
         log.note(
@@ -35,10 +35,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       }
       reduction_with_identity::run_test_for_type<sycl::half>()(queue, log,
                                                                "sycl::half");
-    } catch (const cl::sycl::exception& e) {
-      log_exception(log, e);
-      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/reduction/reduction_with_identity_param_fp64.cpp
+++ b/tests/reduction/reduction_with_identity_param_fp64.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp64)) {
         log.note(
@@ -36,10 +36,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       }
       reduction_with_identity::run_test_for_type<double>()(queue, log,
                                                            "double");
-    } catch (const cl::sycl::exception& e) {
-      log_exception(log, e);
-      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/reduction/reduction_with_several_reductions_in_kernel.cpp
+++ b/tests/reduction/reduction_with_several_reductions_in_kernel.cpp
@@ -26,13 +26,9 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       reduction_with_several_reductions_in_kernel_h::run_all_tests(queue, log);
-    } catch (const cl::sycl::exception& e) {
-      log_exception(log, e);
-      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/sampler/sampler_api.cpp
+++ b/tests/sampler/sampler_api.cpp
@@ -26,7 +26,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       // Ensure all addressing_mode values defined
       check_enum_class_value(sycl::addressing_mode::mirrored_repeat);
       check_enum_class_value(sycl::addressing_mode::repeat);
@@ -63,12 +63,6 @@ class TEST_NAME : public util::test_base {
       auto filterMode = sampler.get_filtering_mode();
       check_return_type<sycl::filtering_mode>(log, filterMode,
                                                   "get_filtering_mode()");
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/sampler/sampler_constructors.cpp
+++ b/tests/sampler/sampler_constructors.cpp
@@ -34,7 +34,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
   */
   void run(util::logger &log) override {
-    try {
+    {
       /** check (bool, addressing_mode, filtering_mode)
       * constructor and destructor
       */
@@ -245,11 +245,6 @@ class TEST_NAME : public util::test_base {
                "failed)");
         }
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/scalars/scalars_interopability_types.cpp
+++ b/tests/scalars/scalars_interopability_types.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // Integral Interop Data Types
       if (!check_type_min_size<cl_bool>(1)) {
         FAIL(log,
@@ -191,12 +191,6 @@ class TEST_NAME : public util::test_base {
       }
 
       myQueue.wait_and_throw();
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/scalars/scalars_sycl_types.cpp
+++ b/tests/scalars/scalars_sycl_types.cpp
@@ -32,7 +32,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       unsigned int host_size_t_size = sizeof(size_t);
 
       // SYCL Integral Data Types
@@ -219,12 +219,6 @@ class TEST_NAME : public util::test_base {
       }
 
       myQueue.wait_and_throw();
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_class_with_member_fun.cpp
+++ b/tests/specialization_constants/specialization_constants_class_with_member_fun.cpp
@@ -37,7 +37,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       sycl::range<1> range(1);
       const int val_A = 3;
@@ -73,16 +73,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
         FAIL(log,
              "case specialization constants with class with a member function "
              "that accesses members");
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      auto errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_defined_various_ways.h
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways.h
@@ -163,7 +163,7 @@ class check_specialization_constants_defined_various_ways_for_type {
 template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_defined_various_ways;
-  try {
+  {
 #ifndef SYCL_CTS_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_defined_various_ways_for_type,
                   via_kb>(get_spec_const::testing_types::types, log);
@@ -174,22 +174,13 @@ static void sc_run_test_core(util::logger &log) {
 #endif
     for_all_types<check_specialization_constants_defined_various_ways_for_type,
                   via_kb>(get_spec_const::testing_types::composite_types, log);
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 
 template <typename via_kb>
 static void sc_run_test_fp16(util::logger &log) {
   using namespace specialization_constants_defined_various_ways;
-  try {
+  {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp16)) {
       log.note(
@@ -207,22 +198,13 @@ static void sc_run_test_fp16(util::logger &log) {
         check_specialization_constants_defined_various_ways_for_type,
         sycl::half, via_kb>(log, "sycl::half");
 #endif
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 
 template <typename via_kb>
 static void sc_run_test_fp64(util::logger &log) {
   using namespace specialization_constants_defined_various_ways;
-  try {
+  {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp64)) {
       log.note(
@@ -239,15 +221,6 @@ static void sc_run_test_fp64(util::logger &log) {
         check_specialization_constants_defined_various_ways_for_type, double,
         via_kb>(log, "double");
 #endif
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_core.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_core.cpp
@@ -28,7 +28,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
 #ifndef SYCL_CTS_FULL_CONFORMANCE
       for_all_types<check_spec_constant_exception_throw_for_type>(
           get_spec_const::testing_types::types, log);
@@ -38,15 +38,6 @@ class TEST_NAME : public util::test_base {
 #endif
       for_all_types<check_spec_constant_exception_throw_for_type>(
           get_spec_const::testing_types::composite_types, log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was thrown: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was thrown: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_fp16.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp16)) {
         log.note(
@@ -45,16 +45,6 @@ class TEST_NAME : public util::test_base {
       for_type_vectors_marray<check_spec_constant_exception_throw_for_type,
                               sycl::half>(log, "sycl::half");
 #endif
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was thrown: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was thrown: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_fp64.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp64)) {
         log.note(
@@ -45,16 +45,6 @@ class TEST_NAME : public util::test_base {
       for_type_vectors_marray<check_spec_constant_exception_throw_for_type,
                               double>(log, "double");
 #endif
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was thrown: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was thrown: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_external_core.cpp
+++ b/tests/specialization_constants/specialization_constants_external_core.cpp
@@ -35,7 +35,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     log.note("SYCL_EXTERNAL is not defined");
 #else
     using namespace specialization_constants_external;
-    try {
+    {
 
 #ifndef SYCL_CTS_FULL_CONFORMANCE
       for_all_types<check_specialization_constants_external>(
@@ -46,16 +46,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #endif
       for_all_types<check_specialization_constants_external>(
           get_spec_const::testing_types::composite_types, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
 #endif  // SYCL_EXTERNAL
   }

--- a/tests/specialization_constants/specialization_constants_external_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_external_fp16.cpp
@@ -36,7 +36,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     log.note("SYCL_EXTERNAL is not defined");
 #else
     using namespace specialization_constants_external;
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp16)) {
         log.note(
@@ -51,16 +51,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       for_type_vectors_marray<check_specialization_constants_external,
                               sycl::half>(log, "sycl::half");
 #endif
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
 #endif  // SYCL_EXTERNAL
   }

--- a/tests/specialization_constants/specialization_constants_external_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_external_fp64.cpp
@@ -36,7 +36,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     log.note("SYCL_EXTERNAL is not defined");
 #else
     using namespace specialization_constants_external;
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp64)) {
         log.note(
@@ -51,16 +51,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       for_type_vectors_marray<check_specialization_constants_external, double>(
           log, "double");
 #endif
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
 #endif  // SYCL_EXTERNAL
   }

--- a/tests/specialization_constants/specialization_constants_multiple.h
+++ b/tests/specialization_constants/specialization_constants_multiple.h
@@ -129,7 +129,7 @@ class check_specialization_constants_multiple_for_type {
 template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_multiple;
-  try {
+  {
 #ifndef SYCL_CTS_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_multiple_for_type, via_kb>(
         get_spec_const::testing_types::types, log);
@@ -140,22 +140,13 @@ static void sc_run_test_core(util::logger &log) {
 #endif
     for_all_types<check_specialization_constants_multiple_for_type, via_kb>(
         get_spec_const::testing_types::composite_types, log);
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 
 template <typename via_kb>
 static void sc_run_test_fp16(util::logger &log) {
   using namespace specialization_constants_multiple;
-  try {
+  {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp16)) {
       log.note(
@@ -171,22 +162,13 @@ static void sc_run_test_fp16(util::logger &log) {
     for_type_vectors_marray<check_specialization_constants_multiple_for_type,
                             sycl::half, via_kb>(log, "sycl::half");
 #endif
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 
 template <typename via_kb>
 static void sc_run_test_fp64(util::logger &log) {
   using namespace specialization_constants_multiple;
-  try {
+  {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp64)) {
       log.note(
@@ -202,15 +184,6 @@ static void sc_run_test_fp64(util::logger &log) {
     for_type_vectors_marray<check_specialization_constants_multiple_for_type,
                             double, via_kb>(log, "double");
 #endif
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 

--- a/tests/specialization_constants/specialization_constants_same_command_group_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_core.cpp
@@ -30,8 +30,7 @@ public:
    */
   void run(util::logger &log) override {
     using namespace specialization_constants_same_command_group_common;
-    try {
-
+    {
 #ifndef SYCL_CTS_FULL_CONFORMANCE
       for_all_types<
           check_specialization_constants_same_command_group>(
@@ -43,16 +42,6 @@ public:
 #endif
       for_all_types<check_specialization_constants_same_command_group>(
           get_spec_const::testing_types::composite_types, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_same_command_group_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_fp16.cpp
@@ -30,7 +30,7 @@ public:
    */
   void run(util::logger &log) override {
     using namespace specialization_constants_same_command_group_common;
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp16)) {
         log.note("Device does not support half precision floating point "
@@ -44,16 +44,6 @@ public:
       for_type_vectors_marray<check_specialization_constants_same_command_group,
                               sycl::half>(log, "sycl::half");
 #endif
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_same_command_group_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_fp64.cpp
@@ -30,7 +30,7 @@ public:
    */
   void run(util::logger &log) override {
     using namespace specialization_constants_same_command_group_common;
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp64)) {
         log.note("Device does not support double precision floating point "
@@ -44,16 +44,6 @@ public:
       for_type_vectors_marray<check_specialization_constants_same_command_group,
                               double>(log, "double");
 #endif
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link.h
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link.h
@@ -114,7 +114,7 @@ class check_specialization_constants_same_name_inter_link_for_type {
 template <int tu_num, typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace spec_const_help;
-  try {
+  {
 #ifndef SYCL_CTS_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_same_name_inter_link_for_type,
                   sc_sn_il_config<tu_num>, via_kb>(
@@ -128,15 +128,6 @@ static void sc_run_test_core(util::logger &log) {
     for_all_types<check_specialization_constants_same_name_inter_link_for_type,
                   sc_sn_il_config<tu_num>, via_kb>(
         get_spec_const::testing_types::composite_types, log);
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 
@@ -144,7 +135,7 @@ static void sc_run_test_core(util::logger &log) {
 template <int tu_num, typename via_kb>
 static void sc_run_test_fp16(util::logger &log) {
   using namespace spec_const_help;
-  try {
+  {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp16)) {
       log.note(
@@ -162,15 +153,6 @@ static void sc_run_test_fp16(util::logger &log) {
         check_specialization_constants_same_name_inter_link_for_type,
         sycl::half, sc_sn_il_config<tu_num>, via_kb>(log, "sycl::half");
 #endif
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 
@@ -178,7 +160,7 @@ static void sc_run_test_fp16(util::logger &log) {
 template <int tu_num, typename via_kb>
 static void sc_run_test_fp64(util::logger &log) {
   using namespace spec_const_help;
-  try {
+  {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp64)) {
       log.note(
@@ -196,15 +178,6 @@ static void sc_run_test_fp64(util::logger &log) {
         check_specialization_constants_same_name_inter_link_for_type, double,
         sc_sn_il_config<tu_num>, via_kb>(log, "double");
 #endif
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 

--- a/tests/specialization_constants/specialization_constants_same_name_stress.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress.h
@@ -181,7 +181,7 @@ class check_specialization_constants_same_name_stress_for_type {
 template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_same_name_stress;
-  try {
+  {
 #ifndef SYCL_CTS_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_same_name_stress_for_type,
                   via_kb>(get_spec_const::testing_types::types, log);
@@ -192,22 +192,13 @@ static void sc_run_test_core(util::logger &log) {
 #endif
     for_all_types<check_specialization_constants_same_name_stress_for_type,
                   via_kb>(get_spec_const::testing_types::composite_types, log);
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 
 template <typename via_kb>
 static void sc_run_test_fp16(util::logger &log) {
   using namespace specialization_constants_same_name_stress;
-  try {
+  {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp16)) {
       log.note(
@@ -224,22 +215,13 @@ static void sc_run_test_fp16(util::logger &log) {
         check_specialization_constants_same_name_stress_for_type, sycl::half,
         via_kb>(log, "sycl::half");
 #endif
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
   }
 }
 
 template <typename via_kb>
 static void sc_run_test_fp64(util::logger &log) {
   using namespace specialization_constants_same_name_stress;
-  try {
+  {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp64)) {
       log.note(
@@ -256,15 +238,7 @@ static void sc_run_test_fp64(util::logger &log) {
         check_specialization_constants_same_name_stress_for_type, double,
         via_kb>(log, "double");
 #endif
-
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
+  }
   }
 }
 

--- a/tests/specialization_constants/specialization_constants_via_handler_core.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_core.cpp
@@ -29,7 +29,7 @@ public:
    */
   void run(util::logger &log) override {
     using namespace specialization_constants_via_handler_common;
-    try {
+    {
 #ifndef SYCL_CTS_FULL_CONFORMANCE
       for_all_types<check_spec_constant_with_handler_for_type>(
           get_spec_const::testing_types::types, log);
@@ -39,16 +39,6 @@ public:
 #endif
       for_all_types<check_spec_constant_with_handler_for_type>(
           get_spec_const::testing_types::composite_types, log);
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_via_handler_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_fp16.cpp
@@ -29,7 +29,7 @@ public:
    */
   void run(util::logger &log) override {
     using namespace specialization_constants_via_handler_common;
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp16)) {
         log.note("Device does not support half precision floating point "
@@ -43,16 +43,6 @@ public:
       for_type_vectors_marray<check_spec_constant_with_handler_for_type,
                               sycl::half>(log, "sycl::half");
 #endif
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_via_handler_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_fp64.cpp
@@ -29,7 +29,7 @@ public:
    */
   void run(util::logger &log) override {
     using namespace specialization_constants_via_handler_common;
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp64)) {
         log.note("Device does not support double precision floating point "
@@ -43,16 +43,6 @@ public:
       for_type_vectors_marray<check_spec_constant_with_handler_for_type,
                               double>(log, "double");
 #endif
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_core.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_core.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
 #ifndef SYCL_CTS_FULL_CONFORMANCE
       for_all_types<check_all>(get_spec_const::testing_types::types, log);
 #else
@@ -39,15 +39,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #endif
       for_all_types<check_all>(get_spec_const::testing_types::composite_types,
                                log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp16.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp16)) {
         log.note(
@@ -42,15 +42,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #else
       for_type_vectors_marray<check_all, sycl::half>(log, "sycl::half");
 #endif
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp64.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       if (!queue.get_device().has(sycl::aspect::fp64)) {
         log.note(
@@ -43,15 +43,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #else
       for_type_vectors_marray<check_all, double>(log, "double");
 #endif
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/stream/stream_api.cpp
+++ b/tests/stream/stream_api.cpp
@@ -115,7 +115,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       /** check sycl::stream_manipulator
       */
       check_enum_class_value(sycl::stream_manipulator::dec);
@@ -302,11 +302,6 @@ class TEST_NAME : public util::test_base {
         check_group_h_item_dims(r31, r32);
 
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/stream/stream_api_fp16.cpp
+++ b/tests/stream/stream_api_fp16.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // Check stream operator for sycl::half
       {
         auto testQueue = util::get_cts_object::queue();
@@ -51,11 +51,6 @@ class TEST_NAME : public util::test_base {
 
         testQueue.wait_and_throw();
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/stream/stream_api_fp64.cpp
+++ b/tests/stream/stream_api_fp64.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       // Check stream operator for sycl::cl_double and double
       auto testQueue = util::get_cts_object::queue();
 
@@ -50,12 +50,6 @@ class TEST_NAME : public util::test_base {
       });
 
       testQueue.wait_and_throw();
-
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/stream/stream_constructors.cpp
+++ b/tests/stream/stream_constructors.cpp
@@ -42,7 +42,7 @@ class TEST_NAME : public util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue = util::get_cts_object::queue();
       size_t bufferSize = 2048;
       size_t maxStatementSize = 80;
@@ -255,11 +255,6 @@ class TEST_NAME : public util::test_base {
       }
 
       queue.wait_and_throw();
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg.c_str());
     }
   }
 };

--- a/tests/usm/usm_allocate_free.h
+++ b/tests/usm/usm_allocate_free.h
@@ -418,17 +418,7 @@ class check_usm_allocate_free {
  */
 template <typename T, typename op>
 static void run_usm_test(util::logger &log) {
-  try {
-    check_usm_allocate_free<T, op>{}(log);
-  } catch (const sycl::exception &e) {
-    log_exception(log, e);
-    std::string errorMsg =
-        "a SYCL exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  } catch (const std::exception &e) {
-    std::string errorMsg = "an exception was caught: " + std::string(e.what());
-    FAIL(log, errorMsg);
-  }
+  { check_usm_allocate_free<T, op>{}(log); }
 }
 
 }  // namespace usm_allocate_free

--- a/tests/usm/usm_allocator_api.cpp
+++ b/tests/usm/usm_allocator_api.cpp
@@ -27,18 +27,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     using namespace usm_allocator_api;
     using TestType = int;
-    try {
-      check_usm_allocator_api<TestType, allocate_general>{}(log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    }
+    { check_usm_allocator_api<TestType, allocate_general>{}(log); }
   }
 };
 

--- a/tests/usm/usm_allocator_api_aligned.cpp
+++ b/tests/usm/usm_allocator_api_aligned.cpp
@@ -27,18 +27,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     using namespace usm_allocator_api;
     using TestType = int;
-    try {
-      check_usm_allocator_api<TestType, allocate_aligned>{}(log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    }
+    { check_usm_allocator_api<TestType, allocate_aligned>{}(log); }
   }
 };
 

--- a/tests/usm/usm_allocator_constructors.cpp
+++ b/tests/usm/usm_allocator_constructors.cpp
@@ -27,18 +27,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     using namespace usm_allocator_constructors;
     using TestType = int;
-    try {
-      check_usm_allocator_constructors<TestType>{}(log);
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      std::string errorMsg =
-          "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      std::string errorMsg =
-          "an exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    }
+    { check_usm_allocator_constructors<TestType>{}(log); }
   }
 };
 

--- a/tests/usm/usm_atomic_access_atomic64.cpp
+++ b/tests/usm/usm_atomic_access_atomic64.cpp
@@ -27,19 +27,12 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue{util::get_cts_object::queue()};
 
       for_all_types<usm_atomic_access::run_all_tests>(
           usm_atomic_access::get_scalar_types(), queue, log,
           usm_atomic_access::with_atomic64);
-    } catch (const cl::sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      auto errorMsg = "a std exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/usm/usm_atomic_access_core.cpp
+++ b/tests/usm/usm_atomic_access_core.cpp
@@ -27,19 +27,12 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue{util::get_cts_object::queue()};
 
       for_all_types<usm_atomic_access::run_all_tests>(
           usm_atomic_access::get_scalar_types(), queue, log,
           usm_atomic_access::without_atomic64);
-    } catch (const cl::sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
-    } catch (const std::exception &e) {
-      auto errorMsg = "a std exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/usm/usm_fill_memset_memcpy.cpp
+++ b/tests/usm/usm_fill_memset_memcpy.cpp
@@ -27,7 +27,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto q = util::get_cts_object::queue();
       if (!q.get_device().has(sycl::aspect::usm_shared_allocations)) {
         log.note(
@@ -67,10 +67,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       for (int i = 1; i < count; i++) {
         CHECK_VALUE_SCALAR(log, output.get()[i], value_for_filling);
       }
-    } catch (const sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -56,7 +56,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger &log) override {
-    try {
+    {
       auto queue{util::get_cts_object::queue()};
 
       {
@@ -73,11 +73,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       run_check<sycl::usm::alloc::shared>(queue, log);
       run_check<sycl::usm::alloc::device>(queue, log);
       run_check<sycl::usm::alloc::host>(queue, log);
-
-    } catch (const cl::sycl::exception &e) {
-      log_exception(log, e);
-      auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
-      FAIL(log, errorMsg);
     }
   }
 };

--- a/util/executor.cpp
+++ b/util/executor.cpp
@@ -52,7 +52,7 @@ bool executor::run_all() {
         // ask the test to set itself up
         if (test->setup(logger)) {
           // ask the test to execute
-          test->run(logger);
+          test->run_test(logger);
         }
         // enforce that each test must give a result
         assert(logger.get_result() != logger::epending);

--- a/util/test_base.cpp
+++ b/util/test_base.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provide implementation of test_base class functions
+//
+*******************************************************************************/
+
+#include "test_base.h"
+
+#include <sycl/sycl.hpp>
+
+#include "../tests/common/macros.h"
+#include "logger.h"
+
+// conformance test suite namespace
+namespace sycl_cts {
+namespace util {
+
+void test_base::run_test(class logger &log) {
+  try {
+    this->run(log);
+  } catch (const sycl::exception &e) {
+    log_exception(log, e);
+    auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  } catch (const std::exception &e) {
+    auto errorMsg = "an exception was caught: " + std::string(e.what());
+    FAIL(log, errorMsg);
+  }
+}
+
+}  // namespace util
+}  // namespace sycl_cts

--- a/util/test_base.h
+++ b/util/test_base.h
@@ -9,6 +9,8 @@
 #ifndef __SYCLCTS_UTIL_TEST_BASE_H
 #define __SYCLCTS_UTIL_TEST_BASE_H
 
+#include <string>
+
 // conformance test suite namespace
 namespace sycl_cts {
 namespace util {
@@ -41,15 +43,17 @@ class test_base {
   /** called before this test is executed
    *  @param log for emitting test notes and results
    */
-  virtual bool setup(class logger &) {
-    // stub
-    return true;
-  }
+  virtual bool setup(class logger &) { return true; }
 
-  /** execute this test
+  /** member function that will be overridden in test file
    *  @param log for emitting test notes and results
    */
   virtual void run(class logger &log) = 0;
+
+  /** overridden member function with try-catch block
+   *  @param log for emitting test notes and results
+   */
+  void run_test(class logger &log);
 
   /** called after this test has executed
    *  @param log for emitting test notes and results


### PR DESCRIPTION
This is essentially the same as #167, but by keeping the `try-catch` blocks' curly braces around, (almost) no formatting changes are required. This makes the patch easier to review and less error prone. Includes changes by @vasilytric that move the `try-catch` block to a new `test_base.cpp` file; I've taken the liberty of squashing some of the later fixes. I've confirmed that the set of tests that compiles for each of the three SYCL implementations remains unchanged.

Includes #189 to allow for CI to pass.

Supersedes #167.
