### PR TITLE
Fix/improve conformance report generation script

### DIFF
--- a/run_conformance_tests.py
+++ b/run_conformance_tests.py
@@ -29,14 +29,12 @@ def handle_args(argv):
     parser.add_argument(
         '-a',
         '--additional-cmake-args',
-        help=
-        'Additional args to hand to CMake required by the tested implementation.',
+        help='Additional args to hand to CMake required by the tested implementation.',
         type=str)
     parser.add_argument(
         '-b',
         '--build-system-name',
-        help=
-        'The name of the build system as known by CMake, for example \'Ninja\'.',
+        help='The name of the build system as known by CMake, for example \'Ninja\'.',
         type=str,
         required=True)
     parser.add_argument(
@@ -51,34 +49,19 @@ def handle_args(argv):
         required=False,
         action='store_true')
     parser.add_argument(
-        '-f',
-        '--conformance-filter',
-        help='The conformance filter to use.',
+        '-e',
+        '--exclude-categories',
+        help='List of test categories to',
         type=str,
-        required=True)
+        required=False)
     parser.add_argument(
         '--fast',
         help='Disable full conformance mode to avoid extensive tests.',
         required=False,
         action='store_true')
     parser.add_argument(
-        '--host-platform-name',
-        help='The name of the host platform to test on.',
-        type=str,
-        required=True)
-    parser.add_argument(
-        '--host-device-name',
-        help='The name of the host device to test on.',
-        type=str,
-        required=True)
-    parser.add_argument(
-        '--opencl-platform-name',
-        help='The name of the opencl platform to test on.',
-        type=str,
-        required=True)
-    parser.add_argument(
-        '--opencl-device-name',
-        help='The name of the opencl device to test on.',
+        '--device',
+        help='Select SYCL device to run CTS on. ECMAScript regular expression syntax can be used.',
         type=str,
         required=True)
     parser.add_argument(
@@ -93,14 +76,13 @@ def handle_args(argv):
                         type=str)
     args = parser.parse_args(argv)
 
-    host_names = (args.host_platform_name, args.host_device_name)
-    opencl_names = (args.opencl_platform_name, args.opencl_device_name)
     full_conformance = 'OFF' if args.fast else 'ON'
 
     return (args.cmake_exe, args.build_system_name, args.build_system_call,
-            full_conformance, args.implementation_name,
-            args.additional_cmake_args, host_names, opencl_names,
+            full_conformance, args.exclude_categories, args.implementation_name,
+            args.additional_cmake_args, args.device,
             args.additional_ctest_args, args.build_only)
+
 
 def split_additional_args(additional_args):
     """
@@ -110,25 +92,26 @@ def split_additional_args(additional_args):
     # shlex doesn't support None
     if additional_args is None:
         return []
-    return shlex.split(shlex.quote(additional_args))
+    return shlex.split(additional_args)
+
 
 def generate_cmake_call(cmake_exe, build_system_name, full_conformance,
-                        additional_cmake_args, host_names,
-                        opencl_names):
+                        exclude_categories, additional_cmake_args, device):
     """
     Generates a CMake call based on the input in a form accepted by
     subprocess.call().
     """
-    return [
+    call = [
         cmake_exe,
         '..',
         '-G' + build_system_name,
         '-DSYCL_CTS_ENABLE_FULL_CONFORMANCE=' + full_conformance,
-        '-Dhost_platform_name=' + host_names[0],
-        '-Dhost_device_name=' + host_names[1],
-        '-Dopencl_platform_name=' + opencl_names[0],
-        '-Dopencl_device_name=' + opencl_names[1],
-    ] + split_additional_args(additional_cmake_args)
+        '-DSYCL_CTS_CTEST_DEVICE=' + device,
+    ]
+    if exclude_categories is not None:
+        call += ['-DSYCL_CTS_EXCLUDE_TEST_CATEGORIES=' + exclude_categories]
+    call += split_additional_args(additional_cmake_args)
+    return call
 
 
 def generate_ctest_call(additional_ctest_args):
@@ -174,62 +157,38 @@ def collect_info_filenames():
     Exits the program if no result files are found.
     """
 
-    host_info_filenames = []
-    opencl_info_filenames = []
+    info_filenames = []
 
     # Get all the test results in Testing
     for filename in os.listdir('Testing'):
         filename_full = os.path.join('Testing', filename)
