### PR TITLE
Fix opencl constructors tests

### DIFF
--- a/ci/dpcpp.filter
+++ b/ci/dpcpp.filter
@@ -1,5 +1,4 @@
 buffer
 exceptions
 multi_ptr
-opencl_interop
 reduction

--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -85,9 +85,6 @@ class TEST_NAME :
         if (interopDeviceID != m_cl_device_id) {
           FAIL(log, "device was not constructed correctly");
         }
-        if (!CHECK_CL_SUCCESS(log, clReleaseDevice(interopDeviceID))) {
-          FAIL(log, "failed to release OpenCL device");
-        }
       }
 
       /** check make_context (cl_context)
@@ -100,9 +97,6 @@ class TEST_NAME :
             sycl::get_native<sycl::backend::opencl>(context);
         if (interopContext != m_cl_context) {
           FAIL(log, "context was not constructed correctly");
-        }
-        if (!CHECK_CL_SUCCESS(log, clReleaseContext(interopContext))) {
-          FAIL(log, "failed to release OpenCL context");
         }
       }
 
@@ -117,9 +111,6 @@ class TEST_NAME :
             sycl::get_native<sycl::backend::opencl>(context);
         if (interopContext != m_cl_context) {
           FAIL(log, "context was not constructed correctly");
-        }
-        if (!CHECK_CL_SUCCESS(log, clReleaseContext(interopContext))) {
-          FAIL(log, "failed to release OpenCL context");
         }
       }
 
@@ -143,13 +134,6 @@ class TEST_NAME :
           FAIL(log, "queue destination was not copy constructed correctly");
         }
 
-        if (!CHECK_CL_SUCCESS(log, clReleaseCommandQueue(clQueueCopy))) {
-          FAIL(log, "failed to release OpenCL command queue");
-        }
-
-        if (!CHECK_CL_SUCCESS(log, clReleaseCommandQueue(interopQueue))) {
-          FAIL(log, "failed to release OpenCL command queue");
-        }
       }
 
       /** check make_queue (cl_command_queue, const context&, async_handler)
@@ -163,9 +147,6 @@ class TEST_NAME :
             sycl::get_native<sycl::backend::opencl>(queue);
         if (interopQueue != m_cl_command_queue) {
           FAIL(log, "queue was not constructed correctly");
-        }
-        if (!CHECK_CL_SUCCESS(log, clReleaseCommandQueue(interopQueue))) {
-          FAIL(log, "failed to release OpenCL command queue");
         }
       }
 
@@ -206,11 +187,6 @@ class TEST_NAME :
             sycl::get_native<sycl::backend::opencl>(kernel_bundle);
         if (interopProgramVec[0] != clProgram) {
           FAIL(log, "program was not constructed correctly");
-        }
-        for (int i = 0; i < interopProgramVec.size(); i++) {
-          if (!CHECK_CL_SUCCESS(log, clReleaseProgram(interopProgramVec[i]))) {
-            FAIL(log, "failed to release OpenCL program");
-          }
         }
       }
 
@@ -255,9 +231,6 @@ class TEST_NAME :
             sycl::get_native<sycl::backend::opencl>(kernel);
         if (interopKernel != clKernel) {
           FAIL(log, "kernel was not constructed correctly");
-        }
-        if (!CHECK_CL_SUCCESS(log, clReleaseKernel(interopKernel))) {
-          FAIL(log, "failed to release OpenCL kernel");
         }
       }
 

--- a/util/test_base.cpp
+++ b/util/test_base.cpp
@@ -20,7 +20,8 @@ namespace util {
 
 void test_base::run_test(class logger &log) {
   try {
-    this->run(log);
+    if (this->setup(log))
+      this->run(log);
   } catch (const sycl::exception &e) {
     log_exception(log, e);
     auto errorMsg = "a SYCL exception was caught: " + std::string(e.what());


### PR DESCRIPTION
Add setup for tests.

Remove opencl tests from dpcpp filter

Remove clRelease* functions for instances from get_native since according to [C.6. Interoperability with the OpenCL API](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:opencl:interfacing-with-opencl) 

> the destructor for the [SYCL runtime](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sycl-runtime) classes which encapsulate a reference counted OpenCL opaque type must release that instance to decrease the reference count of the OpenCL resource

Instances of SYCL classes runtime classes that encapsulate OpenCL opaque types are destructed during tests and get_native retrieve instances of that opaque types, not creating new ones. Instances of OpenCL types are released in test_base_opencl::cleanup()