### PR TITLE
Hotfix type check for sycl::make_error_code

### DIFF
--- a/tests/exceptions/exceptions_make_error_code.cpp
+++ b/tests/exceptions/exceptions_make_error_code.cpp
@@ -21,7 +21,7 @@ using namespace sycl_cts;
 void check_sycl_working(sycl::errc err_c, util::logger &log) {
   auto make_err_c_result{sycl::make_error_code(err_c)};
 
-  CHECK_TYPE(log, make_err_c_result, std::error_code());
+  CHECK_TYPE(log, make_err_c_result, std::error_code{});
   if (!noexcept(sycl::make_error_code(err_c))) {
     FAIL(log, "sycl::make_error_code function are not marked as \"noexcept\"");
   }


### PR DESCRIPTION
`typeid(std::error_code())` uses `typeid(type)` overload