### PR TITLE
Add `<thread>` include for event tests

### DIFF
--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <future>
 #include <string>
+#include <thread>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>


### PR DESCRIPTION
Required for `std::this_thread::sleep_for`