### PR TITLE
Small fix for `util/array.h`

### DIFF
--- a/util/array.h
+++ b/util/array.h
@@ -11,6 +11,8 @@
 #ifndef __SYCLCTS_UTIL_ARRAY_H
 #define __SYCLCTS_UTIL_ARRAY_H
 
+#include <cstddef>
+
 namespace sycl_cts {
 namespace util {
 


### PR DESCRIPTION
This fix adds include directive of the header file with `std::size_t` definition to `util/array.h`.