### PR TITLE
Apply format to `type_coverage` and `type_traits`

### DIFF
--- a/tests/common/type_coverage.h
+++ b/tests/common/type_coverage.h
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-// Provide common functions for type coverage
+//  Provide common functions for type coverage
 //
 *******************************************************************************/
 
@@ -19,9 +19,7 @@
  */
 template <typename T>
 struct type_name_string {
-    static std::string get(std::string dataType) {
-        return dataType;
-    }
+  static std::string get(std::string dataType) { return dataType; }
 };
 
 /**
@@ -31,9 +29,9 @@ struct type_name_string {
  */
 template <typename T, size_t nElements>
 struct type_name_string<sycl::vec<T, nElements>> {
-    static std::string get(const std::string& dataType) {
-      return "sycl::vec<" + dataType + "," + std::to_string(nElements) + ">";
-    }
+  static std::string get(const std::string& dataType) {
+    return "sycl::vec<" + dataType + "," + std::to_string(nElements) + ">";
+  }
 };
 
 /**
@@ -43,31 +41,29 @@ struct type_name_string<sycl::vec<T, nElements>> {
  */
 template <typename T, size_t nElements>
 struct type_name_string<cl::sycl::marray<T, nElements>> {
-    static std::string get(const std::string &dataType) {
-      return "cl::sycl::marray<" + dataType + "," +
-             std::to_string(nElements) + ">";
-    }
+  static std::string get(const std::string& dataType) {
+    return "cl::sycl::marray<" + dataType + "," + std::to_string(nElements) +
+           ">";
+  }
 };
 
 /**
  * @brief Type pack to store types
  */
-template <typename ... T>
-struct type_pack {
-};
+template <typename... T>
+struct type_pack {};
 
 /**
  * @brief Type pack to store types and underlying data type names to use with
  *        type_name_string
  */
-template <typename ... T>
+template <typename... T>
 struct named_type_pack {
   const std::string names[sizeof...(T)];
 
-  template <typename ... nameListT>
-  named_type_pack(nameListT&&... nameList):
-    names{std::forward<nameListT>(nameList)...}{
-  }
+  template <typename... nameListT>
+  named_type_pack(nameListT&&... nameList)
+      : names{std::forward<nameListT>(nameList)...} {}
 };
 
 /**
@@ -78,15 +74,15 @@ struct named_type_pack {
  * @tparam argsT Deduced parameter pack for arguments to forward into the call
  * @param args Arguments to forward into the call
  */
-template <template<typename, typename...> class action,
-          typename ... actionArgsT, typename ... types, typename ... argsT>
-inline void for_all_types(const type_pack<types...>&, argsT&& ... args) {
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
+inline void for_all_types(const type_pack<types...>&, argsT&&... args) {
   /** run action for each type from types... parameter pack
-  */
+   */
   int packExpansion[] = {(
-    action<types, actionArgsT...>{}(std::forward<argsT>(args)...),
-    0 // Dummy initialization value
-  )...};
+      action<types, actionArgsT...>{}(std::forward<argsT>(args)...),
+      0  // Dummy initialization value
+      )...};
   static_cast<void>(packExpansion);
 }
 
@@ -99,20 +95,20 @@ inline void for_all_types(const type_pack<types...>&, argsT&& ... args) {
  * @param typeList Named type pack instance with type names stored
  * @param args Arguments to forward into the call
  */
-template <template<typename, typename...> class action,
-          typename ... actionArgsT, typename ... types, typename ... argsT>
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
 inline void for_all_types(const named_type_pack<types...>& typeList,
-                          argsT&& ... args) {
+                          argsT&&... args) {
   /** run action for each type from types... parameter pack
-  */
+   */
   size_t typeNameIndex = 0;
 
   int packExpansion[] = {(
-    action<types, actionArgsT...>{}(std::forward<argsT>(args)...,
-                                    typeList.names[typeNameIndex]),
-    ++typeNameIndex,
-    0 // Dummy initialization value
-  )...};
+      action<types, actionArgsT...>{}(std::forward<argsT>(args)...,
+                                      typeList.names[typeNameIndex]),
+      ++typeNameIndex,
+      0  // Dummy initialization value
+      )...};
   /** Every initializer clause is sequenced before any initializer clause
    *  that follows it in the braced-init-list. Every expression in comma
    *  operator is also strictly sequnced. So we can use increment safely.
@@ -130,16 +126,13 @@ inline void for_all_types(const named_type_pack<types...>& typeList,
  * @tparam argsT Deduced parameter pack for arguments to forward into the call
  * @param args Arguments to forward into the call
  */
