### PR TITLE
Run accessor_api_image_core test with int coords for nearest only

### DIFF
--- a/tests/accessor/accessor_api_image_common.h
+++ b/tests/accessor/accessor_api_image_common.h
@@ -1117,6 +1117,10 @@ class image_accessor_api_sampled_r {
         check_read<acc_coord_tag::use_float>(idx);
       if (worksForFloat && useNearest) {
         /*
+          SYCL 1.2.1 mentions the following: "SYCL overlays the OpenCL
+          specification and inherits its capabilities and restrictions as well
+          as the additional features it provides on top of OpenCL 1.2."
+          
           OpenCL spec rules that when int is used as the coordinates, the
           filter mode must be NEAREST: "The read_imagef calls that take integer
           coordinates must use a sampler with filter mode set to


### PR DESCRIPTION
The OpenCL specification rules that when int is used as the coordinates, the
filter mode must be NEAREST (see https://man.opencl.org/read_imagef1d.html):

 > The read_imagef calls that take integer coordinates must use a sampler with
 > filter mode set to CLK_FILTER_NEAREST, normalized coordinates set to
 > CLK_NORMALIZED_COORDS_FALSE and addressing mode set to CLK_ADDRESS_CLAMP_TO_EDGE,
 > CLK_ADDRESS_CLAMP or CLK_ADDRESS_NONE; otherwise the values returned are
 > undefined.

Signed-off-by: Pavel Samolysov <pavel.samolysov@intel.com>