### PR TITLE
Remove member function get() that are removed in SYCL 2020

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -167,7 +167,7 @@ void check_equality(sycl_cts::util::logger& log, T& a, T& b) {
   if (queue.get_backend() == sycl::backend::opencl) {
     if (sycl::get_native<sycl::backend::opencl>(a) !=
         sycl::get_native<sycl::backend::opencl>(b)) {
-      FAIL(log, "two objects are not equal (get_native)");
+      FAIL(log, "two objects are not equal");
     }
   }
 #endif  // SYCL_BACKEND_OPENCL

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -160,13 +160,19 @@ void check_equality(sycl_cts::util::logger& log, T& a, T& b, bool checkGet) {
     FAIL(log, "two objects are not equal (is_host)");
   }
 
-  /** check get
+#ifdef SYCL_BACKEND_OPENCL
+  /** check get_native
    */
   if (checkGet) {
-    if (a.get() != b.get()) {
-      FAIL(log, "two objects are not equal (get)");
+    auto queue = util::get_cts_object::queue();
+    if (queue.get_backend() == sycl::backend::opencl) {
+      if ((sycl::get_native<sycl::backend::opencl>(a) !=
+          sycl::get_native<sycl::backend::opencl>(b))) {
+        FAIL(log, "two objects are not equal (get_native)");
+      }
     }
   }
+#endif  // SYCL_BACKEND_OPENCL
 };
 
 /**

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -153,7 +153,7 @@ void check_get_profiling_info_param(sycl_cts::util::logger& log,
  * @brief Helper function to check the equality of two SYCL objects.
  */
 template <typename T>
-void check_equality(sycl_cts::util::logger& log, T& a, T& b, bool checkGet) {
+void check_equality(sycl_cts::util::logger& log, T& a, T& b) {
   /** check is_host
    */
   if (a.is_host() != b.is_host()) {
@@ -163,13 +163,11 @@ void check_equality(sycl_cts::util::logger& log, T& a, T& b, bool checkGet) {
 #ifdef SYCL_BACKEND_OPENCL
   /** check get_native
    */
-  if (checkGet) {
-    auto queue = util::get_cts_object::queue();
-    if (queue.get_backend() == sycl::backend::opencl) {
-      if ((sycl::get_native<sycl::backend::opencl>(a) !=
-          sycl::get_native<sycl::backend::opencl>(b))) {
-        FAIL(log, "two objects are not equal (get_native)");
-      }
+  auto queue = util::get_cts_object::queue();
+  if (queue.get_backend() == sycl::backend::opencl) {
+    if (sycl::get_native<sycl::backend::opencl>(a) !=
+        sycl::get_native<sycl::backend::opencl>(b)) {
+      FAIL(log, "two objects are not equal (get_native)");
     }
   }
 #endif  // SYCL_BACKEND_OPENCL

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -163,7 +163,7 @@ void check_equality(sycl_cts::util::logger& log, T& a, T& b) {
 #ifdef SYCL_BACKEND_OPENCL
   /** check get_native
    */
-  auto queue = util::get_cts_object::queue();
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_backend() == sycl::backend::opencl) {
     if (sycl::get_native<sycl::backend::opencl>(a) !=
         sycl::get_native<sycl::backend::opencl>(b)) {

--- a/tests/context/context_constructors.cpp
+++ b/tests/context/context_constructors.cpp
@@ -131,9 +131,8 @@ class TEST_NAME : public util::test_base {
 #ifdef SYCL_BACKEND_OPENCL
         auto queue = util::get_cts_object::queue();
         if (queue.get_backend() == sycl::backend::opencl) {
-          if (!selector.is_host() &&
-              (sycl::get_native<sycl::backend::opencl>(contextA) !=
-              sycl::get_native<sycl::backend::opencl>(contextB))) {
+          if (sycl::get_native<sycl::backend::opencl>(contextA) !=
+              sycl::get_native<sycl::backend::opencl>(contextB)) {
             FAIL(log, "context was not copied correctly (get)");
           }
         }
@@ -154,9 +153,8 @@ class TEST_NAME : public util::test_base {
 #ifdef SYCL_BACKEND_OPENCL
         auto queue = util::get_cts_object::queue();
         if (queue.get_backend() == sycl::backend::opencl) {
-          if (!selector.is_host() &&
-              (sycl::get_native<sycl::backend::opencl>(contextA) !=
-              sycl::get_native<sycl::backend::opencl>(contextB))) {
+          if (sycl::get_native<sycl::backend::opencl>(contextA) !=
+              sycl::get_native<sycl::backend::opencl>(contextB)) {
             FAIL(log, "context was not assigned correctly (get)");
           }
         }
@@ -203,7 +201,7 @@ class TEST_NAME : public util::test_base {
                "failed)");
         }
         if (!(contextA == contextC)) {
-          check_equality(log, contextA, contextC, !selector.is_host());
+          check_equality(log, contextA, contextC);
           FAIL(log,
                "device equality does not work correctly (equality of equal "
                "failed)");

--- a/tests/context/context_constructors.cpp
+++ b/tests/context/context_constructors.cpp
@@ -128,9 +128,14 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "context was not copied correctly (is_host)");
         }
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-        if (!selector.is_host() && (contextA.get() != contextB.get())) {
-          FAIL(log, "context was not copied correctly (get)");
+#ifdef SYCL_BACKEND_OPENCL
+        auto queue = util::get_cts_object::queue();
+        if (queue.get_backend() == sycl::backend::opencl) {
+          if (!selector.is_host() &&
+              (sycl::get_native<sycl::backend::opencl>(contextA) !=
+              sycl::get_native<sycl::backend::opencl>(contextB))) {
+            FAIL(log, "context was not copied correctly (get)");
+          }
         }
 #endif
       }
@@ -146,9 +151,14 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "context was not assigned correctly (is_host)");
         }
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-        if (!selector.is_host() && (contextA.get() != contextB.get())) {
-          FAIL(log, "context was not assigned correctly (get)");
+#ifdef SYCL_BACKEND_OPENCL
+        auto queue = util::get_cts_object::queue();
+        if (queue.get_backend() == sycl::backend::opencl) {
+          if (!selector.is_host() &&
+              (sycl::get_native<sycl::backend::opencl>(contextA) !=
+              sycl::get_native<sycl::backend::opencl>(contextB))) {
+            FAIL(log, "context was not assigned correctly (get)");
+          }
         }
 #endif
       }

--- a/tests/context/context_constructors.cpp
+++ b/tests/context/context_constructors.cpp
@@ -133,7 +133,7 @@ class TEST_NAME : public util::test_base {
         if (queue.get_backend() == sycl::backend::opencl) {
           if (sycl::get_native<sycl::backend::opencl>(contextA) !=
               sycl::get_native<sycl::backend::opencl>(contextB)) {
-            FAIL(log, "context was not copied correctly (get)");
+            FAIL(log, "context was not copied correctly");
           }
         }
 #endif
@@ -155,7 +155,7 @@ class TEST_NAME : public util::test_base {
         if (queue.get_backend() == sycl::backend::opencl) {
           if (sycl::get_native<sycl::backend::opencl>(contextA) !=
               sycl::get_native<sycl::backend::opencl>(contextB)) {
-            FAIL(log, "context was not assigned correctly (get)");
+            FAIL(log, "context was not assigned correctly");
           }
         }
 #endif

--- a/tests/device/device_api.cpp
+++ b/tests/device/device_api.cpp
@@ -73,19 +73,6 @@ class TEST_NAME : public util::test_base {
                                               "device::get_platform()");
       }
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-      /** check get() member function
-       */
-      {
-        cts_selector selector;
-        auto dev = util::get_cts_object::device(selector);
-        if (!selector.is_host()) {
-          auto clDeviceId = dev.get();
-          check_return_type<cl_device_id>(log, clDeviceId, "device::get()");
-        }
-      }
-#endif
-
       /** check is_host() member function
        */
       {

--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -59,9 +59,14 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "device was not copied correctly (is_host)");
         }
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-        if (!selector.is_host() && deviceA.get() != deviceB.get()) {
-          FAIL(log, "device was not assigned correctly (get)");
+#ifdef SYCL_BACKEND_OPENCL
+        auto queue = util::get_cts_object::queue();
+        if (queue.get_backend() == sycl::backend::opencl) {
+          if (!selector.is_host() &&
+              (sycl::get_native<sycl::backend::opencl>(deviceA) !=
+              sycl::get_native<sycl::backend::opencl>(deviceB))) {
+            FAIL(log, "device was not assigned correctly (get)");
+          }
         }
 #endif
       }
@@ -76,9 +81,14 @@ class TEST_NAME : public util::test_base {
         if (deviceA.is_host() != deviceB.is_host()) {
           FAIL(log, "device was not assigned correctly (is_host)");
         }
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-        if (!selector.is_host() && deviceA.get() != deviceB.get()) {
-          FAIL(log, "device was not assigned correctly (get)");
+#ifdef SYCL_BACKEND_OPENCL
+        auto queue = util::get_cts_object::queue();
+        if (queue.get_backend() == sycl::backend::opencl) {
+          if (!selector.is_host() &&
+              (sycl::get_native<sycl::backend::opencl>(deviceA) !=
+              sycl::get_native<sycl::backend::opencl>(deviceB))) {
+            FAIL(log, "device was not assigned correctly (get)");
+          }
         }
 #endif
       }

--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -62,9 +62,8 @@ class TEST_NAME : public util::test_base {
 #ifdef SYCL_BACKEND_OPENCL
         auto queue = util::get_cts_object::queue();
         if (queue.get_backend() == sycl::backend::opencl) {
-          if (!selector.is_host() &&
-              (sycl::get_native<sycl::backend::opencl>(deviceA) !=
-              sycl::get_native<sycl::backend::opencl>(deviceB))) {
+          if (sycl::get_native<sycl::backend::opencl>(deviceA) !=
+              sycl::get_native<sycl::backend::opencl>(deviceB)) {
             FAIL(log, "device was not assigned correctly (get)");
           }
         }
@@ -84,9 +83,8 @@ class TEST_NAME : public util::test_base {
 #ifdef SYCL_BACKEND_OPENCL
         auto queue = util::get_cts_object::queue();
         if (queue.get_backend() == sycl::backend::opencl) {
-          if (!selector.is_host() &&
-              (sycl::get_native<sycl::backend::opencl>(deviceA) !=
-              sycl::get_native<sycl::backend::opencl>(deviceB))) {
+          if (sycl::get_native<sycl::backend::opencl>(deviceA) !=
+              sycl::get_native<sycl::backend::opencl>(deviceB)) {
             FAIL(log, "device was not assigned correctly (get)");
           }
         }

--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -64,7 +64,7 @@ class TEST_NAME : public util::test_base {
         if (queue.get_backend() == sycl::backend::opencl) {
           if (sycl::get_native<sycl::backend::opencl>(deviceA) !=
               sycl::get_native<sycl::backend::opencl>(deviceB)) {
-            FAIL(log, "device was not assigned correctly (get)");
+            FAIL(log, "device was not assigned correctly");
           }
         }
 #endif
@@ -85,7 +85,7 @@ class TEST_NAME : public util::test_base {
         if (queue.get_backend() == sycl::backend::opencl) {
           if (sycl::get_native<sycl::backend::opencl>(deviceA) !=
               sycl::get_native<sycl::backend::opencl>(deviceB)) {
-            FAIL(log, "device was not assigned correctly (get)");
+            FAIL(log, "device was not assigned correctly");
           }
         }
 #endif

--- a/tests/event/event_api.cpp
+++ b/tests/event/event_api.cpp
@@ -36,20 +36,6 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     {
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-      /** check get()
-      */
-      {
-        auto queue = util::get_cts_object::queue();
-        auto event = get_queue_event<class event_api_kernel_0>(queue);
-
-        if (!queue.is_host()) {
-          auto evt = event.get();
-          check_return_type<cl_event>(log, evt, "sycl::event::get()");
-        }
-        queue.wait_and_throw();
-      }
-#endif
 
       /** check is_host()
       */

--- a/tests/event/event_constructors.cpp
+++ b/tests/event/event_constructors.cpp
@@ -59,9 +59,8 @@ class TEST_NAME : public util::test_base {
 
 #ifdef SYCL_BACKEND_OPENCL
         if (queue.get_backend() == sycl::backend::opencl) {
-          if (!selector.is_host() &&
-              (sycl::get_native<sycl::backend::opencl>(eventA) !=
-              sycl::get_native<sycl::backend::opencl>(eventB))) {
+          if (sycl::get_native<sycl::backend::opencl>(eventA) !=
+              sycl::get_native<sycl::backend::opencl>(eventB)) {
             FAIL(log, "event was not copied correctly.");
           }
         }
@@ -82,9 +81,8 @@ class TEST_NAME : public util::test_base {
 
 #ifdef SYCL_BACKEND_OPENCL
         if (queue.get_backend() == sycl::backend::opencl) {
-          if (!selector.is_host() &&
-              (sycl::get_native<sycl::backend::opencl>(eventA) !=
-              sycl::get_native<sycl::backend::opencl>(eventB))) {
+          if (sycl::get_native<sycl::backend::opencl>(eventA) !=
+              sycl::get_native<sycl::backend::opencl>(eventB)) {
             FAIL(log, "event was not assigned correctly.");
           }
         }

--- a/tests/event/event_constructors.cpp
+++ b/tests/event/event_constructors.cpp
@@ -57,9 +57,13 @@ class TEST_NAME : public util::test_base {
         auto eventA = get_queue_event<class event_constructors_0>(queue);
         sycl::event eventB(eventA);
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-        if (!selector.is_host() && (eventA.get() != eventB.get())) {
-          FAIL(log, "event was not copied correctly.");
+#ifdef SYCL_BACKEND_OPENCL
+        if (queue.get_backend() == sycl::backend::opencl) {
+          if (!selector.is_host() &&
+              (sycl::get_native<sycl::backend::opencl>(eventA) !=
+              sycl::get_native<sycl::backend::opencl>(eventB))) {
+            FAIL(log, "event was not copied correctly.");
+          }
         }
 #endif
 
@@ -76,9 +80,13 @@ class TEST_NAME : public util::test_base {
         auto eventB = get_queue_event<class event_constructors_2>(queue);
         eventB = eventA;
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-        if (!selector.is_host() && (eventA.get() != eventB.get())) {
-          FAIL(log, "event was not assigned correctly.");
+#ifdef SYCL_BACKEND_OPENCL
+        if (queue.get_backend() == sycl::backend::opencl) {
+          if (!selector.is_host() &&
+              (sycl::get_native<sycl::backend::opencl>(eventA) !=
+              sycl::get_native<sycl::backend::opencl>(eventB))) {
+            FAIL(log, "event was not assigned correctly.");
+          }
         }
 #endif
 

--- a/tests/platform/platform_constructors.cpp
+++ b/tests/platform/platform_constructors.cpp
@@ -85,9 +85,8 @@ class TEST_NAME : public util::test_base {
 #ifdef SYCL_BACKEND_OPENCL
         auto queue = util::get_cts_object::queue();
         if (queue.get_backend() == sycl::backend::opencl) {
-          if (!selector.is_host() &&
-              sycl::get_native<sycl::backend::opencl>(platformA) !=
-                  sycl::get_native<sycl::backend::opencl>(platformB)) {
+          if (sycl::get_native<sycl::backend::opencl>(platformA) !=
+              sycl::get_native<sycl::backend::opencl>(platformB)) {
             FAIL(log, "platform was not copy assigned correctly (get)");
           }
         }

--- a/tests/platform/platform_constructors.cpp
+++ b/tests/platform/platform_constructors.cpp
@@ -59,9 +59,14 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "platform was not copy constructed correctly (is_host)");
         }
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-        if (!selector.is_host() && platformA.get() != platformB.get()) {
-          FAIL(log, "platform was not copy constructed correctly (get)");
+#ifdef SYCL_BACKEND_OPENCL
+        auto queue = util::get_cts_object::queue();
+        if (queue.get_backend() == sycl::backend::opencl) {
+          if (!selector.is_host() &&
+              sycl::get_native<sycl::backend::opencl>(platformA) !=
+                  sycl::get_native<sycl::backend::opencl>(platformB)) {
+            FAIL(log, "platform was not copy constructed correctly (get)");
+          }
         }
 #endif
       }
@@ -77,9 +82,14 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "platform was not copy assigned correctly (is_host)");
         }
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-        if (!selector.is_host() && platformA.get() != platformB.get()) {
-          FAIL(log, "platform was not copy assigned correctly (get)");
+#ifdef SYCL_BACKEND_OPENCL
+        auto queue = util::get_cts_object::queue();
+        if (queue.get_backend() == sycl::backend::opencl) {
+          if (!selector.is_host() &&
+              sycl::get_native<sycl::backend::opencl>(platformA) !=
+                  sycl::get_native<sycl::backend::opencl>(platformB)) {
+            FAIL(log, "platform was not copy assigned correctly (get)");
+          }
         }
 #endif
       }

--- a/tests/platform/platform_constructors.cpp
+++ b/tests/platform/platform_constructors.cpp
@@ -65,7 +65,7 @@ class TEST_NAME : public util::test_base {
           if (!selector.is_host() &&
               sycl::get_native<sycl::backend::opencl>(platformA) !=
                   sycl::get_native<sycl::backend::opencl>(platformB)) {
-            FAIL(log, "platform was not copy constructed correctly (get)");
+            FAIL(log, "platform was not copy constructed correctly");
           }
         }
 #endif
@@ -87,7 +87,7 @@ class TEST_NAME : public util::test_base {
         if (queue.get_backend() == sycl::backend::opencl) {
           if (sycl::get_native<sycl::backend::opencl>(platformA) !=
               sycl::get_native<sycl::backend::opencl>(platformB)) {
-            FAIL(log, "platform was not copy assigned correctly (get)");
+            FAIL(log, "platform was not copy assigned correctly");
           }
         }
 #endif

--- a/tests/queue/queue_api.cpp
+++ b/tests/queue/queue_api.cpp
@@ -64,20 +64,6 @@ class TEST_NAME : public util::test_base {
                                             "sycl::queue::get_device()");
       }
 
-#ifdef SYCL_CTS_TEST_OPENCL_INTEROP
-      /** check get() member function
-       */
-      {
-        cts_selector selector;
-        auto queue = util::get_cts_object::queue(selector);
-        if (!selector.is_host()) {
-          auto clQueueObject = queue.get();
-          check_return_type<cl_command_queue>(log, clQueueObject,
-                                              "sycl::queue::get()");
-        }
-      }
-#endif
-
       /** check submit(command_group_scope) member function
       */
       {


### PR DESCRIPTION
In classes context, device, event, platform, queue