### PR TITLE
Replace `log.skip` to `WARN`

### DIFF
--- a/tests/extension/oneapi_device_global/device_global_api_arrow_operator.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_arrow_operator.cpp
@@ -130,9 +130,9 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger& log) override {
 #if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    log.skip("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
-    log.skip("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else
     check_device_global_api_arrow_operator_for_type<
         user_def_types::arrow_operator_overloaded>{}(log, "arrow_operator");

--- a/tests/extension/oneapi_device_global/device_global_api_basic.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_basic.cpp
@@ -473,9 +473,9 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger& log) override {
 #if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    log.skip("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
-    log.skip("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else
     auto types = device_global_types::get_types();
     for_all_types<check_device_global_api_basic_for_type>(types, log);

--- a/tests/extension/oneapi_device_global/device_global_api_subscript_operator.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_subscript_operator.cpp
@@ -147,9 +147,9 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger& log) override {
 #if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    log.skip("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
-    log.skip("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else
     auto types = device_global_types::get_types();
     for_all_types<check_device_global_api_subscript_operator_for_type>(types,

--- a/tests/extension/oneapi_property_list/property_list_prop_eq_op.cpp
+++ b/tests/extension/oneapi_property_list/property_list_prop_eq_op.cpp
@@ -40,9 +40,9 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
 #if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    log.skip("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
-    log.skip("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else
     {
       using namespace sycl::ext::oneapi;

--- a/tests/extension/oneapi_property_list/property_list_property_value.cpp
+++ b/tests/extension/oneapi_property_list/property_list_property_value.cpp
@@ -62,9 +62,9 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
 #if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    log.skip("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
-    log.skip("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else
     {
       property_list props{device_image_scope_v};

--- a/tests/multi_ptr/multi_ptr_accessor_constructor_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_accessor_constructor_fp16.cpp
@@ -36,7 +36,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp16>;
     if (!avaliability::check(queue, log)) {
-      log.skip(
+      WARN(
           "Device does not support half precision floating point operations");
       return;
     }

--- a/tests/multi_ptr/multi_ptr_accessor_constructor_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_accessor_constructor_fp16.cpp
@@ -36,8 +36,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp16>;
     if (!avaliability::check(queue, log)) {
-      WARN(
-          "Device does not support half precision floating point operations");
+      WARN("Device does not support half precision floating point operations");
       return;
     }
 

--- a/tests/multi_ptr/multi_ptr_accessor_constructor_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_accessor_constructor_fp64.cpp
@@ -35,7 +35,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp64>;
     if (!avaliability::check(queue, log)) {
-      log.skip(
+      WARN(
           "Device does not support double precision floating point operations");
       return;
     }

--- a/tests/multi_ptr/multi_ptr_common_constructors_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_common_constructors_fp16.cpp
@@ -36,7 +36,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp16>;
     if (!avaliability::check(queue, log)) {
-      log.skip(
+      WARN(
           "Device does not support half precision floating point operations");
       return;
     }

--- a/tests/multi_ptr/multi_ptr_common_constructors_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_common_constructors_fp16.cpp
@@ -36,8 +36,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp16>;
     if (!avaliability::check(queue, log)) {
-      WARN(
-          "Device does not support half precision floating point operations");
+      WARN("Device does not support half precision floating point operations");
       return;
     }
 

--- a/tests/multi_ptr/multi_ptr_common_constructors_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_common_constructors_fp64.cpp
@@ -36,7 +36,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp64>;
     if (!avaliability::check(queue, log)) {
-      log.skip(
+      WARN(
           "Device does not support double precision floating point operations");
       return;
     }

--- a/tests/multi_ptr/multi_ptr_members_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_members_fp16.cpp
@@ -33,8 +33,7 @@ class TEST_NAME : public util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp16>;
     if (!avaliability::check(queue, log)) {
-      WARN(
-          "Device does not support half precision floating point operations");
+      WARN("Device does not support half precision floating point operations");
       return;
     }
 

--- a/tests/multi_ptr/multi_ptr_members_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_members_fp16.cpp
@@ -33,7 +33,7 @@ class TEST_NAME : public util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp16>;
     if (!avaliability::check(queue, log)) {
-      log.skip(
+      WARN(
           "Device does not support half precision floating point operations");
       return;
     }

--- a/tests/multi_ptr/multi_ptr_members_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_members_fp64.cpp
@@ -33,7 +33,7 @@ class TEST_NAME : public util::test_base {
     using avaliability =
         util::extensions::availability<util::extensions::tag::fp64>;
     if (!avaliability::check(queue, log)) {
-      log.skip(
+      WARN(
           "Device does not support double precision floating point operations");
       return;
     }


### PR DESCRIPTION
This PR provides replacement of deprecated log function `log.skip` to `WARN` function from catch2 framework