### PR TITLE
Add test for sub_group_mask operator[] and sub_group_mask::reference

### DIFF
--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_reference.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_reference.cpp
@@ -43,7 +43,7 @@ struct check_result_reference {
           break;
         case 3:
           // check reference operator bool()
-          if ((bool)ref_to_bit != (N % 2 == 0)) return false;
+          if (!!ref_to_bit != (N % 2 == 0)) return false;
           break;
         case 4:
           // check reference member function flip()
@@ -64,6 +64,11 @@ struct check_type_reference {
                         decltype(sub_group_mask[sycl::id()])>::value;
   }
 };
+
+template <size_t SGSize>
+using verification_func_for_even_predicate =
+    check_mask_api<SGSize, check_result_reference, check_type_reference,
+                   even_predicate, sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
 /** test sycl::oneapi::sub_group_mask interface
@@ -80,8 +85,7 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_non_const_api<check_result_reference, check_type_reference,
-                        even_predicate>(log);
+     check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
 #else
     log.note("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined, test is skipped");
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK


### PR DESCRIPTION
`sub_group_mask` it's an extension, documentations can be found here: [intel/llvm/doc/SubGroupMask](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/SubGroupMask/SubGroupMask.asciidoc)

This PR depends on https://github.com/KhronosGroup/SYCL-CTS/pull/200
`sub_group_mask_common.h` file can be found in PR#200
