### PR TITLE
Introduce test plan for CUDA backend interop

### DIFF
--- a/test_plans/cuda-backend-interop.asciidoc
+++ b/test_plans/cuda-backend-interop.asciidoc
@@ -39,6 +39,7 @@ the following types:
 * `long long int`
 * `unsigned long long int`
 * `float`
+* `double`
 * `bool`
 * `std::byte`
 * `std::int8_t`
@@ -53,7 +54,7 @@ the following types:
 * `vec<T, int dim>` where `T` is each of the scalar types listed above except
    for `bool` and `dim` is `1`, `2`, `3`, `4`, `8`, and `16`.
 * `marray<T, size_t dim>` where `T` is each of the scalar types listed above
-  and `dim` is `2`, `5`, and `10`.
+  and `dim` is `1`, `2`, `5`, and `10`.
 * A user-defined struct with several scalar member variables, no constructor,
   destructor or member functions.
 * A user-defined class with several scalar member variables and a user-defined


### PR DESCRIPTION
Introduce the first draft of a test plan for CUDA backend interoperability as defined in the CUDA backend specification.

A pull request for introducing the CUDA backend specification to the SYCL 2020 specification is here - https://github.com/KhronosGroup/SYCL-Docs/pull/197