### PR TITLE
Fix unsigned wrap in `id` tests

### DIFF
--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -299,7 +299,7 @@ TEMPLATE_TEST_CASE_SIG(
   CHECK(a + b == idh<D>::get(8, 11, 6));
   CHECK(b + a == idh<D>::get(8, 11, 6));
   CHECK(a - b == idh<D>::get(2, 5, 0));
-  CHECK(b - a == idh<D>::get(-2ul, -5ul, 0));
+  CHECK(b - a == idh<D>::get(-2, -5, 0));
   CHECK(a * b == idh<D>::get(15, 24, 9));
   CHECK(b * a == idh<D>::get(15, 24, 9));
   CHECK(a / b == idh<D>::get(1, 2, 1));
@@ -332,7 +332,7 @@ TEMPLATE_TEST_CASE_SIG(
   CHECK(DEVICE_EVAL(a + b) == idh<D>::get(8, 11, 6));
   CHECK(DEVICE_EVAL(b + a) == idh<D>::get(8, 11, 6));
   CHECK(DEVICE_EVAL(a - b) == idh<D>::get(2, 5, 0));
-  CHECK(DEVICE_EVAL(b - a) == idh<D>::get(-2ul, -5ul, 0));
+  CHECK(DEVICE_EVAL(b - a) == idh<D>::get(-2, -5, 0));
   CHECK(DEVICE_EVAL(a * b) == idh<D>::get(15, 24, 9));
   CHECK(DEVICE_EVAL(b * a) == idh<D>::get(15, 24, 9));
   CHECK(DEVICE_EVAL(a / b) == idh<D>::get(1, 2, 1));


### PR DESCRIPTION
The `size_t` doesn't have guarantee in size compared to `unsigned long` or `unsigned long long`.
Therefore we should either explicitly cast to `size_t` or use implicit cast.

Implicit cast fits better, because it uses the type of `get_cts_object::id<>::get()` parameters, avoiding possible support efforts in future.