### PR TITLE
Add support for compile-time disabled test cases

### DIFF
--- a/ci/hipsycl.filter
+++ b/ci/hipsycl.filter
@@ -12,7 +12,6 @@ h_item
 handler
 hierarchical
 host_task
-id
 image
 item
 kernel

--- a/tests/common/disabled_for_test_case.h
+++ b/tests/common/disabled_for_test_case.h
@@ -1,0 +1,138 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_COMMON_DISABLED_FOR_TEST_CASE_H
+#define __SYCLCTS_TESTS_COMMON_DISABLED_FOR_TEST_CASE_H
+
+#include "macro_utils.h"
+
+// TODO: Add other Catch2 test case variants, as needed
+
+/**
+ * Registers a test case that is compile-time disabled for one or more SYCL
+ * implementations. This is useful for when a test case contains code that
+ * currently does not compile for a given implementation, while other test cases
+ * in the same translation unit would otherwise compile.
+ *
+ * The following implementations can be specified: ComputeCpp, DPCPP, hipSYCL.
+ * A disabled test case will fail automatically at runtime.
+ *
+ * Usage example:
+ * ```
+ * DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)("my test case", "[my-tag]")({
+ *  // ...
+ * });
+ * ```
+ *
+ * Apart from the initial list of implementations, the test case definition is
+ * quite similar to a regular test case, with two additional caveats:
+ *  1. The test case body needs to be wrapped in parentheses.
+ *  2. Unlike for regular TEST_CASE, tags are non-optional and must be provided.
+ */
+#define DISABLED_FOR_TEST_CASE(...) \
+  INTERNAL_CTS_DISABLED_FOR_TEST_CASE(__VA_ARGS__)
+
+#define DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(...) \
+  INTERNAL_CTS_DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(__VA_ARGS__)
+
+// ------------------------------------------------------------------------------------
+
+#if defined(__COMPUTECPP__)
+#define INTERNAL_CTS_SYCL_IMPL_ComputeCpp ()
+#elif defined(__HIPSYCL__)
+#define INTERNAL_CTS_SYCL_IMPL_hipSYCL ()
+#else
+// FIXME Don't assume DPC++ by default
+#define INTERNAL_CTS_SYCL_IMPL_DPCPP ()
+#endif
+
+// ------------------------------------------------------------------------------------
+
+#define INTERNAL_CTS_IMPL_PROBE(impl) \
+  _INTERNAL_CTS_IMPL_PROBE_APPEND(    \
+      INTERNAL_CTS_CAT(INTERNAL_CTS_SYCL_IMPL_, impl))
+#define _INTERNAL_CTS_IMPL_PROBE_APPEND(x) _INTERNAL_CTS_IMPL_PROBE_EXPAND x
+#define _INTERNAL_CTS_IMPL_PROBE_EXPAND(...) INTERNAL_CTS_PROBE()
+
+// Returns 1 if INTERNAL_CTS_SYCL_IMPL_<impl> is set to `()`, 0 otherwise.
+#define INTERNAL_CTS_IS_IMPL(impl) \
+  INTERNAL_CTS_CHECK(INTERNAL_CTS_IMPL_PROBE(impl))
+
+// ------------------------------------------------------------------------------------
+
+// Helper macros for expanding recursive calls.
+// This allows us to check for up to 16 + 1 SYCL implementations, which should
+// be plenty. (Otherwise this could always be extended by another factor of
+// two).
+#define INTERNAL_CTS_EVAL(...) INTERNAL_CTS_EVAL16(__VA_ARGS__)
+#define INTERNAL_CTS_EVAL16(...) \
+  INTERNAL_CTS_EVAL8(INTERNAL_CTS_EVAL8(__VA_ARGS__))
+#define INTERNAL_CTS_EVAL8(...) \
+  INTERNAL_CTS_EVAL4(INTERNAL_CTS_EVAL4(__VA_ARGS__))
+#define INTERNAL_CTS_EVAL4(...) \
+  INTERNAL_CTS_EVAL2(INTERNAL_CTS_EVAL2(__VA_ARGS__))
+#define INTERNAL_CTS_EVAL2(...) __VA_ARGS__
+
+#define INTERNAL_CTS_EMPTY()
+// Defers macro expansion to allow for recursion (prevent macros from being
+// "painted blue"). Depending on the nesting level of the recursive call, we
+// need multiple defers (3 in this case).
+#define INTERNAL_CTS_DEFER3(x) \
+  x INTERNAL_CTS_EMPTY INTERNAL_CTS_EMPTY INTERNAL_CTS_EMPTY()()()
+
+// ------------------------------------------------------------------------------------
+
+#define INTERNAL_CTS_FIRST(a, ...) a
+#define INTERNAL_CTS_HAS_ARGS(...) \
+  INTERNAL_CTS_BOOL(               \
+      INTERNAL_CTS_FIRST(_INTERNAL_CTS_END_OF_ARGS_ __VA_ARGS__)())
+#define _INTERNAL_CTS_END_OF_ARGS_() 0
+
+// In case we are compiling with a disabled implementation,
+// replace test case with this auto-failing proxy.
+// Note that we explicitly receive a description and tags here,
+// so we can use the same macro for all types of test cases,
+// including those that receive additional parameters.
+// A downside of this is that we require test cases to provide
+// tags, which normally would be optional.
+#define INTERNAL_CTS_DISABLED_TEST_CASE(description, tags, ...) \
+  TEST_CASE(description, tags) {                                \
+    FAIL("This test case has been compile-time disabled.");     \
+  }                                                             \
+  _INTERNAL_CTS_DISCARD
+#define _INTERNAL_CTS_DISCARD(...)
+
+#define INTERNAL_CTS_ENABLED_TEST_CASE_BODY(...) \
+  { __VA_ARGS__; }
+
+#define INTERNAL_CTS_CHECK_ALL_IMPLS(catchMacroProxy, impl, ...)          \
+  INTERNAL_CTS_IF(INTERNAL_CTS_IS_IMPL(impl))                             \
+  (INTERNAL_CTS_DISABLED_TEST_CASE,                                       \
+   INTERNAL_CTS_IF(INTERNAL_CTS_HAS_ARGS(__VA_ARGS__))(                   \
+       INTERNAL_CTS_DEFER3(_INTERNAL_CTS_CHECK_ALL_IMPLS)()(__VA_ARGS__), \
+       catchMacroProxy))
+#define _INTERNAL_CTS_CHECK_ALL_IMPLS() INTERNAL_CTS_CHECK_ALL_IMPLS
+
+#define INTERNAL_CTS_MAYBE_DISABLE_TEST_CASE(catchMacroProxy, ...) \
+  INTERNAL_CTS_EVAL(INTERNAL_CTS_CHECK_ALL_IMPLS(catchMacroProxy, __VA_ARGS__))
+
+// Define proxies for all supported test macro types
+
+#define INTERNAL_CTS_ENABLED_TEST_CASE(...) \
+  TEST_CASE(__VA_ARGS__) INTERNAL_CTS_ENABLED_TEST_CASE_BODY
+#define INTERNAL_CTS_DISABLED_FOR_TEST_CASE(...)                       \
+  INTERNAL_CTS_MAYBE_DISABLE_TEST_CASE(INTERNAL_CTS_ENABLED_TEST_CASE, \
+                                       __VA_ARGS__)
+
+#define INTERNAL_CTS_ENABLED_TEMPLATE_TEST_CASE_SIG(...) \
+  TEMPLATE_TEST_CASE_SIG(__VA_ARGS__) INTERNAL_CTS_ENABLED_TEST_CASE_BODY
+#define INTERNAL_CTS_DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(...) \
+  INTERNAL_CTS_MAYBE_DISABLE_TEST_CASE(                       \
+      INTERNAL_CTS_ENABLED_TEMPLATE_TEST_CASE_SIG, __VA_ARGS__)
+
+#endif

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -13,6 +13,7 @@
 
 #include "../common/common.h"
 #include "../common/device_eval.h"