-        if filename.endswith('host.info'):
-            host_info_filenames.append(filename_full)
-        if filename.endswith('opencl.info'):
-            opencl_info_filenames.append(filename_full)
+        if filename.endswith('.info'):
+            info_filenames.append(filename_full)
 
     # Exit if we didn't find any test results
-    if (len(host_info_filenames) == 0 or len(opencl_info_filenames) == 0):
-        print("Fatal error: couldn't find any test result files")
+    if (len(info_filenames) == 0):
+        print("Fatal error: Could not find any device info dumps")
         exit(-1)
 
-    return host_info_filenames, opencl_info_filenames
+    return info_filenames
 
 
-def get_valid_host_json_info(host_info_filenames):
+def get_valid_json_info(info_filenames):
     """
-    Ensures that all the host.info files have the same data, then returns the
+    Ensures that all the .info files have the same data, then returns the
     parsed json.
     """
 
-    reference_host_info = None
-    for host_info_file in host_info_filenames:
-        with open(host_info_file, 'r') as host_info:
-            if reference_host_info is None:
-                reference_host_info = host_info.read()
-            elif host_info.read() != reference_host_info:
-                print('Fatal error: mismatch in host info between tests')
+    reference_info = None
+    for info_file in info_filenames:
+        with open(info_file, 'r') as info:
+            if reference_info is None:
+                reference_info = info.read()
+            elif info.read() != reference_info:
+                print('Fatal error: mismatch in device info dumps between tests')
                 exit(-1)
 
-    return json.loads(reference_host_info)
-
-
-def get_valid_opencl_json_info(opencl_info_filenames):
-    """
-    Ensures that all the opencl.info files have the same data, then returns the
-    parsed json.
-    """
-
-    reference_opencl_info = None
-    for opencl_info_file in opencl_info_filenames:
-        with open(opencl_info_file, 'r') as opencl_info:
-            if reference_opencl_info is None:
-                reference_opencl_info = opencl_info.read()
-            elif opencl_info.read() != reference_opencl_info:
-                print('Fatal error: mismatch in OpenCL info between tests')
-                exit(-1)
-
-    # Some drivers add \x00 to their output.
-    # We have to remove this to parse the json
-    reference_opencl_info = reference_opencl_info.replace('\x00', '')
-    return json.loads(reference_opencl_info)
+    return json.loads(reference_info)
 
 
 def get_xml_test_results():
@@ -245,9 +204,9 @@ def get_xml_test_results():
     return test_xml_tree.getroot()
 
 
