### PR TITLE
Bump dpcpp version in ci

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -55,7 +55,7 @@ jobs:
           # - sycl-impl: computecpp
           # version: 2.8.0
           - sycl-impl: dpcpp
-            version: f810047
+            version: 48ed880
           - sycl-impl: hipsycl
             version: 3d8b1cd
     steps:
@@ -94,7 +94,7 @@ jobs:
           - sycl-impl: computecpp
             version: 2.8.0
           - sycl-impl: dpcpp
-            version: f810047
+            version: 48ed880
           - sycl-impl: hipsycl
             version: 3d8b1cd
     env:

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -55,7 +55,7 @@ jobs:
           # - sycl-impl: computecpp
           # version: 2.8.0
           - sycl-impl: dpcpp
-            version: c230f3c
+            version: f810047
           - sycl-impl: hipsycl
             version: 3d8b1cd
     steps:
@@ -94,7 +94,7 @@ jobs:
           - sycl-impl: computecpp
             version: 2.8.0
           - sycl-impl: dpcpp
-            version: c230f3c
+            version: f810047
           - sycl-impl: hipsycl
             version: 3d8b1cd
     env:

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -55,7 +55,7 @@ jobs:
           # - sycl-impl: computecpp
           # version: 2.8.0
           - sycl-impl: dpcpp
-            version: 48ed880
+            version: 977f22d
           - sycl-impl: hipsycl
             version: 3d8b1cd
     steps:
@@ -94,7 +94,7 @@ jobs:
           - sycl-impl: computecpp
             version: 2.8.0
           - sycl-impl: dpcpp
-            version: 48ed880
+            version: 977f22d
           - sycl-impl: hipsycl
             version: 3d8b1cd
     env:


### PR DESCRIPTION
This will allow us to enable most of the tests from https://github.com/KhronosGroup/SYCL-CTS/pull/287, as the current version of the compiler doesn't support using `[[sycl::device_has()]]` with lambdas