### PR TITLE
Fix allocation USM for host device

### DIFF
--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -21,7 +21,7 @@ template <sycl::usm::alloc alloc>
 void run_check(const sycl::queue &queue, sycl_cts::util::logger &log) {
   const auto &context{queue.get_context()};
   // According to the SYCL 2020 the first device in context should be
-  // used for alloc::host
+  // used for alloc::host.
   const auto &device{(alloc == sycl::usm::alloc::host)
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -20,8 +20,8 @@ using namespace sycl_cts;
 template <sycl::usm::alloc alloc>
 void run_check(const sycl::queue &queue, sycl_cts::util::logger &log) {
   const auto &context{queue.get_context()};
-  // According to the SYCL 2020 the first device in context should be
-  // used for alloc::host.
+  // According to the SYCL 2020 (rev. 4, $4.8.4. Unified shared memory pointer
+  // queries) the first device in context should be used for alloc::host.
   const auto &device{(alloc == sycl::usm::alloc::host)
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -19,8 +19,12 @@ using namespace sycl_cts;
 
 template <sycl::usm::alloc alloc>
 void run_check(const sycl::queue &queue, sycl_cts::util::logger &log) {
-  const auto &device{queue.get_device()};
   const auto &context{queue.get_context()};
+  // According to the SYCL 2020 the first device in context should be
+  // used for alloc::host
+  const auto &device{(alloc == sycl::usm::alloc::host)
+                         ? queue.get_context().get_devices()[0]
+                         : queue.get_device()};
 
   auto str_usm_alloc_type{usm_helper::get_allocation_description<alloc>()};
 

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -22,7 +22,7 @@ void run_check(const sycl::queue &queue, sycl_cts::util::logger &log) {
   const auto &context{queue.get_context()};
   // According to the SYCL 2020 (rev. 4, $4.8.4. Unified shared memory pointer
   // queries) the first device in context should be used for alloc::host.
-  const auto &device{(alloc == sycl::usm::alloc::host)
+  const auto &device{alloc == sycl::usm::alloc::host
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};
 

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -23,7 +23,7 @@ void run_check(const sycl::queue &queue, sycl_cts::util::logger &log) {
   // According to the SYCL 2020 (rev. 4, $4.8.4. Unified shared memory pointer
   // queries) 'get_pointer_device' must return the first device in context for
   // the usm::alloc::host kind.
-  const auto &device{(alloc == sycl::usm::alloc::host)
+  const auto &device{alloc == sycl::usm::alloc::host
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};
 

--- a/tests/usm/usm_get_pointer_queries.cpp
+++ b/tests/usm/usm_get_pointer_queries.cpp
@@ -21,8 +21,9 @@ template <sycl::usm::alloc alloc>
 void run_check(const sycl::queue &queue, sycl_cts::util::logger &log) {
   const auto &context{queue.get_context()};
   // According to the SYCL 2020 (rev. 4, $4.8.4. Unified shared memory pointer
-  // queries) the first device in context should be used for alloc::host.
-  const auto &device{alloc == sycl::usm::alloc::host
+  // queries) 'get_pointer_device' must return the first device in context for
+  // the usm::alloc::host kind.
+  const auto &device{(alloc == sycl::usm::alloc::host)
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};
 

--- a/util/usm_helper.h
+++ b/util/usm_helper.h
@@ -24,7 +24,7 @@ auto allocate_usm_memory(const sycl::queue &queue, size_t num_elements = 1) {
   const auto &context{queue.get_context()};
   // According to the SYCL 2020 (rev. 4, $4.8.4. Unified shared memory pointer
   // queries) the first device in context should be used for alloc::host.
-  const auto &device{(alloc == sycl::usm::alloc::host)
+  const auto &device{alloc == sycl::usm::alloc::host
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};
 

--- a/util/usm_helper.h
+++ b/util/usm_helper.h
@@ -22,8 +22,8 @@ namespace usm_helper {
 template <sycl::usm::alloc alloc, typename elems_typeT>
 auto allocate_usm_memory(const sycl::queue &queue, size_t num_elements = 1) {
   const auto &context{queue.get_context()};
-  // According to the SYCL 2020 the first device in context should be
-  // used for alloc::host.
+  // According to the SYCL 2020 (rev. 4, $4.8.4. Unified shared memory pointer
+  // queries) the first device in context should be used for alloc::host.
   const auto &device{(alloc == sycl::usm::alloc::host)
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};

--- a/util/usm_helper.h
+++ b/util/usm_helper.h
@@ -23,7 +23,8 @@ template <sycl::usm::alloc alloc, typename elems_typeT>
 auto allocate_usm_memory(const sycl::queue &queue, size_t num_elements = 1) {
   const auto &context{queue.get_context()};
   // According to the SYCL 2020 (rev. 4, $4.8.4. Unified shared memory pointer
-  // queries) the first device in context should be used for alloc::host.
+  // queries) 'get_pointer_device' must return the first device in context for
+  // the usm::alloc::host kind.
   const auto &device{alloc == sycl::usm::alloc::host
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};

--- a/util/usm_helper.h
+++ b/util/usm_helper.h
@@ -23,7 +23,7 @@ template <sycl::usm::alloc alloc, typename elems_typeT>
 auto allocate_usm_memory(const sycl::queue &queue, size_t num_elements = 1) {
   const auto &context{queue.get_context()};
   // According to the SYCL 2020 the first device in context should be
-  // used for alloc::host
+  // used for alloc::host.
   const auto &device{(alloc == sycl::usm::alloc::host)
                          ? queue.get_context().get_devices()[0]
                          : queue.get_device()};

--- a/util/usm_helper.h
+++ b/util/usm_helper.h
@@ -21,8 +21,12 @@ namespace usm_helper {
  */
 template <sycl::usm::alloc alloc, typename elems_typeT>
 auto allocate_usm_memory(const sycl::queue &queue, size_t num_elements = 1) {
-  const auto &device{queue.get_device()};
   const auto &context{queue.get_context()};
+  // According to the SYCL 2020 the first device in context should be
+  // used for alloc::host
+  const auto &device{(alloc == sycl::usm::alloc::host)
+                         ? queue.get_context().get_devices()[0]
+                         : queue.get_device()};
 
   auto deleter = [=](elems_typeT *ptr) { sycl::free(ptr, context); };
 


### PR DESCRIPTION
This fix is needed because the spec says that the first device
should be used if allocation is usm::alloc::host