### PR TITLE
Functional test for extension `oneapi::device_global`. Pass a pointer to the underlying `T` type to another kernel.

### DIFF
--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -91,6 +91,17 @@ struct value_helper {
   static void change_val(T& value, const int new_val = 1) { value = new_val; }
 
   /**
+   * @brief The function changes value from the first parameter to
+   * value from the second parameter of the same type
+   * Disabled if T is int to avoid function ambiguous
+   */
+  template <typename Ty = T>
+  static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
+      T& value, const T new_val) {
+    value = new_val;
+  }
+
+  /**
    * @brief The function compares values from the first
    * parameter value from the second parameter
    */
@@ -115,6 +126,17 @@ struct value_helper<T[N]> {
   static void change_val(arrayT& value, const int new_val = 1) {
     for (size_t i = 0; i < N; ++i) {
       value[i] = new_val;
+    }
+  }
+  /**
+   * @brief The function changes all values of the array from the first parameter to
+   * values of the array from the second parameter
+   * @param value The reference to the array that needs to be change
+   * @param new_vals The array with values that will be set
+   */
+  static void change_val(arrayT& value, const arrayT& new_vals) {
+    for (size_t i = 0; i < N; i++) {
+      value[i] = new_vals[i];
     }
   }
 
@@ -142,6 +164,25 @@ struct value_helper<T[N]> {
     return are_equal;
   }
 };
+
+/** @brief The helper function to get variable address for pointer
+ *  @tparam T Type of variable
+ *  @param data variable to get pointer to
+ */
+template <typename T>
+inline T* pointer_helper(T& data) {
+  return &data;
+}
+
+/** @brief The helper function to get first element od array address for pointer
+ *  @tparam T Type of array values
+ *  @tparam N Size of array
+ *  @param data array to get pointer to
+ */
+template <typename T, size_t N>
+inline T* pointer_helper(T (&data)[N]) {
+  return &data[0];
+}
 }  // namespace device_global_common_functions
 
 #endif  // SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H

--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -92,12 +92,12 @@ struct value_helper {
 
   /**
    * @brief The function changes value from the first parameter to
-   * value from the second parameter of the same type
+   * value from the second parameter of the same type.
    * Disabled if T is int to avoid function ambiguous
    */
   template <typename Ty = T>
   static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
-      T& value, const T new_val) {
+      T& value, const T& new_val) {
     value = new_val;
   }
 
@@ -131,7 +131,7 @@ struct value_helper<T[N]> {
   /**
    * @brief The function changes all values of the array from the first parameter to
    * values of the array from the second parameter
-   * @param value The reference to the array that needs to be change
+   * @param value The reference to the array that needs to be changed
    * @param new_vals The array with values that will be set
    */
   static void change_val(arrayT& value, const arrayT& new_vals) {
@@ -174,7 +174,7 @@ inline T* pointer_helper(T& data) {
   return &data;
 }
 
-/** @brief The helper function to get first element od array address for pointer
+/** @brief The helper function to get first element of array address for pointer
  *  @tparam T Type of array values
  *  @tparam N Size of array
  *  @param data array to get pointer to

--- a/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides functional test for device_global
+//
+//  Tests passing pointer to the underlying data to another kernel
+//
+//  In this test the first kernel called write_kernel change the value of
+//  device_global instance and store address of returned value from .get()
+//  method to buffer accessor, that contains T* ptr.
+//
+//  In the second kernel called read_kernel attempt
+//  to read value by dereferencing the pointer from first step. Test will pass
+//  if dereferenced value from the second kernel will be equal to the
+//  expected value
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+#include "../../common/type_coverage.h"
+#include "device_global_common.h"
+#include "type_pack.h"
+
+#define TEST_NAME device_global_functional_pass_pointer
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace device_global_common_functions;
+
+#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+    defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+namespace oneapi = sycl::ext::oneapi;
+
+namespace pass_pointer_to_another_kernel {
+template <typename T>
+oneapi::device_global<T> dev_global;
+
+template <typename T>
+struct write_kernel;
+template <typename T>
+struct read_kernel;
+
+/**
+ * @brief The function tests that pointer to device_global value correctly
+ * passes from one kernel to another
+ * @tparam T Type of the underlying device_global data
+ */
+template <typename T>
+void run_test(util::logger& log, const std::string& type_name) {
+  // Pointer to T for store address of underlying value in device_global
+  T* ptr;
+
+  auto queue = util::get_cts_object::queue();
+  {
+    sycl::buffer<T*, 1> ptr_buf(&ptr, sycl::range<1>(1));
+    queue.submit([&](sycl::handler& cgh) {
+      using kernel = write_kernel<T>;
+      auto ptr_acc = ptr_buf.template get_access<sycl::access_mode::write>(cgh);
+
+      cgh.single_task<kernel>([=] {
+        // Change the device_global instance and store address to the ptr
+        // through accessor
+        value_helper<T>::change_val(dev_global<T>);
+        ptr_acc[0] = &(dev_global<T>.get());
+      });
+    });
+    queue.wait_and_throw();
+  }
+
+  // Expecting to read the new_value that was set to the device_global instance
+  // in previous kernel
+  T new_val{};
+  // The function change_val have default second parameter, so expect that all
+  // values will change the same
+  value_helper<T>::change_val(new_val);
+
+  bool is_read_correct{true};
+  {
+    // Creating result buffer
+    sycl::buffer<bool, 1> is_read_corr_buf(&is_read_correct, sycl::range<1>(1));
+
+    queue.submit([&](sycl::handler& cgh) {
+      using kernel = write_kernel<T>;
+
+      auto is_read_correct_acc =
+          is_read_corr_buf.template get_access<sycl::access_mode::write>(cgh);
+
+      cgh.single_task<kernel>([=] {
+        is_read_correct_acc[0] =
+            (value_helper<T>::compare_val(*(ptr), new_val));
+      });
+    });
+    queue.wait_and_throw();
+  }
+  if (is_read_correct == false) {
+    FAIL(log, get_case_description(
+                  "device_global: Passing a pointer to the "
+                  "underlying value to another kernel",
+                  "Wrong value after dereferencing pointer in another kernel",
+                  type_name));
+  }
+}
+}  // namespace pass_pointer_to_another_kernel
+
+template <typename T>
+class check_device_global_pass_pointer {
+ public:
+  void operator()(sycl_cts::util::logger& log, const std::string& type_name) {
+    pass_pointer_to_another_kernel::run_test<T>(log, type_name);
+    pass_pointer_to_another_kernel::run_test<T[5]>(log, type_name);
+  }
+};
+#endif
+
+/** test device_global functional
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info& out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger& log) override {
+#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+#else
+    auto types = device_global_types::get_types();
+    for_all_types<check_device_global_pass_pointer>(types, log);
+#endif
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
This PR provides a functional test for device_global:
Tests passing a pointer to the underlying data to another kernel

[Link](https://github.com/KhronosGroup/SYCL-CTS/pull/264/files/2567537a666401fe3c2c28d1fbc92494c0ebfb76..HEAD) to changes related to this PR.

