### PR TITLE
Improve generic code in `type_coverage.h`

### DIFF
--- a/tests/accessor_legacy/accessor_types_core.h
+++ b/tests/accessor_legacy/accessor_types_core.h
@@ -55,14 +55,14 @@ public:
 #ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
     // Specific set of types to cover during ordinary compilation
 
-    const auto vector_types = named_type_pack<int>({"int"});
+    const auto vector_types = named_type_pack<int>::generate("int");
     const auto scalar_types =
         named_type_pack<float,
                         std::size_t,
-                        accessor_utility::user_struct>({
+                        accessor_utility::user_struct>::generate(
                         "float",
                         "std::size_t",
-                        "user struct"});
+                        "user struct");
 #else
     // Extended type coverage
 
@@ -79,7 +79,7 @@ public:
                         sycl::cl_char, sycl::cl_uchar,
                         sycl::cl_short, sycl::cl_ushort,
                         sycl::cl_int, sycl::cl_uint,
-                        sycl::cl_long, sycl::cl_ulong>({
+                        sycl::cl_long, sycl::cl_ulong>::generate(
                         "bool",
                         "char", "signed char", "unsigned char",
                         "short", "unsigned short",
@@ -92,14 +92,14 @@ public:
                         "sycl::cl_char", "sycl::cl_uchar",
                         "sycl::cl_short", "sycl::cl_ushort",
                         "sycl::cl_int", "sycl::cl_uint",
-                        "sycl::cl_long", "sycl::cl_ulong"});
+                        "sycl::cl_long", "sycl::cl_ulong");
     const auto scalar_types =
         named_type_pack<std::size_t,
                         accessor_utility::user_struct,
-                        accessor_utility::user_namespace::user_alias>({
+                        accessor_utility::user_namespace::user_alias>::generate(
                         "std::size_t",
                         "user struct",
-                        "user alias"});
+                        "user alias");
 
 #ifdef INT8_MAX
     if (!std::is_same<std::int8_t, sycl::cl_char>::value) {

--- a/tests/accessor_legacy/accessor_types_image_core.h
+++ b/tests/accessor_legacy/accessor_types_image_core.h
@@ -49,11 +49,11 @@ public:
         named_type_pack<sycl::cl_int4,
                         sycl::cl_uint4,
                         sycl::cl_float4,
-                        user_alias>({
+                        user_alias>::generate(
                         "sycl::cl_int",
                         "sycl::cl_uint",
                         "sycl::cl_float",
-                        "user_alias"});
+                        "user_alias");
 
     for_all_types<check_type>(types, log, queue);
 

--- a/tests/buffer/buffer_type_list.h
+++ b/tests/buffer/buffer_type_list.h
@@ -22,15 +22,15 @@ using diff_namespace_struct = user_struct;
 }
 static const auto vector_types =
     named_type_pack<char, unsigned char, short, unsigned short, int,
-                    unsigned int, long, unsigned long, float>(
-        {"char", "unsigned char", "short", "unsigned short", "int",
-         "unsigned int", "long", "unsigned long", "float"});
+                    unsigned int, long, unsigned long, float>::generate(
+        "char", "unsigned char", "short", "unsigned short", "int",
+         "unsigned int", "long", "unsigned long", "float");
 static const auto scalar_types =
     named_type_pack<std::size_t, user_struct,
                     different_namespace::diff_namespace_struct,
-                    nested_struct::nested_user_struct>(
-        {"std::size_t", "user_struct",
+                    nested_struct::nested_user_struct>::generate(
+         "std::size_t", "user_struct",
          "different_namespace::diff_namespace_struct",
-         "nested_struct::nested_user_struct"});
+         "nested_struct::nested_user_struct");
 } // namespace get_buffer_types
 #endif // __SYCLCTS_TESTS_BUFFER_TYPE_LIST_H

--- a/tests/common/type_coverage.h
+++ b/tests/common/type_coverage.h
@@ -14,7 +14,7 @@
 
 #include <sycl/sycl.hpp>
 
