### PR TITLE
Move definition of fract to resolve nextafter dependency

### DIFF
--- a/ci/dpcpp.filter
+++ b/ci/dpcpp.filter
@@ -1,6 +1,5 @@
 buffer
 exceptions
 host_task
-math_builtin_api
 multi_ptr
 reduction

--- a/util/math_reference.cpp
+++ b/util/math_reference.cpp
@@ -455,6 +455,19 @@ sycl::half fdim(sycl::half a, sycl::half b) {
 }
 #endif
 
+sycl::half fract(sycl::half a, sycl::half *b) {
+  *b = std::floor(a);
+  return std::fmin(a - *b, nextafter(sycl::half(1.0), sycl::half(0.0)));
+}
+float fract(float a, float *b) {
+  *b = std::floor(a);
+  return std::fmin(a - *b, nextafter(1.0f, 0.0f));
+}
+double fract(double a, double *b) {
+  *b = std::floor(a);
+  return std::fmin(a - *b, nextafter(1.0, 0.0));
+}
+
 float nan(unsigned int a) { return std::nanf(std::to_string(a).c_str()); }
 double nan(unsigned long a) { return std::nan(std::to_string(a).c_str()); }
 double nan(unsigned long long a) { return std::nan(std::to_string(a).c_str()); }

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -867,11 +867,9 @@ sycl::vec<T, N> fmod(sycl::vec<T, N> a, sycl::vec<T, N> b) {
       [](T x, T y) { return fmod(x, y); }, a, b);
 }
 
-template <typename T>
-T fract(T a, T *b) {
-  *b = std::floor(a);
-  return std::fmin(a - *b, nextafter(T(1.0), T(0.0)));
-}
+sycl::half fract(sycl::half a, sycl::half *b);
+float fract(float a, float *b);
+double fract(double a, double *b);
 template <typename T, int N>
 sycl::vec<T, N> fract(sycl::vec<T, N> a, sycl::vec<T, N> *b) {
   sycl::vec<T, N> res;


### PR DESCRIPTION
The definition of fract in the math_reference utils rely on nextafter. nextafter is however not declared for half until later in the header, so these changes move the definitions of fract to the source file, making the declarations of nextafter visible.

This PR also enables math_builtin_api for DPCPP after being disabled in https://github.com/KhronosGroup/SYCL-CTS/pull/341.