### PR TITLE
[DPCPP] Upgrade DPCPP version for CI

### DIFF
--- a/.github/workflows/build_ci_containers.yml
+++ b/.github/workflows/build_ci_containers.yml
@@ -41,7 +41,7 @@ jobs:
           # - sycl-impl: computecpp
           # version: 2.6.0
           - sycl-impl: dpcpp
-            version: f5c838cd
+            version: 1f3f9b9b
           - sycl-impl: hipsycl
             version: 72a29fb9
     steps:


### PR DESCRIPTION
I wish to remove the usm tests from the exclude list for
DPCPP and this requires using DPCPP with support for
the sycl::atomic_ref class template. So, the version of
the DPCPP compiler should be upgraded.

Signed-off-by: Pavel Samolysov <pavel.samolysov@intel.com>