### PR TITLE
Unify naming of full-conformance macro and option, fix its usage, reduce compile times

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  compile-cts-support-libraries:
+  compile-cts:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -13,6 +13,7 @@ jobs:
         sycl-impl: [computecpp, dpcpp, hipsycl]
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
+      parallel-build-jobs: 2
     container:
       # image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}
       # ComputeCpp images are hosted by Codeplay
@@ -24,10 +25,15 @@ jobs:
           submodules: true
       - name: Configure CMake
         working-directory: ${{ env.container-workspace }}
-        run: bash /scripts/configure.sh
+        run: |
+          bash /scripts/configure.sh \
+            -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="${{ env.container-workspace }}/ci/${{ matrix.sycl-impl }}.filter"
       - name: Build 'oclmath'
         working-directory: ${{ env.container-workspace }}/build
         run: cmake --build . --target oclmath
       - name: Build 'util'
         working-directory: ${{ env.container-workspace }}/build
         run: cmake --build . --target util
+      - name: Build all supported test categories
+        working-directory: ${{ env.container-workspace }}/build
+        run: cmake --build . --target test_all -- -j${{ env.parallel-build-jobs }}

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ${{ env.container-workspace }}/build
         run: |
           TS_BEFORE=$(date +%s)
-          cmake --build . --target test_all -- -j${{ env.parallel-build-jobs }}
+          cmake --build . --target test_all --parallel ${{ env.parallel-build-jobs }}
           TS_AFTER=$(date +%s)
           ELAPSED=$(($TS_AFTER - $TS_BEFORE))
           sort -rn -o build_times.log build_times.log

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -27,7 +27,8 @@ jobs:
         working-directory: ${{ env.container-workspace }}
         run: |
           bash /scripts/configure.sh \
-            -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="${{ env.container-workspace }}/ci/${{ matrix.sycl-impl }}.filter"
+            -DSYCL_CTS_EXCLUDE_TEST_CATEGORIES="${{ env.container-workspace }}/ci/${{ matrix.sycl-impl }}.filter" \
+            -DSYCL_CTS_MEASURE_BUILD_TIMES=ON
       - name: Build 'oclmath'
         working-directory: ${{ env.container-workspace }}/build
         run: cmake --build . --target oclmath
@@ -36,4 +37,15 @@ jobs:
         run: cmake --build . --target util
       - name: Build all supported test categories
         working-directory: ${{ env.container-workspace }}/build
-        run: cmake --build . --target test_all -- -j${{ env.parallel-build-jobs }}
+        run: |
+          TS_BEFORE=$(date +%s)
+          cmake --build . --target test_all -- -j${{ env.parallel-build-jobs }}
+          TS_AFTER=$(date +%s)
+          ELAPSED=$(($TS_AFTER - $TS_BEFORE))
+          sort -rn -o build_times.log build_times.log
+          echo "Total time: $( date -d@$ELAPSED -u '+%-Hh %-Mm %-Ss' )" >> build_times.log
+      - name: Upload build times artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-times-${{ matrix.sycl-impl }}
+          path: ${{ env.container-workspace }}/build/build_times.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(SYCL_CTS_ENABLE_FULL_CONFORMANCE
        "Enable full conformance mode with extensive tests" OFF)
 if(SYCL_CTS_ENABLE_FULL_CONFORMANCE)
     message(STATUS "Full conformance mode: ON")
