### PR TITLE
Functional test for extension `oneapi::device_global`. Interaction with kernel bundle.

### DIFF
--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -91,6 +91,17 @@ struct value_helper {
   static void change_val(T& value, const int new_val = 1) { value = new_val; }
 
   /**
+   * @brief The function changes value from the first parameter to
+   * value from the second parameter of the same type
+   * Disabled if T is int to avoid function ambiguous
+   */
+  template <typename Ty = T>
+  static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
+      T& value, const T new_val) {
+    value = new_val;
+  }
+
+  /**
    * @brief The function compares values from the first
    * parameter value from the second parameter
    */
@@ -115,6 +126,17 @@ struct value_helper<T[N]> {
   static void change_val(arrayT& value, const int new_val = 1) {
     for (size_t i = 0; i < N; ++i) {
       value[i] = new_val;
+    }
+  }
+  /**
+   * @brief The function changes all values of the array from the first parameter to
+   * values of the array from the second parameter
+   * @param value The reference to the array that needs to be change
+   * @param new_vals The array with values that will be set
+   */
+  static void change_val(arrayT& value, const arrayT& new_vals) {
+    for (size_t i = 0; i < N; i++) {
+      value[i] = new_vals[i];
     }
   }
 
@@ -142,6 +164,25 @@ struct value_helper<T[N]> {
     return are_equal;
   }
 };
+
+/** @brief The helper function to get variable address for pointer
+ *  @tparam T Type of variable
+ *  @param data variable to get pointer to
+ */
+template <typename T>
+inline T* pointer_helper(T& data) {
+  return &data;
+}
+
+/** @brief The helper function to get first element od array address for pointer
+ *  @tparam T Type of array values
+ *  @tparam N Size of array
+ *  @param data array to get pointer to
+ */
+template <typename T, size_t N>
+inline T* pointer_helper(T (&data)[N]) {
+  return &data[0];
+}
 }  // namespace device_global_common_functions
 
 #endif  // SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H

--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -92,12 +92,12 @@ struct value_helper {
 
   /**
    * @brief The function changes value from the first parameter to
-   * value from the second parameter of the same type
+   * value from the second parameter of the same type.
    * Disabled if T is int to avoid function ambiguous
    */
   template <typename Ty = T>
   static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
-      T& value, const T new_val) {
+      T& value, const T& new_val) {
     value = new_val;
   }
 
