### PR TITLE
Add tests for queue copy overloads for device_global

### DIFF
--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -31,6 +31,9 @@ struct user_struct {
     return (((lhs.a + eps > rhs.a) && (lhs.a < rhs.a + eps)) &&
             (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
+  friend bool operator!=(const user_struct &lhs, const user_struct &rhs) {
+    return !(lhs == rhs);
+  }
 };
 
 namespace user_def_types {
@@ -50,6 +53,10 @@ struct no_cnstr {
 
   friend bool operator==(const no_cnstr &lhs, const no_cnstr &rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
+  }
+
+  friend bool operator!=(const no_cnstr &lhs, const no_cnstr &rhs) {
+    return !(lhs == rhs);
   }
 };
 
@@ -78,6 +85,10 @@ struct def_cnstr {
   inline friend bool operator==(const def_cnstr &lhs, const def_cnstr &rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
+
+  friend bool operator!=(const def_cnstr &lhs, const def_cnstr &rhs) {
+    return !(lhs == rhs);
+  }
 };
 
 // A user-defined class with several scalar member variables, a deleted default
@@ -94,6 +105,10 @@ class no_def_cnstr {
 
   friend bool operator==(const no_def_cnstr &lhs, const no_def_cnstr &rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
+  }
+
+  friend bool operator!=(const no_def_cnstr &lhs, const no_def_cnstr &rhs) {
+    return !(lhs == rhs);
   }
 
   // A user-defined struct with several scalar member variables, arrow operator
@@ -116,6 +131,10 @@ class no_def_cnstr {
     friend bool operator==(const arrow_operator_overloaded &lhs,
                            const arrow_operator_overloaded &rhs) {
       return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
+    }
+    friend bool operator!=(const arrow_operator_overloaded &lhs,
+                           const arrow_operator_overloaded &rhs) {
+      return !(lhs == rhs);
     }
   };
 };

--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -74,6 +74,17 @@ struct value_helper {
   static void change_val(T& value, const int new_val = 1) { value = new_val; }
 
   /**
+   * @brief The function changes value from the first parameter to
+   * value from the second parameter of the same type
+   * Disabled if T is int to avoid function ambiguous
+   */
+  template <typename Ty = T>
+  static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
+      T& value, const T new_val) {
+    value = new_val;
+  }
+
+  /**
    * @brief The function compares values from the first
    * parameter value from the second parameter
    */
@@ -98,6 +109,17 @@ struct value_helper<T[N]> {
   static void change_val(arrayT& value, const int new_val = 1) {
     for (size_t i = 0; i < N; ++i) {
       value[i] = new_val;
+    }
+  }
+  /**
+   * @brief The function changes all values of the array from the first parameter to
+   * values of the array from the second parameter
+   * @param value The reference to the array that needs to be change
+   * @param new_vals The array with values that will be set
+   */
+  static void change_val(arrayT& value, const arrayT& new_vals) {
+    for (size_t i = 0; i < N; i++) {
+      value[i] = new_vals[i];
     }
   }
 
@@ -125,6 +147,25 @@ struct value_helper<T[N]> {
     return are_equal;
   }
 };
+
+/** @brief The helper function to get variable address for pointer
+ *  @tparam T Type of variable
+ *  @param data variable to get pointer to
+ */
+template <typename T>
+inline T* pointer_helper(T& data) {
+  return &data;
+}
+
+/** @brief The helper function to get first element od array address for pointer
+ *  @tparam T Type of array values
+ *  @tparam N Size of array
+ *  @param data array to get pointer to
+ */
+template <typename T, size_t N>
+inline T* pointer_helper(T (&data)[N]) {
+  return &data[0];
+}
 }  // namespace device_global_common_functions
 
 #endif  // SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H

--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -157,7 +157,7 @@ inline T* pointer_helper(T& data) {
   return &data;
 }
 
-/** @brief The helper function to get first element od array address for pointer
+/** @brief The helper function to get first element of array address for pointer
  *  @tparam T Type of array values
  *  @tparam N Size of array
  *  @param data array to get pointer to

--- a/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
@@ -97,8 +97,7 @@ void run_test_copy_from_device_global_array(util::logger& log,
   auto event = queue.copy(dev_global_in<T[N]>, dst_data, 1, num_element);
   event.wait();
 
-  // eq op is used because not all custom types have not eq op
-  if (!(data[num_element] == new_val[num_element])) {
+  if (data[num_element] != new_val[num_element]) {
     FAIL(log, get_case_description(
                   "Overload of sycl::queue::copy for device_global",
                   "Didn't copy correct element from device_global array",

--- a/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
@@ -1,0 +1,148 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides test for array for overloads for queue::copy for device_global
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+#include "../../common/type_coverage.h"
+#include "device_global_common.h"
+#include "type_pack.h"
+
+#define TEST_NAME device_global_queue_array_copy
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace device_global_common_functions;
+
+#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+    defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+namespace oneapi = sycl::ext::oneapi;
+
+template <typename T>
+struct queue_array_copy_to_dg_kernel;
+
+template <typename T>
+struct queue_array_change_dg_kernel;
+
+template <typename T>
+oneapi::device_global<T> dev_global_out;
+
+/** @brief The function tests that queue copy overloads correctly copy
+ * single element to device_global
+ *  @tparam T Type of underlying struct
+ */
+template <typename T, size_t N>
+void run_test_copy_to_device_global_array(util::logger& log,
+                                          const std::string& type_name) {
+  T data[N];
+  value_helper<T[N]>::change_val(data, 1);
+  const T* src_data = &data[0];
+  size_t num_element = N / 2;
+
+  auto queue = util::get_cts_object::queue();
+
+  auto event = queue.copy(src_data, dev_global_out<T[N]>, 1, num_element);
+  event.wait();
+
+  bool is_copied_correctly = false;
+  {
+    sycl::buffer<bool, 1> is_cop_corr_buf(&is_copied_correctly,
+                                          sycl::range<1>(1));
+    queue.submit([&](sycl::handler& cgh) {
+      auto is_cop_corr_acc =
+          is_cop_corr_buf.template get_access<sycl::access_mode::write>(cgh);
+      cgh.single_task<queue_array_copy_to_dg_kernel<T>>([=] {
+        is_cop_corr_acc[0] =
+            dev_global_out<T[N]>[num_element] == data[num_element];
+      });
+    });
+    queue.wait_and_throw();
+  }
+  if (!is_copied_correctly) {
+    FAIL(log,
+         get_case_description(
+             "Overload of sycl::queue::copy for device_global",
+             "Didn't copy correct element to device_global array", type_name));
+  }
+}
+
+// Creating instance with default constructor
+template <typename T>
+oneapi::device_global<T> dev_global_in;
+
+/** @brief The function tests that queue copy overloads correctly copy
+ * single element from device_global
+ *  @tparam T Type of underlying struct
+ */
+template <typename T, size_t N>
+void run_test_copy_from_device_global_array(util::logger& log,
+                                            const std::string& type_name) {
+  T new_val[N];
+  value_helper<T[N]>::change_val(new_val, 5);
+  T data[N];
+  std::remove_all_extents_t<T>* dst_data = &data[0];
+  size_t num_element = N / 2;
+
+  auto queue = util::get_cts_object::queue();
+
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.single_task<queue_array_change_dg_kernel<T>>(
+        [=] { value_helper<T[N]>::change_val(dev_global_in<T[N]>, new_val); });
+  });
+  queue.wait_and_throw();
+
+  auto event = queue.copy(dev_global_in<T[N]>, dst_data, 1, num_element);
+  event.wait();
+
+  // eq op is used because not all custom types have not eq op
+  if (!(data[num_element] == new_val[num_element])) {
+    FAIL(log, get_case_description(
+                  "Overload of sycl::queue::copy for device_global",
+                  "Didn't copy correct element from device_global array",
+                  type_name));
+  }
+}
+
+template <typename T>
+class check_queue_overloads_for_device_global_array_for_type {
+ public:
+  void operator()(sycl_cts::util::logger& log, const std::string& type_name) {
+    // Run test for queue overloads
+    run_test_copy_to_device_global_array<T, 5>(log, type_name);
+    run_test_copy_from_device_global_array<T, 5>(log, type_name);
+  }
+};
+#endif
+
+/** test overloads for queue::copy for device_global
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info& out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger& log) override {
+#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+#else
+    auto types = device_global_types::get_types();
+    for_all_types<check_queue_overloads_for_device_global_array_for_type>(types,
+                                                                          log);
+#endif
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE

--- a/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
@@ -31,7 +31,7 @@ template <typename T>
 oneapi::device_global<T> dev_global_out;
 
 /** @brief The function tests that queue copy overloads correctly copy
- * single element to device_global
+ *  a single element to device_global
  *  @tparam T Type of underlying struct
  */
 template <typename T, size_t N>
@@ -39,7 +39,7 @@ void run_test_copy_to_device_global_array(util::logger& log,
                                           const std::string& type_name) {
   T data[N];
   value_helper<T[N]>::change_val(data, 1);
-  const T* src_data = &data[0];
+  const auto src_data = &data[0];
   size_t num_element = N / 2;
 
   auto queue = util::get_cts_object::queue();
@@ -83,7 +83,7 @@ void run_test_copy_from_device_global_array(util::logger& log,
   T new_val[N];
   value_helper<T[N]>::change_val(new_val, 5);
   T data[N];
-  std::remove_all_extents_t<T>* dst_data = &data[0];
+  auto dst_data = &data[0];
   size_t num_element = N / 2;
 
   auto queue = util::get_cts_object::queue();

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -48,7 +48,7 @@ void run_test_copy_to_device_global(util::logger& log,
   using element_type = std::remove_all_extents_t<T>;
   T data{};
   value_helper<T>::change_val(data, 1);
-  const element_type* src_data = pointer_helper(data);
+  const auto src_data = pointer_helper(data);
 
   // to generate events with generator from usm_api.h
   // gens will generate events that will fill array arr_src
@@ -139,9 +139,9 @@ void run_test_copy_from_device_global(util::logger& log,
   T new_val{};
   value_helper<T>::change_val(new_val, 5);
   T data1{}, data2{}, data3{};
-  element_type* dst_data1 = pointer_helper(data1);
-  element_type* dst_data2 = pointer_helper(data2);
-  element_type* dst_data3 = pointer_helper(data3);
+  auto dst_data1 = pointer_helper(data1);
+  auto dst_data2 = pointer_helper(data2);
+  auto dst_data3 = pointer_helper(data3);
 
   sycl::queue queue;
   auto queue = util::get_cts_object::queue();

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -1,0 +1,254 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides functional test for overloads for queue::copy for device_global
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+#include "../../common/type_coverage.h"
+#include "../../usm/usm_api.h"
+#include "device_global_common.h"
+#include "type_pack.h"
+
+#define TEST_NAME device_global_queue_copy
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace device_global_common_functions;
+
+#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+    defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+namespace oneapi = sycl::ext::oneapi;
+
+template <typename T>
+struct check_copy_to_dg_kernel;
+
+template <typename T>
+struct change_dg_kernel;
+
+// Creating instance with default constructor
+template <typename T>
+oneapi::device_global<T> dev_global1;
+
+template <typename T>
+oneapi::device_global<T> dev_global2;
+
+template <typename T>
+oneapi::device_global<T> dev_global3;
+
+/** @brief The function tests that queue copy overloads correctly copy to
+ * device_global
+ *  @tparam T Type of underlying struct
+ */
+template <typename T>
+void run_test_copy_to_device_global(util::logger& log,
+                                    const std::string& type_name) {
+  using element_type = std::remove_all_extents_t<T>;
+  T data{};
+  value_helper<T>::change_val(data, 1);
+  const element_type* src_data = pointer_helper(data);
+
+  // to generate events with generator from usm_api.h
+  // gens will generate events that will fill array arr_src
+  // in single_task that will take a significant amount of time
+  constexpr size_t numEvents = 5;
+  constexpr size_t gen_buf_size = 1000;
+  std::array<usm_api::event_generator<element_type, gen_buf_size>, numEvents>
+      gens{};
+  element_type init_value{1};
+
+  auto queue = util::get_cts_object::queue();
+
+  auto event1 = queue.copy(src_data, dev_global1<T>);
+  event1.wait();
+
+  // List of events that tested usm operation should wait
+  std::vector<sycl::event> depEvents(numEvents);
+  // Run time-consuming tasks to generate events
+  for (size_t i = 0; i < depEvents.size(); ++i) {
+    depEvents[i] = gens[i].init(queue, init_value);
+  }
+
+  // Call overloads with events and check if they wait for events to pass.
+  // Use fast copy arrays for future check. If overloads do not
+  // wait for the passed events to complete, then an incompletely
+  // initialized 'arr_src' will be copied to 'arr_dst' and the test
+  // will fail with generator function check(). Reverse order is used to
+  // increase probability of data race.
+
+  auto event2 =
+      queue.copy(src_data, dev_global2<T>,
+                      sizeof(T) / sizeof(element_type), 0, depEvents[0]);
+  event2.wait();
+  gens[0].copy_arrays(queue);
+
+  auto event3 = queue.copy(src_data, dev_global3<T>,
+                                sizeof(T) / sizeof(element_type), 0, depEvents);
+  event3.wait();
+  for (size_t i = numEvents - 1; i >= 0; --i) {
+    gens[i].copy_arrays(queue);
+  }
+
+  bool events_result = true;
+  for (size_t i = 0; i < numEvents; ++i)
+    events_result &= gens[i].check(init_value);
+
+  if (!events_result)
+    FAIL(log,
+         "One or more generators completed work before the verifier."
+         "Copy overloads to device_global didn't wait for depEvents to "
+         "complete");
+
+  bool is_copied_correctly = false;
+  {
+    sycl::buffer<bool, 1> is_cop_corr_buf(&is_copied_correctly,
+                                          sycl::range<1>(1));
+    queue.submit([&](sycl::handler& cgh) {
+      auto is_cop_corr_acc =
+          is_cop_corr_buf.template get_access<sycl::access_mode::write>(cgh);
+      cgh.single_task<check_copy_to_dg_kernel<T>>([=] {
+        is_cop_corr_acc[0] = value_helper<T>::compare_val(dev_global1<T>, data);
+        is_cop_corr_acc[0] &=
+            value_helper<T>::compare_val(dev_global2<T>, data);
+        is_cop_corr_acc[0] &=
+            value_helper<T>::compare_val(dev_global3<T>, data);
+      });
+    });
+    queue.wait_and_throw();
+  }
+  if (!is_copied_correctly) {
+    FAIL(log, get_case_description(
+                  "Overloads of sycl::queue::copy for device_global",
+                  "Didn't copy correct data to device_global", type_name));
+  }
+}
+
+template <typename T>
+oneapi::device_global<T> dev_global;
+
+/** @brief The function tests that queue copy overloads correctly copy from
+ * device_global
+ *  @tparam T Type of underlying struct
+ */
+template <typename T>
+void run_test_copy_from_device_global(util::logger& log,
+                                      const std::string& type_name) {
+  using element_type = std::remove_all_extents_t<T>;
+  T new_val{};
+  value_helper<T>::change_val(new_val, 5);
+  T data1{}, data2{}, data3{};
+  element_type* dst_data1 = pointer_helper(data1);
+  element_type* dst_data2 = pointer_helper(data2);
+  element_type* dst_data3 = pointer_helper(data3);
+
+  sycl::queue queue;
+  auto queue = util::get_cts_object::queue();
+
+  queue.submit([&](sycl::handler& cgh) {
+    cgh.single_task<change_dg_kernel<T>>(
+        [=] { value_helper<T>::change_val(dev_global<T>, new_val); });
+  });
+  queue.wait_and_throw();
+
+  auto event1 = queue.copy(dev_global<T>, dst_data1);
+  event1.wait();
+
+  // to generate events with generator from usm_api.h
+  // gens will generate events that will fill array arr_src
+  // in single_task that will take a significant amount of time
+  constexpr size_t numEvents = 5;
+  constexpr size_t gen_buf_size = 1000;
+  std::array<usm_api::event_generator<element_type, gen_buf_size>, numEvents>
+      gens{};
+  element_type init_value{1};
+
+  // List of events that tested usm operation should wait
+  std::vector<sycl::event> depEvents(numEvents);
+  // Run time-consuming tasks to generate events
+  for (size_t i = 0; i < depEvents.size(); ++i) {
+    depEvents[i] = gens[i].init(queue, init_value);
+  }
+
+  // Call overloads with events and check if they wait for events to pass.
+  // Use fast copy arrays for future check. If overloads do not
+  // wait for the passed events to complete, then an incompletely
+  // initialized 'arr_src' will be copied to 'arr_dst' and the test
+  // will fail with generator function check(). Reverse order is used to
+  // increase probability of data race.
+
+  auto event2 =
+      queue.copy(dev_global<T>, dst_data2,
+                      sizeof(T) / sizeof(element_type), 0, depEvents[0]);
+  event2.wait();
+  gens[0].copy_arrays(queue);
+
+  auto event3 = queue.copy(dev_global<T>, dst_data3,
+                                sizeof(T) / sizeof(element_type), 0, depEvents);
+  event3.wait();
+  for (size_t i = numEvents - 1; i >= 0; --i) {
+    gens[i].copy_arrays(queue);
+  }
+
+  bool events_result = true;
+  for (size_t i = 0; i < numEvents; ++i)
+    events_result &= gens[i].check(init_value);
+
+  if (!events_result)
+    FAIL(log,
+         "One or more generators completed work before the verifier."
+         "Copy overloads from device_global didn't wait for depEvents to "
+         "complete");
+
+  if (!value_helper<T>::compare_val(data1, new_val) ||
+      !value_helper<T>::compare_val(data2, new_val) ||
+      !value_helper<T>::compare_val(data3, new_val)) {
+    FAIL(log, get_case_description(
+                  "Overloads of sycl::queue::copy for device_global",
+                  "Didn't copy correct data from device_global", type_name));
+  }
+}
+
+template <typename T>
+class check_queue_overloads_for_device_global_for_type {
+ public:
+  void operator()(sycl_cts::util::logger& log, const std::string& type_name) {
+    // Run test for queue overloads
+    run_test_copy_to_device_global<T>(log, type_name);
+    run_test_copy_from_device_global<T>(log, type_name);
+
+    run_test_copy_to_device_global<T[5]>(log, type_name);
+    run_test_copy_from_device_global<T[5]>(log, type_name);
+  }
+};
+#endif
+
+/** test overloads for queue::copy for device_global
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info& out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger& log) override {
+#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+#else
+    auto types = device_global_types::get_types();
+    for_all_types<check_queue_overloads_for_device_global_for_type>(types, log);
+#endif
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
This PR provides a functional test for extension [device_global](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/DeviceGlobal/SYCL_INTEL_device_global.asciidoc)

It checks the correctness of `sycl::queue` shortcuts `copy()` with `device_global` parameter.