-    add_definitions(-DSYCL_CTS_FULL_CONFORMANCE)
+    add_definitions(-DSYCL_CTS_ENABLE_FULL_CONFORMANCE)
 else()
     message(STATUS "Full conformance mode: OFF")
     message(WARNING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,20 @@ endif()
 set(SYCL_CTS_CTEST_DEVICE "" CACHE STRING "Device used when running with CTest")
 # ------------------
 
+# ------------------
+# Measure build times
+option(SYCL_CTS_MEASURE_BUILD_TIMES "Measure build time for each translation unit and write it to 'build_times.log'" OFF)
+if(SYCL_CTS_MEASURE_BUILD_TIMES)
+    if(CMAKE_GENERATOR MATCHES "Makefiles|Ninja")
+        # In case the user already specified a compiler launcher, make sure ours comes first.
+        list(PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_SOURCE_DIR}/tools/measure_build_time.py")
+    else()
+        # Only Makefiles and Ninja support CMake compiler launchers
+        message(FATAL_ERROR "Build time measurements are only supported for the 'Unix Makefiles' and 'Ninja' generators.")
+    endif()
+endif()
+# ------------------
+
 enable_testing()
 
 add_subdirectory(util)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(SYCL_CTS_ENABLE_FULL_CONFORMANCE
        "Enable full conformance mode with extensive tests" OFF)
 if(SYCL_CTS_ENABLE_FULL_CONFORMANCE)
     message(STATUS "Full conformance mode: ON")
-    add_definitions(-DSYCL_CTS_ENABLE_FULL_CONFORMANCE)
+    add_host_and_device_compiler_definitions(-DSYCL_CTS_ENABLE_FULL_CONFORMANCE)
 else()
     message(STATUS "Full conformance mode: OFF")
     message(WARNING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ set(SYCL_CTS_CTEST_DEVICE "" CACHE STRING "Device used when running with CTest")
 option(SYCL_CTS_MEASURE_BUILD_TIMES "Measure build time for each translation unit and write it to 'build_times.log'" OFF)
 if(SYCL_CTS_MEASURE_BUILD_TIMES)
     if(CMAKE_GENERATOR MATCHES "Makefiles|Ninja")
+        # Wrap compiler calls in utility script to measure build times.
+        # Note that SYCL implementations that require custom build steps, e.g. for dedicated
+        # device compiler passes (such as ComputeCpp), may require special handling.
         # In case the user already specified a compiler launcher, make sure ours comes first.
         list(PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_SOURCE_DIR}/tools/measure_build_time.py")
     else()

--- a/cmake/FindComputeCpp.cmake
+++ b/cmake/FindComputeCpp.cmake
@@ -78,7 +78,10 @@ function(build_spir exe_name spir_target_name source_file output_path)
 
     add_custom_command(
     OUTPUT  ${output_bc} ${output_stub}
-    COMMAND ComputeCpp::compute++
+    # We prepend the compiler launcher to enable SYCL_CTS_MEASURE_BUILD_TIMES
+    # to also measure device compiler times.
+    COMMAND ${CMAKE_CXX_COMPILER_LAUNCHER}
+            $<TARGET_FILE:ComputeCpp::compute++>
             -Wno-ignored-attributes
             -O2
             -mllvm -inline-threshold=1000

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,24 +18,28 @@ add_subdirectory("common")
 
 function(get_std_type OUT_LIST)
   set(STD_TYPE_LIST "")
-  list(APPEND STD_TYPE_LIST char
-    "signed char"
-    "unsigned char")
 
-  list(APPEND STD_TYPE_LIST short
-    "unsigned short")
+  list(APPEND STD_TYPE_LIST
+    "char"
+    "int"
+    "float"
+    "double"
+    "sycl::half"
+  )
 
-  list(APPEND STD_TYPE_LIST int
-    "unsigned int")
-
-  list(APPEND STD_TYPE_LIST long
-    "unsigned long"
-    "long long"
-    "unsigned long long")
-
-  list(APPEND STD_TYPE_LIST float
-    double
-    sycl::half)
+  if(SYCL_CTS_ENABLE_FULL_CONFORMANCE)
+    list(APPEND STD_TYPE_LIST
+      "signed char"
+      "unsigned char"
+      "short"
+      "unsigned short"
+      "unsigned int"
+      "long"
+      "unsigned long"
+      "long long"
+      "unsigned long long"
+    )
+  endif()
 
   set(${OUT_LIST} ${${OUT_LIST}} ${STD_TYPE_LIST} PARENT_SCOPE)
 endfunction()
@@ -49,14 +53,22 @@ endfunction()
 
 function(get_fixed_width_type OUT_LIST)
   set(FIXED_WIDTH_LIST "")
-  list(APPEND FIXED_WIDTH_LIST std::int8_t
-    std::int16_t
+
+  list(APPEND FIXED_WIDTH_LIST
+    std::int8_t
     std::int32_t
-    std::int64_t
-    std::uint8_t
-    std::uint16_t
-    std::uint32_t
-    std::uint64_t)
+  )
+
+  if(SYCL_CTS_ENABLE_FULL_CONFORMANCE)
+    list(APPEND FIXED_WIDTH_LIST
+      std::uint8_t
+      std::int16_t
+      std::uint16_t
+      std::uint32_t
+      std::int64_t
+      std::uint64_t
+    )
+  endif()
 
   set(${OUT_LIST} ${${OUT_LIST}} ${FIXED_WIDTH_LIST} PARENT_SCOPE)
 endfunction()

--- a/tests/accessor/accessor_types_core.h
+++ b/tests/accessor/accessor_types_core.h
@@ -52,7 +52,7 @@ public:
     if (!availability::check(queue, log))
       return;
 
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     // Specific set of types to cover during ordinary compilation
 
     const auto vector_types = named_type_pack<int>({"int"});
@@ -150,7 +150,7 @@ public:
     }
 #endif
 
-#endif // SYCL_CTS_FULL_CONFORMANCE
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 
     for_all_types_and_vectors<check_type>(vector_types, log, queue);
 

--- a/tests/accessor/accessor_types_fp16.h
+++ b/tests/accessor/accessor_types_fp16.h
@@ -42,7 +42,7 @@ public:
     if (!availability::check(queue, log))
       return;
 
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     // Specific set of types to cover during ordinary compilation
 
     /** check specific accessor api for half
@@ -58,7 +58,7 @@ public:
     for_type_and_vectors<check_type, sycl::cl_half>(
         log, queue, "sycl::cl_half");
 
-#endif // SYCL_CTS_FULL_CONFORMANCE
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 
     queue.wait_and_throw();
   }

--- a/tests/accessor/accessor_types_fp64.h
+++ b/tests/accessor/accessor_types_fp64.h
@@ -47,7 +47,7 @@ public:
     if (!availability::check(queue, log))
       return;
 
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     // Specific set of types to cover during ordinary compilation
 
     /** check specific accessor api for double
@@ -63,7 +63,7 @@ public:
     for_type_and_vectors<check_type, sycl::cl_double>(
         log, queue, "sycl::cl_double");
 
-#endif // SYCL_CTS_FULL_CONFORMANCE
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 
     queue.wait_and_throw();
   }

--- a/tests/common/common_python_vec.py
+++ b/tests/common/common_python_vec.py
@@ -383,11 +383,11 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(swizzledVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_EXTENSIVE_MODE
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(swizzledVec)) {
                 resAcc[0] = false;
             }
-#endif // SYCL_CTS_EXTENSIVE_MODE
+#endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
     """)
 
     lo_hi_odd_even_template = Template(
@@ -431,11 +431,11 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(inOrderSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_EXTENSIVE_MODE
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(inOrderSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#endif // SYCL_CTS_EXTENSIVE_MODE
+#endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 
             ${type} reversed_vals[] = {${reversed_vals}};
             sycl::vec<${type}, ${size}> reverseOrderSwizzleFunctionVec {${name}DimTestVec.template swizzle<${reverse_order_swiz_indexes}>()};
@@ -451,11 +451,11 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(reverseOrderSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_EXTENSIVE_MODE
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(reverseOrderSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#endif // SYCL_CTS_EXTENSIVE_MODE
+#endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 
             ${type} in_order_reversed_pair_vals[] = {${in_order_pair_vals}};
             sycl::vec<${type}, ${size}> inOrderReversedPairSwizzleFunctionVec {${name}DimTestVec.template swizzle<${in_order_reversed_pair_swiz_indexes}>()};
@@ -471,11 +471,11 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(inOrderReversedPairSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_EXTENSIVE_MODE
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(inOrderReversedPairSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#endif // SYCL_CTS_EXTENSIVE_MODE
+#endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 
             ${type} reverse_order_reversed_pair_vals[] = {${reverse_order_pair_vals}};
             sycl::vec<${type}, ${size}> reverseOrderReversedPairSwizzleFunctionVec {${name}DimTestVec.template swizzle<${reverse_order_reversed_pair_swiz_indexes}>()};
@@ -491,11 +491,11 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(reverseOrderReversedPairSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_EXTENSIVE_MODE
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(reverseOrderReversedPairSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#endif // SYCL_CTS_EXTENSIVE_MODE
+#endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
     """)
 
 def substitute_swizzles_templates(type_str, size, index_subset, value_subset, convert_type_str, as_type_str):

--- a/tests/handler/handler_copy.cpp
+++ b/tests/handler/handler_copy.cpp
@@ -947,7 +947,7 @@ class TEST_NAME : public util::test_base {
       test_all_variants<double>(lh, queue);
       test_all_variants<sycl::double16>(lh, queue);
 
-#if defined(SYCL_CTS_FULL_CONFORMANCE)
+#if defined(SYCL_CTS_ENABLE_FULL_CONFORMANCE)
       test_all_variants<char>(lh, queue);
       test_all_variants<short>(lh, queue);
       test_all_variants<long>(lh, queue);

--- a/tests/specialization_constants/specialization_constants_defined_various_ways.h
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways.h
@@ -164,7 +164,7 @@ template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_defined_various_ways;
   {
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_defined_various_ways_for_type,
                   via_kb>(get_spec_const::testing_types::types, log);
 #else
@@ -188,7 +188,7 @@ static void sc_run_test_fp16(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_defined_various_ways_for_type<sycl::half,
                                                                  via_kb>
         fp16_test{};
@@ -212,7 +212,7 @@ static void sc_run_test_fp64(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_defined_various_ways_for_type<double, via_kb>
         fp64_test{};
     fp64_test(log, "double");

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_core.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_core.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     {
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<check_spec_constant_exception_throw_for_type>(
           get_spec_const::testing_types::types, log);
 #else

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_fp16.cpp
@@ -38,7 +38,7 @@ class TEST_NAME : public util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_spec_constant_exception_throw_for_type<sycl::half> fp16_test{};
       fp16_test(log, "sycl::half");
 #else

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_fp64.cpp
@@ -38,7 +38,7 @@ class TEST_NAME : public util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_spec_constant_exception_throw_for_type<double> fp64_test{};
       fp64_test(log, "double");
 #else

--- a/tests/specialization_constants/specialization_constants_external.h
+++ b/tests/specialization_constants/specialization_constants_external.h
@@ -29,7 +29,7 @@ inline constexpr sycl::specialization_id<T> spec_const_external(
       sycl::kernel_handler h, TYPE);
 
 #ifdef TEST_CORE
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
 CORE_TYPES(FUNC_DECLARE)
 #else
 CORE_TYPES_PARAM(SYCL_VECTORS_MARRAYS, FUNC_DECLARE)
@@ -40,7 +40,7 @@ FUNC_DECLARE(testing_types::no_def_cnstr)
 #endif  // TEST_CORE
 
 #ifdef TEST_FP64
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
 FUNC_DECLARE(double)
 #else
 SYCL_VECTORS_MARRAYS(double, FUNC_DECLARE)
@@ -48,7 +48,7 @@ SYCL_VECTORS_MARRAYS(double, FUNC_DECLARE)
 #endif  // TEST_FP64
 
 #ifdef TEST_FP16
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
 FUNC_DECLARE(sycl::half)
 #else
 SYCL_VECTORS_MARRAYS(sycl::half, FUNC_DECLARE)

--- a/tests/specialization_constants/specialization_constants_external_core.cpp
+++ b/tests/specialization_constants/specialization_constants_external_core.cpp
@@ -37,7 +37,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using namespace specialization_constants_external;
     {
 
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<check_specialization_constants_external>(
           get_spec_const::testing_types::types, log);
 #else

--- a/tests/specialization_constants/specialization_constants_external_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_external_fp16.cpp
@@ -44,7 +44,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_specialization_constants_external<sycl::half> fp16_test{};
       fp16_test(log, "sycl::half");
 #else

--- a/tests/specialization_constants/specialization_constants_external_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_external_fp64.cpp
@@ -44,7 +44,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_specialization_constants_external<double> fp64_test{};
       fp64_test(log, "double");
 #else

--- a/tests/specialization_constants/specialization_constants_multiple.h
+++ b/tests/specialization_constants/specialization_constants_multiple.h
@@ -130,7 +130,7 @@ template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_multiple;
   {
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_multiple_for_type, via_kb>(
         get_spec_const::testing_types::types, log);
 #else
@@ -154,7 +154,7 @@ static void sc_run_test_fp16(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_multiple_for_type<sycl::half, via_kb>
         fp16_test{};
     fp16_test(log, "sycl::half");
@@ -176,7 +176,7 @@ static void sc_run_test_fp64(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_multiple_for_type<double, via_kb>
         fp64_test{};
     fp64_test(log, "double");

--- a/tests/specialization_constants/specialization_constants_same_command_group_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_core.cpp
@@ -31,7 +31,7 @@ public:
   void run(util::logger &log) override {
     using namespace specialization_constants_same_command_group_common;
     {
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<
           check_specialization_constants_same_command_group>(
           get_spec_const::testing_types::types, log);

--- a/tests/specialization_constants/specialization_constants_same_command_group_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_fp16.cpp
@@ -37,7 +37,7 @@ public:
                  "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_specialization_constants_same_command_group<sycl::half> fp16_test{};
       fp16_test(log, "sycl::half");
 #else

--- a/tests/specialization_constants/specialization_constants_same_command_group_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_fp64.cpp
@@ -37,7 +37,7 @@ public:
                  "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_specialization_constants_same_command_group<double> fp64_test{};
       fp64_test(log, "double");
 #else

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link.h
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link.h
@@ -115,7 +115,7 @@ template <int tu_num, typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace spec_const_help;
   {
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_same_name_inter_link_for_type,
                   sc_sn_il_config<tu_num>, via_kb>(
         get_spec_const::testing_types::types, log);
@@ -143,7 +143,7 @@ static void sc_run_test_fp16(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_same_name_inter_link_for_type<
         sycl::half, sc_sn_il_config<tu_num>, via_kb>
         fp16_test{};
@@ -168,7 +168,7 @@ static void sc_run_test_fp64(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_same_name_inter_link_for_type<
         double, sc_sn_il_config<tu_num>, via_kb>
         fp64_test{};

--- a/tests/specialization_constants/specialization_constants_same_name_stress.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress.h
@@ -182,7 +182,7 @@ template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_same_name_stress;
   {
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_same_name_stress_for_type,
                   via_kb>(get_spec_const::testing_types::types, log);
 #else
@@ -206,7 +206,7 @@ static void sc_run_test_fp16(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_same_name_stress_for_type<sycl::half, via_kb>
         fp16_test{};
     fp16_test(log, "sycl::half");
@@ -229,7 +229,7 @@ static void sc_run_test_fp64(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_same_name_stress_for_type<double, via_kb>
         fp64_test{};
     fp64_test(log, "double");

--- a/tests/specialization_constants/specialization_constants_separate_unit.cpp
+++ b/tests/specialization_constants/specialization_constants_separate_unit.cpp
@@ -60,7 +60,7 @@ bool check_kernel_handler_by_value_external(sycl::kernel_handler h,
         TYPE, test_cases_external::by_value_via_bundle>(h, expected);          \
   }
 
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
 CORE_TYPES(FUNC_DEFINE)
 #else
 CORE_TYPES_PARAM(SYCL_VECTORS_MARRAYS, FUNC_DEFINE)
@@ -71,7 +71,7 @@ FUNC_DEFINE(testing_types::def_cnstr)
 FUNC_DEFINE(testing_types::no_def_cnstr)
 
 #ifdef SYCL_CTS_TEST_DOUBLE
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
 FUNC_DEFINE(double)
 #else
 SYCL_VECTORS_MARRAYS(double, FUNC_DEFINE)
@@ -79,7 +79,7 @@ SYCL_VECTORS_MARRAYS(double, FUNC_DEFINE)
 #endif  // SYCL_CTS_TEST_DOUBLE
 
 #ifdef SYCL_CTS_TEST_HALF
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
 FUNC_DEFINE(sycl::half)
 #else
 SYCL_VECTORS_MARRAYS(sycl::half, FUNC_DEFINE)

--- a/tests/specialization_constants/specialization_constants_via_handler_core.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_core.cpp
@@ -30,7 +30,7 @@ public:
   void run(util::logger &log) override {
     using namespace specialization_constants_via_handler_common;
     {
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<check_spec_constant_with_handler_for_type>(
           get_spec_const::testing_types::types, log);
 #else

--- a/tests/specialization_constants/specialization_constants_via_handler_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_fp16.cpp
@@ -36,7 +36,7 @@ public:
                  "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_spec_constant_with_handler_for_type<sycl::half> fp16_test{};
       fp16_test(log, "sycl::half");
 #else

--- a/tests/specialization_constants/specialization_constants_via_handler_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_fp64.cpp
@@ -36,7 +36,7 @@ public:
                  "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_spec_constant_with_handler_for_type<double> fp64_test{};
       fp64_test(log, "double");
 #else

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_core.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_core.cpp
@@ -31,7 +31,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger &log) override {
     {
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<check_all>(get_spec_const::testing_types::types, log);
 #else
       for_all_types_vectors_marray<check_all>(

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp16.cpp
@@ -37,7 +37,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
             "Device does not support half precision floating point operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_all<sycl::half>{}(log, "sycl::half");
 #else
       for_type_vectors_marray<check_all, sycl::half>(log, "sycl::half");

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp64.cpp
@@ -38,7 +38,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_FULL_CONFORMANCE
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_all<double>{}(log, "double");
 #else
       for_type_vectors_marray<check_all, double>(log, "double");

--- a/tools/measure_build_time.py
+++ b/tools/measure_build_time.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import sys
 
+from pathlib import Path
 from timeit import default_timer as timer
 
 args = sys.argv[1:]
@@ -19,11 +20,24 @@ args = sys.argv[1:]
 obj_file = os.path.basename(args[-3])
 src_file = args[-1]
 
+# Locate build root: The compiler may not always be launched directly from
+# within the main build directory. We want to write all results into the
+# same file within the build directory, so we have to locate it first.
+# Walk parents until we find 'CMakeCache.txt'.
+build_root = Path(os.getcwd())
+for p in [build_root] + list(build_root.parents):
+    if os.path.isfile(p / 'CMakeCache.txt'):
+        build_root = p
+        break
+
+# Make source file path relative to build directory
+src_file = os.path.relpath(src_file, build_root)
+
 ts_before = timer()
 subprocess.run(' '.join(args), shell=True)
 ts_after = timer()
 dt = ts_after - ts_before
 
-with open("build_times.log", "a") as output_file:
+with open(build_root / "build_times.log", "a") as output_file:
     print(f"{dt:.1f} {obj_file} ({src_file})",
           file=output_file)

--- a/tools/measure_build_time.py
+++ b/tools/measure_build_time.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+"""
+Utility script for measuring the build time of a translation unit.
+Not intended for manual use.
+To enable, specify SYCL_CTS_MEASURE_BUILD_TIMES=ON during CMake configuration.
+"""
+
+import os
+import subprocess
+import sys
+
+from timeit import default_timer as timer
+
+args = sys.argv[1:]
+
+# We assume arguments to end with '-o <object file> -c <source file>'
+# FIXME: This may not work with MSVC
+obj_file = os.path.basename(args[-3])
+src_file = args[-1]
+
+ts_before = timer()
+subprocess.run(' '.join(args), shell=True)
+ts_after = timer()
+dt = ts_after - ts_before
+
+with open("build_times.log", "a") as output_file:
+    print(f"{dt:.1f} {obj_file} ({src_file})",
+          file=output_file)


### PR DESCRIPTION
Following up on #197, I was looking for ways of reducing compile times. While CI is still running on #197 at the time of writing, the results of the per-translation unit timings are (spoiler alert!) mostly confirming what we already knew: The generated vector tests are taking up most of the compile time.

As you know, we already have the `SYCL_CTS_ENABLE_FULL_CONFORMANCE` option to rein in compile times somewhat. However, even with the option disabled (which it is for CI), compile times are arguably still too long. While looking into why vector tests take that long to compile even in non-full conformance mode, I've noticed that some tests were not correctly using the macro to guard portions of the code: Some tests erroneously used the CMake option's name, as opposed to the (confusingly similar) macro name (`SYCL_CTS_FULL_CONFORMANCE`). Some where even still using the outdated `SYCL_CTS_EXTENSIVE_MODE` macro.

To avoid this confusion in the future, I'm proposing to unify the option's and macro's name to both simply be `SYCL_CTS_ENABLE_FULL_CONFORMANCE`. I've adjusted all relevant locations accordingly.

Additionally, I'm proposing to reduce compile times in non-full conformance mode by drastically reducing the set of data types for which vector tests are being generated.

Note: This PR includes both #195 and #197, so those should be merged first.