@@ -131,7 +131,7 @@ struct value_helper<T[N]> {
   /**
    * @brief The function changes all values of the array from the first parameter to
    * values of the array from the second parameter
-   * @param value The reference to the array that needs to be change
+   * @param value The reference to the array that needs to be changed
    * @param new_vals The array with values that will be set
    */
   static void change_val(arrayT& value, const arrayT& new_vals) {
@@ -174,7 +174,7 @@ inline T* pointer_helper(T& data) {
   return &data;
 }
 
-/** @brief The helper function to get first element od array address for pointer
+/** @brief The helper function to get first element of array address for pointer
  *  @tparam T Type of array values
  *  @tparam N Size of array
  *  @param data array to get pointer to

--- a/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
@@ -1,0 +1,187 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides functional test for device_global
+//
+//  Tests interaction with kernel bundle. In test defines kernel that reads and
+//  writes the device_global value, then create the kernel bundle from the
+//  defined kernel and invokes it. After that, the test builds and invokes the
+//  kernel the second time and checks that device_global value correctly changed
+//  from the first invocation.
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+#include "../../common/type_coverage.h"
+#include "device_global_common.h"
+#include "type_pack.h"
+
+#define TEST_NAME device_global_functional_kernel_bundle
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace device_global_common_functions;
+
+#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+    defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+namespace oneapi = sycl::ext::oneapi;
+
+namespace kernel_bundle_interaction {
+template <typename T>
+oneapi::device_global<T> dev_global;
+
+template <typename T>
+struct kernel_read_then_write;
+
+/**
+ * @brief The class provide static functions to execute read and write
+ * operations in the kernel. Method get_kernel_bundle() will be called to force
+ * an online compilation of kernel before invoking
+ */
+template <typename T>
+class read_and_write_in_kernel {
+ public:
+  /**
+   * @brief The function reads value from device_global instance and then writes
+   * new value in instance. Test will be failed if value from device_global
+   * instance not equal to default value
+   */
+  static inline void expect_def_val(util::logger& log,
+                                    const std::string& type_name) {
+    run(true,
+        "Value read incorrectly from kernel on first invocation. Default "
+        "value expected",
+        log, type_name);
+  }
+
+  /**
+   * @brief The function reads value from device_global instance and then writes
+   * new value in instance. Test will be failed if value from device_global
+   * instance not equal to T{1}
+   */
+  static inline void expect_new_val(util::logger& log,
+                                    const std::string& type_name) {
+    run(false,
+        "Value read incorrectly from kernel on second invocation. "
+        "Changed value expected",
+        log, type_name);
+  }
+
+ private:
+  /**
+   * @brief The function reads value from device_global instance and then
+   * writes new value in instance
+   * @param is_def_val_expected The flag shows if default value expected
+   * @param error_info String to display, when test fails
+   */
+  static inline void run(const bool is_def_val_expected,
+                         const std::string& error_info, util::logger& log,
+                         const std::string& type_name) {
+    // is_read_correct will be set to true if device_global value is equal to
+    // the expected_value inside kernel
+    bool is_read_correct{true};
+
+    // Default value of type T in case if we expect to read default value
+    T def_val{};
+    // Changed value of type T in case if we expect to read modified value
+    T new_val{};
+    // The function change_val have default second parameter, so expect that all
+    // values will change the same
+    value_helper<T>::change_val(new_val);
+
+    {
+      // Creating result buffer
+      sycl::buffer<bool, 1> is_read_corr_buf(&is_read_correct,
+                                             sycl::range<1>(1));
+      // Setting kernel bundle
+      auto queue = util::get_cts_object::queue();
+      auto ctxt = queue.get_context();
+      // Force online compilation
+      auto bundle =
+          sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctxt);
+
+      queue.submit([&](sycl::handler& cgh) {
+        using kernel = kernel_read_then_write<T>;
+        auto is_read_correct_acc =
+            is_read_corr_buf.template get_access<sycl::access_mode::write>(cgh);
+
+        // Using pre-compiled kernel from bundle
+        cgh.use_kernel_bundle(bundle);
+
+        // Kernel that will compare device_global variable with expected and
+        // then write new value
+        cgh.single_task<kernel>([=] {
+          if (is_def_val_expected) {
+            is_read_correct_acc[0] =
+                value_helper<T>::compare_val(dev_global<T>, def_val);
+          } else {
+            is_read_correct_acc[0] =
+                value_helper<T>::compare_val(dev_global<T>, new_val);
+          }
+          value_helper<T>::change_val(dev_global<T>);
+        });
+      });
+      queue.wait_and_throw();
+    }
+    if (is_read_correct == false) {
+      FAIL(log, get_case_description(
+                    "device_global: Interaction with kernel bundles",
+                    error_info, type_name));
+    }
+  }
+};
+
+/**
+ * @brief The function tests that the device_global value is correctly read and
+ * changed while interacting with kernel bundles
+ * @tparam T Type of underlying device_global value
+ */
+template <typename T>
+void run_test(util::logger& log, const std::string& type_name) {
+  using VerifierT = read_and_write_in_kernel<T>;
+  // At the first run expect default value
+  VerifierT::expect_def_val(log, type_name);
+
+  // At the second run expect changed value
+  VerifierT::expect_new_val(log, type_name);
+}
+}  // namespace kernel_bundle_interaction
+
+template <typename T>
+class check_device_global_kernel_bundle {
+ public:
+  void operator()(sycl_cts::util::logger& log, const std::string& type_name) {
+    kernel_bundle_interaction::run_test<T>(log, type_name);
+    kernel_bundle_interaction::run_test<T[5]>(log, type_name);
+  }
+};
+#endif
+
+/** test device_global functional
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info& out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger& log) override {
+#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+#else
+    auto types = device_global_types::get_types();
+    for_all_types<check_device_global_kernel_bundle>(types, log);
+#endif
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
This PR provides a functional test for `device_global`:
Tests interaction with kernel bundle

[Link](https://github.com/KhronosGroup/SYCL-CTS/pull/263/files/f18ede7c70d2e5fddd3ab0171f6c63fa6be0812f..HEAD) to changes related to this PR.