### PR TITLE
Remove /subsystem:console from LINK_FLAGS for DPC++ for CMake <= 3.20

### DIFF
--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -8,6 +8,8 @@ else()
     string(REPLACE "/machine:x64" "" CMAKE_EXE_LINKER_FLAGS
         "${CMAKE_EXE_LINKER_FLAGS}")
     # Remove /subsystem option which is not supported by clang-cl
+    string(REPLACE "/subsystem:console" "" CMAKE_CREATE_CONSOLE_EXE
+        "${CMAKE_CREATE_CONSOLE_EXE}")
     string(REPLACE "/subsystem:console" "" CMAKE_CXX_CREATE_CONSOLE_EXE
         "${CMAKE_CXX_CREATE_CONSOLE_EXE}")
     find_program(DPCPP_CXX_EXECUTABLE NAMES dpcpp clang-cl


### PR DESCRIPTION
In commit 81e0863b897cd0f7ccbf5c5e1d596563ccca8555 the /subsystem:console flag
was removed from LINK_FLAGS for DPC++ on Windows. But this was done for
CMake 3.21+ only. The CMake versions until to CMake 3.20 use the
'CMAKE_CREATE_CONSOLE_EXE' variable instead of 'CMAKE_CXX_CREATE_CONSOLE_EXE
one that is used in the latest version. The 'replace' instruction for the
'CMAKE_CREATE_CONSOLE_EXE' variable is restored.