### PR TITLE
Avoid tabs in command lines

### DIFF
--- a/cmake/FindComputeCpp.cmake
+++ b/cmake/FindComputeCpp.cmake
@@ -89,11 +89,12 @@ function(build_spir exe_name spir_target_name source_file output_path)
             ${computecpp_device_compiler_defs}
             ${COMPUTECPP_USER_FLAGS}
             ${platform_specific_args}
-            $<$<BOOL:${include_directories}>:-I\"$<JOIN:${include_directories},\"\t-I\">\">
-            $<$<BOOL:${device_compile_definitions}>:-D$<JOIN:${device_compile_definitions},\t-D>>
-            $<JOIN:${device_compile_options},\t>
+            $<$<BOOL:${include_directories}>:-I\"$<JOIN:${include_directories},\"\;-I\">\">
+            $<$<BOOL:${device_compile_definitions}>:-D$<JOIN:${device_compile_definitions},\;-D>>
+            $<JOIN:${device_compile_options},\;>
             -o ${output_bc}
             -c ${source_file}
+    COMMAND_EXPAND_LISTS
     DEPENDS ${source_file}
     WORKING_DIRECTORY ${output_path}
     COMMENT "Building SPIR object ${output_bc}")


### PR DESCRIPTION
This commit updates cmake/FindComputeCpp.cmake to avoid the use of tabs in command lines. The tabs are valid but cause issues when copying and pasting commands to run them standalone, as even the pasting of a tab may trigger tab completion, depending on the shell and shell settings.

The tabs were a workaround for older CMake versions, but a sufficiently recent CMake is already required.

I have verified that with this MR applied, with the Ninja generator, the only change to the generated `build.ninja` is the removal of the tabs.

Note: this PR is against SYCL-2020 but also applies cleanly to SYCL-1.2.1/master. If this gets approved and merged to SYCL-2020, I would appreciate it if it could also be cherry-picked there, or I can create a new PR for that.