### PR TITLE
Add test plan for compile time property_list

### DIFF
--- a/test_plans/compile-time-property_list.asciidoc
+++ b/test_plans/compile-time-property_list.asciidoc
@@ -1,0 +1,164 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for compile-time property_list
+
+This is a test plan for the APIs described in
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/PropertyList/SYCL_EXT_ONEAPI_property_list.asciidoc[SYCL_EXT_ONEAPI_property_list.asciidoc]
+
+
+== Testing scope
+
+=== Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line.
+
+=== Feature test macro
+
+All of the tests should use `#ifdef SYCL_EXT_ONEAPI_PROPERTY_LIST` so they can be skipped
+if feature is not supported.
+
+== Tests
+
+Tests are using compile-time properties from extension SYCL_EXT_ONEAPI_DEVICE_GLOBAL,
+because of it test should be skipped if `SYCL_EXT_ONEAPI_DEVICE_GLOBAL` is not defined.
+
+=== Tests for property_value
+
+Get prop_values from prop_lists:
+
+`property_list props1{device_image_scope_v};`
+
+`auto prop_value1 = props.get_property<device_image_scope>();`
+
+`property_list props2{host_access_v<A>};`
+where `A = host_access::access::read, host_access::access::write, host_access::access::read_write, host_access::access::none`
+
+`auto prop_value_A = props.get_property<host_access>();`
+
+Check that for `prop_value1` members `value` and `value_t` are not available.
+
+Check that for every `A` `prop_value_A` member `value` is `A` and member `value_t` is `host_access::access`.
+
+=== Tests for equality and inequality operators for properties
+
+Get prop_values from prop_lists:
+
+`property_list props1{device_image_scope_v};`
+
+`auto prop_value_device_image_scope = props.get_property<device_image_scope>();`
+
+`property_list props2{implement_in_csr_v<true>};`
+
+`auto prop_value_implement_in_csr_true = props.get_property<implement_in_csr_v>();`
+
+`property_list props3{implement_in_csr_v<false>};`
+
+`auto prop_value_implement_in_csr_false = props.get_property<implement_in_csr_v>();`
+
+Check constexpr correctness if required and result for operators:
+
+[%header,cols="3,2,2,1"]
+|===
+|operator
+|first parameter
+|second parameter
+|result
+
+|`template <class Prop, class...A, class...B>
+constexpr bool operator==(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
+|`prop_value_device_image_scope`
+|`prop_value_device_image_scope`
+| `true`
+
+|`template <class Prop, class...A, class...B>
+constexpr bool operator==(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
+|`prop_value_implement_in_csr_true`
+|`prop_value_implement_in_csr_true`
+| `true`
+
+|`template <class Prop, class...A, class...B>
+constexpr bool operator==(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
+|`prop_value_implement_in_csr_true`
+|`prop_value_implement_in_csr_false`
+| `false`
+
+|`template <class Prop, class...A, class...B>
+constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
+|`prop_value_device_image_scope`
+|`prop_value_device_image_scope`
+| `false`
+
+|`template <class Prop, class...A, class...B>
+constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
+|`prop_value_implement_in_csr_false`
+|`prop_value_implement_in_csr_false`
+| `false`
+
+|`template <class Prop, class...A, class...B>
+constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
+|`prop_value_implement_in_csr_true`
+|`prop_value_implement_in_csr_false`
+| `true`
+
+|===
+
+=== Tests for property_list
+
+==== has_property
+
+Create property_list with `property_list P1{device_image_scope_v, implement_in_csr_v<true>, host_access_v<access:read>}`
+and check P1.has_property<T> returns:
+
+* `true` for `T = device_image_scope`
+* `true` for `T = implement_in_csr`
+* `true` for `T = host_access`
+* `false` for `T = init_mode`
+
+=== Tests for is_property_list
+
+* Create property_list with `property_list props{device_image_scope_v, implement_in_csr_v<true>}`
+* Check that `is_property_list<decltype(props)>` is `std::true_type`
+* Check that `is_property_list_v<decltype(props)>` is `true`
+
+* Create custom class A
+* Check that `is_property_list<A>` is `std::false_type`
+* Check that `is_property_list_v<A>` is `false`
+
+=== Different order
+
+* Call property_list constructor `property_list P1{implement_in_csr_v<true>, device_image_scope_v}`
+* Call property_list constructor `property_list P2{device_image_scope_v, implement_in_csr_v<true>}`
+* Check that `std::is_same_v<decltype(P1), decltype(P2)>` is `true`.
+
+=== is_property
+
+* Check that `is_property<device_image_scope>` is `std::true_type`
+* Check that `is_property<host_access>` is `std::true_type`
+* Check that `is_property<init_mode>` is `std::true_type`
+* Check that `is_property<device_image_scope>` is `std::true_type`
+
+=== is_device_copyable
+
+==== is_device_copyable for compile-time-constant properties
+
+* Check that `is_device_copyable<device_image_scope::value_t>` is `std::true_type`
+* Check that `is_device_copyable<host_access::value_t<access::read>>` is `std::true_type`
+* Check that `is_device_copyable<host_access::value_t<access::write>>` is `std::true_type`
+* Check that `is_device_copyable<host_access::value_t<access::read_write>>` is `std::true_type`
+* Check that `is_device_copyable<host_access::value_t<access::none>>` is `std::true_type`
+* Check that `is_device_copyable<init_mode::value_t<trigger::reprogram>>` is `std::true_type`
+* Check that `is_device_copyable<init_mode::value_t<trigger::reset>>` is `std::true_type`
+* Check that `is_device_copyable<implement_in_csr::value_t<true>>` is `std::true_type`
+* Check that `is_device_copyable<implement_in_csr::value_t<false>>` is `std::true_type`
+
+==== is_device_copyable for empty property_list
+
+* Create empty propery_list `property_list P1{}`
+* Check that `is_device_copyable<decltype(P1)>` is `std::true_type`
+
+==== is_device_copyable for property_list with only compile-time-constant properties
+
+* Create property_list `property_list P2{implement_in_csr_v<true>, device_image_scope_v}`
+* Check that `is_device_copyable<decltype(P2)>` is `std::true_type`


### PR DESCRIPTION
Adding test plan for recently added tests in https://github.com/KhronosGroup/SYCL-CTS/tree/SYCL-2020/tests/extension/oneapi_property_list