### PR TITLE
Fix compilation with ComputeCpp; update CI filter

### DIFF
--- a/ci/computecpp.filter
+++ b/ci/computecpp.filter
@@ -2,6 +2,8 @@ accessor
 address_space
 atomic
 buffer
+context
+device
 device_event
 event
 exception_handling
@@ -20,6 +22,7 @@ math_builtin_api
 multi_ptr
 nd_item
 opencl_interop
+platform
 queue
 range
 reduction

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -165,8 +165,12 @@ void check_equality(sycl_cts::util::logger& log, T& a, T& b) {
    */
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_backend() == sycl::backend::opencl) {
+#if !defined(__COMPUTECPP__)
     if (sycl::get_native<sycl::backend::opencl>(a) !=
         sycl::get_native<sycl::backend::opencl>(b)) {
+#else
+    if (a.get() != b.get()) {
+#endif
       FAIL(log, "two objects are not equal");
     }
   }


### PR DESCRIPTION
This should fix compilation with ComputeCpp again, which was broken in #203. Also update CI filter for ComputeCpp to include three new test categories that no longer compile (`context`, `device` and `platform`).