-#include "type_traits.h"
+#include "../../util/type_traits.h"
 
 /**
  * @brief Retrieve type name; by default just forward the given one

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -176,7 +176,7 @@ inline auto get_vector_types() {
                       long long, unsigned long long, float, sycl::cl_float,
                       sycl::byte, sycl::cl_bool, sycl::cl_char, sycl::cl_uchar,
                       sycl::cl_short, sycl::cl_ushort, sycl::cl_int,
-                      sycl::cl_uint, sycl::cl_long, sycl::cl_ulong>{
+                      sycl::cl_uint, sycl::cl_long, sycl::cl_ulong>::generate(
           "bool",
           "char",
           "signed char",
@@ -200,7 +200,7 @@ inline auto get_vector_types() {
           "sycl::cl_int",
           "sycl::cl_uint",
           "sycl::cl_long",
-          "sycl::cl_ulong"};
+          "sycl::cl_ulong");
   return pack;
 }
 }  // namespace get_cts_types

--- a/tests/extension/oneapi_device_global/type_pack.h
+++ b/tests/extension/oneapi_device_global/type_pack.h
@@ -15,8 +15,8 @@
 namespace device_global_types {
 inline auto get_types() {
   static const auto types =
-      named_type_pack<int, bool, user_def_types::no_cnstr>{"int", "bool",
-                                                           "no_cnstr"};
+      named_type_pack<int, bool, user_def_types::no_cnstr>::generate("int", "bool",
+                                                           "no_cnstr");
   return types;
 }
 }  // namespace device_global_types

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_common.h
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_common.h
@@ -19,13 +19,13 @@ namespace {
 static const auto types =
     named_type_pack<char, signed char, unsigned char, short, unsigned short,
                     int, unsigned int, long, unsigned long, long long,
-                    unsigned long long>{
+                    unsigned long long>::generate(
         "char",           "signed char", "unsigned char",     "short",
         "unsigned short", "int",         "unsigned int",      "long",
-        "unsigned long",  "long long",   "unsigned long long"};
+        "unsigned long",  "long long",   "unsigned long long");
 #else
 static const auto types =
-    named_type_pack<char, int>{"char", "int"};
+    named_type_pack<char, int>::generate("char", "int");
 #endif  // SYCL_CTS_FULL_CONFORMANCE
 
 template <typename funT, typename PredT, typename T, size_t SGSize>

--- a/tests/kernel_bundle/get_kernel_bundle.h
+++ b/tests/kernel_bundle/get_kernel_bundle.h
@@ -23,7 +23,7 @@ inline auto kernels_with_attributes = named_type_pack<
     kernels::kernel_likely_unsupported_sub_group_size_descriptor,
     kernels::kernel_likely_supported_sub_group_size_descriptor,
     kernels::kernel_likely_unsupported_work_group_size_descriptor,
-    kernels::kernel_likely_supported_work_group_size_descriptor>{
+    kernels::kernel_likely_supported_work_group_size_descriptor>::generate(
     "kernel_cpu_descriptor",
     "kernel_gpu_descriptor",
     "kernel_accelerator_descriptor",
@@ -32,17 +32,17 @@ inline auto kernels_with_attributes = named_type_pack<
     "kernel_likely_unsupported_sub_group_size_descriptor",
     "kernel_likely_supported_sub_group_size_descriptor",
     "kernel_likely_unsupported_work_group_size_descriptor",
-    "kernel_likely_supported_work_group_size_descriptor"};
+    "kernel_likely_supported_work_group_size_descriptor");
 
 inline auto kernels_without_attributes =
     named_type_pack<kernels::simple_kernel_descriptor,
                     kernels::simple_kernel_descriptor_second,
                     kernels::kernel_fp16_no_attr_descriptor,
                     kernels::kernel_fp64_no_attr_descriptor,
-                    kernels::kernel_atomic64_no_attr_descriptor>{
+                    kernels::kernel_atomic64_no_attr_descriptor>::generate(
         "simple_kernel_descriptor", "simple_kernel_descriptor_second",
         "kernel_fp16_no_attr_descriptor", "kernel_fp64_no_attr_descriptor",
-        "kernel_atomic64_no_attr_descriptor"};
+        "kernel_atomic64_no_attr_descriptor");
 
 template <sycl::bundle_state BundleState>
 class TestCaseDescription

--- a/tests/kernel_bundle/has_kernel_bundle.h
+++ b/tests/kernel_bundle/has_kernel_bundle.h
@@ -23,8 +23,8 @@ static const std::string unexpected_exception_msg{
     "unexpected SYCL exception error code was caught"};
 
 static const auto simple_kernel =
-    named_type_pack<kernels::simple_kernel_descriptor>{
-        "simple_kernel_descriptor"};
+    named_type_pack<kernels::simple_kernel_descriptor>::generate(
+        "simple_kernel_descriptor");
 
 template <sycl::bundle_state BundleState>
 class TestCaseDescription

--- a/tests/kernel_bundle/has_kernel_bundle_core.h
+++ b/tests/kernel_bundle/has_kernel_bundle_core.h
@@ -17,21 +17,21 @@ namespace sycl_cts::tests::has_kernel_bundle {
 
 static const auto kernels_types_sub_group = named_type_pack<
     kernels::kernel_likely_unsupported_sub_group_size_descriptor,
-    kernels::kernel_likely_supported_sub_group_size_descriptor>{
+    kernels::kernel_likely_supported_sub_group_size_descriptor>::generate(
     "kernel_likely_unsupported_sub_group_size_descriptor",
-    "kernel_likely_supported_sub_group_size_descriptor"};
+    "kernel_likely_supported_sub_group_size_descriptor");
 
 static const auto kernels_types_work_group = named_type_pack<
     kernels::kernel_likely_supported_work_group_size_descriptor,
-    kernels::kernel_likely_unsupported_work_group_size_descriptor>{
+    kernels::kernel_likely_unsupported_work_group_size_descriptor>::generate(
     "kernel_large_work_group_size_descriptor",
-    "kernel_small_work_group_size_descriptor"};
+    "kernel_small_work_group_size_descriptor");
 
 static const auto kernels_types_fp16_fp64_at64 =
     named_type_pack<kernels::kernel_fp16_descriptor,
                     kernels::kernel_fp64_descriptor,
-                    kernels::kernel_atomic64_descriptor>{
-        "kernel_fp16", "kernel_fp64", "kernel_atomic64"};
+                    kernels::kernel_atomic64_descriptor>::generate(
+        "kernel_fp16", "kernel_fp64", "kernel_atomic64");
 
 static const auto kernels_types_for_aspect_required = named_type_pack<
     kernels::kernel_cpu_descriptor, kernels::kernel_gpu_descriptor,
@@ -46,7 +46,7 @@ static const auto kernels_types_for_aspect_required = named_type_pack<
     kernels::kernel_usm_atomic_host_allocations_descriptor,
     kernels::kernel_usm_shared_allocations_descriptor,
     kernels::kernel_usm_atomic_shared_allocations_descriptor,
-    kernels::kernel_usm_system_allocations_descriptor>{
+    kernels::kernel_usm_system_allocations_descriptor>::generate(
     "kernel_cpu_descriptor",
     "kernel_gpu_descriptor",
     "kernel_accelerator_descriptor",
@@ -63,7 +63,7 @@ static const auto kernels_types_for_aspect_required = named_type_pack<
     "kernel_usm_atomic_host_allocations_descriptor",
     "kernel_usm_shared_allocations_descriptor",
     "kernel_usm_atomic_shared_allocations_descriptor",
-    "kernel_usm_system_allocations_descriptor"};
+    "kernel_usm_system_allocations_descriptor");
 
 namespace check {
 

--- a/tests/kernel_bundle/kernel_bundle.h
+++ b/tests/kernel_bundle/kernel_bundle.h
@@ -29,11 +29,11 @@ inline auto kernels_for_link_and_build = named_type_pack<
     kernels::simple_kernel_descriptor_second,
     kernels::kernel_fp16_no_attr_descriptor,
     kernels::kernel_fp64_no_attr_descriptor,
-    kernels::kernel_atomic64_no_attr_descriptor>{
+    kernels::kernel_atomic64_no_attr_descriptor>::generate(
     "kernel_cpu_descriptor",           "kernel_gpu_descriptor",
     "kernel_accelerator_descriptor",   "simple_kernel_descriptor",
     "simple_kernel_descriptor_second", "kernel_fp16_no_attr_descriptor",
-    "kernel_fp64_no_attr_descriptor",  "kernel_atomic64_no_attr_descriptor"};
+    "kernel_fp64_no_attr_descriptor",  "kernel_atomic64_no_attr_descriptor");
 
 using cpu_kernel = kernels::kernel_cpu_descriptor::type;
 using gpu_kernel = kernels::kernel_gpu_descriptor::type;

--- a/tests/kernel_bundle/use_kernel_bundle.h
+++ b/tests/kernel_bundle/use_kernel_bundle.h
@@ -46,9 +46,9 @@ static const std::string skip_test_for_builtin_kernels_msg{
 inline auto user_def_kernels =
     named_type_pack<kernels::kernel_cpu_descriptor,
                     kernels::kernel_gpu_descriptor,
-                    kernels::kernel_accelerator_descriptor>{
+                    kernels::kernel_accelerator_descriptor>::generate(
         "kernel_cpu_descriptor", "kernel_gpu_descriptor",
-        "kernel_accelerator_descriptor"};
+        "kernel_accelerator_descriptor");
 
 template <sycl::bundle_state BundleState>
 class TestCaseDescription

--- a/tests/multi_ptr/multi_ptr_common.h
+++ b/tests/multi_ptr/multi_ptr_common.h
@@ -47,16 +47,16 @@ inline auto get_types() {
                          short, unsigned short,       //
                          int, unsigned int,           //
                          long, unsigned long,         //
-                         long long, unsigned long long>{
+                         long long, unsigned long long>::generate(
       "bool",        "float",
       "double",      "char",
       "signed char", "unsigned char",
       "short",       "unsigned short",
       "int",         "unsigned int",
       "long",        "unsigned long",
-      "long long",   "unsigned long long"};
+      "long long",   "unsigned long long");
 #else
-  return named_type_pack<int, float>{"int", "float"};
+  return named_type_pack<int, float>::generate("int", "float");
 #endif  // SYCL_CTS_FULL_CONFORMANCE
 }
 
@@ -64,10 +64,10 @@ inline auto get_types() {
 inline auto get_composite_types() {
 #ifdef SYCL_CTS_FULL_CONFORMANCE
   return named_type_pack<user_def_types::no_cnstr, user_def_types::def_cnstr,
-                         user_def_types::no_def_cnstr>(
-      {"no_cnstr", "def_cnstr", "no_def_cnstr"});
+                         user_def_types::no_def_cnstr>::generate(
+      "no_cnstr", "def_cnstr", "no_def_cnstr");
 #else
-  return named_type_pack<user_def_types::def_cnstr>({"def_cnstr"});
+  return named_type_pack<user_def_types::def_cnstr>::generate("def_cnstr");
 #endif  // SYCL_CTS_FULL_CONFORMANCE
 }
 

--- a/tests/reduction/reduction_common.h
+++ b/tests/reduction/reduction_common.h
@@ -32,11 +32,11 @@ const auto scalar_types =
     named_type_pack<char, signed char, unsigned char, short int,
                     unsigned short int, int, unsigned int, long int,
                     unsigned long int, float, long long int,
-                    unsigned long long int>(
-        {"char", "signed char", "unsigned char", "short int",
+                    unsigned long long int>::generate(
+         "char", "signed char", "unsigned char", "short int",
          "unsigned short int", "int", "unsigned int", "long int",
          "unsigned long int", "float", "long long int",
-         "unsigned long long int"});
+         "unsigned long long int");
 
 /** @brief Returns expected value for testing
  *  @tparam VariableT The type of the variable with which the test runs

--- a/tests/specialization_constants/specialization_constants_common.h
+++ b/tests/specialization_constants/specialization_constants_common.h
@@ -23,19 +23,19 @@ static const auto types = named_type_pack<
     bool, char, signed char, unsigned char, short, unsigned short, int,
     unsigned int, long, unsigned long, long long, unsigned long long, float,
     sycl::byte, std::int8_t, std::uint8_t, std::int16_t, std::uint16_t,
-    std::int32_t, std::uint32_t, std::int64_t, std::uint64_t, std::size_t>{
+    std::int32_t, std::uint32_t, std::int64_t, std::uint64_t, std::size_t>::generate(
     "bool",         "char",           "signed char",  "unsigned char",
     "short",        "unsigned short", "int",          "unsigned int",
     "long",         "unsigned long",  "long long",    "unsigned long long",
     "float",        "sycl::byte",     "std::int8_t",  "std::uint8_t",
     "std::int16_t", "std::uint16_t",  "std::int32_t", "std::uint32_t",
-    "std::int64_t", "std::uint64_t",  "std::size_t"};
+    "std::int64_t", "std::uint64_t",  "std::size_t");
 
 // custom data types that will be used in type coverage
 static const auto composite_types =
     named_type_pack<user_def_types::no_cnstr, user_def_types::def_cnstr,
-                    user_def_types::no_def_cnstr>(
-        {"no_cnstr", "def_cnstr", "no_def_cnstr"});
+                    user_def_types::no_def_cnstr>::generate(
+        "no_cnstr", "def_cnstr", "no_def_cnstr");
 
 }  // namespace testing_types
 

--- a/tests/usm/usm_atomic_access.h
+++ b/tests/usm/usm_atomic_access.h
@@ -24,9 +24,9 @@ static auto get_scalar_types() {
   static const auto scalar_types =
       named_type_pack<int, unsigned int, long,
                       unsigned long, float, double, long long,
-                      unsigned long long>({"int", "unsigned int", "long",
+                      unsigned long long>::generate("int", "unsigned int", "long",
                                            "unsigned long", "float", "double",
-                                           "long long", "unsigned long long"});
+                                           "long long", "unsigned long long");
   return scalar_types;
 }
 

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -11,11 +11,12 @@
 
 #include <climits>
 #include <type_traits>
+#include <sycl/sycl.hpp>
 
 namespace {
 
 // Common type traits functions
-template <typename ... T>
+template <typename... T>
 struct contains;
 
 template <typename T>
@@ -24,11 +25,10 @@ struct contains<T> : std::false_type {};
 /**
  * @brief Verify type is within the list of types
  */
