### PR TITLE
Add missing includes in util/extensions.h

### DIFF
--- a/util/extensions.h
+++ b/util/extensions.h
@@ -10,6 +10,9 @@
 #define __SYCLCTS_UTIL_EXTENSIONS_H
 
 #include <sycl/sycl.hpp>
+#include "logger.h"
+
+#include <string>
 
 namespace sycl_cts {
 namespace util {


### PR DESCRIPTION
Otherwise we might trigger compilation failure depending on order of includes in test