### PR TITLE
Functional test for extension `oneapi::device_global`. Spec constants interaction

### DIFF
--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -91,6 +91,17 @@ struct value_helper {
   static void change_val(T& value, const int new_val = 1) { value = new_val; }
 
   /**
+   * @brief The function changes value from the first parameter to
+   * value from the second parameter of the same type
+   * Disabled if T is int to avoid function ambiguous
+   */
+  template <typename Ty = T>
+  static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
+      T& value, const T new_val) {
+    value = new_val;
+  }
+
+  /**
    * @brief The function compares values from the first
    * parameter value from the second parameter
    */
@@ -115,6 +126,17 @@ struct value_helper<T[N]> {
   static void change_val(arrayT& value, const int new_val = 1) {
     for (size_t i = 0; i < N; ++i) {
       value[i] = new_val;
+    }
+  }
+  /**
+   * @brief The function changes all values of the array from the first parameter to
+   * values of the array from the second parameter
+   * @param value The reference to the array that needs to be change
+   * @param new_vals The array with values that will be set
+   */
+  static void change_val(arrayT& value, const arrayT& new_vals) {
+    for (size_t i = 0; i < N; i++) {
+      value[i] = new_vals[i];
     }
   }
 
@@ -142,6 +164,25 @@ struct value_helper<T[N]> {
     return are_equal;
   }
 };
+
+/** @brief The helper function to get variable address for pointer
+ *  @tparam T Type of variable
+ *  @param data variable to get pointer to
+ */
+template <typename T>
+inline T* pointer_helper(T& data) {
+  return &data;
+}
+
+/** @brief The helper function to get first element od array address for pointer
+ *  @tparam T Type of array values
+ *  @tparam N Size of array
+ *  @param data array to get pointer to
+ */
+template <typename T, size_t N>
+inline T* pointer_helper(T (&data)[N]) {
+  return &data[0];
+}
 }  // namespace device_global_common_functions
 
 #endif  // SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H

--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -92,12 +92,12 @@ struct value_helper {
 
   /**
    * @brief The function changes value from the first parameter to
-   * value from the second parameter of the same type
+   * value from the second parameter of the same type.
    * Disabled if T is int to avoid function ambiguous
    */
   template <typename Ty = T>
   static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
-      T& value, const T new_val) {
+      T& value, const T& new_val) {
     value = new_val;
   }
 
