### PR TITLE
Move modify/compare functions into separate file

### DIFF
--- a/tests/accessor_legacy/accessor_api_image_common.h
+++ b/tests/accessor_legacy/accessor_api_image_common.h
@@ -666,12 +666,12 @@ class image_accessor_failure_storage {
   struct printer{
     template <typename valT = dataT>
     auto operator()(std::stringstream& stream, const valT& value)
-        -> typename std::enable_if<!is_cl_float_type<valT>::value, void>::type {
+        -> typename std::enable_if<!is_sycl_floating_point<valT>::value, void>::type {
       stream << value;
     }
     template <typename valT = dataT>
     auto operator()(std::stringstream& stream, const valT& value)
-        -> typename std::enable_if<is_cl_float_type<valT>::value, void>::type {
+        -> typename std::enable_if<is_sycl_floating_point<valT>::value, void>::type {
       const auto representation =
           reinterpret_cast<const typename data_type<valT>::base&>(value);
       stream << value << " 0x" << std::hex << representation;
@@ -1304,7 +1304,7 @@ class check_image_accessor_api_reads {
   using failure_item_t = typename failure_storage_t::item_t;
 
   static constexpr bool supportsLinearFilering =
-      is_cl_float_type<typename T::element_type>::value;
+      is_sycl_floating_point<typename T::element_type>::value;
 
  public:
   static constexpr auto isImageArray =

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -25,6 +25,7 @@
 #include "get_cts_object.h"
 #include "macros.h"
 #include "string_makers.h"
+#include "value_helper.h"
 
 #include <cinttypes>
 #include <numeric>
@@ -193,7 +194,8 @@ void check_equality(sycl_cts::util::logger& log, T& a, T& b) {
 };
 
 /**
- * @brief Helper function to test two arrays have equal elements
+ * @brief Helper function to test two arrays have equal elements. Deprecated.
+ * Use \c value_helper::are_equal instead
  */
 template <typename arrT, int size>
 void check_array_equality(arrT* arr1, arrT* arr2) {
@@ -205,7 +207,8 @@ void check_array_equality(arrT* arr1, arrT* arr2) {
 }
 
 /**
- * @deprecated Use overload without logger.
+ * @deprecated Use overload without logger. Deprecated.
+ * Use \c value_helper::are_equal instead
  */
 template <typename arrT, int size>
 void check_array_equality(sycl_cts::util::logger& log, arrT* arr1, arrT* arr2) {
@@ -266,15 +269,17 @@ void check_type_min_size_sign_log(sycl_cts::util::logger& log, size_t minSize,
 }
 
 /**
- * @brief Verify two values are equal
+ * @brief Verify two values are equal. Deprecated.
+ * Use \c value_helper::are_equal instead
  */
 template <typename T>
 bool check_equal_values(const T& lhs, const T& rhs) {
-  return lhs == rhs;
+  return value_helper::are_equal(lhs, rhs);
 }
 
 /**
- * @brief Instantiation for vectors with the same API as for scalar values
+ * @brief Instantiation for vectors with the same API as for scalar values. 
+ * Deprecated. Use \c value_helper::are_equal instead
  */
 template <typename T, int numElements>
 bool check_equal_values(const sycl::vec<T, numElements>& lhs,
@@ -291,6 +296,7 @@ bool check_equal_values(const sycl::vec<T, numElements>& lhs,
 #if !defined(__COMPUTECPP__) && !defined(__HIPSYCL__)
 /**
  * @brief Instantiation for marray with the same API as for scalar values
+ * Deprecated. Use \c value_helper::are_equal instead
  */
 template <typename T, std::size_t numElements>
 bool check_equal_values(const sycl::marray<T, numElements>& lhs,

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -25,7 +25,7 @@
 #include "get_cts_object.h"
 #include "macros.h"
 #include "string_makers.h"
-#include "value_helper.h"
+#include "value_operations.h"
 
 #include <cinttypes>
 #include <numeric>
@@ -195,7 +195,7 @@ void check_equality(sycl_cts::util::logger& log, T& a, T& b) {
 
 /**
  * @brief Helper function to test two arrays have equal elements. Deprecated.
- * Use \c value_helper::are_equal instead
+ * Use \c value_operations::are_equal instead
  */
 template <typename arrT, int size>
 void check_array_equality(arrT* arr1, arrT* arr2) {
@@ -208,7 +208,7 @@ void check_array_equality(arrT* arr1, arrT* arr2) {
 
 /**
  * @deprecated Use overload without logger. Deprecated.
- * Use \c value_helper::are_equal instead
+ * Use \c value_operations::are_equal instead
  */
 template <typename arrT, int size>
 void check_array_equality(sycl_cts::util::logger& log, arrT* arr1, arrT* arr2) {
@@ -270,16 +270,16 @@ void check_type_min_size_sign_log(sycl_cts::util::logger& log, size_t minSize,
 
 /**
  * @brief Verify two values are equal. Deprecated.
- * Use \c value_helper::are_equal instead
+ * Use \c value_operations::are_equal instead
  */
 template <typename T>
 bool check_equal_values(const T& lhs, const T& rhs) {
-  return value_helper::are_equal(lhs, rhs);
+  return value_operations::are_equal(lhs, rhs);
 }
 
 /**
  * @brief Instantiation for vectors with the same API as for scalar values. 
- * Deprecated. Use \c value_helper::are_equal instead
+ * Deprecated. Use \c value_operations::are_equal instead
  */
 template <typename T, int numElements>
 bool check_equal_values(const sycl::vec<T, numElements>& lhs,
@@ -296,7 +296,7 @@ bool check_equal_values(const sycl::vec<T, numElements>& lhs,
 #if !defined(__COMPUTECPP__) && !defined(__HIPSYCL__)
 /**
  * @brief Instantiation for marray with the same API as for scalar values
- * Deprecated. Use \c value_helper::are_equal instead
+ * Deprecated. Use \c value_operations::are_equal instead
  */
 template <typename T, std::size_t numElements>
 bool check_equal_values(const sycl::marray<T, numElements>& lhs,

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -754,5 +754,4 @@ inline bool kernel_supports_wg_size(sycl_cts::util::logger& log,
       }                                                                  \
     }                                                                    \
   }
-}
 #endif  // __SYCLCTS_TESTS_COMMON_COMMON_H

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -748,5 +748,5 @@ inline bool kernel_supports_wg_size(sycl_cts::util::logger& log,
       }                                                                  \
     }                                                                    \
   }
-
+}
 #endif  // __SYCLCTS_TESTS_COMMON_COMMON_H

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -57,7 +57,7 @@ bool check_vector_values(sycl::vec<vecType, numOfElems> vector,
  *        for division result are accurate enough
  */
 template <typename vecType, int numOfElems>
-typename std::enable_if<is_cl_float_type<vecType>::value, bool>::type
+typename std::enable_if<is_sycl_floating_point<vecType>::value, bool>::type
 check_vector_values_div(sycl::vec<vecType, numOfElems> vector,
                         vecType *vals) {
   for (int i = 0; i < numOfElems; i++) {
@@ -80,7 +80,7 @@ check_vector_values_div(sycl::vec<vecType, numOfElems> vector,
  * @brief Helper function to check that vector values for division are correct
  */
 template <typename vecType, int numOfElems>
-typename std::enable_if<!is_cl_float_type<vecType>::value, bool>::type
+typename std::enable_if<!is_sycl_floating_point<vecType>::value, bool>::type
 check_vector_values_div(sycl::vec<vecType, numOfElems> vector,
                         vecType *vals) {
   return check_vector_values(vector, vals);
@@ -119,7 +119,7 @@ T2 float_map_match(T1 floats[], T2 vals[], int size, T1 src) {
 
 template <typename sourceType, typename targetType>
 static constexpr bool if_FP_to_non_FP_conv_v =
-    is_cl_float_type<sourceType>::value && !is_cl_float_type<targetType>::value;
+    is_sycl_floating_point<sourceType>::value && !is_sycl_floating_point<targetType>::value;
 
 template <typename vecType, int N, typename convertType>
 sycl::vec<convertType, N> convert_vec(sycl::vec<vecType, N> inputVec) {
@@ -236,7 +236,7 @@ sycl::vec<convertType, N> rtn(sycl::vec<vecType, N> inputVec) {
 // values instead.
 template <typename vecType, int N, typename convertType>
 void handleFPToUnsignedConv(sycl::vec<vecType, N>& inputVec) {
-  if constexpr (is_cl_float_type<vecType>::value &&
+  if constexpr (is_sycl_floating_point<vecType>::value &&
                 std::is_unsigned_v<convertType>) {
     for (size_t i = 0; i < N; ++i) {
       vecType elem = getElement(inputVec, i);

--- a/tests/common/value_helper.h
+++ b/tests/common/value_helper.h
@@ -38,8 +38,9 @@ inline void change_val(ArrayT<LeftArrT, LeftArrN>& left,
 }
 
 template <typename LeftArrT, typename RightNonArrT>
-inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT>> change_val(
-    LeftArrT& left, const RightNonArrT& right) {
+inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
+                                 !has_subscript_operator_v<RightNonArrT>>
+change_val(LeftArrT& left, const RightNonArrT& right) {
   for (size_t i = 0; i < left.size(); ++i) {
     left[i] = right;
   }
@@ -47,11 +48,11 @@ inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT>> change_val(
 
 template <typename LeftArrT, typename RightArrT>
 inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
-                                 has_subscript_operator_v<LeftArrT>>
+                                 has_subscript_operator_v<RightArrT>>
 change_val(LeftArrT& left, const RightArrT& right) {
   assert((left.size() == right.size()) && "Arrays have to be the same size");
   for (size_t i = 0; i < left.size(); ++i) {
-    left[i] = right;
+    left[i] = right[i];
   }
 }
 
@@ -84,7 +85,9 @@ inline bool are_equal(const ArrayT<LeftArrT, LeftArrN>& left,
 }
 
 template <typename LeftArrT, typename RightNonArrT>
-inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT>, bool>
+inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
+                                     !has_subscript_operator_v<RightNonArrT>,
+                                 bool>
 are_equal(const LeftArrT& left, const RightNonArrT& right) {
   for (size_t i = 0; i < left.size(); ++i) {
     if (left[i] != right) return false;

--- a/tests/common/value_helper.h
+++ b/tests/common/value_helper.h
@@ -48,7 +48,7 @@ inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT>> change_val(
 template <typename LeftArrT, typename RightArrT>
 inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
                                  has_subscript_operator_v<LeftArrT>>
-change_val(LeftArrT& left, const RightNonArrT& right) {
+change_val(LeftArrT& left, const RightArrT& right) {
   assert((left.size() == right.size()) && "Arrays have to be the same size");
   for (size_t i = 0; i < left.size(); ++i) {
     left[i] = right;
@@ -56,8 +56,9 @@ change_val(LeftArrT& left, const RightNonArrT& right) {
 }
 
 template <typename LeftNonArrT, typename RightNonArrT = LeftNonArrT>
-inline typename std::enable_if_t<!has_subscript_operator_v<T>> change_val(
-    LeftNonArrT& left, const RightNonArrT& right) {
+inline typename std::enable_if_t<!has_subscript_operator_v<LeftNonArrT> &&
+                                 !has_subscript_operator_v<RightNonArrT>>
+change_val(LeftNonArrT& left, const RightNonArrT& right) {
   left = right;
 }
 /////////////////////////// Modify functions
@@ -95,7 +96,7 @@ template <typename LeftArrT, typename RightArrT>
 inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
                                      has_subscript_operator_v<RightArrT>,
                                  bool>
-are_equal(const LeftArrT& left, const RightNonArrT& right) {
+are_equal(const LeftArrT& left, const RightArrT& right) {
   assert((left.size() == right.size()) && "Arrays have to be the same size");
   for (size_t i = 0; i < left.size(); ++i) {
     if (left[i] != right) return false;
@@ -104,8 +105,10 @@ are_equal(const LeftArrT& left, const RightNonArrT& right) {
 }
 
 template <typename LeftNonArrT, typename RightNonArrT = LeftNonArrT>
-inline typename std::enable_if_t<!has_subscript_operator_v<T>, bool> are_equal(
-    const LeftNonArrT& left, const RightNonArrT& right) {
+inline typename std::enable_if_t<!has_subscript_operator_v<LeftNonArrT> &&
+                                     !has_subscript_operator_v<RightNonArrT>,
+                                 bool>
+are_equal(const LeftNonArrT& left, const RightNonArrT& right) {
   return (left == right);
 }
 //////////////////////////// Compare functions

--- a/tests/common/value_helper.h
+++ b/tests/common/value_helper.h
@@ -1,0 +1,114 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2020-2022 The Khronos Group Inc.
+//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+//  This file contains helper functions for modifying and comparing values,
+//  arrays, and objects that implements operator[]
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_COMMON_VALUE_HELPER_H
+#define __SYCLCTS_TESTS_COMMON_VALUE_HELPER_H
+#include "../../util/type_traits.h"
+
+namespace value_helper {
+
+template <typename T, size_t N>
+using ArrayT = T[N];
+
+// Modify functions
+template <typename T, size_t N>
+inline void change_val(ArrayT<T, N>& left, const T& right) {
+  for (size_t i = 0; i < N; ++i) {
+    left[i] = right;
+  }
+}
+
+template <typename LeftArrT, size_t LeftArrN, typename RightArrT,
+          size_t RightArrN>
+inline void change_val(ArrayT<LeftArrT, LeftArrN>& left,
+                       const ArrayT<RightArrT, RightArrN>& right) {
+  static_assert(LeftArrN == RightArrN, "Arrays have to be the same size");
+  for (size_t i = 0; i < LeftArrN; ++i) {
+    left[i] = right[i];
+  }
+}
+
+template <typename LeftArrT, typename RightNonArrT>
+inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT>> change_val(
+    LeftArrT& left, const RightNonArrT& right) {
+  for (size_t i = 0; i < left.size(); ++i) {
+    left[i] = right;
+  }
+}
+
+template <typename LeftArrT, typename RightArrT>
+inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
+                                 has_subscript_operator_v<LeftArrT>>
+change_val(LeftArrT& left, const RightNonArrT& right) {
+  assert((left.size() == right.size()) && "Arrays have to be the same size");
+  for (size_t i = 0; i < left.size(); ++i) {
+    left[i] = right;
+  }
+}
+
+template <typename LeftNonArrT, typename RightNonArrT = LeftNonArrT>
+inline typename std::enable_if_t<!has_subscript_operator_v<T>> change_val(
+    LeftNonArrT& left, const RightNonArrT& right) {
+  left = right;
+}
+/////////////////////////// Modify functions
+
+// Compare functions
+template <typename T, size_t N>
+inline bool are_equal(const ArrayT<T, N>& left, const T& right) {
+  for (size_t i = 0; i < N; ++i) {
+    if (left[i] != right) return false;
+  }
+  return true;
+}
+
+template <typename LeftArrT, size_t LeftArrN, typename RightArrT,
+          size_t RightArrN>
+inline bool are_equal(const ArrayT<LeftArrT, LeftArrN>& left,
+                      const ArrayT<RightArrT, RightArrN>& right) {
+  static_assert(LeftArrN == RightArrN, "Arrays have to be the same size");
+  for (size_t i = 0; i < LeftArrN; ++i) {
+    if (left[i] != right[i]) return false;
+  }
+  return true;
+}
+
+template <typename LeftArrT, typename RightNonArrT>
+inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT>, bool>
+are_equal(const LeftArrT& left, const RightNonArrT& right) {
+  for (size_t i = 0; i < left.size(); ++i) {
+    if (left[i] != right) return false;
+  }
+  return true;
+}
+
+template <typename LeftArrT, typename RightArrT>
+inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
+                                     has_subscript_operator_v<RightArrT>,
+                                 bool>
+are_equal(const LeftArrT& left, const RightNonArrT& right) {
+  assert((left.size() == right.size()) && "Arrays have to be the same size");
+  for (size_t i = 0; i < left.size(); ++i) {
+    if (left[i] != right) return false;
+  }
+  return true;
+}
+
+template <typename LeftNonArrT, typename RightNonArrT = LeftNonArrT>
+inline typename std::enable_if_t<!has_subscript_operator_v<T>, bool> are_equal(
+    const LeftNonArrT& left, const RightNonArrT& right) {
+  return (left == right);
+}
+//////////////////////////// Compare functions
+
+}  // namespace value_helper
+#endif  //__SYCLCTS_TESTS_COMMON_VALUE_HELPER_H

--- a/tests/common/value_helper.h
+++ b/tests/common/value_helper.h
@@ -14,6 +14,8 @@
 #define __SYCLCTS_TESTS_COMMON_VALUE_HELPER_H
 #include "../../util/type_traits.h"
 
+#include <cassert>
+
 namespace value_helper {
 
 template <typename T, size_t N>
@@ -102,7 +104,7 @@ inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
 are_equal(const LeftArrT& left, const RightArrT& right) {
   assert((left.size() == right.size()) && "Arrays have to be the same size");
   for (size_t i = 0; i < left.size(); ++i) {
-    if (left[i] != right) return false;
+    if (left[i] != right[i]) return false;
   }
   return true;
 }

--- a/tests/common/value_operations.h
+++ b/tests/common/value_operations.h
@@ -10,13 +10,13 @@
 //
 *******************************************************************************/
 
-#ifndef __SYCLCTS_TESTS_COMMON_VALUE_HELPER_H
-#define __SYCLCTS_TESTS_COMMON_VALUE_HELPER_H
+#ifndef __SYCLCTS_TESTS_COMMON_VALUE_OPERATIONS_H
+#define __SYCLCTS_TESTS_COMMON_VALUE_OPERATIONS_H
 #include "../../util/type_traits.h"
 
 #include <cassert>
 
-namespace value_helper {
+namespace value_operations {
 
 template <typename T, size_t N>
 using ArrayT = T[N];
@@ -118,5 +118,5 @@ are_equal(const LeftNonArrT& left, const RightNonArrT& right) {
 }
 //////////////////////////// Compare functions
 
-}  // namespace value_helper
-#endif  //__SYCLCTS_TESTS_COMMON_VALUE_HELPER_H
+}  // namespace value_operations
+#endif  //__SYCLCTS_TESTS_COMMON_VALUE_OPERATIONS_H

--- a/tests/common/value_operations.h
+++ b/tests/common/value_operations.h
@@ -23,7 +23,7 @@ using ArrayT = T[N];
 
 // Modify functions
 template <typename T, size_t N>
-inline void change_val(ArrayT<T, N>& left, const T& right) {
+inline void assign(ArrayT<T, N>& left, const T& right) {
   for (size_t i = 0; i < N; ++i) {
     left[i] = right;
   }
@@ -31,8 +31,8 @@ inline void change_val(ArrayT<T, N>& left, const T& right) {
 
 template <typename LeftArrT, size_t LeftArrN, typename RightArrT,
           size_t RightArrN>
-inline void change_val(ArrayT<LeftArrT, LeftArrN>& left,
-                       const ArrayT<RightArrT, RightArrN>& right) {
+inline void assign(ArrayT<LeftArrT, LeftArrN>& left,
+                   const ArrayT<RightArrT, RightArrN>& right) {
   static_assert(LeftArrN == RightArrN, "Arrays have to be the same size");
   for (size_t i = 0; i < LeftArrN; ++i) {
     left[i] = right[i];
@@ -42,7 +42,7 @@ inline void change_val(ArrayT<LeftArrT, LeftArrN>& left,
 template <typename LeftArrT, typename RightNonArrT>
 inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
                                  !has_subscript_operator_v<RightNonArrT>>
-change_val(LeftArrT& left, const RightNonArrT& right) {
+assign(LeftArrT& left, const RightNonArrT& right) {
   for (size_t i = 0; i < left.size(); ++i) {
     left[i] = right;
   }
@@ -51,7 +51,7 @@ change_val(LeftArrT& left, const RightNonArrT& right) {
 template <typename LeftArrT, typename RightArrT>
 inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
                                  has_subscript_operator_v<RightArrT>>
-change_val(LeftArrT& left, const RightArrT& right) {
+assign(LeftArrT& left, const RightArrT& right) {
   assert((left.size() == right.size()) && "Arrays have to be the same size");
   for (size_t i = 0; i < left.size(); ++i) {
     left[i] = right[i];
@@ -61,7 +61,7 @@ change_val(LeftArrT& left, const RightArrT& right) {
 template <typename LeftNonArrT, typename RightNonArrT = LeftNonArrT>
 inline typename std::enable_if_t<!has_subscript_operator_v<LeftNonArrT> &&
                                  !has_subscript_operator_v<RightNonArrT>>
-change_val(LeftNonArrT& left, const RightNonArrT& right) {
+assign(LeftNonArrT& left, const RightNonArrT& right) {
   left = right;
 }
 /////////////////////////// Modify functions

--- a/tests/extension/oneapi_device_global/device_global_api_basic.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_basic.cpp
@@ -106,12 +106,12 @@ void run_test(util::logger& log, const std::string& type_name) {
         result_acc[integral(indx::correct_def_val_non_const)] =
             (*(mptr.get()) == def_value);
         // Change value, that multi_ptr points to
-        value_helper<T>::change_val(*mptr);
+        value_helper::change_val<T>(*mptr, 42);
         // Get current value from device_global, that should change in previous
         // step
         const T& current_value = dev_global<T>.get();
         result_acc[integral(indx::correct_changed_val)] =
-            value_helper<T>::compare_val(*mptr, current_value);
+            value_helper::are_equal<T>(*mptr, current_value);
       });
     });
   }
@@ -181,13 +181,13 @@ void run_test(util::logger& log, const std::string& type_name) {
             (default_value == const_instance);
 
         // Changing non-const value
-        value_helper<T>::change_val(dev_global<T>);
+        value_helper::change_val<T>(dev_global<T>, 42);
         // Get current value from the device_global, which should change in
         // previous step
         T& current_value = dev_global<T>.get();
         // Check, that the device_global object contains new value
         result_acc[integral(indx::correct_changed_val)] =
-            value_helper<T>::compare_val(dev_global<T>, current_value);
+            value_helper::are_equal<T>(dev_global<T>, current_value);
       });
     });
   }
@@ -263,9 +263,9 @@ void run_test(util::logger& log, const std::string& type_name) {
             (instance == def_value);
         // Assign new value an check that device_global instance contains new
         // value
-        value_helper<T>::change_val(instance);
+        value_helper::change_val<T>(instance, 42);
         result_acc[integral(indx::correct_changed_val)] =
-            value_helper<T>::compare_val(dev_global<T>, instance);
+            value_helper::are_equal<T>(dev_global<T>, instance);
       });
     });
   }

--- a/tests/extension/oneapi_device_global/device_global_api_basic.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_basic.cpp
@@ -106,12 +106,12 @@ void run_test(util::logger& log, const std::string& type_name) {
         result_acc[integral(indx::correct_def_val_non_const)] =
             (*(mptr.get()) == def_value);
         // Change value, that multi_ptr points to
-        value_helper::change_val<T>(*mptr, 42);
+        value_operations::change_val<T>(*mptr, 42);
         // Get current value from device_global, that should change in previous
         // step
         const T& current_value = dev_global<T>.get();
         result_acc[integral(indx::correct_changed_val)] =
-            value_helper::are_equal<T>(*mptr, current_value);
+            value_operations::are_equal<T>(*mptr, current_value);
       });
     });
   }
@@ -181,13 +181,13 @@ void run_test(util::logger& log, const std::string& type_name) {
             (default_value == const_instance);
 
         // Changing non-const value
-        value_helper::change_val<T>(dev_global<T>, 42);
+        value_operations::change_val<T>(dev_global<T>, 42);
         // Get current value from the device_global, which should change in
         // previous step
         T& current_value = dev_global<T>.get();
         // Check, that the device_global object contains new value
         result_acc[integral(indx::correct_changed_val)] =
-            value_helper::are_equal<T>(dev_global<T>, current_value);
+            value_operations::are_equal<T>(dev_global<T>, current_value);
       });
     });
   }
@@ -263,9 +263,9 @@ void run_test(util::logger& log, const std::string& type_name) {
             (instance == def_value);
         // Assign new value an check that device_global instance contains new
         // value
-        value_helper::change_val<T>(instance, 42);
+        value_operations::change_val<T>(instance, 42);
         result_acc[integral(indx::correct_changed_val)] =
-            value_helper::are_equal<T>(dev_global<T>, instance);
+            value_operations::are_equal<T>(dev_global<T>, instance);
       });
     });
   }

--- a/tests/extension/oneapi_device_global/device_global_api_basic.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_basic.cpp
@@ -106,7 +106,7 @@ void run_test(util::logger& log, const std::string& type_name) {
         result_acc[integral(indx::correct_def_val_non_const)] =
             (*(mptr.get()) == def_value);
         // Change value, that multi_ptr points to
-        value_operations::change_val<T>(*mptr, 42);
+        value_operations::assign<T>(*mptr, 42);
         // Get current value from device_global, that should change in previous
         // step
         const T& current_value = dev_global<T>.get();
@@ -181,7 +181,7 @@ void run_test(util::logger& log, const std::string& type_name) {
             (default_value == const_instance);
 
         // Changing non-const value
-        value_operations::change_val<T>(dev_global<T>, 42);
+        value_operations::assign<T>(dev_global<T>, 42);
         // Get current value from the device_global, which should change in
         // previous step
         T& current_value = dev_global<T>.get();
@@ -263,7 +263,7 @@ void run_test(util::logger& log, const std::string& type_name) {
             (instance == def_value);
         // Assign new value an check that device_global instance contains new
         // value
-        value_operations::change_val<T>(instance, 42);
+        value_operations::assign<T>(instance, 42);
         result_acc[integral(indx::correct_changed_val)] =
             value_operations::are_equal<T>(dev_global<T>, instance);
       });

--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -8,7 +8,7 @@
 #ifndef SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H
 #define SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H
 #include "../../common/get_cts_string.h"
-#include "../../common/value_helper.h"
+#include "../../common/value_operations.h"
 
 namespace device_global_common_functions {
 

--- a/tests/extension/oneapi_device_global/device_global_common.h
+++ b/tests/extension/oneapi_device_global/device_global_common.h
@@ -7,8 +7,8 @@
 *******************************************************************************/
 #ifndef SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H
 #define SYCL_CTS_TEST_DEVICE_GLOBAL_COMMON_H
-
 #include "../../common/get_cts_string.h"
+#include "../../common/value_helper.h"
 
 namespace device_global_common_functions {
 
@@ -76,108 +76,6 @@ inline std::string get_case_description(const std::string& test_name,
   message += "<" + type_name + ">";
   return message;
 }
-
-/** @brief Utility class helps to change and compare generic values
- *  @tparam T Type of value
- */
-template <typename T>
-struct value_helper {
-  /**
-   * @brief The function changes value from the first parameter to
-   * value from the second parameter
-   * @param value The reference to the array that needs to be change
-   * @param new_val The new value that will be set
-   */
-  static void change_val(T& value, const int new_val = 1) { value = new_val; }
-
-  /**
-   * @brief The function changes value from the first parameter to
-   * value from the second parameter of the same type.
-   * Disabled if T is int to avoid function ambiguous
-   */
-  template <typename Ty = T>
-  static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
-      T& value, const T& new_val) {
-    value = new_val;
-  }
-
-  /**
-   * @brief The function compares values from the first
-   * parameter value from the second parameter
-   */
-  static bool compare_val(const T& left, const T& right) {
-    return (left == right);
-  }
-};
-
-/** @brief Utility class helps to change and compare arrays
- *  @tparam T Type of array values
- *  @tparam N Size of array
- */
-template <typename T, size_t N>
-struct value_helper<T[N]> {
-  using arrayT = T[N];
-  /**
-   * @brief The function changes all values of the array from the first
-   * parameter to value from the second parameter
-   * @param value The reference to the array that needs to be changed
-   * @param new_val The new value that will be set
-   */
-  static void change_val(arrayT& value, const int new_val = 1) {
-    for (size_t i = 0; i < N; ++i) {
-      value[i] = new_val;
-    }
-  }
-  /**
-   * @brief The function changes all values of the array from the first
-   * parameter to value of type T from the second parameter
-   * Disabled if T is int to avoid function ambiguous
-   * @param value The reference to the array that needs to be changed
-   * @param new_val The new value that will be set
-   */
-  template <typename Ty = T>
-  static typename std::enable_if_t<!std::is_same_v<Ty, int>> change_val(
-      arrayT& value, const T new_val) {
-    for (size_t i = 0; i < N; i++) {
-      value[i] = new_val;
-    }
-  }
-  /**
-   * @brief The function changes all values of the array from the first
-   * parameter to values of the array from the second parameter
-   * @param value The reference to the array that needs to be changed
-   * @param new_vals The array with values that will be set
-   */
-  static void change_val(arrayT& value, const arrayT& new_vals) {
-    for (size_t i = 0; i < N; i++) {
-      value[i] = new_vals[i];
-    }
-  }
-
-  /**
-   * @brief The function compares all i-th values of the array from the first
-   * parameter with all i-th values of the array from the second parameter
-   */
-  static bool compare_val(const arrayT& left, const arrayT& right) {
-    bool are_equal = true;
-    for (size_t i = 0; i < N; ++i) {
-      are_equal &= left[i] == right[i];
-    }
-    return are_equal;
-  }
-
-  /**
-   * @brief The function compares all i-th values of the array from the first
-   * parameter value from the second parameter
-   */
-  static bool compare_val(const arrayT& left, const T& right) {
-    bool are_equal = true;
-    for (size_t i = 0; i < N; ++i) {
-      are_equal &= left[i] == right;
-    }
-    return are_equal;
-  }
-};
 
 /** @brief The helper function to get variable address for pointer
  *  @tparam T Type of variable

--- a/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
@@ -56,7 +56,7 @@ template <typename T>
 void run_test(util::logger& log, const std::string& type_name) {
   T def_value{};
   T new_val{};
-  value_operations<T>::change_val(new_val, 1);
+  value_operations<T>::assign(new_val, 1);
 
   auto queue = util::get_cts_object::queue();
   bool is_defined_correctly = false;
@@ -80,9 +80,9 @@ void run_test(util::logger& log, const std::string& type_name) {
         is_default_acc[0] &= value_operations::are_equal<T>(dg2, def_value);
         is_default_acc[0] &= value_operations::are_equal<T>(dg3, def_value);
 
-        value_operations<T>::change_val(dg1, new_val);
-        value_operations<T>::change_val(dg2, new_val);
-        value_operations<T>::change_val(dg3, new_val);
+        value_operations<T>::assign(dg1, new_val);
+        value_operations<T>::assign(dg2, new_val);
+        value_operations<T>::assign(dg3, new_val);
 
         is_def_corr_acc[0] =
             value_operations::are_equal<T>(dev_global<T>, new_val);

--- a/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
@@ -56,7 +56,7 @@ template <typename T>
 void run_test(util::logger& log, const std::string& type_name) {
   T def_value{};
   T new_val{};
-  value_helper<T>::change_val(new_val, 1);
+  value_operations<T>::change_val(new_val, 1);
 
   auto queue = util::get_cts_object::queue();
   bool is_defined_correctly = false;
@@ -76,20 +76,20 @@ void run_test(util::logger& log, const std::string& type_name) {
         auto& dg3 = dum_struct::dev_global<T>.get();
 
         // Check that contains default values
-        is_default_acc[0] = value_helper::are_equal<T>(dg1, def_value);
-        is_default_acc[0] &= value_helper::are_equal<T>(dg2, def_value);
-        is_default_acc[0] &= value_helper::are_equal<T>(dg3, def_value);
+        is_default_acc[0] = value_operations::are_equal<T>(dg1, def_value);
+        is_default_acc[0] &= value_operations::are_equal<T>(dg2, def_value);
+        is_default_acc[0] &= value_operations::are_equal<T>(dg3, def_value);
 
-        value_helper<T>::change_val(dg1, new_val);
-        value_helper<T>::change_val(dg2, new_val);
-        value_helper<T>::change_val(dg3, new_val);
+        value_operations<T>::change_val(dg1, new_val);
+        value_operations<T>::change_val(dg2, new_val);
+        value_operations<T>::change_val(dg3, new_val);
 
         is_def_corr_acc[0] =
-            value_helper::are_equal<T>(dev_global<T>, new_val);
+            value_operations::are_equal<T>(dev_global<T>, new_val);
         is_def_corr_acc[0] &=
-            value_helper::are_equal<T>(dum_namespace::dev_global<T>, new_val);
+            value_operations::are_equal<T>(dum_namespace::dev_global<T>, new_val);
         is_def_corr_acc[0] &=
-            value_helper::are_equal<T>(dum_struct::dev_global<T>, new_val);
+            value_operations::are_equal<T>(dum_struct::dev_global<T>, new_val);
       });
     });
     queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
@@ -76,20 +76,20 @@ void run_test(util::logger& log, const std::string& type_name) {
         auto& dg3 = dum_struct::dev_global<T>.get();
 
         // Check that contains default values
-        is_default_acc[0] = value_helper<T>::compare_val(dg1, def_value);
-        is_default_acc[0] &= value_helper<T>::compare_val(dg2, def_value);
-        is_default_acc[0] &= value_helper<T>::compare_val(dg3, def_value);
+        is_default_acc[0] = value_helper::are_equal<T>(dg1, def_value);
+        is_default_acc[0] &= value_helper::are_equal<T>(dg2, def_value);
+        is_default_acc[0] &= value_helper::are_equal<T>(dg3, def_value);
 
         value_helper<T>::change_val(dg1, new_val);
         value_helper<T>::change_val(dg2, new_val);
         value_helper<T>::change_val(dg3, new_val);
 
         is_def_corr_acc[0] =
-            value_helper<T>::compare_val(dev_global<T>, new_val);
+            value_helper::are_equal<T>(dev_global<T>, new_val);
         is_def_corr_acc[0] &=
-            value_helper<T>::compare_val(dum_namespace::dev_global<T>, new_val);
+            value_helper::are_equal<T>(dum_namespace::dev_global<T>, new_val);
         is_def_corr_acc[0] &=
-            value_helper<T>::compare_val(dum_struct::dev_global<T>, new_val);
+            value_helper::are_equal<T>(dum_struct::dev_global<T>, new_val);
       });
     });
     queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
@@ -86,9 +86,9 @@ class read_and_write_in_kernel {
     T def_val{};
     // Changed value of type T in case if we expect to read modified value
     T new_val{};
-    // The function change_val have default second parameter, so expect that all
+    // The function assign have default second parameter, so expect that all
     // values will change the same
-    value_operations::change_val<T>(new_val, 42);
+    value_operations::assign<T>(new_val, 42);
 
     {
       // Creating result buffer
@@ -119,7 +119,7 @@ class read_and_write_in_kernel {
             is_read_correct_acc[0] =
                 value_operations::are_equal<T>(dev_global<T>, new_val);
           }
-          value_operations::change_val<T>(dev_global<T>, 42);
+          value_operations::assign<T>(dev_global<T>, 42);
         });
       });
       queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
@@ -88,7 +88,7 @@ class read_and_write_in_kernel {
     T new_val{};
     // The function change_val have default second parameter, so expect that all
     // values will change the same
-    value_helper<T>::change_val(new_val);
+    value_helper::change_val<T>(new_val, 42);
 
     {
       // Creating result buffer
@@ -114,12 +114,12 @@ class read_and_write_in_kernel {
         cgh.single_task<kernel>([=] {
           if (is_def_val_expected) {
             is_read_correct_acc[0] =
-                value_helper<T>::compare_val(dev_global<T>, def_val);
+                value_helper::are_equal<T>(dev_global<T>, def_val);
           } else {
             is_read_correct_acc[0] =
-                value_helper<T>::compare_val(dev_global<T>, new_val);
+                value_helper::are_equal<T>(dev_global<T>, new_val);
           }
-          value_helper<T>::change_val(dev_global<T>);
+          value_helper::change_val<T>(dev_global<T>, 42);
         });
       });
       queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
@@ -88,7 +88,7 @@ class read_and_write_in_kernel {
     T new_val{};
     // The function change_val have default second parameter, so expect that all
     // values will change the same
-    value_helper::change_val<T>(new_val, 42);
+    value_operations::change_val<T>(new_val, 42);
 
     {
       // Creating result buffer
@@ -114,12 +114,12 @@ class read_and_write_in_kernel {
         cgh.single_task<kernel>([=] {
           if (is_def_val_expected) {
             is_read_correct_acc[0] =
-                value_helper::are_equal<T>(dev_global<T>, def_val);
+                value_operations::are_equal<T>(dev_global<T>, def_val);
           } else {
             is_read_correct_acc[0] =
-                value_helper::are_equal<T>(dev_global<T>, new_val);
+                value_operations::are_equal<T>(dev_global<T>, new_val);
           }
-          value_helper::change_val<T>(dev_global<T>, 42);
+          value_operations::change_val<T>(dev_global<T>, 42);
         });
       });
       queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
@@ -81,7 +81,7 @@ class read_and_write_in_kernel {
 
     // Changed value of type T in case if we expect to read modified value
     T new_val{};
-    value_helper::change_val<T>(new_val, 42);
+    value_operations::change_val<T>(new_val, 42);
 
     // is_read_correct will be set to true if device_global value is equal to
     // the expected value inside kernel
@@ -100,13 +100,13 @@ class read_and_write_in_kernel {
         // then write new value
         cgh.single_task<kernel>([=] {
           if (expect_def_value) {
-            is_read_correct_acc[0] = value_helper::are_equal<T>(
+            is_read_correct_acc[0] = value_operations::are_equal<T>(
                 dev_global<T, prop_value_t>, def_val);
           } else {
-            is_read_correct_acc[0] = value_helper::are_equal<T>(
+            is_read_correct_acc[0] = value_operations::are_equal<T>(
                 dev_global<T, prop_value_t>, new_val);
           }
-          value_helper::change_val<T>(dev_global<T, prop_value_t>, 42);
+          value_operations::change_val<T>(dev_global<T, prop_value_t>, 42);
         });
       });
       queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
@@ -81,7 +81,7 @@ class read_and_write_in_kernel {
 
     // Changed value of type T in case if we expect to read modified value
     T new_val{};
-    value_operations::change_val<T>(new_val, 42);
+    value_operations::assign<T>(new_val, 42);
 
     // is_read_correct will be set to true if device_global value is equal to
     // the expected value inside kernel
@@ -106,7 +106,7 @@ class read_and_write_in_kernel {
             is_read_correct_acc[0] = value_operations::are_equal<T>(
                 dev_global<T, prop_value_t>, new_val);
           }
-          value_operations::change_val<T>(dev_global<T, prop_value_t>, 42);
+          value_operations::assign<T>(dev_global<T, prop_value_t>, 42);
         });
       });
       queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
@@ -81,7 +81,7 @@ class read_and_write_in_kernel {
 
     // Changed value of type T in case if we expect to read modified value
     T new_val{};
-    value_helper<T>::change_val(new_val);
+    value_helper::change_val<T>(new_val, 42);
 
     // is_read_correct will be set to true if device_global value is equal to
     // the expected value inside kernel
@@ -100,13 +100,13 @@ class read_and_write_in_kernel {
         // then write new value
         cgh.single_task<kernel>([=] {
           if (expect_def_value) {
-            is_read_correct_acc[0] = value_helper<T>::compare_val(
+            is_read_correct_acc[0] = value_helper::are_equal<T>(
                 dev_global<T, prop_value_t>, def_val);
           } else {
-            is_read_correct_acc[0] = value_helper<T>::compare_val(
+            is_read_correct_acc[0] = value_helper::are_equal<T>(
                 dev_global<T, prop_value_t>, new_val);
           }
-          value_helper<T>::change_val(dev_global<T, prop_value_t>);
+          value_helper::change_val<T>(dev_global<T, prop_value_t>, 42);
         });
       });
       queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
@@ -61,7 +61,7 @@ void run_test(util::logger& log, const std::string& type_name) {
       cgh.single_task<kernel>([=] {
         // Change the device_global instance and store address to the ptr
         // through accessor
-        value_helper::change_val<T>(dev_global<T>, 42);
+        value_operations::change_val<T>(dev_global<T>, 42);
         ptr_acc[0] = &(dev_global<T>.get());
       });
     });
@@ -73,7 +73,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   T new_val{};
   // The function change_val have default second parameter, so expect that all
   // values will change the same
-  value_helper::change_val<T>(new_val, 42);
+  value_operations::change_val<T>(new_val, 42);
 
   bool is_read_correct{true};
   {
@@ -88,7 +88,7 @@ void run_test(util::logger& log, const std::string& type_name) {
 
       cgh.single_task<kernel>([=] {
         is_read_correct_acc[0] =
-            (value_helper::are_equal<T>(*(ptr), new_val));
+            (value_operations::are_equal<T>(*(ptr), new_val));
       });
     });
     queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
@@ -61,7 +61,7 @@ void run_test(util::logger& log, const std::string& type_name) {
       cgh.single_task<kernel>([=] {
         // Change the device_global instance and store address to the ptr
         // through accessor
-        value_operations::change_val<T>(dev_global<T>, 42);
+        value_operations::assign<T>(dev_global<T>, 42);
         ptr_acc[0] = &(dev_global<T>.get());
       });
     });
@@ -71,9 +71,9 @@ void run_test(util::logger& log, const std::string& type_name) {
   // Expecting to read the new_value that was set to the device_global instance
   // in previous kernel
   T new_val{};
-  // The function change_val have default second parameter, so expect that all
+  // The function assign have default second parameter, so expect that all
   // values will change the same
-  value_operations::change_val<T>(new_val, 42);
+  value_operations::assign<T>(new_val, 42);
 
   bool is_read_correct{true};
   {

--- a/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
@@ -61,7 +61,7 @@ void run_test(util::logger& log, const std::string& type_name) {
       cgh.single_task<kernel>([=] {
         // Change the device_global instance and store address to the ptr
         // through accessor
-        value_helper<T>::change_val(dev_global<T>);
+        value_helper::change_val<T>(dev_global<T>, 42);
         ptr_acc[0] = &(dev_global<T>.get());
       });
     });
@@ -73,7 +73,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   T new_val{};
   // The function change_val have default second parameter, so expect that all
   // values will change the same
-  value_helper<T>::change_val(new_val);
+  value_helper::change_val<T>(new_val, 42);
 
   bool is_read_correct{true};
   {
@@ -88,7 +88,7 @@ void run_test(util::logger& log, const std::string& type_name) {
 
       cgh.single_task<kernel>([=] {
         is_read_correct_acc[0] =
-            (value_helper<T>::compare_val(*(ptr), new_val));
+            (value_helper::are_equal<T>(*(ptr), new_val));
       });
     });
     queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_several_kernels_one_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_several_kernels_one_device.cpp
@@ -58,7 +58,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   {
     queue.submit([&](sycl::handler& cgh) {
       cgh.single_task<first_kernel<T>>([=](sycl::kernel_handler h) {
-        value_helper::change_val<T>(dev_global<T>, 42);
+        value_operations::change_val<T>(dev_global<T>, 42);
       });
     });
     queue.wait_and_throw();
@@ -78,7 +78,7 @@ void run_test(util::logger& log, const std::string& type_name) {
 
   // For const value expecting that value not changed,so keep default value
   util::array<bool, checks_size> changed_correct;
-  value_helper<element_type>::change_val(
+  value_operations<element_type>::change_val(
       expected_value[integral(indx::non_const_expected)]);
 
   {
@@ -91,11 +91,11 @@ void run_test(util::logger& log, const std::string& type_name) {
       // Comparing current device_global val with expected in second kernel
       cgh.single_task<second_kernel<T>>([=](sycl::kernel_handler h) {
         changed_corr[integral(indx::const_expected)] =
-            value_helper::are_equal<T>(
+            value_operations::are_equal<T>(
                 const_dev_global<T>,
                 expected_value[integral(indx::const_expected)]);
         changed_corr[integral(indx::non_const_expected)] =
-            value_helper::are_equal<T>(
+            value_operations::are_equal<T>(
                 dev_global<T>,
                 expected_value[integral(indx::non_const_expected)]);
       });

--- a/tests/extension/oneapi_device_global/device_global_functional_several_kernels_one_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_several_kernels_one_device.cpp
@@ -12,9 +12,9 @@
 //
 *******************************************************************************/
 
+#include "../../../util/array.h"
 #include "../../common/common.h"
 #include "../../common/type_coverage.h"
-#include "../../../util/array.h"
 #include "device_global_common.h"
 #include "type_pack.h"
 
@@ -58,7 +58,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   {
     queue.submit([&](sycl::handler& cgh) {
       cgh.single_task<first_kernel<T>>([=](sycl::kernel_handler h) {
-        value_helper<T>::change_val(dev_global<T>);
+        value_helper::change_val<T>(dev_global<T>, 42);
       });
     });
     queue.wait_and_throw();
@@ -91,11 +91,11 @@ void run_test(util::logger& log, const std::string& type_name) {
       // Comparing current device_global val with expected in second kernel
       cgh.single_task<second_kernel<T>>([=](sycl::kernel_handler h) {
         changed_corr[integral(indx::const_expected)] =
-            value_helper<T>::compare_val(
+            value_helper::are_equal<T>(
                 const_dev_global<T>,
                 expected_value[integral(indx::const_expected)]);
         changed_corr[integral(indx::non_const_expected)] =
-            value_helper<T>::compare_val(
+            value_helper::are_equal<T>(
                 dev_global<T>,
                 expected_value[integral(indx::non_const_expected)]);
       });

--- a/tests/extension/oneapi_device_global/device_global_functional_several_kernels_one_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_several_kernels_one_device.cpp
@@ -58,7 +58,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   {
     queue.submit([&](sycl::handler& cgh) {
       cgh.single_task<first_kernel<T>>([=](sycl::kernel_handler h) {
-        value_operations::change_val<T>(dev_global<T>, 42);
+        value_operations::assign<T>(dev_global<T>, 42);
       });
     });
     queue.wait_and_throw();
@@ -78,7 +78,7 @@ void run_test(util::logger& log, const std::string& type_name) {
 
   // For const value expecting that value not changed,so keep default value
   util::array<bool, checks_size> changed_correct;
-  value_operations<element_type>::change_val(
+  value_operations<element_type>::assign(
       expected_value[integral(indx::non_const_expected)]);
 
   {

--- a/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
@@ -77,7 +77,7 @@ class read_and_write_in_kernel {
     T def_val{};
     // Changed value of type T in case if we expect to read modified value
     T new_val{};
-    value_helper<T>::change_val(new_val);
+    value_helper::change_val<T>(new_val, 42);
 
     constexpr int initial_sc_val = 1;
     constexpr int changed_sc_val = 2;
@@ -105,10 +105,10 @@ class read_and_write_in_kernel {
         cgh.single_task<kernel>([=](sycl::kernel_handler h) {
           if (is_def_val_expected) {
             is_read_correct_acc[0] =
-                value_helper<T>::compare_val(dev_global<T>, def_val);
+                value_helper::are_equal<T>(dev_global<T>, def_val);
           } else {
             is_read_correct_acc[0] =
-                value_helper<T>::compare_val(dev_global<T>, new_val);
+                value_helper::are_equal<T>(dev_global<T>, new_val);
           }
 
           // Get specialization constant value for change device_global instance

--- a/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
@@ -77,7 +77,7 @@ class read_and_write_in_kernel {
     T def_val{};
     // Changed value of type T in case if we expect to read modified value
     T new_val{};
-    value_operations::change_val<T>(new_val, 42);
+    value_operations::assign<T>(new_val, 42);
 
     constexpr int initial_sc_val = 1;
     constexpr int changed_sc_val = 2;
@@ -113,7 +113,7 @@ class read_and_write_in_kernel {
 
           // Get specialization constant value for change device_global instance
           int sc_val = h.template get_specialization_constant<spec_const_id>();
-          value_operations<T>::change_val(dev_global<T>, sc_val);
+          value_operations<T>::assign(dev_global<T>, sc_val);
         });
       });
       queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
@@ -77,7 +77,7 @@ class read_and_write_in_kernel {
     T def_val{};
     // Changed value of type T in case if we expect to read modified value
     T new_val{};
-    value_helper::change_val<T>(new_val, 42);
+    value_operations::change_val<T>(new_val, 42);
 
     constexpr int initial_sc_val = 1;
     constexpr int changed_sc_val = 2;
@@ -105,15 +105,15 @@ class read_and_write_in_kernel {
         cgh.single_task<kernel>([=](sycl::kernel_handler h) {
           if (is_def_val_expected) {
             is_read_correct_acc[0] =
-                value_helper::are_equal<T>(dev_global<T>, def_val);
+                value_operations::are_equal<T>(dev_global<T>, def_val);
           } else {
             is_read_correct_acc[0] =
-                value_helper::are_equal<T>(dev_global<T>, new_val);
+                value_operations::are_equal<T>(dev_global<T>, new_val);
           }
 
           // Get specialization constant value for change device_global instance
           int sc_val = h.template get_specialization_constant<spec_const_id>();
-          value_helper<T>::change_val(dev_global<T>, sc_val);
+          value_operations<T>::change_val(dev_global<T>, sc_val);
         });
       });
       queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
@@ -83,7 +83,7 @@ void call_write_kernel(sycl::queue& q) {
   using kernel = write_kernel<T>;
   q.submit([&](sycl::handler& cgh) {
     cgh.single_task<kernel>(
-        [=] { value_helper<T>::change_val(dev_global<T>); });
+        [=] { value_helper::change_val<T>(dev_global<T>, 42); });
   });
 }
 
@@ -106,7 +106,7 @@ void call_read_kernel(sycl::queue& q, util::logger& log,
       cgh.single_task<kernel>([=] {
         T def_value{};
         is_default_val_acc[0] =
-            value_helper<T>::compare_val(dev_global<T>, def_value);
+            value_helper::are_equal<T>(dev_global<T>, def_value);
       });
     });
   }

--- a/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
@@ -83,7 +83,7 @@ void call_write_kernel(sycl::queue& q) {
   using kernel = write_kernel<T>;
   q.submit([&](sycl::handler& cgh) {
     cgh.single_task<kernel>(
-        [=] { value_helper::change_val<T>(dev_global<T>, 42); });
+        [=] { value_operations::change_val<T>(dev_global<T>, 42); });
   });
 }
 
@@ -106,7 +106,7 @@ void call_read_kernel(sycl::queue& q, util::logger& log,
       cgh.single_task<kernel>([=] {
         T def_value{};
         is_default_val_acc[0] =
-            value_helper::are_equal<T>(dev_global<T>, def_value);
+            value_operations::are_equal<T>(dev_global<T>, def_value);
       });
     });
   }

--- a/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
@@ -83,7 +83,7 @@ void call_write_kernel(sycl::queue& q) {
   using kernel = write_kernel<T>;
   q.submit([&](sycl::handler& cgh) {
     cgh.single_task<kernel>(
-        [=] { value_operations::change_val<T>(dev_global<T>, 42); });
+        [=] { value_operations::assign<T>(dev_global<T>, 42); });
   });
 }
 

--- a/tests/extension/oneapi_device_global/device_global_functional_variables_with_same_name.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_variables_with_same_name.cpp
@@ -50,7 +50,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   bool is_changed_correctly{false};
   T def_val{};
   T new_val{};
-  value_helper<T>::change_val(new_val);
+  value_helper::change_val<T>(new_val, 42);
   auto queue = util::get_cts_object::queue();
   {
     sycl::buffer<bool, 1> is_changed_corr_buf(&is_changed_correctly,
@@ -67,14 +67,14 @@ void run_test(util::logger& log, const std::string& type_name) {
         // Write different values to instances
         value_helper<T>::change_val(dg1, def_val);
         value_helper<T>::change_val(dg2, new_val);
-        is_changed_corr_acc[0] = value_helper<T>::compare_val(dg1, def_val);
-        is_changed_corr_acc[0] &= value_helper<T>::compare_val(dg2, new_val);
+        is_changed_corr_acc[0] = value_helper::are_equal<T>(dg1, def_val);
+        is_changed_corr_acc[0] &= value_helper::are_equal<T>(dg2, new_val);
 
         // Write again but in different order
         value_helper<T>::change_val(dg1, new_val);
         value_helper<T>::change_val(dg2, def_val);
-        is_changed_corr_acc[0] &= value_helper<T>::compare_val(dg1, new_val);
-        is_changed_corr_acc[0] &= value_helper<T>::compare_val(dg2, def_val);
+        is_changed_corr_acc[0] &= value_helper::are_equal<T>(dg1, new_val);
+        is_changed_corr_acc[0] &= value_helper::are_equal<T>(dg2, def_val);
       });
     });
     queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_variables_with_same_name.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_variables_with_same_name.cpp
@@ -50,7 +50,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   bool is_changed_correctly{false};
   T def_val{};
   T new_val{};
-  value_operations::change_val<T>(new_val, 42);
+  value_operations::assign<T>(new_val, 42);
   auto queue = util::get_cts_object::queue();
   {
     sycl::buffer<bool, 1> is_changed_corr_buf(&is_changed_correctly,
@@ -65,14 +65,14 @@ void run_test(util::logger& log, const std::string& type_name) {
         auto& dg2 = variables_with_same_name::dev_global<T>;
 
         // Write different values to instances
-        value_operations<T>::change_val(dg1, def_val);
-        value_operations<T>::change_val(dg2, new_val);
+        value_operations<T>::assign(dg1, def_val);
+        value_operations<T>::assign(dg2, new_val);
         is_changed_corr_acc[0] = value_operations::are_equal<T>(dg1, def_val);
         is_changed_corr_acc[0] &= value_operations::are_equal<T>(dg2, new_val);
 
         // Write again but in different order
-        value_operations<T>::change_val(dg1, new_val);
-        value_operations<T>::change_val(dg2, def_val);
+        value_operations<T>::assign(dg1, new_val);
+        value_operations<T>::assign(dg2, def_val);
         is_changed_corr_acc[0] &= value_operations::are_equal<T>(dg1, new_val);
         is_changed_corr_acc[0] &= value_operations::are_equal<T>(dg2, def_val);
       });

--- a/tests/extension/oneapi_device_global/device_global_functional_variables_with_same_name.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_variables_with_same_name.cpp
@@ -50,7 +50,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   bool is_changed_correctly{false};
   T def_val{};
   T new_val{};
-  value_helper::change_val<T>(new_val, 42);
+  value_operations::change_val<T>(new_val, 42);
   auto queue = util::get_cts_object::queue();
   {
     sycl::buffer<bool, 1> is_changed_corr_buf(&is_changed_correctly,
@@ -65,16 +65,16 @@ void run_test(util::logger& log, const std::string& type_name) {
         auto& dg2 = variables_with_same_name::dev_global<T>;
 
         // Write different values to instances
-        value_helper<T>::change_val(dg1, def_val);
-        value_helper<T>::change_val(dg2, new_val);
-        is_changed_corr_acc[0] = value_helper::are_equal<T>(dg1, def_val);
-        is_changed_corr_acc[0] &= value_helper::are_equal<T>(dg2, new_val);
+        value_operations<T>::change_val(dg1, def_val);
+        value_operations<T>::change_val(dg2, new_val);
+        is_changed_corr_acc[0] = value_operations::are_equal<T>(dg1, def_val);
+        is_changed_corr_acc[0] &= value_operations::are_equal<T>(dg2, new_val);
 
         // Write again but in different order
-        value_helper<T>::change_val(dg1, new_val);
-        value_helper<T>::change_val(dg2, def_val);
-        is_changed_corr_acc[0] &= value_helper::are_equal<T>(dg1, new_val);
-        is_changed_corr_acc[0] &= value_helper::are_equal<T>(dg2, def_val);
+        value_operations<T>::change_val(dg1, new_val);
+        value_operations<T>::change_val(dg2, def_val);
+        is_changed_corr_acc[0] &= value_operations::are_equal<T>(dg1, new_val);
+        is_changed_corr_acc[0] &= value_operations::are_equal<T>(dg2, def_val);
       });
     });
     queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
+++ b/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
@@ -60,7 +60,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T src_value;
-  value_operations<T>::change_val(src_value, init_value);
+  value_operations<T>::assign(src_value, init_value);
 
   element_ptr src = pointer_helper(src_value);
 
@@ -151,7 +151,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T dest_value;
-  value_operations<T>::change_val(dest_value, changed_value);
+  value_operations<T>::assign(dest_value, changed_value);
 
   element_ptr dest = pointer_helper(dest_value);
 
@@ -248,7 +248,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T src_value;
-  value_operations<T>::change_val(src_value, init_value);
+  value_operations<T>::assign(src_value, init_value);
   void_ptr src = static_cast<void_ptr>(pointer_helper(src_value));
 
   bool is_copy_correct{false};
@@ -340,7 +340,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T dest_value;
-  value_operations<T>::change_val(dest_value, changed_value);
+  value_operations<T>::assign(dest_value, changed_value);
 
   void_ptr dest = pointer_helper(dest_value);
 

--- a/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
+++ b/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
@@ -82,7 +82,7 @@ void run_test(util::logger& log, const std::string& type_name) {
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *src after copy
         is_copy_correct_acc[0] =
-            value_helper<T>::compare_val(dev_global<T>, *src);
+            value_helper::are_equal<T>(dev_global<T>, *src);
       });
     });
     queue.wait_and_throw();
@@ -105,7 +105,7 @@ void run_test(util::logger& log, const std::string& type_name) {
         cgh.single_task<kernel2<T>>([=] {
           // dev_global have to be equal to *src after copy
           is_copy_correct_acc[0] &=
-              value_helper<T>::compare_val(dev_global<T>, *src);
+              value_helper::are_equal<T>(dev_global<T>, *src);
         });
       });
       queue.wait_and_throw();
@@ -174,7 +174,7 @@ void run_test(util::logger& log, const std::string& type_name) {
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *dest after copy
         is_copy_correct_acc[0] =
-            value_helper<T>::compare_val(dev_global<T>, *dest);
+            value_helper::are_equal<T>(dev_global<T>, *dest);
       });
     });
     queue.wait_and_throw();
@@ -201,7 +201,7 @@ void run_test(util::logger& log, const std::string& type_name) {
         cgh.single_task<kernel3<T>>([=] {
           // Compare again after copy
           is_copy_correct_acc[0] &=
-              value_helper<T>::compare_val(dev_global<T>, *dest);
+              value_helper::are_equal<T>(dev_global<T>, *dest);
         });
       });
       queue.wait_and_throw();
@@ -269,7 +269,7 @@ void run_test(util::logger& log, const std::string& type_name) {
               cgh);
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *src after copy
-        is_copy_correct_acc[0] = value_helper<T>::compare_val(
+        is_copy_correct_acc[0] = value_helper::are_equal<T>(
             dev_global<T>, *(static_cast<element_ptr>(src)));
       });
     });
@@ -293,7 +293,7 @@ void run_test(util::logger& log, const std::string& type_name) {
                 cgh);
         cgh.single_task<kernel2<T>>([=] {
           // Compare again after copy
-          is_copy_correct_acc[0] &= value_helper<T>::compare_val(
+          is_copy_correct_acc[0] &= value_helper::are_equal<T>(
               dev_global<T>, *(static_cast<element_ptr>(src)));
         });
       });
@@ -362,7 +362,7 @@ void run_test(util::logger& log, const std::string& type_name) {
               cgh);
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *dest after copy
-        is_copy_correct_acc[0] = value_helper<T>::compare_val(
+        is_copy_correct_acc[0] = value_helper::are_equal<T>(
             dev_global<T>, *(static_cast<element_ptr>(dest)));
       });
     });
@@ -389,7 +389,7 @@ void run_test(util::logger& log, const std::string& type_name) {
                 cgh);
         cgh.single_task<kernel3<T>>([=] {
           // Compare again after copy
-          is_copy_correct_acc[0] = value_helper<T>::compare_val(
+          is_copy_correct_acc[0] = value_helper::are_equal<T>(
               dev_global<T>, *(static_cast<element_type*>(dest)));
         });
       });

--- a/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
+++ b/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
@@ -60,7 +60,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T src_value;
-  value_helper<T>::change_val(src_value, init_value);
+  value_operations<T>::change_val(src_value, init_value);
 
   element_ptr src = pointer_helper(src_value);
 
@@ -82,7 +82,7 @@ void run_test(util::logger& log, const std::string& type_name) {
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *src after copy
         is_copy_correct_acc[0] =
-            value_helper::are_equal<T>(dev_global<T>, *src);
+            value_operations::are_equal<T>(dev_global<T>, *src);
       });
     });
     queue.wait_and_throw();
@@ -105,7 +105,7 @@ void run_test(util::logger& log, const std::string& type_name) {
         cgh.single_task<kernel2<T>>([=] {
           // dev_global have to be equal to *src after copy
           is_copy_correct_acc[0] &=
-              value_helper::are_equal<T>(dev_global<T>, *src);
+              value_operations::are_equal<T>(dev_global<T>, *src);
         });
       });
       queue.wait_and_throw();
@@ -151,7 +151,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T dest_value;
-  value_helper<T>::change_val(dest_value, changed_value);
+  value_operations<T>::change_val(dest_value, changed_value);
 
   element_ptr dest = pointer_helper(dest_value);
 
@@ -174,7 +174,7 @@ void run_test(util::logger& log, const std::string& type_name) {
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *dest after copy
         is_copy_correct_acc[0] =
-            value_helper::are_equal<T>(dev_global<T>, *dest);
+            value_operations::are_equal<T>(dev_global<T>, *dest);
       });
     });
     queue.wait_and_throw();
@@ -201,7 +201,7 @@ void run_test(util::logger& log, const std::string& type_name) {
         cgh.single_task<kernel3<T>>([=] {
           // Compare again after copy
           is_copy_correct_acc[0] &=
-              value_helper::are_equal<T>(dev_global<T>, *dest);
+              value_operations::are_equal<T>(dev_global<T>, *dest);
         });
       });
       queue.wait_and_throw();
@@ -248,7 +248,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T src_value;
-  value_helper<T>::change_val(src_value, init_value);
+  value_operations<T>::change_val(src_value, init_value);
   void_ptr src = static_cast<void_ptr>(pointer_helper(src_value));
 
   bool is_copy_correct{false};
@@ -269,7 +269,7 @@ void run_test(util::logger& log, const std::string& type_name) {
               cgh);
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *src after copy
-        is_copy_correct_acc[0] = value_helper::are_equal<T>(
+        is_copy_correct_acc[0] = value_operations::are_equal<T>(
             dev_global<T>, *(static_cast<element_ptr>(src)));
       });
     });
@@ -293,7 +293,7 @@ void run_test(util::logger& log, const std::string& type_name) {
                 cgh);
         cgh.single_task<kernel2<T>>([=] {
           // Compare again after copy
-          is_copy_correct_acc[0] &= value_helper::are_equal<T>(
+          is_copy_correct_acc[0] &= value_operations::are_equal<T>(
               dev_global<T>, *(static_cast<element_ptr>(src)));
         });
       });
@@ -340,7 +340,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T dest_value;
-  value_helper<T>::change_val(dest_value, changed_value);
+  value_operations<T>::change_val(dest_value, changed_value);
 
   void_ptr dest = pointer_helper(dest_value);
 
@@ -362,7 +362,7 @@ void run_test(util::logger& log, const std::string& type_name) {
               cgh);
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *dest after copy
-        is_copy_correct_acc[0] = value_helper::are_equal<T>(
+        is_copy_correct_acc[0] = value_operations::are_equal<T>(
             dev_global<T>, *(static_cast<element_ptr>(dest)));
       });
     });
@@ -389,7 +389,7 @@ void run_test(util::logger& log, const std::string& type_name) {
                 cgh);
         cgh.single_task<kernel3<T>>([=] {
           // Compare again after copy
-          is_copy_correct_acc[0] = value_helper::are_equal<T>(
+          is_copy_correct_acc[0] = value_operations::are_equal<T>(
               dev_global<T>, *(static_cast<element_type*>(dest)));
         });
       });

--- a/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
@@ -38,7 +38,7 @@ template <typename T, size_t N>
 void run_test_copy_to_device_global_array(util::logger& log,
                                           const std::string& type_name) {
   T data[N];
-  value_operations<T[N]>::change_val(data, 1);
+  value_operations<T[N]>::assign(data, 1);
   const auto src_data = &data[0];
   size_t num_element = N / 2;
 
@@ -81,7 +81,7 @@ template <typename T, size_t N>
 void run_test_copy_from_device_global_array(util::logger& log,
                                             const std::string& type_name) {
   T new_val[N];
-  value_operations<T[N]>::change_val(new_val, 5);
+  value_operations<T[N]>::assign(new_val, 5);
   T data[N];
   auto dst_data = &data[0];
   size_t num_element = N / 2;
@@ -90,7 +90,7 @@ void run_test_copy_from_device_global_array(util::logger& log,
 
   queue.submit([&](sycl::handler& cgh) {
     cgh.single_task<queue_array_change_dg_kernel<T>>(
-        [=] { value_operations<T[N]>::change_val(dev_global_in<T[N]>, new_val); });
+        [=] { value_operations<T[N]>::assign(dev_global_in<T[N]>, new_val); });
   });
   queue.wait_and_throw();
 

--- a/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_array_copy.cpp
@@ -38,7 +38,7 @@ template <typename T, size_t N>
 void run_test_copy_to_device_global_array(util::logger& log,
                                           const std::string& type_name) {
   T data[N];
-  value_helper<T[N]>::change_val(data, 1);
+  value_operations<T[N]>::change_val(data, 1);
   const auto src_data = &data[0];
   size_t num_element = N / 2;
 
@@ -81,7 +81,7 @@ template <typename T, size_t N>
 void run_test_copy_from_device_global_array(util::logger& log,
                                             const std::string& type_name) {
   T new_val[N];
-  value_helper<T[N]>::change_val(new_val, 5);
+  value_operations<T[N]>::change_val(new_val, 5);
   T data[N];
   auto dst_data = &data[0];
   size_t num_element = N / 2;
@@ -90,7 +90,7 @@ void run_test_copy_from_device_global_array(util::logger& log,
 
   queue.submit([&](sycl::handler& cgh) {
     cgh.single_task<queue_array_change_dg_kernel<T>>(
-        [=] { value_helper<T[N]>::change_val(dev_global_in<T[N]>, new_val); });
+        [=] { value_operations<T[N]>::change_val(dev_global_in<T[N]>, new_val); });
   });
   queue.wait_and_throw();
 

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -47,7 +47,7 @@ void run_test_copy_to_device_global(util::logger& log,
                                     const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T data{};
-  value_operations<T>::change_val(data, 1);
+  value_operations<T>::assign(data, 1);
   const auto src_data = pointer_helper(data);
 
   // to generate events with generator from usm_api.h
@@ -139,7 +139,7 @@ void run_test_copy_from_device_global(util::logger& log,
                                       const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T new_val{};
-  value_operations<T>::change_val(new_val, 5);
+  value_operations<T>::assign(new_val, 5);
   T data1{}, data2{}, data3{};
   auto dst_data1 = pointer_helper(data1);
   auto dst_data2 = pointer_helper(data2);
@@ -150,7 +150,7 @@ void run_test_copy_from_device_global(util::logger& log,
 
   queue.submit([&](sycl::handler& cgh) {
     cgh.single_task<change_dg_kernel<T>>(
-        [=] { value_operations<T>::change_val(dev_global<T>, new_val); });
+        [=] { value_operations<T>::assign(dev_global<T>, new_val); });
   });
   queue.wait_and_throw();
 

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -47,7 +47,7 @@ void run_test_copy_to_device_global(util::logger& log,
                                     const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T data{};
-  value_helper<T>::change_val(data, 1);
+  value_operations<T>::change_val(data, 1);
   const auto src_data = pointer_helper(data);
 
   // to generate events with generator from usm_api.h
@@ -111,11 +111,11 @@ void run_test_copy_to_device_global(util::logger& log,
       auto is_cop_corr_acc =
           is_cop_corr_buf.template get_access<sycl::access_mode::write>(cgh);
       cgh.single_task<check_copy_to_dg_kernel<T>>([=] {
-        is_cop_corr_acc[0] = value_helper::are_equal<T>(dev_global1<T>, data);
+        is_cop_corr_acc[0] = value_operations::are_equal<T>(dev_global1<T>, data);
         is_cop_corr_acc[0] &=
-            value_helper::are_equal<T>(dev_global2<T>, data);
+            value_operations::are_equal<T>(dev_global2<T>, data);
         is_cop_corr_acc[0] &=
-            value_helper::are_equal<T>(dev_global3<T>, data);
+            value_operations::are_equal<T>(dev_global3<T>, data);
       });
     });
     queue.wait_and_throw();
@@ -139,7 +139,7 @@ void run_test_copy_from_device_global(util::logger& log,
                                       const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T new_val{};
-  value_helper<T>::change_val(new_val, 5);
+  value_operations<T>::change_val(new_val, 5);
   T data1{}, data2{}, data3{};
   auto dst_data1 = pointer_helper(data1);
   auto dst_data2 = pointer_helper(data2);
@@ -150,7 +150,7 @@ void run_test_copy_from_device_global(util::logger& log,
 
   queue.submit([&](sycl::handler& cgh) {
     cgh.single_task<change_dg_kernel<T>>(
-        [=] { value_helper<T>::change_val(dev_global<T>, new_val); });
+        [=] { value_operations<T>::change_val(dev_global<T>, new_val); });
   });
   queue.wait_and_throw();
 
@@ -205,9 +205,9 @@ void run_test_copy_from_device_global(util::logger& log,
          "Copy overloads from device_global didn't wait for depEvents to "
          "complete");
 
-  if (!value_helper::are_equal<T>(data1, new_val) ||
-      !value_helper::are_equal<T>(data2, new_val) ||
-      !value_helper::are_equal<T>(data3, new_val)) {
+  if (!value_operations::are_equal<T>(data1, new_val) ||
+      !value_operations::are_equal<T>(data2, new_val) ||
+      !value_operations::are_equal<T>(data3, new_val)) {
     FAIL(log, get_case_description(
                   "Overloads of sycl::queue::copy for device_global",
                   "Didn't copy correct data from device_global", type_name));

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -111,11 +111,11 @@ void run_test_copy_to_device_global(util::logger& log,
       auto is_cop_corr_acc =
           is_cop_corr_buf.template get_access<sycl::access_mode::write>(cgh);
       cgh.single_task<check_copy_to_dg_kernel<T>>([=] {
-        is_cop_corr_acc[0] = value_helper<T>::compare_val(dev_global1<T>, data);
+        is_cop_corr_acc[0] = value_helper::are_equal<T>(dev_global1<T>, data);
         is_cop_corr_acc[0] &=
-            value_helper<T>::compare_val(dev_global2<T>, data);
+            value_helper::are_equal<T>(dev_global2<T>, data);
         is_cop_corr_acc[0] &=
-            value_helper<T>::compare_val(dev_global3<T>, data);
+            value_helper::are_equal<T>(dev_global3<T>, data);
       });
     });
     queue.wait_and_throw();
@@ -205,9 +205,9 @@ void run_test_copy_from_device_global(util::logger& log,
          "Copy overloads from device_global didn't wait for depEvents to "
          "complete");
 
-  if (!value_helper<T>::compare_val(data1, new_val) ||
-      !value_helper<T>::compare_val(data2, new_val) ||
-      !value_helper<T>::compare_val(data3, new_val)) {
+  if (!value_helper::are_equal<T>(data1, new_val) ||
+      !value_helper::are_equal<T>(data2, new_val) ||
+      !value_helper::are_equal<T>(data3, new_val)) {
     FAIL(log, get_case_description(
                   "Overloads of sycl::queue::copy for device_global",
                   "Didn't copy correct data from device_global", type_name));

--- a/tests/extension/oneapi_device_global/device_global_queue_memcpy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_memcpy.cpp
@@ -47,7 +47,7 @@ void run_test_memcpy_to_device_global(util::logger& log,
                                       const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T data{};
-  value_helper<T>::change_val(data, 1);
+  value_operations<T>::change_val(data, 1);
   const void* src_data = pointer_helper(data);
 
   // to generate events with generator from usm_api.h
@@ -110,11 +110,11 @@ void run_test_memcpy_to_device_global(util::logger& log,
           is_memcpy_corr_buf.template get_access<sycl::access_mode::write>(cgh);
       cgh.single_task<check_memcpy_to_dg_kernel<T>>([=] {
         is_memcpy_corr_acc[0] =
-            value_helper::are_equal<T>(dev_global1<T>, data);
+            value_operations::are_equal<T>(dev_global1<T>, data);
         is_memcpy_corr_acc[0] &=
-            value_helper::are_equal<T>(dev_global2<T>, data);
+            value_operations::are_equal<T>(dev_global2<T>, data);
         is_memcpy_corr_acc[0] &=
-            value_helper::are_equal<T>(dev_global3<T>, data);
+            value_operations::are_equal<T>(dev_global3<T>, data);
       });
     });
     queue.wait_and_throw();
@@ -141,13 +141,13 @@ void run_test_memcpy_from_device_global(util::logger& log,
                                         bool val_default) {
   using element_type = std::remove_all_extents_t<T>;
   T new_val{};
-  value_helper<T>::change_val(new_val, 5);
+  value_operations<T>::change_val(new_val, 5);
   T expected{};
   T data1{}, data2{}, data3{};
   if (val_default) {
-    value_helper<T>::change_val(data1, new_val);
-    value_helper<T>::change_val(data2, new_val);
-    value_helper<T>::change_val(data3, new_val);
+    value_operations<T>::change_val(data1, new_val);
+    value_operations<T>::change_val(data2, new_val);
+    value_operations<T>::change_val(data3, new_val);
   }
   void* dst_data1 = pointer_helper(data1);
   void* dst_data2 = pointer_helper(data2);
@@ -156,10 +156,10 @@ void run_test_memcpy_from_device_global(util::logger& log,
   auto queue = util::get_cts_object::queue();
 
   if (!val_default) {
-    value_helper<T>::change_val(expected, new_val);
+    value_operations<T>::change_val(expected, new_val);
     queue.submit([&](sycl::handler& cgh) {
       cgh.single_task<memcpy_change_dg_kernel<T>>(
-          [=] { value_helper<T>::change_val(dev_global<T>, new_val); });
+          [=] { value_operations<T>::change_val(dev_global<T>, new_val); });
     });
     queue.wait_and_throw();
   }
@@ -213,9 +213,9 @@ void run_test_memcpy_from_device_global(util::logger& log,
          "Memcpy overloads from device_global didn't wait for depEvents to "
          "complete");
 
-  if (!value_helper::are_equal<T>(data1, expected) ||
-      !value_helper::are_equal<T>(data2, expected) ||
-      !value_helper::are_equal<T>(data3, expected)) {
+  if (!value_operations::are_equal<T>(data1, expected) ||
+      !value_operations::are_equal<T>(data2, expected) ||
+      !value_operations::are_equal<T>(data3, expected)) {
     FAIL(log, get_case_description(
                   "Overloads of sycl::queue::memcpy for device_global",
                   "Didn't copy correct data from device_global", type_name));

--- a/tests/extension/oneapi_device_global/device_global_queue_memcpy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_memcpy.cpp
@@ -47,7 +47,7 @@ void run_test_memcpy_to_device_global(util::logger& log,
                                       const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T data{};
-  value_operations<T>::change_val(data, 1);
+  value_operations<T>::assign(data, 1);
   const void* src_data = pointer_helper(data);
 
   // to generate events with generator from usm_api.h
@@ -141,13 +141,13 @@ void run_test_memcpy_from_device_global(util::logger& log,
                                         bool val_default) {
   using element_type = std::remove_all_extents_t<T>;
   T new_val{};
-  value_operations<T>::change_val(new_val, 5);
+  value_operations<T>::assign(new_val, 5);
   T expected{};
   T data1{}, data2{}, data3{};
   if (val_default) {
-    value_operations<T>::change_val(data1, new_val);
-    value_operations<T>::change_val(data2, new_val);
-    value_operations<T>::change_val(data3, new_val);
+    value_operations<T>::assign(data1, new_val);
+    value_operations<T>::assign(data2, new_val);
+    value_operations<T>::assign(data3, new_val);
   }
   void* dst_data1 = pointer_helper(data1);
   void* dst_data2 = pointer_helper(data2);
@@ -156,10 +156,10 @@ void run_test_memcpy_from_device_global(util::logger& log,
   auto queue = util::get_cts_object::queue();
 
   if (!val_default) {
-    value_operations<T>::change_val(expected, new_val);
+    value_operations<T>::assign(expected, new_val);
     queue.submit([&](sycl::handler& cgh) {
       cgh.single_task<memcpy_change_dg_kernel<T>>(
-          [=] { value_operations<T>::change_val(dev_global<T>, new_val); });
+          [=] { value_operations<T>::assign(dev_global<T>, new_val); });
     });
     queue.wait_and_throw();
   }

--- a/tests/extension/oneapi_device_global/device_global_queue_memcpy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_memcpy.cpp
@@ -110,11 +110,11 @@ void run_test_memcpy_to_device_global(util::logger& log,
           is_memcpy_corr_buf.template get_access<sycl::access_mode::write>(cgh);
       cgh.single_task<check_memcpy_to_dg_kernel<T>>([=] {
         is_memcpy_corr_acc[0] =
-            value_helper<T>::compare_val(dev_global1<T>, data);
+            value_helper::are_equal<T>(dev_global1<T>, data);
         is_memcpy_corr_acc[0] &=
-            value_helper<T>::compare_val(dev_global2<T>, data);
+            value_helper::are_equal<T>(dev_global2<T>, data);
         is_memcpy_corr_acc[0] &=
-            value_helper<T>::compare_val(dev_global3<T>, data);
+            value_helper::are_equal<T>(dev_global3<T>, data);
       });
     });
     queue.wait_and_throw();
@@ -213,9 +213,9 @@ void run_test_memcpy_from_device_global(util::logger& log,
          "Memcpy overloads from device_global didn't wait for depEvents to "
          "complete");
 
-  if (!value_helper<T>::compare_val(data1, expected) ||
-      !value_helper<T>::compare_val(data2, expected) ||
-      !value_helper<T>::compare_val(data3, expected)) {
+  if (!value_helper::are_equal<T>(data1, expected) ||
+      !value_helper::are_equal<T>(data2, expected) ||
+      !value_helper::are_equal<T>(data3, expected)) {
     FAIL(log, get_case_description(
                   "Overloads of sycl::queue::memcpy for device_global",
                   "Didn't copy correct data from device_global", type_name));

--- a/tests/reduction/reduction_without_identity_param_common.h
+++ b/tests/reduction/reduction_without_identity_param_common.h
@@ -283,7 +283,7 @@ void run_test_for_all_reductions_types(FunctorT functor, RangeT &range,
                                        sycl::queue &queue,
                                        sycl_cts::util::logger &log,
                                        const std::string &type_name) {
-  if constexpr (is_cl_float_type<VariableT>::value &&
+  if constexpr (is_sycl_floating_point<VariableT>::value &&
                 (std::is_same<FunctorT, sycl::bit_and<VariableT>>::value ||
                  std::is_same<FunctorT, sycl::bit_or<VariableT>>::value ||
                  std::is_same<FunctorT, sycl::bit_xor<VariableT>>::value)) {

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -50,14 +50,6 @@ using has_atomic_support = contains<T, int, unsigned int, long, unsigned long,
  * @brief Checks whether T is a floating-point sycl type
  */
 template <typename T>
-using is_cl_float_type =
-    std::bool_constant<std::is_floating_point<T>::value ||
-                       std::is_same<sycl::half, T>::value ||
-                       std::is_same<sycl::cl_float, T>::value ||
-                       std::is_same<sycl::cl_double, T>::value ||
-                       std::is_same<sycl::cl_half, T>::value>;
-
-template <typename T>
 using is_sycl_floating_point =
     std::bool_constant<std::is_floating_point_v<T> ||
                        std::is_same_v<T, sycl::half>>;

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -10,8 +10,8 @@
 #define __SYCLCTS_UTIL_TYPE_TRAITS_H
 
 #include <climits>
-#include <type_traits>
 #include <sycl/sycl.hpp>
+#include <type_traits>
 
 namespace {
 
@@ -84,6 +84,30 @@ template <typename T>
 struct to_string<T, std::void_t<decltype(T::to_string())>> : std::true_type {};
 
 }  // namespace has_static_member
+
+/**
+ * @brief Verify \c T has subscript subscript operator
+ */
+template <typename T, typename = void>
+struct has_subscript_operator : std::false_type {};
+
+template <typename T>
+struct has_subscript_operator<
+    T, std::void_t<decltype(std::declval<T>()[std::declval<size_t>()])>>
+    : std::true_type {};
+
+/**
+ * @brief Shortcut for has_subscript_operator::type
+ */
+template <typename T>
+using has_subscript_operator_t = typename has_subscript_operator<T>::type;
+
+/**
+ * @brief Shortcut for has_subscript_operator::value
+ */
+template <typename T>
+inline constexpr bool has_subscript_operator_v =
+    has_subscript_operator_t<T>::value;
 
 }  // namespace
 


### PR DESCRIPTION
As we already have `value_helper` in `device_global` and in #318, we can move functions for modifying and comparing values to separate file to reuse them in existing tests and future tests.

Depends on:
- #322 