### PR TITLE
Update return type for get_native_mem() per SYCL 2020

### DIFF
--- a/ci/dpcpp.filter
+++ b/ci/dpcpp.filter
@@ -1,6 +1,5 @@
 buffer
 exceptions
-host_task
 math_builtin_api
 multi_ptr
 reduction

--- a/tests/host_task/host_task_interop_api.cpp
+++ b/tests/host_task/host_task_interop_api.cpp
@@ -103,8 +103,9 @@ class TEST_NAME : public sycl_cts::util::test_base {
           auto buf_acc_dev{buf.get_access<sycl::access_mode::read_write>(cgh)};
           cgh.host_task([=](sycl::interop_handle ih) {
             cl_command_queue native_queue = ih.get_native_queue();
-            cl_mem native_mem = ih.get_native_mem(buf_acc_dev);
-            call_opencl(native_queue, native_mem, size, pattern);
+            std::vector<cl_mem> native_mems = ih.get_native_mem(buf_acc_dev);
+            for (auto native_mem : native_mems)
+              call_opencl(native_queue, native_mem, size, pattern);
           });
         });
 


### PR DESCRIPTION
Per "C.6. Interoperability with the OpenCL API" of the SYCL 2020
specification native type for sycl::buffer is std::vector<cl_mem>.

Update test accordingly.

Signed-off-by: Artur Gainullin <artur.gainullin@intel.com>