### PR TITLE
Tests for sycl::get_kernel_id and sycl::get_kernel_ids

### DIFF
--- a/ci/computecpp.filter
+++ b/ci/computecpp.filter
@@ -18,6 +18,7 @@ invoke
 item
 kernel
 kernel_args
+kernel_bundle
 math_builtin_api
 multi_ptr
 nd_item

--- a/ci/hipsycl.filter
+++ b/ci/hipsycl.filter
@@ -17,6 +17,7 @@ image
 item
 kernel
 kernel_args
+kernel_bundle
 math_builtin_api
 multi_ptr
 nd_item

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,6 +181,7 @@ function(add_cts_test_helper)
   target_sources(test_all PRIVATE $<TARGET_OBJECTS:${test_exe_name}_objects>)
 endfunction()
 
+# Create one *.exe-file from all of the provided *.cpp-files
 function(add_cts_test)
   # To make check that any .cpp files are passed
   # List created because, direct check on "${ARGN}" gives false-positive result
@@ -194,6 +195,7 @@ function(add_cts_test)
   endif()
 endfunction()
 
+# Create a separate *.exe-file from each of the provided *.cpp-files
 function(add_independent_cts_tests)
   set(tests_list "${ARGN}")
   foreach(ind_test IN LISTS tests_list)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -206,8 +206,7 @@ function(add_independent_cts_tests)
 
       add_cts_test_helper(${test_exe_name} "${test_cases_list}")
     else()
-      # this comment will be removed after testing TMT run
-      message(STATUS ">>>>>>>>>>>>>>>>>>>>> no file named ${ind_test}")
+      message(FATAL_ERROR "No file named ${ind_test}")
     endif()
   endforeach()
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,19 +1,31 @@
+set(tests_dir ${CMAKE_CURRENT_SOURCE_DIR})
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+set(SYCL_CTS_TEST_FILTER "" CACHE FILEPATH "Path to the SYCL CTS test filter for building.")
+
+# Get the list of test categories to build
+# All test categories are built unless a test filter was given
 if(SYCL_CTS_TEST_FILTER)
