### PR TITLE
Bump DPC++ and hipSYCL versions used for CI

### DIFF
--- a/.github/workflows/build_ci_containers.yml
+++ b/.github/workflows/build_ci_containers.yml
@@ -41,9 +41,9 @@ jobs:
           # - sycl-impl: computecpp
           # version: 2.6.0
           - sycl-impl: dpcpp
-            version: f5c838cd
+            version: 6699a5d
           - sycl-impl: hipsycl
-            version: 72a29fb9
+            version: b836149
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build_ci_containers.yml
+++ b/.github/workflows/build_ci_containers.yml
@@ -61,8 +61,8 @@ jobs:
         with:
           context: docker/${{ matrix.sycl-impl }}
           push: true
-          tags: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}
-          cache-from: type=registry,ref=khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}
+          tags: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
+          cache-from: type=registry,ref=khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
           cache-to: type=inline
           build-args: |
             IMPL_VERSION=${{ matrix.version }}

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -10,14 +10,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sycl-impl: [computecpp, dpcpp, hipsycl]
+        include:
+          - sycl-impl: computecpp
+            version: 2.6.0
+          - sycl-impl: dpcpp
+            version: f5c838cd
+          - sycl-impl: hipsycl
+            version: 72a29fb9
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       parallel-build-jobs: 2
     container:
-      # image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}
+      # image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
       # ComputeCpp images are hosted by Codeplay
-      image: ${{ format('{0}/sycl-cts-ci:{1}', matrix.sycl-impl != 'computecpp' && 'khronosgroup' || 'scottstraughan', matrix.sycl-impl) }}
+      image: ${{ format('{0}/sycl-cts-ci:{1}-{2}', matrix.sycl-impl != 'computecpp' && 'khronosgroup' || 'scottstraughan', matrix.sycl-impl, matrix.version) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -14,9 +14,9 @@ jobs:
           - sycl-impl: computecpp
             version: 2.6.0
           - sycl-impl: dpcpp
-            version: f5c838cd
+            version: 6699a5d
           - sycl-impl: hipsycl
-            version: 72a29fb9
+            version: b836149
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       parallel-build-jobs: 2

--- a/ci/dpcpp.filter
+++ b/ci/dpcpp.filter
@@ -1,15 +1,5 @@
-accessor
-atomic
 buffer
-handler
-hierarchical
-id
-invoke
-item
-math_builtin_api
-multi_ptr
-nd_item
-range
+exceptions
+opencl_interop
 reduction
-specialization_constants
 usm

--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -38,6 +38,9 @@ else()
 endif()
 set(CMAKE_CXX_FLAGS "${DPCPP_FP_FLAG} ${CMAKE_CXX_FLAGS}")
 
+# Disable range rounding feature to reduce # of SYCL kernels.
+set(CMAKE_CXX_FLAGS "-D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__")
+
 option(DPCPP_DISABLE_SYCL2020_DEPRECATION_WARNINGS
   "Disable SYCL 2020 deprecation warnings" ON)
 if(DPCPP_DISABLE_SYCL2020_DEPRECATION_WARNINGS)


### PR DESCRIPTION
This bumps the version of DPC++ to 6699a5d (December 8) and hipSYCL to b836149 (December 9). I've also updated the CI filter for DPC++, which is now able to compile 12 additional test categories, failing for 2 new ones, for a total of 5 categories that do not compile yet.

I've also adjusted the CI workflow to encode an implementation's version into the Docker image tag (i.e. there is now a `dpcpp-6699a5d` tag, as opposed to just `dpcpp`) so that submitting this PR won't affect current CI runs (until it is merged).

Disable DPC++ range rounding feature to speed up compilation.