### PR TITLE
Fix accessor_api_image_core test for image arrays

### DIFF
--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -312,7 +312,7 @@ struct use_normalization_coefficient<sycl::cl_half4> : std::true_type {};
 template <typename T>
 typename image_format_channel<T>::storage_t get_expected_image_value() {
   using storage_t = typename image_format_channel<T>::storage_t;
-  if (use_normalization_coefficient<T>::value) {
+  if constexpr (use_normalization_coefficient<T>::value) {
     return static_cast<storage_t>(0.2f);
   } else {
     return static_cast<storage_t>(17);
@@ -390,66 +390,30 @@ std::vector<sycl::byte> get_image_input_data(
   return convert_image_data_to_bytes<T>(data, byteSize);
 }
 
-/**
- * @brief Returns an image_array's index to read an image by
- *        coordinates from
- * @tparam dims Number of accessor dimensions
- * @param idx Work-item ID
- * @return Index of the image to read
- */
-template <int dims>
-size_t get_slice_index(image_array_id_t<dims> idx) {
-  return idx[dims];
-}
-
-/**
- * @brief Returns an image_array's index to read an image by
- *        coordinates from
- * @tparam dims Number of accessor dimensions
- * @tparam coordT Type of the tag to mark the right index for test
- * @param coordTag A tag to mark the right index for test
- * @param filteringMode A filtering mode used by the sampler to read the image
- * @param idx Work-item ID
- * @return Index of the image to read. If the linear filtering mode is used
- *         and coordT is equal to acc_coord_tag::use_normalized_upper, the
- *         function returns the next index.
- */
-template <int dims, typename coordT>
-size_t get_slice_index(const coordT& coordTag,
-                       sycl::filtering_mode filteringMode,
-                       image_array_id_t<dims> idx) {
-  if (std::is_same_v<coordT, acc_coord_tag::use_normalized_upper> &&
-      filteringMode == sycl::filtering_mode::linear) {
-    return idx[dims] + 1;
-  }
-  return idx[dims];
-}
-
 template <typename T, int dims, sycl::target target,
-          sycl::access_mode access_mode>
-T read_image_acc(const sycl::accessor<T, dims, access_mode, target> &acc,
+          sycl::access_mode mode>
+T read_image_acc(const sycl::accessor<T, dims, mode, target> &acc,
                  sycl::id<dims> idx) {
   return acc.read(image_access<dims>::get_int(idx));
 }
 
-template <typename T, int dims, sycl::access_mode access_mode>
-T read_image_acc(const sycl::accessor<T, dims, access_mode,
+template <typename T, int dims, sycl::access_mode mode>
+T read_image_acc(const sycl::accessor<T, dims, mode,
                                     sycl::target::image_array> &acc,
                  image_array_id_t<dims> idx) {
   // Verify __image_array_slice__ read
   using coordT = acc_coord_tag::use_int;
   const auto coords = image_array_coords<dims>::get(coordT{}, idx);
-  return acc[get_slice_index<dims>(idx)].read(coords);
+  return acc[idx[dims]].read(coords);
 }
 
 template <typename T, int dims, sycl::target target,
-          sycl::access_mode access_mode, typename coordT>
-T read_image_acc_sampled(const sycl::accessor<T, dims, access_mode, target> &acc,
+          sycl::access_mode mode, typename coordT>
+T read_image_acc_sampled(const sycl::accessor<T, dims, mode, target> &acc,
                          const sycl::sampler& smpl,
                          sycl::id<dims> idx,
                          sycl::range<dims> range,
-                         const coordT& coordTag,
-                         sycl::filtering_mode filteringMode) {
+                         const coordT& coordTag) {
   if constexpr (std::is_same_v<coordT, acc_coord_tag::use_int>) {
     // Verify read using integer unnormalized coordinates
     return acc.read(image_access<dims>::get_int(idx), smpl);
@@ -463,18 +427,16 @@ T read_image_acc_sampled(const sycl::accessor<T, dims, access_mode, target> &acc
     return acc.read(coords, smpl);
   }
 }
-template <typename T, int dims, sycl::access_mode access_mode, typename coordT>
-T read_image_acc_sampled(const sycl::accessor<T, dims, access_mode,
+template <typename T, int dims, sycl::access_mode mode, typename coordT>
+T read_image_acc_sampled(const sycl::accessor<T, dims, mode,
                                     sycl::target::image_array> &acc,
                          sycl::sampler smpl,
                          image_array_id_t<dims> idx,
                          image_array_range_t<dims> range,
-                         const coordT& coordTag,
-                         sycl::filtering_mode filteringMode) {
+                         const coordT& coordTag) {
   // Verify __image_array_slice__ read
   const auto coords = image_array_coords<dims>::get(coordTag, idx, range);
-  return acc[get_slice_index<dims>(coordTag, filteringMode, idx)].read(coords,
-                                                                       smpl);
+  return acc[idx[dims]].read(coords, smpl);
 }
 
 template <typename T, int dims, sycl::target target,
@@ -1022,9 +984,22 @@ class image_accessor_api_sampled_r {
        *    ftp://ftp.icsi.berkeley.edu/pub/theory/priest-thesis.ps.Z
        *  for details
        */
-      return get_expected_value_linear(idx + 1);
+      return get_expected_value_linear(next_idx(idx));
     }
   }
+
+  template <int dims>
+  sycl::id<dims> next_idx(sycl::id<dims> idx) const {
+    if constexpr (target == sycl::target::image_array) {
+      auto res = idx;
+      for (int i = 0; i + 1 < dims; i++) {
+        res[i]++;
+      }
+      return res;
+    }
+    return idx + 1;
+  }
+
 
   /**
    *  @brief Error for floating point image data
@@ -1108,7 +1083,7 @@ class image_accessor_api_sampled_r {
     const T expected = get_expected_value<coordT>(idx);
     const T elem =
         read_image_acc_sampled(m_acc, m_sampler.instance, idx, m_range,
-                               coordT{}, m_sampler.filtering_mode);
+                               coordT{});
 
     const bool succeed = check_texel_value(elem, expected);
     if (!succeed) {

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -996,14 +996,12 @@ class image_accessor_api_sampled_r {
    */
   template <int dims>
   sycl::id<dims> next_id(sycl::id<dims> idx) const {
+    static_assert(dims > 0);
+    ++idx;
     if constexpr (target == sycl::target::image_array) {
-      auto res = idx;
-      for (int i = 0; i + 1 < dims; i++) {
-        res[i]++;
-      }
-      return res;
+      --idx[dims-1];
     }
-    return idx + 1;
+    return idx;
   }
 
   /**

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -421,9 +421,8 @@ size_t get_slice_index(const coordT& coordTag,
   if (std::is_same_v<coordT, acc_coord_tag::use_normalized_upper> &&
       filteringMode == sycl::filtering_mode::linear) {
     return idx[dims] + 1;
-  } else {
-    return idx[dims];
   }
+  return idx[dims];
 }
 
 template <typename T, int dims, sycl::target target,

--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -984,12 +984,18 @@ class image_accessor_api_sampled_r {
        *    ftp://ftp.icsi.berkeley.edu/pub/theory/priest-thesis.ps.Z
        *  for details
        */
-      return get_expected_value_linear(next_idx(idx));
+      return get_expected_value_linear(next_id(idx));
     }
   }
 
+  /**
+   *  @brief Computes the next id for getting an expected upper value for the
+   *  linear filtration. If the target is target::image_array, the last
+   *  component is not a coordinate, it is the index of an image in the array
+   *  to read from, so the last component should not be incremented.
+   */
   template <int dims>
-  sycl::id<dims> next_idx(sycl::id<dims> idx) const {
+  sycl::id<dims> next_id(sycl::id<dims> idx) const {
     if constexpr (target == sycl::target::image_array) {
       auto res = idx;
       for (int i = 0; i + 1 < dims; i++) {
@@ -999,7 +1005,6 @@ class image_accessor_api_sampled_r {
     }
     return idx + 1;
   }
-
 
   /**
    *  @brief Error for floating point image data


### PR DESCRIPTION
When the acc_coord_tag::use_normalized_upper tag is used to compute
the expected values in the linear filtering mode, the value for idx + 1
is used as expected (see the return get_expected_value_linear(idx + 1)
line in the body of the T get_expected_value(image_id_t<dim, target> idx)
method of the image_accessor_api_sampled_r class). This fact is taken into
account in the image_access<dims>::get_normalized() function and works
fine for a single image but not for image arrays since for the image array,
a correct slice should be the next one when the linear filtering mode is
used and the test is run for acc_coord_tag::use_normalized_upper tag.

Signed-off-by: Pavel Samolysov <pavel.samolysov@intel.com>