### PR TITLE
Run CI when pushing to SYCL-2020 branch

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -3,6 +3,10 @@ name: SYCL CTS CI
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      # Run on our default base branch to prime ccache for faster CI runs in PRs.
+      - SYCL-2020
 
 jobs:
   # Pushing container images requires DockerHub credentials, provided as GitHub secrets.


### PR DESCRIPTION
...to prime `ccache` for faster PR runs. Due to the way GitHub workflows [restrict access to the cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), PRs cannot access `ccache` data from workflow runs on other PRs. However, PRs *can* access caches generated by workflow runs on the base (target) branch.