-template <typename T, typename headT, typename ... tailT>
-struct contains<T, headT, tailT...> :
-    std::conditional<std::is_same<T, headT>::value,
-                     std::true_type,
-                     contains<T, tailT...>>::type {};
+template <typename T, typename headT, typename... tailT>
+struct contains<T, headT, tailT...>
+    : std::conditional<std::is_same<T, headT>::value, std::true_type,
+                       contains<T, tailT...>>::type {};
 
 /**
  * @brief Verify type has the given number of bits
@@ -43,12 +43,8 @@ using bits_eq = std::bool_constant<(sizeof(T) * CHAR_BIT) == bits>;
  *        into this set
  */
 template <typename T>
-using has_atomic_support =
-    contains<T,
-             int, unsigned int,
-             long, unsigned long,
-             long long, unsigned long long,
-             float>;
+using has_atomic_support = contains<T, int, unsigned int, long, unsigned long,
+                                    long long, unsigned long long, float>;
 
 /**
  * @brief Checks whether T is a floating-point sycl type
@@ -61,6 +57,34 @@ using is_cl_float_type =
                        std::is_same<sycl::cl_double, T>::value ||
                        std::is_same<sycl::cl_half, T>::value>;
 
-} // namespace
+template <typename T>
+using is_sycl_floating_point =
+    std::bool_constant<std::is_floating_point_v<T> ||
+                       std::is_same_v<T, sycl::half>>;
 
-#endif // __SYCLCTS_UTIL_TYPE_TRAITS_H
+template <typename T>
+inline constexpr bool is_sycl_floating_point_v{
+    is_sycl_floating_point<T>::value};
+
+template <typename T>
+using is_nonconst_rvalue_reference =
+    std::bool_constant<std::is_rvalue_reference_v<T> &&
+                       !std::is_const_v<typename std::remove_reference_t<T>>>;
+
+template <typename T>
+inline constexpr bool is_nonconst_rvalue_reference_v{
+    is_nonconst_rvalue_reference<T>::value};
+
+namespace has_static_member {
+
+template <typename, typename = void>
+struct to_string : std::false_type {};
+
+template <typename T>
+struct to_string<T, std::void_t<decltype(T::to_string())>> : std::true_type {};
+
+}  // namespace has_static_member
+
+}  // namespace
+
+#endif  // __SYCLCTS_UTIL_TYPE_TRAITS_H


### PR DESCRIPTION
This PR provides a new function `for_all_combinations` that can combinate types, values, etc.
Refactor old functions like `for_all_type` for removing unused variable and dummy values in fold expression.
Also made constructor of `named_type_pack` private. Instead of a constructor, there is the factory function `generate_named`. This change will allow us to freely change attributes and the way to construct the actual type pack inside the class without changing existing tests.

The function `for_all_combinations` will be used in new accessor tests.

Depends on:
- #308 