### PR TITLE
Bump hipSYCL CI container version to 3d8b1cd

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -57,7 +57,7 @@ jobs:
           - sycl-impl: dpcpp
             version: ec97c57
           - sycl-impl: hipsycl
-            version: b836149
+            version: 3d8b1cd
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -96,7 +96,7 @@ jobs:
           - sycl-impl: dpcpp
             version: ec97c57
           - sycl-impl: hipsycl
-            version: b836149
+            version: 3d8b1cd
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       parallel-build-jobs: 2

--- a/ci/hipsycl.filter
+++ b/ci/hipsycl.filter
@@ -22,7 +22,6 @@ math_builtin_api
 multi_ptr
 nd_item
 nd_range
-platform
 queue
 range
 reduction
@@ -30,7 +29,6 @@ sampler
 scalars
 specialization_constants
 stream
-sub_group_mask
 usm
 vector_alias
 vector_api


### PR DESCRIPTION
Two new test categories now compile: platform and sub_group_mask.