### PR TITLE
accessor::get_pointer() should ignore offset

### DIFF
--- a/tests/accessor/accessor_api_common_buffer_local.h
+++ b/tests/accessor/accessor_api_common_buffer_local.h
@@ -254,9 +254,10 @@ struct buffer_accessor_get_pointer_w {
   template <typename accT, typename errorAccT>
   static void check(const accT& acc, const errorAccT&,
                     const sycl_id_t<dim>& offset) {
-    sycl_id_t<dim>
-        zero_offset;  // In SYCL 2020, get_pointer() always returns the base
-                      // buffer pointer, ignoring any offset.
+    // In SYCL 2020, get_pointer() always returns the base
+    // buffer pointer, ignoring any offset.
+    sycl_id_t<dim> zero_offset;
+
     const auto value = expected_value_t::expected_write(zero_offset);
     auto ptr = acc.get_pointer();
 
@@ -278,9 +279,10 @@ struct buffer_accessor_get_pointer_rw {
   static void check(const acc_t<placeholder>& acc,
                     const errorAccT& errorAccessor,
                     const sycl_id_t<dim>& offset) {
-    sycl_id_t<dim>
-        zero_offset;  // In SYCL 2020, get_pointer() always returns the base
-                      // buffer pointer, ignoring any offset.
+    // In SYCL 2020, get_pointer() always returns the base
+    // buffer pointer, ignoring any offset.
+    sycl_id_t<dim> zero_offset;
+
     const auto expectedRead = expected_value_t::expected_read(zero_offset);
     const auto expectedWrite = expected_value_t::expected_write(zero_offset);
     constexpr bool noInitExpected =

--- a/tests/accessor/accessor_api_common_buffer_local.h
+++ b/tests/accessor/accessor_api_common_buffer_local.h
@@ -231,7 +231,10 @@ struct buffer_accessor_get_pointer_r {
   template <typename accT, typename errorAccT>
   static void check(const accT& acc, const errorAccT& errorAccessor,
                     const sycl_id_t<dim>& offset) {
-    const auto expectedRead = expected_value_t::expected_read(offset);
+    sycl_id_t<dim>
+        zero_offset;  // In SYCL 2020, get_pointer() always returns the base
+                      // buffer pointer, ignoring any offset.
+    const auto expectedRead = expected_value_t::expected_read(zero_offset);
     auto ptr = acc.get_pointer();
 
     T elem = *ptr;
@@ -250,7 +253,10 @@ struct buffer_accessor_get_pointer_w {
   template <typename accT, typename errorAccT>
   static void check(const accT& acc, const errorAccT&,
                     const sycl_id_t<dim>& offset) {
-    const auto value = expected_value_t::expected_write(offset);
+    sycl_id_t<dim>
+        zero_offset;  // In SYCL 2020, get_pointer() always returns the base
+                      // buffer pointer, ignoring any offset.
+    const auto value = expected_value_t::expected_write(zero_offset);
     auto ptr = acc.get_pointer();
 
     *ptr = value;
@@ -271,8 +277,11 @@ struct buffer_accessor_get_pointer_rw {
   static void check(const acc_t<placeholder>& acc,
                     const errorAccT& errorAccessor,
                     const sycl_id_t<dim>& offset) {
-    const auto expectedRead = expected_value_t::expected_read(offset);
-    const auto expectedWrite = expected_value_t::expected_write(offset);
+    sycl_id_t<dim>
+        zero_offset;  // In SYCL 2020, get_pointer() always returns the base
+                      // buffer pointer, ignoring any offset.
+    const auto expectedRead = expected_value_t::expected_read(zero_offset);
+    const auto expectedWrite = expected_value_t::expected_write(zero_offset);
     constexpr bool noInitExpected =
         (target == sycl::target::local) ||
         (mode == sycl::access_mode::discard_read_write);

--- a/tests/accessor/accessor_api_common_buffer_local.h
+++ b/tests/accessor/accessor_api_common_buffer_local.h
@@ -231,9 +231,10 @@ struct buffer_accessor_get_pointer_r {
   template <typename accT, typename errorAccT>
   static void check(const accT& acc, const errorAccT& errorAccessor,
                     const sycl_id_t<dim>& offset) {
-    sycl_id_t<dim>
-        zero_offset;  // In SYCL 2020, get_pointer() always returns the base
-                      // buffer pointer, ignoring any offset.
+    // In SYCL 2020, get_pointer() always returns the base
+    // buffer pointer, ignoring any offset.
+    sycl_id_t<dim> zero_offset;
+
     const auto expectedRead = expected_value_t::expected_read(zero_offset);
     auto ptr = acc.get_pointer();
 


### PR DESCRIPTION
SYCL 2020 specifies that `accessor::get_pointer()` always returns the base buffer pointer, ignoring any offset.  Update the tests to reflect this expectation.

This is my first PR for the CTS tests on KhronosGroup.  Let me know if there are procedural conventions that I overlooked.  