-def update_xml_attribs(host_info_json, opencl_info_json, implementation_name,
-                       test_xml_root, full_conformance, cmake_call,
-                       build_system_name, build_system_call, ctest_call):
+def update_xml_attribs(info_json, implementation_name, test_xml_root,
+                       full_conformance, cmake_call, build_system_name,
+                       build_system_call, ctest_call):
     """
     Adds attributes to the root of the xml trees json required by the
     conformance report.
@@ -257,50 +216,21 @@ def update_xml_attribs(host_info_json, opencl_info_json, implementation_name,
 
     # Set Host Device Information attribs
     test_xml_root.attrib["BuildName"] = implementation_name
-    test_xml_root.attrib["HostPlatformName"] = host_info_json['platform-name']
-    test_xml_root.attrib["HostPlatformVendor"] = host_info_json[
+    test_xml_root.attrib["PlatformName"] = info_json['platform-name']
+    test_xml_root.attrib["PlatformVendor"] = info_json[
         'platform-vendor']
-    test_xml_root.attrib["HostPlatformVersion"] = host_info_json[
+    test_xml_root.attrib["PlatformVersion"] = info_json[
         'platform-version']
-    test_xml_root.attrib["HostDeviceName"] = host_info_json['device-name']
-    test_xml_root.attrib["HostDeviceVendor"] = host_info_json['device-vendor']
-    test_xml_root.attrib["HostDeviceVersion"] = host_info_json[
+    test_xml_root.attrib["DeviceName"] = info_json['device-name']
+    test_xml_root.attrib["DeviceVendor"] = info_json['device-vendor']
+    test_xml_root.attrib["DeviceVersion"] = info_json[
         'device-version']
-    test_xml_root.attrib["HostDeviceType"] = host_info_json['device-type']
+    test_xml_root.attrib["DeviceType"] = info_json['device-type']
 
-    # Set Host Device Extension Support attribs
-    test_xml_root.attrib["HostDeviceFP16"] = host_info_json['device-fp16']
-    test_xml_root.attrib["HostDeviceFP64"] = host_info_json['device-fp64']
-    test_xml_root.attrib["HostDeviceInt64Base"] = host_info_json[
-        'device-int64-base']
-    test_xml_root.attrib["HostDeviceInt64Extended"] = host_info_json[
-        'device-int64-extended']
-    test_xml_root.attrib["HostDevice3DWrites"] = host_info_json[
-        'device-3d-writes']
-
-    # Set OpenCL Device Information attribs
-    test_xml_root.attrib["OpenCLPlatformName"] = opencl_info_json[
-        'platform-name']
-    test_xml_root.attrib["OpenCLPlatformVendor"] = opencl_info_json[
-        'platform-vendor']
-    test_xml_root.attrib["OpenCLPlatformVersion"] = opencl_info_json[
-        'platform-version']
-    test_xml_root.attrib["OpenCLDeviceName"] = opencl_info_json['device-name']
-    test_xml_root.attrib["OpenCLDeviceVendor"] = opencl_info_json[
-        'device-vendor']
-    test_xml_root.attrib["OpenCLDeviceVersion"] = opencl_info_json[
-        'device-version']
-
-    # Set OpenCL Device Extension Support attribs
-    test_xml_root.attrib["OpenCLDeviceType"] = opencl_info_json['device-type']
-    test_xml_root.attrib["OpenCLDeviceFP16"] = opencl_info_json['device-fp16']
-    test_xml_root.attrib["OpenCLDeviceFP64"] = opencl_info_json['device-fp64']
-    test_xml_root.attrib["OpenCLDeviceInt64Base"] = opencl_info_json[
-        'device-int64-base']
-    test_xml_root.attrib["OpenCLDeviceInt64Extended"] = opencl_info_json[
-        'device-int64-extended']
-    test_xml_root.attrib["OpenCLDevice3DWrites"] = opencl_info_json[
-        'device-3d-writes']
+    # Set Device Extension Support attribs
+    # TODO: Revisit this for SYCL 2020 aspects
+    test_xml_root.attrib["DeviceFP16"] = info_json['device-fp16']
+    test_xml_root.attrib["DeviceFP64"] = info_json['device-fp64']
 
     # Set Build Information attribs
     test_xml_root.attrib["FullConformanceMode"] = full_conformance
@@ -316,13 +246,13 @@ def main(argv=sys.argv[1:]):
 
     # Parse and gather all the script args
     (cmake_exe, build_system_name, build_system_call, full_conformance,
-     implementation_name, additional_cmake_args, host_names,
-     opencl_names, additional_ctest_args, build_only) = handle_args(argv)
+     exclude_categories, implementation_name, additional_cmake_args, device,
+     additional_ctest_args, build_only) = handle_args(argv)
 
     # Generate a cmake call in a form accepted by subprocess.call()
     cmake_call = generate_cmake_call(cmake_exe, build_system_name,
-                                     full_conformance, additional_cmake_args,
-                                     host_names, opencl_names)
+                                     full_conformance, exclude_categories,
+                                     additional_cmake_args, device)
 
     # Generate a CTest call in a form accepted by subprocess.call()
     ctest_call = generate_ctest_call(additional_ctest_args)
@@ -340,17 +270,15 @@ def main(argv=sys.argv[1:]):
         return error_code
 
     # Collect the test info files, validate them and get the contents as json.
-    host_info_filenames, opencl_info_filenames = collect_info_filenames()
-    host_info_json = get_valid_host_json_info(host_info_filenames)
-    opencl_info_json = get_valid_opencl_json_info(opencl_info_filenames)
+    info_filenames = collect_info_filenames()
+    info_json = get_valid_json_info(info_filenames)
 
     # Get the xml results and update with the necessary information.
     result_xml_root = get_xml_test_results()
-    result_xml_root = update_xml_attribs(host_info_json, opencl_info_json,
-                                         implementation_name, result_xml_root,
-                                         full_conformance, cmake_call,
-                                         build_system_name, build_system_call,
-                                         ctest_call)
+    result_xml_root = update_xml_attribs(info_json, implementation_name,
+                                         result_xml_root, full_conformance,
+                                         cmake_call, build_system_name,
+                                         build_system_call, ctest_call)
 
     # Get the xml report stylesheet and add it to the results.
     stylesheet_xml_file = os.path.join("..", "tools", "stylesheet.xml")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,8 +155,6 @@ function(add_cts_test)
   target_include_directories(${test_exe_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
   set(info_dump_dir "${CMAKE_BINARY_DIR}/Testing")
-  # FIXME: run_conformance_tests.py does not yet set SYCL_CTS_CTEST_DEVICE.
-  # The script is currently broken in more than one way and in need of an overhaul.
   add_test(NAME ${test_exe_name}
            COMMAND ${test_exe_name}
                    --device ${SYCL_CTS_CTEST_DEVICE}

--- a/tools/stylesheet.xml
+++ b/tools/stylesheet.xml
@@ -3,146 +3,129 @@
 <xsl:stylesheet id="stylesheet" version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:template match="/">
-	<html>
-		<head>
-			<title>SYCL 2020 Conformance Report</title>
-			<style type="text/css">
-				body {
-					margin: 40px auto;
-					max-width: 800px;
-					font-size: 18px;
-					font-family: Sans-Serif;
-					padding: 0 10px
-				}
+    <html>
+        <head>
+            <title>SYCL 2020 Conformance Report</title>
+            <style type="text/css">
+                body {
+                    margin: 40px auto;
+                    max-width: 800px;
+                    font-size: 18px;
+                    font-family: Sans-Serif;
+                    padding: 0 10px
+                }
 
-				h1,h2,h3 {
-					line-height: 1.2
-				}
+                h1,h2,h3 {
+                    line-height: 1.2
+                }
 
-				.site-header {
-					font-weight: bold;
-					text-align: center;
-					line-height: 3;
-				}
+                .site-header {
+                    font-weight: bold;
+                    text-align: center;
+                    line-height: 3;
+                }
 
-				table {
-					table-layout: fixed;
-					border-spacing: 0px 2px;
-					width: 100%;
-				}
+                table {
+                    table-layout: fixed;
+                    border-spacing: 0px 2px;
+                    width: 100%;
+                }
 
-				tr td:nth-child(1) {
-   					font-weight: bold;
-   					line-height: 1.6;
-				}
+                tr td:nth-child(1) {
+                    font-weight: bold;
+                    line-height: 1.6;
+                }
 
-				tr td:nth-child(2) {
-   					text-align: right;
-   					line-height: 1.6;
-				}
+                tr td:nth-child(2) {
+                    text-align: right;
+                    line-height: 1.6;
+                }
 
-				th {
-					text-align: center;
-					font-weight: bold;
-					line-height: 2;
-					font-size: 18px;
-				}
+                th {
+                    text-align: center;
+                    font-weight: bold;
+                    line-height: 2;
+                    font-size: 18px;
+                }
 
-				.test-result {
-					background-color: #ef9a9a;
-				}
+                .test-result {
+                    background-color: #ef9a9a;
+                }
 
-				.test-result.passed {
-					background-color: #a5d6a7;
-				}
+                .test-result.passed {
+                    background-color: #a5d6a7;
+                }
 
-				pre {
-					font-family: monospace;
-				}
+                pre {
+                    font-family: monospace;
+                }
 
-				summary {
-					display: flex;
-				}
+                summary {
+                    display: flex;
+                }
 
-				details summary::-webkit-details-marker {
-					margin-top: 10px;
-				}
+                details summary::-webkit-details-marker {
+                    margin-top: 10px;
+                }
 
-			</style>
-		</head>
-		<body>
-			<center>
-				<img src="https://upload.wikimedia.org/wikipedia/en/1/19/Khronos_Group_SYCL_logo.svg" width="500px"/>
-				<h1>SYCL 2020 Conformance Report</h1>
-				<xsl:apply-templates select="Site"/>
-				<h2>Test Results</h2>
-				<xsl:apply-templates select="Site/Testing/Test"/>
-			</center>
-		</body>
-	</html>
+            </style>
+        </head>
+        <body>
+            <center>
+                <img src="https://upload.wikimedia.org/wikipedia/en/1/19/Khronos_Group_SYCL_logo.svg" width="500px"/>
+                <h1>SYCL 2020 Conformance Report</h1>
+                <xsl:apply-templates select="Site"/>
+                <h2>Test Results</h2>
+                <xsl:apply-templates select="Site/Testing/Test"/>
+            </center>
+        </body>
+    </html>
 </xsl:template>
 
 <xsl:template match="Site">
-  <table>
-  	<tr><td class="site-header" colspan="2">Implementation</td></tr>
-  	<tr><td>Name</td><td><xsl:value-of select="./@BuildName" /></td></tr>
-  	<tr><td class="site-header" colspan="2">Host System</td></tr>
-		<tr><td>Date</td><td><xsl:value-of select="/Site/Testing/StartDateTime"/></td></tr>
-  	<tr><td>Operating System</td><td><xsl:value-of select="./@OSName" /></td></tr>
-  	<tr><td>OS Release</td><td><xsl:value-of select="./@OSRelease" /></td></tr>
-  	<tr><td>CPU Architecture</td><td><xsl:value-of select="./@OSPlatform" /></td></tr>
-		<tr><td class="site-header" colspan="2">Host Device Information</td></tr>
-		<tr><td>Host Platform Name</td><td><xsl:value-of select="./@HostPlatformName" /></td></tr>
-		<tr><td>Host Platform Vendor</td><td><xsl:value-of select="./@HostPlatformVendor" /></td></tr>
-		<tr><td>Host Platform Version</td><td><xsl:value-of select="./@HostPlatformVersion" /></td></tr>
-		<tr><td>Host Device Name</td><td><xsl:value-of select="./@HostDeviceName" /></td></tr>
-		<tr><td>Host Device Vendor</td><td><xsl:value-of select="./@HostDeviceVendor" /></td></tr>
-		<tr><td>Host Device Version</td><td><xsl:value-of select="./@HostDeviceVersion" /></td></tr>
-    <tr><td class="site-header" colspan="2">Host Device Extension Support</td></tr>
-    <tr><td>Half Precision Floating Point</td><td><xsl:value-of select="./@HostDeviceFP16" /></td></tr>
-		<tr><td>Double Precision Floating Point</td><td><xsl:value-of select="./@HostDeviceFP64" /></td></tr>
-		<tr><td>Int64 Base Atomics</td><td><xsl:value-of select="./@HostDeviceInt64Base" /></td></tr>
-		<tr><td>Int64 Extended Atomics</td><td><xsl:value-of select="./@HostDeviceInt64Extended" /></td></tr>
-		<tr><td>3D Image Write</td><td><xsl:value-of select="./@HostDevice3DWrites" /></td></tr>
-		<tr><td class="site-header" colspan="2">OpenCL Device Information</td></tr>
-		<tr><td>OpenCL Platform Name</td><td><xsl:value-of select="./@OpenCLPlatformName" /></td></tr>
-		<tr><td>OpenCL Platform Vendor</td><td><xsl:value-of select="./@OpenCLPlatformVendor" /></td></tr>
-		<tr><td>OpenCL Platform Version</td><td><xsl:value-of select="./@OpenCLPlatformVersion" /></td></tr>
-		<tr><td>OpenCL Device Name</td><td><xsl:value-of select="./@OpenCLDeviceName" /></td></tr>
-		<tr><td>OpenCL Device Vendor</td><td><xsl:value-of select="./@OpenCLDeviceVendor" /></td></tr>
-		<tr><td>OpenCL Device Version</td><td><xsl:value-of select="./@OpenCLDeviceVersion" /></td></tr>
-		<tr><td>OpenCL Device Type</td><td><xsl:value-of select="./@OpenCLDeviceType" /></td></tr>
-		<tr><td class="site-header" colspan="2">OpenCL Device Extension Support</td></tr>
-    <tr><td>Half Precision Floating Point</td><td><xsl:value-of select="./@OpenCLDeviceFP16" /></td></tr>
-		<tr><td>Double Precision Floating Point</td><td><xsl:value-of select="./@OpenCLDeviceFP64" /></td></tr>
-		<tr><td>Int64 Base Atomics</td><td><xsl:value-of select="./@OpenCLDeviceInt64Base" /></td></tr>
-		<tr><td>Int64 Extended Atomics</td><td><xsl:value-of select="./@OpenCLDeviceInt64Extended" /></td></tr>
-		<tr><td>3D Image Write</td><td><xsl:value-of select="./@OpenCLDevice3DWrites" /></td></tr>
-		<tr><td class="site-header" colspan="2">Build Information</td></tr>
-		<tr><td>Full Conformance Mode</td><td><xsl:value-of select="./@FullConformanceMode" /></td></tr>
-  	<tr><td>CMake Input</td><td><xsl:value-of select="./@CMakeInput" /></td></tr>
-  	<tr><td>Build System Generator</td><td><xsl:value-of select="./@BuildSystemGenerator" /></td></tr>
-  	<tr><td>Build System Call</td><td><xsl:value-of select="./@BuildSystemCall" /></td></tr>
-  	<tr><td>CTest Call</td><td><xsl:value-of select="./@CTestCall" /></td></tr>
-  </table>  
+    <table>
+        <tr><td class="site-header" colspan="2">Implementation</td></tr>
+        <tr><td>Name</td><td><xsl:value-of select="./@BuildName" /></td></tr>
+        <tr><td class="site-header" colspan="2">Host System</td></tr>
+        <tr><td>Date</td><td><xsl:value-of select="/Site/Testing/StartDateTime"/></td></tr>
+        <tr><td>Operating System</td><td><xsl:value-of select="./@OSName" /></td></tr>
+        <tr><td>OS Release</td><td><xsl:value-of select="./@OSRelease" /></td></tr>
+        <tr><td>CPU Architecture</td><td><xsl:value-of select="./@OSPlatform" /></td></tr>
+        <tr><td class="site-header" colspan="2">Device Information</td></tr>
+        <tr><td>Platform Name</td><td><xsl:value-of select="./@PlatformName" /></td></tr>
+        <tr><td>Platform Vendor</td><td><xsl:value-of select="./@PlatformVendor" /></td></tr>
+        <tr><td>Platform Version</td><td><xsl:value-of select="./@PlatformVersion" /></td></tr>
+        <tr><td>Device Name</td><td><xsl:value-of select="./@DeviceName" /></td></tr>
+        <tr><td>Device Vendor</td><td><xsl:value-of select="./@DeviceVendor" /></td></tr>
+        <tr><td>Device Version</td><td><xsl:value-of select="./@DeviceVersion" /></td></tr>
+        <tr><td class="site-header" colspan="2">Device Extension Support</td></tr>
+        <tr><td>Half Precision Floating Point</td><td><xsl:value-of select="./@DeviceFP16" /></td></tr>
+        <tr><td>Double Precision Floating Point</td><td><xsl:value-of select="./@DeviceFP64" /></td></tr>
+        <tr><td class="site-header" colspan="2">Build Information</td></tr>
+        <tr><td>Full Conformance Mode</td><td><xsl:value-of select="./@FullConformanceMode" /></td></tr>
+        <tr><td>CMake Input</td><td><xsl:value-of select="./@CMakeInput" /></td></tr>
+        <tr><td>Build System Generator</td><td><xsl:value-of select="./@BuildSystemGenerator" /></td></tr>
+        <tr><td>Build System Call</td><td><xsl:value-of select="./@BuildSystemCall" /></td></tr>
+        <tr><td>CTest Call</td><td><xsl:value-of select="./@CTestCall" /></td></tr>
+    </table>
 </xsl:template>
 
 <xsl:template match="Test">
-	<details>
-		<summary>
-			<table>
-				<tr class="test-result {@Status}">
-					<td><xsl:value-of select="Name"/></td>
-					<td><xsl:value-of select="./@Status" /></td>
-				</tr>
-			</table>
-		</summary>
-		<table>
-			<tr>
-				<td colspan="2"><pre><xsl:value-of select="Results/Measurement/Value"/></pre></td>
-			</tr>
-		</table>
-	</details>
+    <details>
+        <summary>
+            <table>
+                <tr class="test-result {@Status}">
+                    <td><xsl:value-of select="Name"/></td>
+                    <td><xsl:value-of select="./@Status" /></td>
+                </tr>
+            </table>
+        </summary>
+        <table>
+            <tr>
+                <td colspan="2"><pre><xsl:value-of select="Results/Measurement/Value"/></pre></td>
+            </tr>
+        </table>
+    </details>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
As promised in #192, this fixes various problems with the conformance report generation script and updates it to properly handle recently introduced mechanisms/changes:

- Add support for new exclude list filter (via the `--exclude-categories` parameter, which is optional)
- Add support for new `--device` regex parameter
- Retire notion of distinct "Host Device" and "OpenCL Device";  only a single device is tested for conformance
- Remove support for listing device extensions that are no longer reported by the `test_manager`
- Fix forwarding of multiple `--additional-cmake-args`
- Reformat stylesheet.xml to use LF line endings and space indentations

Here's what a report generated for hipSYCL looks like:
![image](https://user-images.githubusercontent.com/791348/137325201-1f84a544-077b-4e9d-aec5-f1b0b4a7bb28.png)