### PR TITLE
Add possible to see which tests were skipped and which tests were passed

### DIFF
--- a/util/executor.cpp
+++ b/util/executor.cpp
@@ -21,6 +21,7 @@ bool executor::run_all() {
   // find the number of tests in the collection
   const int32_t nTests = get<collection>().get_test_count();
   int32_t numPassed = 0;
+  int32_t numSkipped = 0;
 
   // iterate over all tests
   for (int32_t i = 0; i < nTests; i++) {
@@ -57,9 +58,12 @@ bool executor::run_all() {
         // enforce that each test must give a result
         assert(logger.get_result() != logger::epending);
 
-        if ((logger.get_result() == logger::epass) ||
-            (logger.get_result() == logger::eskip)) {
+        if (logger.get_result() == logger::epass) {
           ++numPassed;
+        }
+
+        if (logger.get_result() == logger::eskip) {
+          ++numSkipped;
         }
 
         // ask the test to clean up after itself
@@ -83,9 +87,17 @@ bool executor::run_all() {
     if ((successRate > 99.f) && (numPassed < nTests)) {
       successRate = 99.f;
     }
+    auto skipRate =
+        100 * static_cast<float>(numSkipped) / static_cast<float>(nTests);
+    if ((skipRate > 99.f) && (numSkipped < nTests)) {
+      skipRate = 99.f;
+    }
     log.note("Passed %d/%d tests (%.0f%%)", numPassed, nTests, successRate);
+    if (numSkipped > 0) {
+      log.note("Skipped %d/%d tests (%.0f%%)", numSkipped, nTests, skipRate);
+    }
   }
-  return (numPassed == nTests);
+  return ((numPassed + numSkipped) == nTests);
 }
 
 }  // namespace util


### PR DESCRIPTION
Add message to the console with the information about number skipped tests, the message will look like:
```
--- some_test
  . **Check #1 skipped**
  - skip
  . **Check #2 passed**

  . Passed 0/1 tests (0%)
  . Skipped 1/1 tests (100%)
```

The test will be marked as `Skipped` after `log.skip()` called even if some other check in the same test passed