### PR TITLE
CI: Pull hipSYCL from sycl-cts branch instead of fixed commit

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -57,7 +57,7 @@ jobs:
           - sycl-impl: dpcpp
             version: ec97c57
           - sycl-impl: hipsycl
-            version: b836149
+            version: sycl-cts
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -96,7 +96,7 @@ jobs:
           - sycl-impl: dpcpp
             version: ec97c57
           - sycl-impl: hipsycl
-            version: b836149
+            version: sycl-cts
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       parallel-build-jobs: 2


### PR DESCRIPTION
Pull hipSYCL used in CI from `sycl-cts` branch instead of using fixed commit of hipSYCL. This allows us to fix CTS issues that come up in CTS CI due to hipSYCL bugs without having to change CTS CI everytime.

(I hope it works the way I did it by just specifying branch instead of commit hash)