### PR TITLE
Functional test for extension `oneapi::device_global`. Defined in various ways.

### DIFF
--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -91,6 +91,17 @@ struct value_helper {
   static void change_val(T& value, const int new_val = 1) { value = new_val; }
 
   /**
+   * @brief The function changes value from the first parameter to
+   * value from the second parameter of the same type
+   * Disabled if T is int to avoid function ambiguous
+   */
+  template <typename Ty = T>
+  static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
+      T& value, const T new_val) {
+    value = new_val;
+  }
+
+  /**
    * @brief The function compares values from the first
    * parameter value from the second parameter
    */
@@ -115,6 +126,17 @@ struct value_helper<T[N]> {
   static void change_val(arrayT& value, const int new_val = 1) {
     for (size_t i = 0; i < N; ++i) {
       value[i] = new_val;
+    }
+  }
+  /**
+   * @brief The function changes all values of the array from the first parameter to
+   * values of the array from the second parameter
+   * @param value The reference to the array that needs to be change
+   * @param new_vals The array with values that will be set
+   */
+  static void change_val(arrayT& value, const arrayT& new_vals) {
+    for (size_t i = 0; i < N; i++) {
+      value[i] = new_vals[i];
     }
   }
 
@@ -142,6 +164,25 @@ struct value_helper<T[N]> {
     return are_equal;
   }
 };
+
+/** @brief The helper function to get variable address for pointer
+ *  @tparam T Type of variable
+ *  @param data variable to get pointer to
+ */
+template <typename T>
+inline T* pointer_helper(T& data) {
+  return &data;
+}
+
+/** @brief The helper function to get first element od array address for pointer
+ *  @tparam T Type of array values
+ *  @tparam N Size of array
+ *  @param data array to get pointer to
+ */
+template <typename T, size_t N>
+inline T* pointer_helper(T (&data)[N]) {
+  return &data[0];
+}
 }  // namespace device_global_common_functions
 
 #endif  // SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H

--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -92,12 +92,12 @@ struct value_helper {
 
   /**
    * @brief The function changes value from the first parameter to
-   * value from the second parameter of the same type
+   * value from the second parameter of the same type.
    * Disabled if T is int to avoid function ambiguous
    */
   template <typename Ty = T>
   static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
-      T& value, const T new_val) {
+      T& value, const T& new_val) {
     value = new_val;
   }
 
