### PR TITLE
Add section name builder

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -51,22 +51,6 @@ struct StringMaker<accessor_tests_common::accessor_type> {
     }
   }
 };
-
-template <>
-struct StringMaker<sycl::target> {
-  using type = sycl::target;
-  static std::string convert(type value) {
-    switch (value) {
-      case type::device:
-        return "target::device";
-      case type::host_task:
-        return "target::host_task";
-      default:
-        // no stringification for deprecated ones
-        return "unknown target";
-    }
-  }
-};
 }  // namespace Catch
 
 namespace accessor_tests_common {

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -11,12 +11,11 @@
 
 #include "../../util/sycl_exceptions.h"
 #include "../common/common.h"
+#include "../common/section_name_builder.h"
 #include "../common/type_coverage.h"
 #include "../common/value_operations.h"
 
 #include <catch2/matchers/catch_matchers.hpp>
-#include <sstream>
-#include <utility>
 
 namespace accessor_tests_common {
 using namespace sycl_cts;
@@ -89,47 +88,6 @@ struct StringMaker<sycl::target> {
 }  // namespace Catch
 
 namespace accessor_tests_common {
-/**
- * @brief Builder for a section name with the fluent interface
- * @details Be aware that Catch2 doesn't support nested sections with the same
- *          name, see https://github.com/catchorg/Catch2/issues/816 for details.
- *          So if you see
- *              Assertion `m_parent' failed.
- *          that's probably the case.
- */
-class section_name {
-  std::string m_description;
-  std::ostringstream m_parameters;
-
- public:
-  section_name(const section_name& other)
-      : m_description(other.m_description),
-        m_parameters(other.m_parameters.str()) {}
-
-  // Avoid implicit move constructor removal
-  section_name(section_name&& other) = default;
-
-  section_name(const std::string& description) : m_description(description) {}
-
-  template <typename T>
-  section_name& with(const std::string& name, T&& value) {
-    m_parameters << ' ' << name << ": "
-                 << Catch::StringMaker<T>::convert(std::forward<T>(value))
-                 << ',';
-    return *this;
-  }
-
-  std::string create() const {
-    std::string result(m_description);
-
-    const auto parameters = m_parameters.str();
-    if (!parameters.empty()) {
-      // remove last comma and re-use first space from parameters
-      result += " with" + parameters + "\b \b";
-    }
-    return result;
-  }
-};
 
 /**
  * @brief Function helps to get string section name that will contain template

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -53,24 +53,6 @@ struct StringMaker<accessor_tests_common::accessor_type> {
 };
 
 template <>
-struct StringMaker<sycl::access_mode> {
-  using type = sycl::access_mode;
-  static std::string convert(type value) {
-    switch (value) {
-      case type::read:
-        return "access_mode::read";
-      case type::write:
-        return "access_mode::write";
-      case type::read_write:
-        return "access_mode::read_write";
-      default:
-        // no stringification for deprecated ones
-        return "unknown access mode";
-    }
-  }
-};
-
-template <>
 struct StringMaker<sycl::target> {
   using type = sycl::target;
   static std::string convert(type value) {

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -15,6 +15,7 @@
 #include "../common/value_operations.h"
 
 #include <catch2/matchers/catch_matchers.hpp>
+#include <sstream>
 #include <utility>
 
 namespace accessor_tests_common {

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -109,11 +109,7 @@ class section_name {
   // Avoid implicit move constructor removal
   section_name(section_name&& other) = default;
 
-  section_name(const std::string& description) : m_description(description) {
-    if (m_description.empty()) {
-      m_description = "run";
-    }
-  }
+  section_name(const std::string& description) : m_description(description) {}
 
   template <typename T>
   section_name& with(const std::string& name, T&& value) {
@@ -124,12 +120,12 @@ class section_name {
   }
 
   std::string create() const {
-    std::string result("Test " + m_description);
+    std::string result(m_description);
 
     const auto parameters = m_parameters.str();
     if (!parameters.empty()) {
-      // remove last comma
-      result += " with " + parameters + "\b \b";
+      // remove last comma and re-use first space from parameters
+      result += " with" + parameters + "\b \b";
     }
     return result;
   }

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -15,6 +15,7 @@
 #include "../common/value_operations.h"
 
 #include <catch2/matchers/catch_matchers.hpp>
+#include <utility>
 
 namespace accessor_tests_common {
 using namespace sycl_cts;
@@ -30,6 +31,107 @@ enum class accessor_type {
                      // spec)
   local_accessor,
   host_accessor,
+};
+}  // namespace accessor_tests_common
+
+namespace Catch {
+template <>
+struct StringMaker<accessor_tests_common::accessor_type> {
+  using type = accessor_tests_common::accessor_type;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::generic_accessor:
+        return "sycl::accessor";
+      case type::local_accessor:
+        return "sycl::local_accessor";
+      case type::host_accessor:
+        return "sycl::host_accessor";
+      default:
+        return "unknown accessor type";
+    }
+  }
+};
+
+template <>
+struct StringMaker<sycl::access_mode> {
+  using type = sycl::access_mode;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::read:
+        return "access_mode::read";
+      case type::write:
+        return "access_mode::write";
+      case type::read_write:
+        return "access_mode::read_write";
+      default:
+        // no stringification for deprecated ones
+        return "unknown access mode";
+    }
+  }
+};
+
+template <>
+struct StringMaker<sycl::target> {
+  using type = sycl::target;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::device:
+        return "target::device";
+      case type::host_task:
+        return "target::host_task";
+      default:
+        // no stringification for deprecated ones
+        return "unknown target";
+    }
+  }
+};
+}  // namespace Catch
+
+namespace accessor_tests_common {
+/**
+ * @brief Builder for a section name with the fluent interface
+ * @details Be aware that Catch2 doesn't support nested sections with the same
+ *          name, see https://github.com/catchorg/Catch2/issues/816 for details.
+ *          So if you see
+ *              Assertion `m_parent' failed.
+ *          that's probably the case.
+ */
+class section_name {
+  std::string m_description;
+  std::ostringstream m_parameters;
+
+ public:
+  section_name(const section_name& other)
+      : m_description(other.m_description),
+        m_parameters(other.m_parameters.str()) {}
+
+  // Avoid implicit move constructor removal
+  section_name(section_name&& other) = default;
+
+  section_name(const std::string& description) : m_description(description) {
+    if (m_description.empty()) {
+      m_description = "run";
+    }
+  }
+
+  template <typename T>
+  section_name& with(const std::string& name, T&& value) {
+    m_parameters << ' ' << name << ": "
+                 << Catch::StringMaker<T>::convert(std::forward<T>(value))
+                 << ',';
+    return *this;
+  }
+
+  std::string create() const {
+    std::string result("Test " + m_description);
+
+    const auto parameters = m_parameters.str();
+    if (!parameters.empty()) {
+      // remove last comma
+      result += " with " + parameters + "\b \b";
+    }
+    return result;
+  }
 };
 
 /**
@@ -48,17 +150,12 @@ inline std::string get_section_name(const std::string& type_name,
                                     const std::string& access_mode_name,
                                     const std::string& target_name,
                                     const std::string& section_description) {
-  std::string name = "Test ";
-  name += section_description;
-  name += " with parameters: <";
-  name += type_name;
-  name += "><";
-  name += access_mode_name;
-  name += "><";
-  name += target_name;
-  name += "><";
-  name += std::to_string(Dimension) + ">";
-  return name;
+  return section_name(section_description)
+      .with("T", type_name)
+      .with("access mode", access_mode_name)
+      .with("target", target_name)
+      .with("dimension", Dimension)
+      .create();
 }
 
 /**
@@ -72,21 +169,33 @@ inline std::string get_section_name(const std::string& type_name,
  * @param section_description String with human-readable description of the test
  * @return std::string String with name for section
  */
-template <int DimensionT>
+template <int Dimension>
 inline std::string get_section_name(const std::string& type_name,
                                     const std::string& access_mode_name,
                                     const std::string& section_description) {
-  using namespace sycl_cts::get_cts_string;
+  return section_name(section_description)
+      .with("T", type_name)
+      .with("access mode", access_mode_name)
+      .with("dimension", Dimension)
+      .create();
+}
 
-  std::string name = "Test ";
-  name += section_description;
-  name += " with parameters: <";
-  name += type_name;
-  name += "><";
-  name += access_mode_name;
-  name += "><";
-  name += std::to_string(DimensionT) + ">";
-  return name;
+/**
+ * @brief Function helps to get string section name that will contain template
+ * parameters and function arguments
+ *
+ * @tparam Dimension Integer representing dimension
+ * @param type_name String with name of the testing type
+ * @param section_description String with human-readable description of the test
+ * @return std::string String with name for section
+ */
+template <int Dimension>
+inline std::string get_section_name(const std::string& type_name,
+                                    const std::string& section_description) {
+  return section_name(section_description)
+      .with("T", type_name)
+      .with("dimension", Dimension)
+      .create();
 }
 
 /**
@@ -135,11 +244,10 @@ inline auto get_lightweight_type_pack() {
  * @brief Factory function for getting type_pack with access modes values
  */
 inline auto get_access_modes() {
-  static const auto access_modes = value_pack<
-      sycl::access_mode, sycl::access_mode::read, sycl::access_mode::write,
-      sycl::access_mode::read_write>::generate_named("access_mode::read",
-                                                     "access_mode::write",
-                                                     "access_mode::read_write");
+  static const auto access_modes =
+      value_pack<sycl::access_mode, sycl::access_mode::read,
+                 sycl::access_mode::write,
+                 sycl::access_mode::read_write>::generate_named();
   return access_modes;
 }
 
@@ -157,8 +265,7 @@ inline auto get_dimensions() {
 inline auto get_targets() {
   static const auto targets =
       value_pack<sycl::target, sycl::target::device,
-                 sycl::target::host_task>::generate_named("target::device",
-                                                          "target::host_task");
+                 sycl::target::host_task>::generate_named();
   return targets;
 }
 

--- a/tests/common/section_name_builder.h
+++ b/tests/common/section_name_builder.h
@@ -1,0 +1,61 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_COMMON_SECTION_NAME_BUILDER_H
+#define __SYCLCTS_TESTS_COMMON_SECTION_NAME_BUILDER_H
+
+#include "string_makers.h"
+
+#include <sstream>
+#include <utility>
+
+namespace sycl_cts {
+
+/**
+ * @brief Builder for a section name with the fluent interface
+ * @details Be aware that Catch2 doesn't support nested sections with the same
+ *          name, see https://github.com/catchorg/Catch2/issues/816 for details.
+ *          So if you see
+ *              "Assertion `m_parent' failed."
+ *          that's probably the case.
+ */
+class section_name {
+  std::string m_description;
+  std::ostringstream m_parameters;
+
+ public:
+  section_name(const section_name& other)
+      : m_description(other.m_description),
+        m_parameters(other.m_parameters.str()) {}
+
+  // Avoid implicit move constructor removal
+  section_name(section_name&& other) = default;
+
+  section_name(const std::string& description) : m_description(description) {}
+
+  template <typename T>
+  section_name& with(const std::string& name, T&& value) {
+    m_parameters << ' ' << name << ": "
+                 << Catch::StringMaker<T>::convert(std::forward<T>(value))
+                 << ',';
+    return *this;
+  }
+
+  std::string create() const {
+    std::string result(m_description);
+
+    const auto parameters = m_parameters.str();
+    if (!parameters.empty()) {
+      // remove last comma and re-use first space from parameters
+      result += " with" + parameters + "\b \b";
+    }
+    return result;
+  }
+};
+
+}  // namespace sycl_cts
+
+#endif  // __SYCLCTS_TESTS_COMMON_SECTION_NAME_BUILDER_H

--- a/tests/common/string_makers.h
+++ b/tests/common/string_makers.h
@@ -26,8 +26,13 @@ struct StringMaker<sycl::access_mode> {
         return "access_mode::write";
       case type::read_write:
         return "access_mode::read_write";
+      case type::discard_write:
+        return "access_mode::discard_write (deprecated)";
+      case type::discard_read_write:
+        return "access_mode::discard_read_write (deprecated)";
+      case type::atomic:
+        return "access_mode::atomic (deprecated)";
       default:
-        // no stringification for deprecated ones
         return "unknown access mode";
     }
   }

--- a/tests/common/string_makers.h
+++ b/tests/common/string_makers.h
@@ -15,6 +15,24 @@
 #include <sycl/sycl.hpp>
 
 namespace Catch {
+template <>
+struct StringMaker<sycl::access_mode> {
+  using type = sycl::access_mode;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::read:
+        return "access_mode::read";
+      case type::write:
+        return "access_mode::write";
+      case type::read_write:
+        return "access_mode::read_write";
+      default:
+        // no stringification for deprecated ones
+        return "unknown access mode";
+    }
+  }
+};
+
 template <int Dimensions>
 struct StringMaker<sycl::id<Dimensions>> {
   static std::string convert(const sycl::id<Dimensions>& id) {

--- a/tests/common/string_makers.h
+++ b/tests/common/string_makers.h
@@ -53,6 +53,32 @@ struct StringMaker<sycl::id<Dimensions>> {
     return ss.str();
   }
 };
+
+template <>
+struct StringMaker<sycl::target> {
+  using type = sycl::target;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::device:
+        return "target::device";
+
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+      case type::host_task:
+        return "target::host_task";
+#endif
+
+      case type::constant_buffer:
+        return "target::constant_buffer (deprecated)";
+      case type::local:
+        return "target::local (deprecated)";
+      case type::host_buffer:
+        return "target::host_buffer (deprecated)";
+      default:
+        return "unknown target";
+    }
+  }
+};
 }  // namespace Catch
 
 #endif  // __SYCLCTS_TESTS_COMMON_STRING_MAKERS_H


### PR DESCRIPTION
Using a builder with fluent interface makes any combination of parameters
explicit and possible. It might be useful for accessor conversion coverage
for example.

The `get_section_name` factory functions are left for backwards compatibility
