### PR TITLE
Fix usm_atomic_access_atomic64 using unsupported atomics

### DIFF
--- a/tests/usm/usm_atomic_access.h
+++ b/tests/usm/usm_atomic_access.h
@@ -72,6 +72,16 @@ void check_atomic_access(sycl::queue &queue, sycl_cts::util::logger &log,
              " memory allocation");
     return;
   }
+  auto orders =
+      queue.get_device()
+          .get_info<sycl::info::device::atomic_memory_order_capabilities>();
+  if (std::find(orders.begin(), orders.end(), sycl::memory_order::seq_cst) ==
+      orders.end()) {
+    log.note(
+        "Device does not support atomics with sequentially consistent memory "
+        "order");
+    return;
+  }
 
   auto flag{usm_helper::allocate_usm_memory<AllocMemT, int>(queue)};
   auto counter{usm_helper::allocate_usm_memory<AllocMemT, CounterT>(queue)};


### PR DESCRIPTION
Fixes usm_atomic_access_atomic64 that used seq_cst atomics without checking if they are supported by the device. This PR changes the test to only run if seq_cst atomics are supported.

Here is a report of this test failing when run with DPC++ on a Nvidia GPU: https://github.com/intel/llvm/issues/5210