### PR TITLE
Fix includes in usm tests

### DIFF
--- a/tests/usm/usm_atomic_access.h
+++ b/tests/usm/usm_atomic_access.h
@@ -10,6 +10,7 @@
 #define __SYCL_CTS_TEST_USM_ATOMIC_ACCESS_H
 
 #include "../../util/usm_helper.h"
+#include "../common/common.h"
 #include "../common/type_coverage.h"
 #include <chrono>
 #include <cstring>

--- a/tests/usm/usm_fill_memset_memcpy.cpp
+++ b/tests/usm/usm_fill_memset_memcpy.cpp
@@ -7,6 +7,7 @@
 *******************************************************************************/
 
 #include "../../util/usm_helper.h"
+#include "../common/common.h"
 #include <cstring>
 
 #define TEST_NAME usm_fill_memset_memcpy

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -9,6 +9,7 @@
 *******************************************************************************/
 
 #include "../../util/usm_helper.h"
+#include "../common/common.h"
 #include <cstring>
 
 #define TEST_NAME usm_get_pointer_queries

--- a/util/usm_helper.h
+++ b/util/usm_helper.h
@@ -9,9 +9,9 @@
 #ifndef __SYCL_CTS_UTIL_USM_HELPER_H
 #define __SYCL_CTS_UTIL_USM_HELPER_H
 
-#include "../common/common.h"
 #include <memory>
 #include <string_view>
+#include <sycl/sycl.hpp>
 
 namespace usm_helper {
 


### PR DESCRIPTION
Remove incorrect include `common.h` from `usm.helper`.
And add include `common.h` where it's actually required.