### PR TITLE
Disable _Pragma to work around Clang 8 bug

### DIFF
--- a/tests/common/disabled_for_test_case.h
+++ b/tests/common/disabled_for_test_case.h
@@ -51,6 +51,17 @@
 #define INTERNAL_CTS_SYCL_IMPL_DPCPP ()
 #endif
 
+// Clang 8 does not properly handle _Pragma inside macro expansions.
+// See https://compiler-explorer.com/z/4WebY11TM.
+// As a crude workaround we disable _Pragma altogether.
+// This is required as of ComputeCpp 2.8.0, which is based on Clang 8.
+#if defined(__clang__) && __clang_major__ <= 8
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbuiltin-macro-redefined"
+#define _Pragma(...)
+#pragma clang diagnostic pop
+#endif
+
 // ------------------------------------------------------------------------------------
 
 #define INTERNAL_CTS_IMPL_PROBE(impl) \
@@ -86,12 +97,6 @@
   x INTERNAL_CTS_EMPTY INTERNAL_CTS_EMPTY INTERNAL_CTS_EMPTY()()()
 
 // ------------------------------------------------------------------------------------
-
-#define INTERNAL_CTS_FIRST(a, ...) a
-#define INTERNAL_CTS_HAS_ARGS(...) \
-  INTERNAL_CTS_BOOL(               \
-      INTERNAL_CTS_FIRST(_INTERNAL_CTS_END_OF_ARGS_ __VA_ARGS__)())
-#define _INTERNAL_CTS_END_OF_ARGS_() 0
 
 // In case we are compiling with a disabled implementation,
 // replace test case with this auto-failing proxy.


### PR DESCRIPTION
...when using DISABLED_FOR_* test case macros. This is required as of ComputeCpp 2.8.0, which is based on Clang 8.

Also remove some duplicated macro definitions.