### PR TITLE
Remove stub from `device_global` test

### DIFF
--- a/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
+++ b/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
@@ -29,7 +29,7 @@ using namespace device_global_common_functions;
 
 #if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
-namespace oneapi = sycl_stub::ext::oneapi;
+namespace oneapi = sycl::ext::oneapi;
 
 namespace copy_to_dg {
 template <typename T>


### PR DESCRIPTION
This provides changing of non-existing `sycl_stub` namespace to the `sycl` namespace that corresponds to the spec.