-template <template<typename, typename...> class action, typename T,
-          typename ... actionArgsT, typename ... argsT>
-void for_type_and_vectors(argsT&& ... args) {
-  static const auto types = type_pack<T,
-                                      typename sycl::template vec<T,1>,
-                                      typename sycl::template vec<T,2>,
-                                      typename sycl::template vec<T,3>,
-                                      typename sycl::template vec<T,4>,
-                                      typename sycl::template vec<T,8>,
-                                      typename sycl::template vec<T,16>>{};
+template <template <typename, typename...> class action, typename T,
+          typename... actionArgsT, typename... argsT>
+void for_type_and_vectors(argsT&&... args) {
+  static const auto types = type_pack<
+      T, typename sycl::template vec<T, 1>, typename sycl::template vec<T, 2>,
+      typename sycl::template vec<T, 3>, typename sycl::template vec<T, 4>,
+      typename sycl::template vec<T, 8>, typename sycl::template vec<T, 16>>{};
   // Use type_pack without names here for lazy log message construction
   for_all_types<action, actionArgsT...>(types, std::forward<argsT>(args)...);
 }
@@ -154,23 +147,22 @@ void for_type_and_vectors(argsT&& ... args) {
  * @param typeList Named type pack instance with underlying type names stored
  * @param args Arguments to forward into the call
  */
-template <template<typename, typename...> class action,
-          typename ... actionArgsT, typename ... types, typename ... argsT>
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
 void for_all_types_and_vectors(const named_type_pack<types...>& typeList,
-                               argsT&& ... args) {
+                               argsT&&... args) {
   /** run action for each type from types... parameter pack
-  */
+   */
   size_t typeNameIndex = 0;
 
   int packExpansion[] = {(
-    for_type_and_vectors<action, types, actionArgsT...>(std::forward<argsT>(args)...,
-                                    typeList.names[typeNameIndex]),
-    ++typeNameIndex,
-    0 // Dummy initialization value
-  )...};
+      for_type_and_vectors<action, types, actionArgsT...>(
+          std::forward<argsT>(args)..., typeList.names[typeNameIndex]),
+      ++typeNameIndex,
+      0  // Dummy initialization value
+      )...};
   static_cast<void>(packExpansion);
 }
-
 
 /**
  * @brief Run action for type, vectors and marrays of this type
@@ -268,7 +260,8 @@ void for_all_types_and_marrays(const named_type_pack<types...>& typeList,
   size_t typeNameIndex = 0;
 
   ((for_type_and_marrays<action, types, actionArgsT...>(
-          std::forward<argsT>(args)..., typeList.names[typeNameIndex]),
-    ++typeNameIndex), ...);
+        std::forward<argsT>(args)..., typeList.names[typeNameIndex]),
+    ++typeNameIndex),
+   ...);
 }
 #endif  // __SYCLCTS_TESTS_COMMON_TYPE_COVERAGE_H

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -15,7 +15,7 @@
 namespace {
 
 // Common type traits functions
-template <typename ... T>
+template <typename... T>
 struct contains;
 
 template <typename T>
@@ -24,11 +24,10 @@ struct contains<T> : std::false_type {};
 /**
  * @brief Verify type is within the list of types
  */
-template <typename T, typename headT, typename ... tailT>
-struct contains<T, headT, tailT...> :
-    std::conditional<std::is_same<T, headT>::value,
-                     std::true_type,
-                     contains<T, tailT...>>::type {};
+template <typename T, typename headT, typename... tailT>
+struct contains<T, headT, tailT...>
+    : std::conditional<std::is_same<T, headT>::value, std::true_type,
+                       contains<T, tailT...>>::type {};
 
 /**
  * @brief Verify type has the given number of bits
@@ -43,12 +42,8 @@ using bits_eq = std::bool_constant<(sizeof(T) * CHAR_BIT) == bits>;
  *        into this set
  */
 template <typename T>
-using has_atomic_support =
-    contains<T,
-             int, unsigned int,
-             long, unsigned long,
-             long long, unsigned long long,
-             float>;
+using has_atomic_support = contains<T, int, unsigned int, long, unsigned long,
+                                    long long, unsigned long long, float>;
 
 /**
  * @brief Checks whether T is a floating-point sycl type
@@ -61,6 +56,6 @@ using is_cl_float_type =
                        std::is_same<sycl::cl_double, T>::value ||
                        std::is_same<sycl::cl_half, T>::value>;
 
-} // namespace
+}  // namespace
 
-#endif // __SYCLCTS_UTIL_TYPE_TRAITS_H
+#endif  // __SYCLCTS_UTIL_TYPE_TRAITS_H


### PR DESCRIPTION
This PR doesn't contain functional or logical changes, only format applying to `type_coverage` and `type_traits`. 
Mostly to simplify the review process for #306, as after merging this PR, #306 will contain only functional changes.