### PR TITLE
Remove /subsystem:console from LINK_FLAGS for DPC++ on Windows

### DIFF
--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -8,8 +8,8 @@ else()
     string(REPLACE "/machine:x64" "" CMAKE_EXE_LINKER_FLAGS
         "${CMAKE_EXE_LINKER_FLAGS}")
     # Remove /subsystem option which is not supported by clang-cl
-    string(REPLACE "/subsystem:console" "" CMAKE_CREATE_CONSOLE_EXE
-        ${CMAKE_CREATE_CONSOLE_EXE})
+    string(REPLACE "/subsystem:console" "" CMAKE_CXX_CREATE_CONSOLE_EXE
+        "${CMAKE_CXX_CREATE_CONSOLE_EXE}")
     find_program(DPCPP_CXX_EXECUTABLE NAMES dpcpp clang-cl
         HINTS ${DPCPP_INSTALL_DIR}
         PATH_SUFFIXES bin)


### PR DESCRIPTION
The clang-cl compiler doesn't support the '/subsystem:console' link flag.
CMake sets up the flag in the 'CMAKE_CXX_CREATE_CONSOLE_EXE' variable,
not in CMAKE_CREATE_CONSOLE_EXE one (I'm not sure in which CMake version
the variable was changed.) The patch replaces the flag in the
CMAKE_CXX_CREATE_CONSOLE_EXE with an empty string.