-  message(FATAL_ERROR "SYCL_CTS_TEST_FILTER is no longer supported. Use SYCL_CTS_EXCLUDE_TEST_CATEGORIES instead.")
+    message(WARNING "A filter file has been given to cts, only tests matching the ones on the file will be build.")
+    message(STATUS "SYCL_CTS_TEST_FILTER='${SYCL_CTS_TEST_FILTER}'")
+    file(STRINGS "${SYCL_CTS_TEST_FILTER}" test_projects_dir_list)
+else()
+    # create separate targets for each test project
+    set(test_projects_dir_list "")
+    file(GLOB subdirectories RELATIVE ${tests_dir} ${tests_dir}/*)
+    foreach(dir ${subdirectories})
+        if(${dir} MATCHES "common")
+            # The common folder is always included
+            continue()
+        endif()
+        if(EXISTS "${tests_dir}/${dir}/CMakeLists.txt")
+            list(APPEND test_projects_dir_list ${dir})
+        endif()
+    endforeach()
 endif()
-set(SYCL_CTS_EXCLUDE_TEST_CATEGORIES "" CACHE FILEPATH "Optional filter specifying test categories to be excluded from build.")
+list(REMOVE_DUPLICATES test_projects_dir_list)
 
-set(exclude_categories "")
-if(SYCL_CTS_EXCLUDE_TEST_CATEGORIES)
-  if(NOT EXISTS "${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}" OR IS_DIRECTORY "${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}")
-    message(FATAL_ERROR "Invalid filter file '${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}'.")
-  endif()
-  message(STATUS "Using test category filter '${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}'.")
-  file(STRINGS "${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}" exclude_categories)
-endif()
-
+# The common folder is always included
 add_subdirectory("common")
 
 function(get_std_type OUT_LIST)
@@ -96,11 +108,6 @@ function(generate_cts_test)
     "EXTRA_ARGS;DEPENDS"
     ${ARGN}
   )
-  get_filename_component(test_dir ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-  if(${test_dir} IN_LIST exclude_categories)
-    return()
-  endif()
-
   message(STATUS "Setup test generation rules for: " ${GEN_TEST_OUTPUT})
 
   set(GEN_TEST_FILE_NAME ${GEN_TEST_OUTPUT})
@@ -141,17 +148,9 @@ endfunction()
 add_executable(test_all)
 
 # create test executable targets for each test project using the build_sycl function
-function(add_cts_test)
-  get_filename_component(test_dir ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-  set(test_exe_name test_${test_dir})
-  set(test_cases_list ${ARGN})
-
-  if(NOT ${test_dir} IN_LIST exclude_categories)
-    message(STATUS "Adding test: " ${test_exe_name})
-  else()
-    message(STATUS "Skipping excluded test: " ${test_exe_name})
-    return()
-  endif()
+function(add_cts_test_helper)
+  set(test_exe_name test_${ARGV0})
+  set(test_cases_list ${ARGV1})
 
   if(NOT SYCL_CTS_ENABLE_HALF_TESTS)
     list(FILTER test_cases_list EXCLUDE REGEX .*_fp16\\.cpp$)
@@ -182,12 +181,37 @@ function(add_cts_test)
   target_sources(test_all PRIVATE $<TARGET_OBJECTS:${test_exe_name}_objects>)
 endfunction()
 
-file(GLOB test_category_dirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
-list(REMOVE_ITEM test_category_dirs "common")
-foreach(dir ${test_category_dirs})
-  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/CMakeLists.txt")
-    add_subdirectory(${dir})
+function(add_cts_test)
+  # To make check that any .cpp files are passed
+  # List created because, direct check on "${ARGN}" gives false-positive result
+  set(tests_list "${ARGN}")
+  if (tests_list)
+    get_filename_component(test_dir ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+    set(test_exe_name ${test_dir})
+    set(test_cases_list "${ARGN}")
+
+    add_cts_test_helper(${test_exe_name} "${test_cases_list}")
   endif()
+endfunction()
+
+function(add_independent_cts_tests)
+  set(tests_list "${ARGN}")
+  foreach(ind_test IN LISTS tests_list)
+    if(EXISTS "${ind_test}")
+      get_filename_component(cpp_name "${ind_test}" NAME_WE)
+      set(test_exe_name "${cpp_name}")
+      set(test_cases_list "${ind_test}")
+
+      add_cts_test_helper(${test_exe_name} "${test_cases_list}")
+    else()
+      # this comment will be removed after testing TMT run
+      message(STATUS ">>>>>>>>>>>>>>>>>>>>> no file named ${ind_test}")
+    endif()
+  endforeach()
+endfunction()
+
+foreach(dir ${test_projects_dir_list})
+  add_subdirectory(${dir})
 endforeach()
 
 target_link_libraries(test_all PRIVATE CTS::util CTS::main_function oclmath)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,31 +1,19 @@
-set(tests_dir ${CMAKE_CURRENT_SOURCE_DIR})
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set(SYCL_CTS_TEST_FILTER "" CACHE FILEPATH "Path to the SYCL CTS test filter for building.")
-
-# Get the list of test categories to build
-# All test categories are built unless a test filter was given
 if(SYCL_CTS_TEST_FILTER)
-    message(WARNING "A filter file has been given to cts, only tests matching the ones on the file will be build.")
-    message(STATUS "SYCL_CTS_TEST_FILTER='${SYCL_CTS_TEST_FILTER}'")
-    file(STRINGS "${SYCL_CTS_TEST_FILTER}" test_projects_dir_list)
-else()
-    # create separate targets for each test project
-    set(test_projects_dir_list "")
-    file(GLOB subdirectories RELATIVE ${tests_dir} ${tests_dir}/*)
-    foreach(dir ${subdirectories})
-        if(${dir} MATCHES "common")
-            # The common folder is always included
-            continue()
-        endif()
-        if(EXISTS "${tests_dir}/${dir}/CMakeLists.txt")
-            list(APPEND test_projects_dir_list ${dir})
-        endif()
-    endforeach()
+  message(FATAL_ERROR "SYCL_CTS_TEST_FILTER is no longer supported. Use SYCL_CTS_EXCLUDE_TEST_CATEGORIES instead.")
 endif()
-list(REMOVE_DUPLICATES test_projects_dir_list)
+set(SYCL_CTS_EXCLUDE_TEST_CATEGORIES "" CACHE FILEPATH "Optional filter specifying test categories to be excluded from build.")
 
-# The common folder is always included
+set(exclude_categories "")
+if(SYCL_CTS_EXCLUDE_TEST_CATEGORIES)
+  if(NOT EXISTS "${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}" OR IS_DIRECTORY "${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}")
+    message(FATAL_ERROR "Invalid filter file '${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}'.")
+  endif()
+  message(STATUS "Using test category filter '${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}'.")
+  file(STRINGS "${SYCL_CTS_EXCLUDE_TEST_CATEGORIES}" exclude_categories)
+endif()
+
 add_subdirectory("common")
 
 function(get_std_type OUT_LIST)
@@ -108,6 +96,11 @@ function(generate_cts_test)
     "EXTRA_ARGS;DEPENDS"
     ${ARGN}
   )
+  get_filename_component(test_dir ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+  if(${test_dir} IN_LIST exclude_categories)
+    return()
+  endif()
+
   message(STATUS "Setup test generation rules for: " ${GEN_TEST_OUTPUT})
 
   set(GEN_TEST_FILE_NAME ${GEN_TEST_OUTPUT})
@@ -149,8 +142,16 @@ add_executable(test_all)
 
 # create test executable targets for each test project using the build_sycl function
 function(add_cts_test_helper)
+  get_filename_component(test_dir ${CMAKE_CURRENT_SOURCE_DIR} NAME)
   set(test_exe_name test_${ARGV0})
   set(test_cases_list ${ARGV1})
+
+  if(NOT ${test_dir} IN_LIST exclude_categories)
+    message(STATUS "Adding test: " ${test_exe_name})
+  else()
+    message(STATUS "Skipping excluded test: " ${test_exe_name})
+    return()
+  endif()
 
   if(NOT SYCL_CTS_ENABLE_HALF_TESTS)
     list(FILTER test_cases_list EXCLUDE REGEX .*_fp16\\.cpp$)
@@ -211,8 +212,12 @@ function(add_independent_cts_tests)
   endforeach()
 endfunction()
 
-foreach(dir ${test_projects_dir_list})
-  add_subdirectory(${dir})
+file(GLOB test_category_dirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
+list(REMOVE_ITEM test_category_dirs "common")
+foreach(dir ${test_category_dirs})
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/CMakeLists.txt")
+    add_subdirectory(${dir})
+  endif()
 endforeach()
 
 target_link_libraries(test_all PRIVATE CTS::util CTS::main_function oclmath)

--- a/tests/common/common_by_reference.h
+++ b/tests/common/common_by_reference.h
@@ -1,0 +1,135 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+// Provides verification for common by-reference semantics
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_COMMON_COMMON_BY_REFERENCE_H
+#define __SYCLCTS_TESTS_COMMON_COMMON_BY_REFERENCE_H
+
+#include "common.h"
+#include "common_semantics.h"
+#include "../../util/exceptions.h"
+
+#include <string>
+#include <utility>
+
+namespace common_by_reference {
+using namespace sycl_cts;
+
+/** @brief Can be used as condition in custom mutator
+ */
+enum class mutation : int {
+  const_correctness,
+  mutate_b,
+  mutate_a,
+  SIZE  // This should be last
+};
+
+/** @brief Predefined functor without mutation of passed object
+ */
+struct no_mutation {
+  template <typename T>
+  void operator()(T&, mutation) const {} // No mutation expected
+};
+
+/** @brief Check that object follows common reference semantics.
+ *  @attention Test for this check must be independent or last because passed
+ *             object will be moved during this check. So we can't use object
+ *             anymore.
+ */
+template <typename T, typename StorageT, typename MutatorT>
+void check_on_host(sycl_cts::util::logger &log, T& a, T& other,
+                   const std::string &testName, MutatorT mutator) {
+  common_semantics::check_on_host(log, a, other, testName);
+  // Create storage for following checks
+  StorageT storage;
+
+  auto mkInfo = [&](const std::string &check_name){
+    return testName + " Common reference semantics. " + check_name;
+  };
+
+  // Check that hashes are equal for a and copy, but different for a and other
+  std::hash<T> hasher;
+  T copy_to_hash = a;
+  if (hasher(a) != hasher(copy_to_hash)) {
+    FAIL(log, testName + "(Hashes of 'a' and 'b' are not equal)");
+  }
+  if (hasher(a) == hasher(other)) {
+    FAIL(log, "(Hashes should not be equal for 'a' and 'other')");
+  }
+
+  // Check that object is copy constructable
+  storage.store(a);
+  T copy_constructed_obj(a);
+  if (a != copy_constructed_obj) {
+    FAIL(log, testName + " is not copy constructible");
+  }
+  util::run_check(log, mkInfo("Copy construction."), [&]{
+    if (!storage.check(copy_constructed_obj)) {
+      FAIL(log, testName + " is not copy constructible (storage::check())");
+    }
+  });
+
+  // Check that obect is copy assignable
+  storage.store(a);
+  T copy_assigned_obj = a;
+  if (a != copy_assigned_obj) {
+    FAIL(log, testName + " is not copy assignable");
+  }
+  util::run_check(log, mkInfo("Copy assignment."), [&]{
+    if (!storage.check(copy_assigned_obj)) {
+      FAIL(log, testName + " is not copy assignable (storage::check())");
+    }
+  });
+
+  // Check const-correctness
+  const auto &const_obj = a;
+  storage.store(const_obj);
+  mutator(a, mutation::const_correctness);
+  util::run_check(log, mkInfo("Const-correcntess."), [&]{
+    if (!storage.check(const_obj)) {
+      FAIL(log, testName + " ignores const correctness (storage::check())");
+    }
+  });
+
+  // Check that mutation applied to both object and copy of object
+  T mutable_obj = a;
+  mutator(mutable_obj, mutation::mutate_b);
+  if (a != mutable_obj) {
+    FAIL(log, testName + " does not follow common reference semantics. (a != b"
+              "after mutation of 'b')");
+  }
+
+  mutator(a, mutation::mutate_a);
+  if (a != mutable_obj) {
+    FAIL(log, testName + " does not follow common reference semantics. (a != b"
+              "after mutation of 'a')");
+  }
+
+  // Move construction check
+  // Store object data before it is moved
+  storage.store(a);
+  T move_constructed_obj(std::move(a));
+  util::run_check(log, mkInfo("Move construction"), [&]{
+    if (!storage.check(move_constructed_obj)) {
+      FAIL(log, testName + " is not move constructible (storage::check())");
+    }
+  });
+
+  // Move assignment check
+  // Store object data before it is moved
+  storage.store(move_constructed_obj);
+  T move_assigned_obj = std::move(move_constructed_obj);
+  util::run_check(log, mkInfo("Move assignment."), [&]{
+    if (!storage.check(move_assigned_obj)) {
+      FAIL(log, testName + " is not move assignable (storage::check())");
+    }
+  });
+}
+
+}  // common_by_reference
+
+#endif  // __SYCLCTS_TESTS_COMMON_COMMON_BY_REFERENCE_H