@@ -131,7 +131,7 @@ struct value_helper<T[N]> {
   /**
    * @brief The function changes all values of the array from the first parameter to
    * values of the array from the second parameter
-   * @param value The reference to the array that needs to be change
+   * @param value The reference to the array that needs to be changed
    * @param new_vals The array with values that will be set
    */
   static void change_val(arrayT& value, const arrayT& new_vals) {
@@ -174,7 +174,7 @@ inline T* pointer_helper(T& data) {
   return &data;
 }
 
-/** @brief The helper function to get first element od array address for pointer
+/** @brief The helper function to get first element of array address for pointer
  *  @tparam T Type of array values
  *  @tparam N Size of array
  *  @param data array to get pointer to

--- a/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
@@ -1,0 +1,148 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides functional test for device_global
+//
+//  The test creates device_global instance in a various ways:
+//  1. In anonymous namespace
+//  2. In namespace
+//  3. As static member of a structure
+//
+//  The test tries to modify all device_global values inside the kernel and
+//  verify that they changed as expected.
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+#include "../../common/type_coverage.h"
+#include "device_global_common.h"
+#include "type_pack.h"
+
+#define TEST_NAME device_global_functional_define_various_ways
+
+namespace TEST_NAMESPACE {
+using namespace sycl_cts;
+using namespace device_global_common_functions;
+
+#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+    defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+namespace oneapi = sycl::ext::oneapi;
+
+namespace define_various_ways {
+
+namespace {
+template <typename T>
+oneapi::device_global<T> dev_global;
+}
+namespace dum_namespace {
+template <typename T>
+oneapi::device_global<T> dev_global;
+}
+struct dum_struct {
+  template <typename T>
+  static inline oneapi::device_global<T> dev_global;
+};
+
+template <typename T>
+struct kernel;
+
+/**
+ * @brief The function tests that the device_global instance can be correctly
+ * defined in various ways
+ * @tparam T Type of underlying device_global value
+ */
+template <typename T>
+void run_test(util::logger& log, const std::string& type_name) {
+  T def_value{};
+  T new_val{};
+  value_helper<T>::change_val(new_val, 1);
+
+  auto queue = util::get_cts_object::queue();
+  bool is_defined_correctly = false;
+  bool is_default_values = false;
+  {
+    sycl::buffer<bool, 1> is_def_corr_buf(&is_defined_correctly,
+                                          sycl::range<1>(1));
+    sycl::buffer<bool, 1> is_default_buf(&is_default_values, sycl::range<1>(1));
+    queue.submit([&](sycl::handler& cgh) {
+      auto is_def_corr_acc =
+          is_def_corr_buf.template get_access<sycl::access_mode::write>(cgh);
+      auto is_default_acc =
+          is_default_buf.template get_access<sycl::access_mode::write>(cgh);
+      cgh.single_task<kernel<T>>([=] {
+        auto& dg1 = dev_global<T>.get();
+        auto& dg2 = dum_namespace::dev_global<T>.get();
+        auto& dg3 = dum_struct::dev_global<T>.get();
+
+        // Check that contains default values
+        is_default_acc[0] = value_helper<T>::compare_val(dg1, def_value);
+        is_default_acc[0] &= value_helper<T>::compare_val(dg2, def_value);
+        is_default_acc[0] &= value_helper<T>::compare_val(dg3, def_value);
+
+        value_helper<T>::change_val(dg1, new_val);
+        value_helper<T>::change_val(dg2, new_val);
+        value_helper<T>::change_val(dg3, new_val);
+
+        is_def_corr_acc[0] =
+            value_helper<T>::compare_val(dev_global<T>, new_val);
+        is_def_corr_acc[0] &=
+            value_helper<T>::compare_val(dum_namespace::dev_global<T>, new_val);
+        is_def_corr_acc[0] &=
+            value_helper<T>::compare_val(dum_struct::dev_global<T>, new_val);
+      });
+    });
+    queue.wait_and_throw();
+  }
+  if (!is_default_values) {
+    FAIL(log, get_case_description(
+                  "device_global: Define various ways",
+                  "Instances were created with non-default values", type_name));
+  }
+  if (!is_defined_correctly) {
+    FAIL(log,
+         get_case_description(
+             "device_global: Define various ways",
+             "Wrong value after change when defined device_global various ways",
+             type_name));
+  }
+}
+}  // namespace define_various_ways
+
+template <typename T>
+class check_device_global_define_various_ways {
+ public:
+  void operator()(sycl_cts::util::logger& log, const std::string& type_name) {
+    define_various_ways::run_test<T>(log, type_name);
+    define_various_ways::run_test<T[5]>(log, type_name);
+  }
+};
+#endif
+
+/** test device_global functional
+ */
+class TEST_NAME : public sycl_cts::util::test_base {
+ public:
+  /** return information about this test
+   */
+  void get_info(test_base::info& out) const override {
+    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  }
+
+  /** execute the test
+   */
+  void run(util::logger& log) override {
+#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
+    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
+    WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
+#else
+    auto types = device_global_types::get_types();
+    for_all_types<check_device_global_define_various_ways>(types, log);
+#endif
+  }
+};
+
+// construction of this proxy will register the above test
+util::test_proxy<TEST_NAME> proxy;
+}  // namespace TEST_NAMESPACE


### PR DESCRIPTION
This PR provides a functional test for `device_global`:
The test creates `device_global` instance in various ways and verifies that the instance was created correctly. 

[Link](https://github.com/KhronosGroup/SYCL-CTS/pull/265/files/6f2f595870aee957abf06af19bb2424b1a6c18c0..HEAD) to changes related to this PR.