### PR TITLE
Add option to measure per-translation unit build times; enable for CI

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  compile-cts-support-libraries:
+  compile-cts:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -13,6 +13,7 @@ jobs:
         sycl-impl: [computecpp, dpcpp, hipsycl]
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
+      parallel-build-jobs: 2
     container:
       # image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}
       # ComputeCpp images are hosted by Codeplay
@@ -24,10 +25,15 @@ jobs:
           submodules: true
       - name: Configure CMake
         working-directory: ${{ env.container-workspace }}
-        run: bash /scripts/configure.sh
+        run: |
+          bash /scripts/configure.sh \
+            -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="${{ env.container-workspace }}/ci/${{ matrix.sycl-impl }}.filter"
       - name: Build 'oclmath'
         working-directory: ${{ env.container-workspace }}/build
         run: cmake --build . --target oclmath
       - name: Build 'util'
         working-directory: ${{ env.container-workspace }}/build
         run: cmake --build . --target util
+      - name: Build all supported test categories
+        working-directory: ${{ env.container-workspace }}/build
+        run: cmake --build . --target test_all -- -j${{ env.parallel-build-jobs }}

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -27,7 +27,8 @@ jobs:
         working-directory: ${{ env.container-workspace }}
         run: |
           bash /scripts/configure.sh \
-            -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="${{ env.container-workspace }}/ci/${{ matrix.sycl-impl }}.filter"
+            -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="${{ env.container-workspace }}/ci/${{ matrix.sycl-impl }}.filter" \
+            -DSYCL_CTS_MEASURE_BUILD_TIMES=ON
       - name: Build 'oclmath'
         working-directory: ${{ env.container-workspace }}/build
         run: cmake --build . --target oclmath
@@ -36,4 +37,15 @@ jobs:
         run: cmake --build . --target util
       - name: Build all supported test categories
         working-directory: ${{ env.container-workspace }}/build
-        run: cmake --build . --target test_all -- -j${{ env.parallel-build-jobs }}
+        run: |
+          TS_BEFORE=$(date +%s)
+          cmake --build . --target test_all -- -j${{ env.parallel-build-jobs }}
+          TS_AFTER=$(date +%s)
+          ELAPSED=$(($TS_AFTER - $TS_BEFORE))
+          sort -rn -o build_times.log build_times.log
+          echo "Total time: $( date -d@$ELAPSED -u '+%-Hh %-Mm %-Ss' )" >> build_times.log
+      - name: Upload build times artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-times-${{ matrix.sycl-impl }}
+          path: ${{ env.container-workspace }}/build/build_times.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,20 @@ endif()
 set(SYCL_CTS_CTEST_DEVICE "" CACHE STRING "Device used when running with CTest")
 # ------------------
 
+# ------------------
+# Measure build times
+option(SYCL_CTS_MEASURE_BUILD_TIMES "Measure build time for each translation unit and write it to 'build_times.log'" OFF)
+if(SYCL_CTS_MEASURE_BUILD_TIMES)
+    if(CMAKE_GENERATOR MATCHES "Makefiles|Ninja")
+        # In case the user already specified a compiler launcher, make sure ours comes first.
+        list(PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_SOURCE_DIR}/tools/measure_build_time.py")
+    else()
+        # Only Makefiles and Ninja support CMake compiler launchers
+        message(FATAL_ERROR "Build time measurements are only supported for the 'Unix Makefiles' and 'Ninja' generators.")
+    endif()
+endif()
+# ------------------
+
 enable_testing()
 
 add_subdirectory(util)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ set(SYCL_CTS_CTEST_DEVICE "" CACHE STRING "Device used when running with CTest")
 option(SYCL_CTS_MEASURE_BUILD_TIMES "Measure build time for each translation unit and write it to 'build_times.log'" OFF)
 if(SYCL_CTS_MEASURE_BUILD_TIMES)
     if(CMAKE_GENERATOR MATCHES "Makefiles|Ninja")