--- a/tests/common/common_semantics.h
+++ b/tests/common/common_semantics.h
@@ -2,12 +2,12 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-// Provides verification for common by-value semantics
+// Provides generic semantics verification
 //
 *******************************************************************************/
 
-#ifndef __SYCLCTS_TESTS_COMMON_COMMON_BY_VALUE_H
-#define __SYCLCTS_TESTS_COMMON_COMMON_BY_VALUE_H
+#ifndef __SYCLCTS_TESTS_COMMON_SEMANTICS_H
+#define __SYCLCTS_TESTS_COMMON_SEMANTICS_H
 
 #include "common.h"
 
@@ -15,13 +15,13 @@
 #include <string>
 #include <type_traits>
 
-namespace {
+namespace common_semantics {
 
 /**
  * @brief Check equality-comparable operations on the host side
  */
 template <typename T>
-void check_equality_comparable_generic(sycl_cts::util::logger& log, const T& a,
+void check_on_host(sycl_cts::util::logger& log, const T& a,
                                        const std::string& testName) {
   /** check for reflexivity
    */
@@ -65,10 +65,42 @@ void check_equality_comparable_generic(sycl_cts::util::logger& log, const T& a,
 }
 
 /**
+ * @brief Check equality-comparable operations on the host side with extra
+ *        checks for symmetry
+ */
+template <typename T>
+void check_on_host(sycl_cts::util::logger& log, const T& a,
+                                       const T& other,
+                                       const std::string& testName) {
+    check_on_host(log, a, testName);
+
+    /** extra checks for symmetry (comparsion with other)
+     */
+    if (a == other) {
+      FAIL(log, (testName +
+                 " is not equality-comparable (operator==, different value)"));
+    }
+    if (other == a) {
+      FAIL(log, (testName +
+                 " is not equality-comparable (operator== symmetry failed," +
+                 " different value)"));
+    }
+    if (!(a != other)) {
+      FAIL(log, (testName +
+                 " is not equality-comparable (operator!=, different value)"));
+    }
+    if (!(other != a)) {
+      FAIL(log, (testName +
+                 " is not equality-comparable (operator!= symmetry failed," +
+                 " different value)"));
+    }
+}
+
+/**
  * @brief Check equality-comparable operations on the device side
  */
 template <typename T>
-class equality_comparable_on_device
+class on_device_checker
 {
   /**
    * @brief Provides a safe index for checking an operation
@@ -93,9 +125,8 @@ class equality_comparable_on_device
 
 public:
   template <typename kernelT>
-  static void check_on_kernel(sycl_cts::util::logger& log,
-                              const std::array<T, 2>& items,
-                              const std::string& testName) {
+  static void run(sycl_cts::util::logger& log, const std::array<T, 2>& items,
+                  const std::string& testName) {
     // Store comparison results from kernel into a success array
     success_array_t success;
     std::fill(std::begin(success), std::end(success), false);
@@ -222,4 +253,4 @@ public:
 
 }  // namespace
 
-#endif  // __SYCLCTS_TESTS_COMMON_COMMON_BY_VALUE_H
+#endif  // __SYCLCTS_TESTS_COMMON_SEMANTICS_H

--- a/tests/group/group_constructors.cpp
+++ b/tests/group/group_constructors.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 #include "../common/invoke.h"
 #include "../../util/array.h"
 

--- a/tests/group/group_equality.cpp
+++ b/tests/group/group_equality.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 #include "../common/invoke.h"
 
 #define TEST_NAME group_equality
@@ -43,14 +43,13 @@ class TEST_NAME : public util::test_base {
           store_instances<numItems, invoke_group<numDims, setup_kernel_t>>();
 
       // Check nd_item equality operator on the device side
-      equality_comparable_on_device<item_t>::
-          template check_on_kernel<group_equality_kernel<numDims>>(
+      common_semantics::on_device_checker<item_t>::template
+          run<group_equality_kernel<numDims>>(
               log, items, "group " + std::to_string(numDims) + " (device)");
 
       // Check group equality operator on the host side
-      check_equality_comparable_generic(log, items[0],
-                                        "group " + std::to_string(numDims) +
-                                        " (host)");
+      common_semantics::check_on_host(
+          log, items[0], "group " + std::to_string(numDims) + " (host)");
     }
   }
 
@@ -66,4 +65,4 @@ class TEST_NAME : public util::test_base {
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-}  // namespace TEST_NAME
+}  // namespace TEST_NAMESPACE

--- a/tests/h_item/h_item_equality.cpp
+++ b/tests/h_item/h_item_equality.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 
 #include <array>
 #include <string>
@@ -75,7 +75,7 @@ class TEST_NAME : public util::test_base {
 
         // Retrieve two h_item objects and store them
         sycl::buffer<item_t> itemBuf(items.data(),
-                                         sycl::range<1>(items.size()));
+                                     sycl::range<1>(items.size()));
         testQueue.submit([&](sycl::handler& cgh) {
           auto itemAcc =
               itemBuf.template get_access<sycl::access_mode::write>(cgh);
@@ -90,7 +90,7 @@ class TEST_NAME : public util::test_base {
 
         // Perform comparisons on the stored h_item objects
         sycl::buffer<bool> successBuf(success.data(),
-                                          sycl::range<1>(success.size()));
+                                      sycl::range<1>(success.size()));
         testQueue.submit([&](sycl::handler& cgh) {
           auto itemAcc =
               itemBuf.template get_access<sycl::access_mode::read>(cgh);
@@ -126,8 +126,8 @@ class TEST_NAME : public util::test_base {
       }
 
       // Check h_item equality operator
-      check_equality_comparable_generic(log, items[0],
-                                        "h_item " + std::to_string(numDims));
+      common_semantics::check_on_host(log, items[0],
+                                      "h_item " + std::to_string(numDims));
       CHECK_VALUE(log, success[static_cast<size_t>(current_check::equal_self)],
                   true, numDims);
       CHECK_VALUE(log,

--- a/tests/id/id_constructors.cpp
+++ b/tests/id/id_constructors.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 
 #define TEST_NAME id_constructors
 
@@ -98,7 +98,7 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "id with id was not move assigned correctly for dim = 1");
         }
 
-        check_equality_comparable_generic(log, id_explicit, std::string("id"));
+        common_semantics::check_on_host(log, id_explicit, std::string("id"));
       }
 
       // dim 2
@@ -140,7 +140,7 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "id with id was not move assigned correctly for dim = 2");
         }
 
-        check_equality_comparable_generic(log, id_explicit, std::string("id"));
+        common_semantics::check_on_host(log, id_explicit, std::string("id"));
       }
 
       // dim 3
@@ -189,7 +189,7 @@ class TEST_NAME : public util::test_base {
           FAIL(log, "id with id was not move assigned correctly for dim = 3");
         }
 
-        check_equality_comparable_generic(log, id_explicit, std::string("id"));
+        common_semantics::check_on_host(log, id_explicit, std::string("id"));
       }
 
       // construct from an item
@@ -201,9 +201,8 @@ class TEST_NAME : public util::test_base {
         {
           sycl::buffer<bool, 1> b(&success, sycl::range<1>(1));
           q.submit([&](sycl::handler &cgh) {
-            auto hasSucceded =
-                b.get_access<sycl::access_mode::read_write,
-                             sycl::target::device>(cgh);
+            auto hasSucceded = b.get_access<sycl::access_mode::read_write,
+                                            sycl::target::device>(cgh);
 
             auto my_range = sycl::range<1>(sizes[0]);
 
@@ -230,9 +229,8 @@ class TEST_NAME : public util::test_base {
         {
           sycl::buffer<bool, 1> b(&success, sycl::range<1>(1));
           q.submit([&](sycl::handler &cgh) {
-            auto hasSucceded =
-                b.get_access<sycl::access_mode::read_write,
-                             sycl::target::device>(cgh);
+            auto hasSucceded = b.get_access<sycl::access_mode::read_write,
+                                            sycl::target::device>(cgh);
 
             auto my_range = sycl::range<2>(sizes[0], sizes[1]);
 
@@ -242,7 +240,6 @@ class TEST_NAME : public util::test_base {
                   (id.get(1) != item.get_id(1))) {
                 hasSucceded[0] = false;
               }
-
             };
             cgh.parallel_for<class id_it2>(my_range, my_kernel);
           });
@@ -261,9 +258,8 @@ class TEST_NAME : public util::test_base {
         {
           sycl::buffer<bool, 1> b(&success, sycl::range<1>(1));
           q.submit([&](sycl::handler &cgh) {
-            auto hasSucceded =
-                b.get_access<sycl::access_mode::read_write,
-                             sycl::target::device>(cgh);
+            auto hasSucceded = b.get_access<sycl::access_mode::read_write,
+                                            sycl::target::device>(cgh);
 
             auto my_range = sycl::range<3>(sizes[0], sizes[1], sizes[2]);
 
@@ -274,7 +270,6 @@ class TEST_NAME : public util::test_base {
                   (id.get(2) != item.get_id(2))) {
                 hasSucceded[0] = false;
               }
-
             };
             cgh.parallel_for<class id_it3>(my_range, my_kernel);
           });
@@ -292,4 +287,4 @@ class TEST_NAME : public util::test_base {
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-} /* namespace id_constructors__ */
+}  // namespace TEST_NAMESPACE

--- a/tests/item/item_equality.cpp
+++ b/tests/item/item_equality.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 
 #include <array>
 
@@ -74,7 +74,7 @@ class TEST_NAME : public util::test_base {
 
         // Retrieve two item objects and store them
         sycl::buffer<item_t> itemBuf(items.data(),
-                                         sycl::range<1>(items.size()));
+                                     sycl::range<1>(items.size()));
         testQueue.submit([&](sycl::handler& cgh) {
           auto itemAcc =
               itemBuf.template get_access<sycl::access_mode::write>(cgh);
@@ -86,7 +86,7 @@ class TEST_NAME : public util::test_base {
 
         // Perform comparisons on the stored item objects
         sycl::buffer<bool> successBuf(success.data(),
-                                          sycl::range<1>(success.size()));
+                                      sycl::range<1>(success.size()));
         testQueue.submit([&](sycl::handler& cgh) {
           auto itemAcc =
               itemBuf.template get_access<sycl::access_mode::read>(cgh);
@@ -122,8 +122,8 @@ class TEST_NAME : public util::test_base {
       }
 
       // Check item equality operator
-      check_equality_comparable_generic(log, items[0],
-                                        "item " + std::to_string(numDims));
+      common_semantics::check_on_host(log, items[0],
+                                      "item " + std::to_string(numDims));
       CHECK_VALUE(log, success[static_cast<size_t>(current_check::equal_self)],
                   true, numDims);
       CHECK_VALUE(log,

--- a/tests/kernel_bundle/CMakeLists.txt
+++ b/tests/kernel_bundle/CMakeLists.txt
@@ -1,0 +1,13 @@
+file(GLOB test_cases_list *.cpp)
+
+set(independent_cases_list
+  get_kernel_ids_multiple_kernels.cpp
+  get_kernel_ids_single_kernel.cpp
+  get_kernel_ids_no_kernels.cpp
+)
+
+list(TRANSFORM independent_cases_list PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+list(REMOVE_ITEM test_cases_list ${independent_cases_list})
+
+add_cts_test(${test_cases_list})
+add_independent_cts_tests(${independent_cases_list})

--- a/tests/kernel_bundle/get_kernel_id.h
+++ b/tests/kernel_bundle/get_kernel_id.h
@@ -1,0 +1,62 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides common functions for sycl::get_kernel_id or sycl::get_kernel_id
+//  tests.
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_GET_KERNEL_ID_H
+#define __SYCLCTS_TESTS_GET_KERNEL_ID_H
+
+#include "../../util/exceptions.h"
+#include "../common/common.h"
+
+namespace sycl_cts {
+namespace tests {
+namespace get_kernel_id {
+
+constexpr bool by_handler{true};
+constexpr bool by_queue{false};
+
+/** @brief Srorage class for saving kernel_id properties for future checks.
+ */
+class kernel_id_storage {
+  std::string k_id_name;
+
+ public:
+  void store(const sycl::kernel_id &k_id) {
+    if (k_id.get_name() == nullptr)
+      throw util::fail_check(
+          "kernel_id::get_name() returned nullptr (in "
+          "kernel_id_storage::store()). ");
+    k_id_name = k_id.get_name();
+  }
+
+  bool check(const sycl::kernel_id &k_id) const {
+    if (k_id.get_name() == nullptr)
+      throw util::fail_check(
+          "kernel_id::get_name() returned nullptr (in "
+          "kernel_id_storage::check()). ");
+    return k_id.get_name() == k_id_name;
+  }
+};
+
+/** @brief Run test by sycl::queue or sycl::handler
+ */
+template <bool ByHandler, typename TestFunctorT>
+void run_verification(sycl_cts::util::logger &log, TestFunctorT action) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if constexpr (ByHandler) {
+    queue.submit(action);
+  } else {
+    action(queue);
+  }
+}
+
+}  // namespace get_kernel_id
+}  // namespace tests
+}  // namespace sycl_cts
+
+#endif  // __SYCLCTS_TESTS_GET_KERNEL_ID_H

--- a/tests/kernel_bundle/get_kernel_id_function.cpp
+++ b/tests/kernel_bundle/get_kernel_id_function.cpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::kernel_id::get_kernel_id()
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "get_kernel_id.h"
+#include "kernel_bundle.h"
+
+#define TEST_NAME get_kernel_id_function
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace sycl_cts::tests::get_kernel_id;
+using namespace sycl_cts::tests::kernel_bundle;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    /** Check return type of sycl::get_kernel_id()
+     */
+    run_verification<by_queue>(log, [&](sycl::queue &queue) {
+      using kernel_name = class k_id_ret_type;
+      using RetType =
+          std::invoke_result_t<decltype(sycl::get_kernel_id<k_id_ret_type>)>;
+      if (!std::is_same_v<RetType, sycl::kernel_id>) {
+        FAIL(log, "Wrong return type of sycl::get_kernel_id()");
+      }
+
+      define_kernel<kernel_name>(queue);
+    });
+
+    /** Call sycl::get_kernel_id() for two existing kernels and make
+     *  sure that return is different
+     */
+    run_verification<by_queue>(log, [&](sycl::queue &queue) {
+      using kernel_name = class k_id_get_kernel_id;
+      using kernel_name_other = class k_id_get_kernel_id_other;
+      sycl::kernel_id k_id = sycl::get_kernel_id<kernel_name>();
+      sycl::kernel_id k_id_other = sycl::get_kernel_id<kernel_name_other>();
+
+      if (k_id == k_id_other) {
+        FAIL(log, "Expected different kernel_ids for different kernels");
+      }
+      define_kernel<kernel_name>(queue);
+      define_kernel<kernel_name_other>(queue);
+    });
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/kernel_bundle/get_kernel_ids_multiple_kernels.cpp
+++ b/tests/kernel_bundle/get_kernel_ids_multiple_kernels.cpp
@@ -1,0 +1,95 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::kernel_id::get_kernel_ids() for multiple kernels
+//  in application.
+//
+//  IMPORTANT: This file should not be merged with another *.cpp file because we
+//  must have a strictly defined kernels in the application because tested
+//  function uses all available kernels and we can't chose specific kernel.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "get_kernel_id.h"
+#include "kernel_bundle.h"
+
+#define TEST_NAME get_kernel_ids_multiple_kernels
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace sycl_cts::tests::get_kernel_id;
+using namespace sycl_cts::tests::kernel_bundle;
+
+template <size_t idx>
+class get_kernel_ids_multiple;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    /** Check return type of sycl::get_kernel_ids()
+     */
+    {
+      using RetType = std::invoke_result_t<decltype(sycl::get_kernel_ids)>;
+      if (!std::is_same_v<RetType, std::vector<sycl::kernel_id>>) {
+        FAIL(log, "Wrong return type of sycl::get_kernel_id()");
+      }
+    }
+
+    /** Call sycl::get_kernel_id() for multiple kernels in application
+     */
+    run_verification<by_queue>(log, [&](sycl::queue &queue) {
+      constexpr size_t kernels_count = 4;
+      using k_name_1 = get_kernel_ids_multiple<1>;
+      using k_name_2 = get_kernel_ids_multiple<2>;
+      using k_name_3 = get_kernel_ids_multiple<3>;
+      using k_name_4 = get_kernel_ids_multiple<4>;
+      auto k_ids = sycl::get_kernel_ids();
+      if (k_ids.size() == 0) {
+        FAIL(log,
+             "Empty kernel_ids vector returned. Vector should include"
+             "exactly " +
+                 std::to_string(kernels_count) + " kernel_id");
+      } else if (k_ids.size() < kernels_count) {
+        FAIL(log,
+             "Less than expected kernel_ids in returned vector."
+             " Expected: " +
+                 std::to_string(kernels_count) +
+                 " Returned: " + std::to_string(k_ids.size()));
+      } else if (k_ids.size() > kernels_count) {
+        FAIL(log,
+             "More than expected kernel_ids in returned vector."
+             " Expected: " +
+                 std::to_string(kernels_count) +
+                 " Returned: " + std::to_string(k_ids.size()));
+      }
+      // Check that all kernel_ids are different
+      for (auto it_main = k_ids.begin(); it_main != k_ids.end(); ++it_main) {
+        for (auto it_nes = it_main + 1; it_nes != k_ids.end(); ++it_nes) {
+          if (*it_main == *it_nes)
+            FAIL(log,
+                 "Multiple kernels in application should provide non-equal"
+                 "kernel_ids.");
+        }
+      }
+      define_kernel<k_name_1>(queue);
+      define_kernel<k_name_2>(queue);
+      define_kernel<k_name_3>(queue);
+      define_kernel<k_name_4>(queue);
+    });
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/kernel_bundle/get_kernel_ids_no_kernels.cpp
+++ b/tests/kernel_bundle/get_kernel_ids_no_kernels.cpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::kernel_id::get_kernel_ids() for zero kernels in
+//  application.
+//
+//  IMPORTANT: This file should not be merged with another *.cpp file because we
+//  must have a strictly defined kernels in the application because tested
+//  function uses all available kernels and we can't chose specific kernel.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "get_kernel_id.h"
+#include "kernel_bundle.h"
+
+#define TEST_NAME get_kernel_ids_no_kernels
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace sycl_cts::tests::get_kernel_id;
+using namespace sycl_cts::tests::kernel_bundle;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    /** Call sycl::get_kernel_ids() without any kernels in application
+     */
+    run_verification<by_handler>(log, [&](sycl::handler &cgh) {
+      auto k_ids = sycl::get_kernel_ids();
+      if (k_ids.size() > 0) {
+        FAIL(log, "One or more kernel_ids returned (" +
+                      std::to_string(k_ids.size()) +
+                      "). Return vector should not"
+                      " include built-in kernel ids from any device");
+      }
+    });
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/kernel_bundle/get_kernel_ids_single_kernel.cpp
+++ b/tests/kernel_bundle/get_kernel_ids_single_kernel.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::kernel_id::get_kernel_ids() for single kernel in
+//  application.
+//
+//  IMPORTANT: This file should not be merged with another *.cpp file because we
+//  must have a strictly defined kernels in the application because tested
+//  function uses all available kernels and we can't chose specific kernel.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/common_by_reference.h"
+#include "get_kernel_id.h"
+#include "kernel_bundle.h"
+
+#define TEST_NAME get_kernel_ids_single_kernel
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace sycl_cts::tests::get_kernel_id;
+using namespace sycl_cts::tests::kernel_bundle;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    /** Call sycl::get_kernel_id() for single kernel in application
+     */
+    run_verification<by_handler>(log, [&](sycl::handler &cgh) {
+      using kernel_name = class get_kernel_ids_single;
+      auto k_ids = sycl::get_kernel_ids();
+      if (k_ids.size() == 0) {
+        FAIL(log,
+             "Empty kernel_ids vector returned. Vector should include"
+             "exactly one kernel_id");
+      } else if (k_ids.size() > 1) {
+        FAIL(log, "More than one kernel_ids in returned vector (" +
+                      std::to_string(k_ids.size()) +
+                      "). Vector should"
+                      " include exactly one kernel_id");
+      }
+      cgh.single_task<kernel_name>([=]() {});
+    });
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/kernel_bundle/kernel_bundle.h
+++ b/tests/kernel_bundle/kernel_bundle.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides common functions for sycl::kernel_bundle tests
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_KERNEL_BUNDLE_H
+#define __SYCLCTS_TESTS_KERNEL_BUNDLE_H
+
+#include "../../util/exceptions.h"
+#include "../common/common.h"
+
+namespace sycl_cts {
+namespace tests {
+namespace kernel_bundle {
+
+/** @brief Submit dummy kernel with specific kernel name
+ */
+template <typename KernelName>
+void define_kernel(sycl::queue &queue) {
+  queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<KernelName>([=]() {}); });
+}
+
+}  // namespace kernel_bundle
+}  // namespace tests
+}  // namespace sycl_cts
+
+#endif  // __SYCLCTS_TESTS_KERNEL_BUNDLE_H

--- a/tests/kernel_bundle/kernel_id_api.cpp
+++ b/tests/kernel_bundle/kernel_id_api.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::kernel_id API
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/common_by_reference.h"
+#include "get_kernel_id.h"
+#include "kernel_bundle.h"
+
+#include <type_traits>
+
+#define TEST_NAME kernel_id_api
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace sycl_cts::tests::get_kernel_id;
+using namespace sycl_cts::tests::kernel_bundle;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    /** Check that kernel_id does not have default constructor
+     */
+    if (std::is_default_constructible_v<sycl::kernel_id>) {
+      FAIL(log, "sycl::kernel_id should not have default constructor");
+    }
+
+    /** Check that kernel_id is destructible
+     */
+    if (!std::is_destructible_v<sycl::kernel_id>) {
+      FAIL(log, "sycl::kernel_id should be destructible");
+    }
+
+    /** Check kernel_id::get_name() return type
+     */
+    using RetType = std::invoke_result_t<decltype(&sycl::kernel_id::get_name),
+                                         sycl::kernel_id>;
+    if (!std::is_same_v<RetType, const char *>) {
+      FAIL(log, "Incorrect return type of kernel_id::get_name()");
+    }
+
+    /** Check const correctness of kernel_id::get_name()
+     */
+    run_verification<by_handler>(log, [&](sycl::handler &cgh) {
+      using kernel_name = class k_id_get_name_const_correctness;
+      const sycl::kernel_id k_id = sycl::get_kernel_id<kernel_name>();
+      if (k_id.get_name() == nullptr) {
+        FAIL(log, "sycl::kernel_id::get_name returned nullptr.");
+      }
+
+      cgh.single_task<kernel_name>([=] {});
+    });
+
+    /** Check noexcept specifier for kernel_id::get_name()
+     */
+    run_verification<by_handler>(log, [&](sycl::handler &cgh) {
+      if constexpr (!noexcept(std::declval<sycl::kernel_id>().get_name())) {
+        FAIL(log, "Missing 'noexcept' specifier for kernel_id::get_name()");
+      }
+    });
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/kernel_bundle/kernel_id_common_reference_semantics.cpp
+++ b/tests/kernel_bundle/kernel_id_common_reference_semantics.cpp
@@ -1,0 +1,69 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::kernel_id common reference semantics
+//
+*******************************************************************************/
+
+#include "../../util/exceptions.h"
+#include "../common/common.h"
+#include "../common/common_by_reference.h"
+#include "get_kernel_id.h"
+#include "kernel_bundle.h"
+
+#define TEST_NAME kernel_id_common_reference_semantics
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace sycl_cts::tests::get_kernel_id;
+using namespace sycl_cts::tests::kernel_bundle;
+
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info &out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger &log) override {
+    using k_id_vector = std::vector<sycl::kernel_id>;
+    /** Check that sycl::kernel_id follows common reference semantics
+     */
+    run_verification<by_queue>(log, [&](sycl::queue &queue) {
+      using k_name = class kernel_id_comm_ref_sem;
+      using k_name_other = class kernel_id_other_comm_ref_sem;
+      sycl::kernel_id k_id = sycl::get_kernel_id<k_name>();
+      sycl::kernel_id k_id_other = sycl::get_kernel_id<k_name_other>();
+      common_by_reference::check_on_host<sycl::kernel_id, kernel_id_storage>(
+          log, k_id, k_id_other, "sycl::kernel_id",
+          common_by_reference::no_mutation{});
+      define_kernel<k_name>(queue);
+      define_kernel<k_name_other>(queue);
+    });
+
+    /** Check that two sycl::kernel_ids referring to the same kernel name are
+     *  equal
+     */
+    run_verification<by_handler>(log, [&](sycl::handler &cgh) {
+      using k_name = class two_kernel_ids_same_kernel;
+      sycl::kernel_id k_id = sycl::get_kernel_id<k_name>();
+      sycl::kernel_id k_id_same = sycl::get_kernel_id<k_name>();
+      if (k_id != k_id_same) {
+        FAIL(log,
+             "Two kernel_ids referring to the same kernel name should be"
+             " equal");
+      }
+      // Dummy kernel
+      cgh.single_task<k_name>([] {});
+    });
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/nd_item/nd_item_constructors.cpp
+++ b/tests/nd_item/nd_item_constructors.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 #include "../common/invoke.h"
 #include "../../util/array.h"
 

--- a/tests/nd_item/nd_item_equality.cpp
+++ b/tests/nd_item/nd_item_equality.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 #include "../common/invoke.h"
 
 #define TEST_NAME nd_item_equality
@@ -43,14 +43,13 @@ class TEST_NAME : public util::test_base {
           store_instances<numItems, invoke_nd_item<numDims, setup_kernel_t>>();
 
       // Check nd_item equality operator on the device side
-      equality_comparable_on_device<item_t>::
-          template check_on_kernel<nd_item_equality_kernel<numDims>>(
+      common_semantics::on_device_checker<item_t>::template
+          run<nd_item_equality_kernel<numDims>>(
               log, items, "nd_item " + std::to_string(numDims) + " (device)");
 
       // Check nd_item equality operator on the host side
-      check_equality_comparable_generic(log, items[0],
-                                        "nd_item " + std::to_string(numDims) +
-                                        " (host)");
+      common_semantics::check_on_host(
+          log, items[0], "nd_item " + std::to_string(numDims) + " (host)");
     }
   }
 
@@ -66,4 +65,4 @@ class TEST_NAME : public util::test_base {
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-}  // namespace TEST_NAME
+}  // namespace TEST_NAMESPACE

--- a/tests/nd_range/nd_range_equality.cpp
+++ b/tests/nd_range/nd_range_equality.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 
 #include <array>
 
@@ -123,8 +123,8 @@ class TEST_NAME : public util::test_base {
       }
 
       // Check nd_range equality operator
-      check_equality_comparable_generic(log, objects[0],
-                                        "nd_range " + std::to_string(numDims));
+      common_semantics::check_on_host(log, objects[0],
+                                      "nd_range " + std::to_string(numDims));
       CHECK_VALUE(log, success[current_check::equal_self], true, numDims);
       CHECK_VALUE(log, success[current_check::not_equal_self], false, numDims);
       CHECK_VALUE(log, success[current_check::equal_other_same_global], false,

--- a/tests/range/range_constructors.cpp
+++ b/tests/range/range_constructors.cpp
@@ -7,7 +7,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/common_by_value.h"
+#include "../common/common_semantics.h"
 
 #define TEST_NAME range_constructors
 
@@ -68,8 +68,8 @@ class TEST_NAME : public util::test_base {
                "range with range was not move assigned correctly for dim = 1");
         }
 
-        check_equality_comparable_generic(log, range_explicit,
-                                          std::string("range"));
+        common_semantics::check_on_host(log, range_explicit,
+                                        std::string("range"));
       }
 
       // dim 2
@@ -111,8 +111,8 @@ class TEST_NAME : public util::test_base {
                "range with range was not move assigned correctly for dim = 2");
         }
 
-        check_equality_comparable_generic(log, range_explicit,
-                                          std::string("range"));
+        common_semantics::check_on_host(log, range_explicit,
+                                        std::string("range"));
       }
 
       // dim 3
@@ -161,8 +161,8 @@ class TEST_NAME : public util::test_base {
                "range with range was not move assigned correctly for dim = 3");
         }
 
-        check_equality_comparable_generic(log, range_explicit,
-                                          std::string("range"));
+        common_semantics::check_on_host(log, range_explicit,
+                                        std::string("range"));
       }
     }
   }