@@ -131,7 +131,7 @@ struct value_helper<T[N]> {
   /**
    * @brief The function changes all values of the array from the first parameter to
    * values of the array from the second parameter
-   * @param value The reference to the array that needs to be change
+   * @param value The reference to the array that needs to be changed
    * @param new_vals The array with values that will be set
    */
   static void change_val(arrayT& value, const arrayT& new_vals) {
@@ -174,7 +174,7 @@ inline T* pointer_helper(T& data) {
   return &data;
 }
 
-/** @brief The helper function to get first element od array address for pointer
+/** @brief The helper function to get first element of array address for pointer
  *  @tparam T Type of array values
  *  @tparam N Size of array
  *  @param data array to get pointer to

--- a/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
@@ -4,7 +4,7 @@
 //
 //  Provides functional test for device_global
 //
-//  Checks interaction of device_global instance with a specialization
+//  Checks interaction of device_global instance with specialization
 //  constants. At the first kernel run check that device_global contains default
 //  value and then change the device_global to value from specialization
 //  constant. At the second run change specialization constant value and check
@@ -45,7 +45,7 @@ class read_and_write_in_kernel {
  public:
   /**
    * @brief The function reads value from device_global instance and then writes
-   * new value from specialization constants in instance. Test will be failed if
+   * new value from specialization constants in instance. Test will fail if
    * value from device_global instance not equal to default value
    */
   static inline void expect_def_val(util::logger& log,

--- a/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
@@ -1,0 +1,181 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides functional test for device_global
+//
+//  Checks interaction of device_global instance with a specialization
+//  constants. At the first kernel run check that device_global contains default
+//  value and then change the device_global to value from specialization
+//  constant. At the second run change specialization constant value and check
+//  that the device_global value contains new value from first run.
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+#include "../../common/type_coverage.h"
+#include "device_global_common.h"
+#include "type_pack.h"
+
+#define TEST_NAME device_global_functional_spec_constants
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace device_global_common_functions;
+
+#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+    defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+namespace oneapi = sycl::ext::oneapi;
+
+namespace spec_constants_interaction {
+template <typename T>
+oneapi::device_global<T> dev_global;
+
+constexpr sycl::specialization_id<int> spec_const_id;
+
+template <typename T>
+struct kernel_read_then_write;
+
+/**
+ * @brief The class provide static functions to execute read and write
+ * operations in the kernel
+ */
+template <typename T>
+class read_and_write_in_kernel {
+ public:
+  /**
+   * @brief The function reads value from device_global instance and then writes
+   * new value from specialization constants in instance. Test will be failed if
+   * value from device_global instance not equal to default value
+   */
+  static inline void expect_def_val(util::logger& log,
+                                    const std::string& type_name) {
+    run(true, "Expect to read default value", log, type_name);
+  }
+
+  /**
+   * @brief The function reads value from device_global instance and then writes
+   * new value from specialization constants in instance. Test will be failed if
+   * value from device_global instance not equal to T{1}
+   */
+  static inline void expect_new_val(util::logger& log,
+                                    const std::string& type_name) {
+    run(false, "Expect to read modified value", log, type_name);
+  }
+
+ private:
+  /**
+   * @brief The function reads value from device_global instance and then
+   * writes new value from specialization constants in instance.
+   * @param is_def_val_expected The flag shows if default value expected
+   * @param error_info String to display, when test fails
+   */
+  static inline void run(const bool is_def_val_expected,
+                         const std::string& error_info, util::logger& log,
+                         const std::string& type_name) {
+    // Default value of type T in case if we expect to read default value
+    T def_val{};
+    // Changed value of type T in case if we expect to read modified value
+    T new_val{};
+    value_helper<T>::change_val(new_val);
+
+    constexpr int initial_sc_val = 1;
+    constexpr int changed_sc_val = 2;
+    const int sc_val = is_def_val_expected ? initial_sc_val : changed_sc_val;
+
+    // is_read_correct will be set to true if device_global value is equal to
+    // the expected_val inside kernel
+    bool is_read_correct{false};
+
+    {
+      // Creating result buffer
+      sycl::buffer<bool, 1> is_read_corr_buf(&is_read_correct,
+                                             sycl::range<1>(1));
+      auto queue = util::get_cts_object::queue();
+      queue.submit([&](sycl::handler& cgh) {
+        using kernel = kernel_read_then_write<T>;
+
+        cgh.template set_specialization_constant<spec_const_id>(sc_val);
+
+        auto is_read_correct_acc =
+            is_read_corr_buf.template get_access<sycl::access_mode::write>(cgh);
+
+        // Kernel that will compare device_global variable with expected and
+        // then write new value from specialization constants
+        cgh.single_task<kernel>([=](sycl::kernel_handler h) {
+          if (is_def_val_expected) {
+            is_read_correct_acc[0] =
+                value_helper<T>::compare_val(dev_global<T>, def_val);
+          } else {
+            is_read_correct_acc[0] =
+                value_helper<T>::compare_val(dev_global<T>, new_val);
+          }
+
+          // Get specialization constant value for change device_global instance
+          int sc_val = h.template get_specialization_constant<spec_const_id>();
+          value_helper<T>::change_val(dev_global<T>, sc_val);
+        });
+      });
+      queue.wait_and_throw();
+    }
+    if (is_read_correct == false) {
+      FAIL(log, get_case_description(
+                    "device_global: Interaction with specialization constants",
+                    error_info, type_name));
+    }
+  }
+};
+
+/**
+ * @brief The function tests that the device_global value is correctly read and
+ * changed while interacting with specialization constants
+ * @tparam T Type of underlying device_global value
+ */
+template <typename T>
+void run_test(util::logger& log, const std::string& type_name) {
+  using VerifierT = read_and_write_in_kernel<T>;
+  // At the first run expect default value
+  VerifierT::expect_def_val(log, type_name);
+
+  // At the second run expect changed value
+  VerifierT::expect_new_val(log, type_name);
+}
+}  // namespace spec_constants_interaction
+
+template <typename T>
+class check_device_global_spec_constants {
+ public:
+  void operator()(sycl_cts::util::logger& log, const std::string& type_name) {
+    spec_constants_interaction::run_test<T>(log, type_name);
+    spec_constants_interaction::run_test<T[5]>(log, type_name);
+  }
+};
+#endif
+
+/** test device_global functional
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info& out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger& log) override {
+#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+#else
+    auto types = device_global_types::get_types();
+    for_all_types<check_device_global_spec_constants>(types, log);
+#endif
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
This PR provides a functional test for `device_global`:
Checks interaction of `device_global` instance with specialization constants

[Link](https://github.com/KhronosGroup/SYCL-CTS/pull/262/files/a3e2c57ea7eb8525dc8508da9022743487d57bf3..HEAD) to changes related to this PR.