+        # Wrap compiler calls in utility script to measure build times.
+        # Note that SYCL implementations that require custom build steps, e.g. for dedicated
+        # device compiler passes (such as ComputeCpp), may require special handling.
         # In case the user already specified a compiler launcher, make sure ours comes first.
         list(PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_SOURCE_DIR}/tools/measure_build_time.py")
     else()

--- a/cmake/FindComputeCpp.cmake
+++ b/cmake/FindComputeCpp.cmake
@@ -78,7 +78,10 @@ function(build_spir exe_name spir_target_name source_file output_path)
 
     add_custom_command(
     OUTPUT  ${output_bc} ${output_stub}
-    COMMAND ComputeCpp::compute++
+    # We prepend the compiler launcher to enable SYCL_CTS_MEASURE_BUILD_TIMES
+    # to also measure device compiler times.
+    COMMAND ${CMAKE_CXX_COMPILER_LAUNCHER}
+            $<TARGET_FILE:ComputeCpp::compute++>
             -Wno-ignored-attributes
             -O2
             -mllvm -inline-threshold=1000

--- a/tools/measure_build_time.py
+++ b/tools/measure_build_time.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import sys
 
+from pathlib import Path
 from timeit import default_timer as timer
 
 args = sys.argv[1:]
@@ -19,11 +20,24 @@ args = sys.argv[1:]
 obj_file = os.path.basename(args[-3])
 src_file = args[-1]
 
+# Locate build root: The compiler may not always be launched directly from
+# within the main build directory. We want to write all results into the
+# same file within the build directory, so we have to locate it first.
+# Walk parents until we find 'CMakeCache.txt'.
+build_root = Path(os.getcwd())
+for p in [build_root] + list(build_root.parents):
+    if os.path.isfile(p / 'CMakeCache.txt'):
+        build_root = p
+        break
+
+# Make source file path relative to build directory
+src_file = os.path.relpath(src_file, build_root)
+
 ts_before = timer()
 subprocess.run(' '.join(args), shell=True)
 ts_after = timer()
 dt = ts_after - ts_before
 
-with open("build_times.log", "a") as output_file:
+with open(build_root / "build_times.log", "a") as output_file:
     print(f"{dt:.1f} {obj_file} ({src_file})",
           file=output_file)

--- a/tools/measure_build_time.py
+++ b/tools/measure_build_time.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+"""
+Utility script for measuring the build time of a translation unit.
+Not intended for manual use.
+To enable, specify SYCL_CTS_MEASURE_BUILD_TIMES=ON during CMake configuration.
+"""
+
+import os
+import subprocess
+import sys
+
+from timeit import default_timer as timer
+
+args = sys.argv[1:]
+
+# We assume arguments to end with '-o <object file> -c <source file>'
+# FIXME: This may not work with MSVC
+obj_file = os.path.basename(args[-3])
+src_file = args[-1]
+
+ts_before = timer()
+subprocess.run(' '.join(args), shell=True)
+ts_after = timer()
+dt = ts_after - ts_before
+
+with open("build_times.log", "a") as output_file:
+    print(f"{dt:.1f} {obj_file} ({src_file})",
+          file=output_file)


### PR DESCRIPTION
With the introduction of full(-ish) CTS builds during CI in #195 comes the downside that builds now take considerably longer. While CI on #195 is still running at the time of writing, from an [earlier build of that PR in my fork of the CTS](https://github.com/psalz/SYCL-CTS/actions/runs/1329373241) you can see that the run took over 2½ hours to complete (note that DPC++ is compiling a lot more tests than the other implementations, which is why it takes so much longer).

While I think it is to be expected that the CTS requires some time to compile, we should still try and bring that number down to something more reasonable. To do so in an informed way, we must first identify which parts of the CTS take up the bulk of the overall compile time. To that end, I'm introducing a new CMake option `SYCL_CTS_MEASURE_BUILD_TIMES` that, when enabled, uses a compiler launcher script to measure the build time on a per-translation unit basis.

I've enabled this option for CI runs and added a mechanism to upload the resulting logfiles as build artifacts to GitHub. This way we can easily identify offending translation units in future PRs.

Note: This PR includes #195, so that one should be merged first.