### PR TITLE
Add tests for sycl::exception_list

### DIFF
--- a/test_plans/exceptions.asciidoc
+++ b/test_plans/exceptions.asciidoc
@@ -219,7 +219,7 @@ Verify that:
 For default-constructed `exception_list` check that:
 
 * `exception_list::size()` is zero
-* `++exception_list::begin()` is equal to `exception_list::end()`
+* `exception_list::begin()` is equal to `exception_list::end()`
 
 === sycl::async_handler
 

--- a/tests/exceptions/exception_list.cpp
+++ b/tests/exceptions/exception_list.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::exception_list
+//
+*******************************************************************************/
+
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "../common/common.h"
+
+using namespace sycl_cts;
+
+TEST_CASE("Check sycl::exception_list member types", "[exception]") {
+  using sycl::exception_list;
+  CHECK(std::is_same_v<exception_list::value_type, std::exception_ptr>);
+  CHECK(std::is_same_v<exception_list::reference, exception_list::value_type&>);
+  CHECK(std::is_same_v<exception_list::const_reference,
+                       const exception_list::value_type&>);
+  CHECK(std::is_same_v<exception_list::size_type, std::size_t>);
+}
+
+TEST_CASE(
+    "Check that sycl::exception_list iterators satisfy LegacyForwardIterator "
+    "requirements",
+    "[exception]") {
+  using It = sycl::exception_list::iterator;
+  CHECK(std::is_base_of_v<std::forward_iterator_tag,
+                          std::iterator_traits<It>::iterator_category>);
+  using ConstIt = sycl::exception_list::iterator;
+  CHECK(std::is_base_of_v<std::forward_iterator_tag,
+                          std::iterator_traits<ConstIt>::iterator_category>);
+}
+
+TEST_CASE("Check default-constructed sycl::exception_list", "[exception]") {
+  sycl::exception_list list;
+  CHECK(list.size() == 0);
+  CHECK(list.begin() == list.end());
+}


### PR DESCRIPTION
Tests for [2.5. sycl::exception_list](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/exceptions.asciidoc#25-syclexception_list)

Fix test plan because for empty exception_list begin() and end() should be equal.