### PR TITLE
Bump DPC++ and hipSYCL versions used for CI

### DIFF
--- a/.github/workflows/build_ci_containers.yml
+++ b/.github/workflows/build_ci_containers.yml
@@ -41,9 +41,9 @@ jobs:
           # - sycl-impl: computecpp
           # version: 2.6.0
           - sycl-impl: dpcpp
-            version: f5c838cd
+            version: 1f3f9b9
           - sycl-impl: hipsycl
-            version: 72a29fb9
+            version: b836149
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build_ci_containers.yml
+++ b/.github/workflows/build_ci_containers.yml
@@ -61,8 +61,8 @@ jobs:
         with:
           context: docker/${{ matrix.sycl-impl }}
           push: true
-          tags: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}
-          cache-from: type=registry,ref=khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}
+          tags: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
+          cache-from: type=registry,ref=khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
           cache-to: type=inline
           build-args: |
             IMPL_VERSION=${{ matrix.version }}

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -15,9 +15,9 @@ jobs:
           - sycl-impl: computecpp
             tag: computecpp
           - sycl-impl: dpcpp
-            tag: dpcpp-f5c838cd
+            tag: dpcpp-1f3f9b9
           - sycl-impl: hipsycl
-            tag: hipsycl-72a29fb9
+            tag: hipsycl-b836149
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       parallel-build-jobs: 2

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -10,14 +10,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sycl-impl: [computecpp, dpcpp, hipsycl]
+        include:
+          # FIXME: Generate tag from version string once ComputeCpp has been updated to use versioned image tags
+          - sycl-impl: computecpp
+            tag: computecpp
+          - sycl-impl: dpcpp
+            tag: dpcpp-f5c838cd
+          - sycl-impl: hipsycl
+            tag: hipsycl-72a29fb9
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       parallel-build-jobs: 2
     container:
-      # image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}
+      # image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
       # ComputeCpp images are hosted by Codeplay
-      image: ${{ format('{0}/sycl-cts-ci:{1}', matrix.sycl-impl != 'computecpp' && 'khronosgroup' || 'scottstraughan', matrix.sycl-impl) }}
+      image: ${{ format('{0}/sycl-cts-ci:{1}', matrix.sycl-impl != 'computecpp' && 'khronosgroup' || 'scottstraughan', matrix.tag) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/ci/dpcpp.filter
+++ b/ci/dpcpp.filter
@@ -1,6 +1,7 @@
 accessor
 atomic
 buffer
+exceptions
 handler
 hierarchical
 id
@@ -9,6 +10,7 @@ item
 math_builtin_api
 multi_ptr
 nd_item
+opencl_interop
 range
 reduction
 specialization_constants


### PR DESCRIPTION
This PR supersedes both #234 and #240.

Changes compared to #234:
- Bump DPC++ to 1f3f9b9 (December 19) to accommodate #240 
- Work around ComputeCpp container images not using versioned tags yet
- Don't enable a ton of new test categories for DPC++ due to compile time concerns (which we should address in a separate PR, see also the discussion on #234).

(Note that CI will fail on this initially since the new container for DPC++ is [still building](https://github.com/KhronosGroup/SYCL-CTS/runs/4586121973?check_suite_focus=true), need to re-run checks after that).