+#include "../common/disabled_for_test_case.h"
 
 using namespace sycl_cts;
 
@@ -289,10 +290,10 @@ TEMPLATE_TEST_CASE_SIG(
   CHECK(DEVICE_EVAL(a >= b) == idh<D>::get(1, 1, 1));
 }
 
-TEMPLATE_TEST_CASE_SIG(
-    "id supports various binary operators of the form `id OP size_t` and "
-    "`size_t OP id`",
-    "[id]", ((int D), D), 1, 2, 3) {
+DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(hipSYCL)
+("id supports various binary operators of the form `id OP size_t` and "
+ "`size_t OP id`",
+ "[id]", ((int D), D), 1, 2, 3)({
   const auto a = idh<D>::get(5, 8, 3);
   const size_t b = 3;
 
@@ -361,7 +362,7 @@ TEMPLATE_TEST_CASE_SIG(
   CHECK(DEVICE_EVAL(b <= a) == idh<D>::get(1, 1, 1));
   CHECK(DEVICE_EVAL(a >= b) == idh<D>::get(1, 1, 1));
   CHECK(DEVICE_EVAL(b >= a) == idh<D>::get(0, 0, 1));
-}
+});
 
 #define COMPOUND_OP(operand_value, expr) \
   ([=](auto x) { return expr, x; })(operand_value)
@@ -430,8 +431,8 @@ TEMPLATE_TEST_CASE_SIG(
 
 #undef COMPOUND_OP
 
-TEMPLATE_TEST_CASE_SIG("id supports unary +/- operators", "[id]", ((int D), D),
-                       1, 2, 3) {
+DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(hipSYCL)
+("id supports unary +/- operators", "[id]", ((int D), D), 1, 2, 3)({
   const auto a = idh<D>::get(5, 8, 3);
   const auto b = idh<D>::get(-5, -8, -3);
   CHECK(+a == a);
@@ -443,14 +444,14 @@ TEMPLATE_TEST_CASE_SIG("id supports unary +/- operators", "[id]", ((int D), D),
   CHECK(DEVICE_EVAL(-a) == b);
   CHECK(DEVICE_EVAL(+b) == b);
   CHECK(DEVICE_EVAL(-b) == a);
-}
+});
 
-TEMPLATE_TEST_CASE_SIG(
-    "id supports pre- and postfix increment/decrement operators", "[id]",
-    ((int D), D), 1, 2, 3) {
 #define INC_DEC_OP(operand_value, expr) \
   ([=](auto x) { return std::pair{expr, x}; })(operand_value)
 
+DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(hipSYCL)
+("id supports pre- and postfix increment/decrement operators", "[id]",
+ ((int D), D), 1, 2, 3)({
   const auto a = idh<D>::get(5, 8, 3);
   const auto b = idh<D>::get(6, 9, 4);
   const auto c = idh<D>::get(4, 7, 2);
@@ -466,9 +467,9 @@ TEMPLATE_TEST_CASE_SIG(
   CHECK(DEVICE_EVAL_T(id_pair, INC_DEC_OP(a, --x)) == std::pair{c, c});
   CHECK(DEVICE_EVAL_T(id_pair, INC_DEC_OP(a, x++)) == std::pair{a, b});
   CHECK(DEVICE_EVAL_T(id_pair, INC_DEC_OP(a, x--)) == std::pair{a, c});
+});
 
 #undef INC_DEC_OP
-}
 
 TEST_CASE("id can deduce dimensionality from constructor parameters", "[id]") {
   using sycl::id;


### PR DESCRIPTION
This introduces a new type of test case macro that can be used to disable test cases during compile-time. This is useful for when a test case contains code that  currently does not compile for a given implementation, while other test cases in the same translation unit would otherwise compile.

A disabled test case will fail automatically at runtime.

While all Catch2 test macros could likely be supported in principle, this initial implementation is limited to these two:

 - `DISABLED_FOR_TEST_CASE` (corresponding to `TEST_CASE`)
 - `DISABLED_FOR_TEMPLATE_TEST_CASE_SIG` (corresponding to `TEMPLATE_TEST_CASE_SIG`)

Usage example from `id` tests:
```c++
DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(hipSYCL)
("id supports unary +/- operators", "[id]", ((int D), D), 1, 2, 3)({
  // ...
});
```

which then produces the following console output:

![image](https://user-images.githubusercontent.com/791348/155559477-41daced8-7eba-4bf5-b95b-2a85479d3f9d.png)
