### PR TITLE
Include SYCL header for DISABLED_FOR_* implementation detection

### DIFF
--- a/tests/common/disabled_for_test_case.h
+++ b/tests/common/disabled_for_test_case.h
@@ -9,6 +9,9 @@
 #ifndef __SYCLCTS_TESTS_COMMON_DISABLED_FOR_TEST_CASE_H
 #define __SYCLCTS_TESTS_COMMON_DISABLED_FOR_TEST_CASE_H
 
+// This is required for detecting the active SYCL implementation
+#include <sycl/sycl.hpp>
+
 #include "macro_utils.h"
 
 // TODO: Add other Catch2 test case variants, as needed


### PR DESCRIPTION
This may not be needed for all implementations, but at least ComputeCpp defines `__COMPUTECPP__` inside a header, instead of on the command line.