--- a/util/exceptions.h
+++ b/util/exceptions.h
@@ -9,6 +9,9 @@
 #ifndef __SYCLCTS_UTIL_EXCEPTIONS_H
 #define __SYCLCTS_UTIL_EXCEPTIONS_H
 
+#include "../tests/common/macros.h"
+#include "logger.h"
+
 #include <stdexcept>
 #include <utility>
 
@@ -18,22 +21,40 @@ namespace util {
 /** @brief Exception to be thrown if the single check should be skipped, but the
  *         test itself should continue to run
  *  @details This exception is designed to be handled by the test code itself
+ *           without propagation to the test_base
  */
 class skip_check : public std::runtime_error {
  public:
   template <typename argT>
-  skip_check(argT&& arg) : std::runtime_error(std::forward<argT>(arg)) {}
+  skip_check(argT &&arg) : std::runtime_error(std::forward<argT>(arg)) {}
 };
 
 /** @brief Exception to be thrown if the single check should be reported as the
  *         failed one, but the test itself should continue to run
  *  @details This exception is designed to be handled by the test code itself
+ *           without propagation to the test_base
  */
 class fail_check : public std::runtime_error {
  public:
   template <typename argT>
-  fail_check(argT&& arg) : std::runtime_error(std::forward<argT>(arg)) {}
+  fail_check(argT &&arg) : std::runtime_error(std::forward<argT>(arg)) {}
 };
+
+/** @brief Provides in-place exception handling to catch expected exceptions
+ *         and do not stop testing process
+ */
+template <typename F>
+static void run_check(logger &log, const std::string &checkName, F functor) {
+  try {
+    functor();
+  } catch (const skip_check &skip_e) {
+    log.note(checkName + " " + skip_e.what() + " (test skipped)");
+  } catch (const fail_check &fail_e) {
+    FAIL(log, checkName + " " + fail_e.what());
+  } catch (...) {
+    throw;
+  }
+}
 
 }  // namespace util
 }  // namespace sycl_cts


### PR DESCRIPTION
Some of these test required containing in separate *.exe-file: `get_kernel_ids_multiple_kernels`, `get_kernel_ids_single_kernel` and `get_kernel_ids_no_kernels` because these files required stricted list of available kernels
for build this tests need call building process for each test separately: `make test_get_kernel_ids_multiple_kernels`, `make test_get_kernel_ids_single_kernel` and `make test_get_kernel_ids_no_kernels`
But if use `make` all tests will be builded