### PR TITLE
Add tests for SYCL accessor implicit conversions

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -65,19 +65,17 @@ inline std::string get_section_name(const std::string& type_name,
  * @brief Function helps to get string section name that will contain template
  * parameters and function arguments
  *
- * @tparam DimensionT Integer representing dimension
+ * @tparam Dimension Integer representing dimension
  * @param type_name String with name of the testing type
  * @param access_mode_name String with name of the testing access mode
  * @param target_name String with name of the testing target
  * @param section_description String with human-readable description of the test
  * @return std::string String with name for section
  */
-template <int DimensionT>
+template <int Dimension>
 inline std::string get_section_name(const std::string& type_name,
                                     const std::string& access_mode_name,
                                     const std::string& section_description) {
-  using namespace sycl_cts::get_cts_string;
-
   std::string name = "Test ";
   name += section_description;
   name += " with parameters: <";
@@ -85,7 +83,7 @@ inline std::string get_section_name(const std::string& type_name,
   name += "><";
   name += access_mode_name;
   name += "><";
-  name += std::to_string(DimensionT) + ">";
+  name += std::to_string(Dimension) + ">";
   return name;
 }
 
@@ -286,7 +284,8 @@ void check_def_constructor(GetAccFunctorT get_accessor_functor) {
   sycl::range<1> r(1);
   const size_t conditions_checks_size = 8;
   bool conditions_check[conditions_checks_size]{false};
-  {
+
+  if constexpr (AccType != accessor_type::host_accessor) {
     sycl::buffer res_buf(conditions_check, sycl::range(conditions_checks_size));
 
     queue
@@ -303,6 +302,9 @@ void check_def_constructor(GetAccFunctorT get_accessor_functor) {
           }
         })
         .wait_and_throw();
+  } else {
+    auto acc = get_accessor_functor();
+    check_def_constructor_post_conditions(acc, conditions_check);
   }
 
   for (size_t i = 0; i < conditions_checks_size; i++) {
@@ -347,14 +349,15 @@ void read_write_zero_dim_acc(AccT testing_acc, ResultAccT res_acc) {
  * @tparam GetAccFunctorT Type of functor for accessor creation
  */
 template <accessor_type AccType, typename DataT, sycl::access_mode AccessMode,
-          sycl::target Target, typename GetAccFunctorT>
+          sycl::target Target = sycl::target::device, typename GetAccFunctorT>
 void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor) {
   auto queue = util::get_cts_object::queue();
   sycl::range<1> r(1);
   DataT some_data(expected_val);
 
   bool compare_res = false;
-  {
+
+  if constexpr (AccType != accessor_type::host_accessor) {
     sycl::buffer res_buf(&compare_res, r);
     sycl::buffer<DataT, 1> data_buf(&some_data, r);
 
@@ -374,6 +377,13 @@ void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor) {
           }
         })
         .wait_and_throw();
+  } else {
+    sycl::buffer<DataT, 1> data_buf(&some_data, r);
+    auto acc = get_accessor_functor(data_buf);
+    // Argument for storing result should support subscript operator
+    bool compare_res_arr[1]{false};
+    read_write_zero_dim_acc<DataT, AccessMode>(acc, compare_res_arr);
+    compare_res = compare_res_arr[0];
   }
 
   if constexpr (AccessMode != sycl::access_mode::write) {
@@ -422,14 +432,15 @@ void read_write_acc(AccT testing_acc, ResultAccT res_acc) {
  * @param r Range for accessors buffer
  */
 template <accessor_type AccType, typename DataT, int Dimension,
-          sycl::access_mode AccessMode, sycl::target Target,
-          typename GetAccFunctorT>
+          sycl::access_mode AccessMode,
+          sycl::target Target = sycl::target::device, typename GetAccFunctorT>
 void check_common_constructor(GetAccFunctorT get_accessor_functor,
                               const sycl::range<Dimension> r) {
   auto queue = util::get_cts_object::queue();
   bool compare_res = false;
   DataT some_data(expected_val);
-  {
+
+  if constexpr (AccType != accessor_type::host_accessor) {
     sycl::buffer res_buf(&compare_res, sycl::range(1));
     sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
 
@@ -453,6 +464,13 @@ void check_common_constructor(GetAccFunctorT get_accessor_functor,
           }
         })
         .wait_and_throw();
+  } else {
+    sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
+    auto acc = get_accessor_functor(data_buf);
+    // Argument for storing result should support subscript operator
+    bool compare_res_arr[1]{false};
+    read_write_acc<DataT, Dimension, AccessMode>(acc, compare_res_arr);
+    compare_res = compare_res_arr[0];
   }
 
   if constexpr (AccessMode != sycl::access_mode::write) {

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -539,14 +539,14 @@ void read_write_acc(AccT testing_acc, ResultAccT res_acc) {
  * @tparam Dimension Dimensions of the accessor
  * @tparam AccessMode Access mode of the accessor
  * @tparam Target Target of accessor
- * @tparam GetAccFunctorT Type of functor for accessor creation
  * @param r Range for accessors buffer
+ * @param get_accessor_functor Functor for accessor creation
  */
 template <accessor_type AccType, typename DataT, int Dimension,
           sycl::access_mode AccessMode,
           sycl::target Target = sycl::target::device, typename GetAccFunctorT>
-void check_common_constructor(GetAccFunctorT get_accessor_functor,
-                              const sycl::range<Dimension> r) {
+void check_common_constructor(const sycl::range<Dimension>& r,
+                              GetAccFunctorT get_accessor_functor) {
   auto queue = util::get_cts_object::queue();
   bool compare_res = false;
   DataT some_data(expected_val);
@@ -608,14 +608,14 @@ void check_common_constructor(GetAccFunctorT get_accessor_functor,
  * @tparam Dimension Dimensions of the accessor
  * @tparam AccessMode Access mode of the accessor
  * @tparam Target Target of accessor
- * @tparam GetAccFunctorT Type of functor for accessor creation
  * @param r Range for accessors buffer
+ * @param get_accessor_functor Functor for accessor creation
  */
 template <accessor_type AccType, typename DataT, int Dimension,
           sycl::access_mode AccessMode, sycl::target Target,
           typename GetAccFunctorT>
-void check_placeholder_accessor_exception(GetAccFunctorT get_accessor_functor,
-                                          const sycl::range<Dimension> r) {
+void check_placeholder_accessor_exception(const sycl::range<Dimension>& r,
+                                          GetAccFunctorT get_accessor_functor) {
   auto queue = util::get_cts_object::queue();
   DataT some_data(expected_val);
   bool is_placeholder = false;

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -15,6 +15,8 @@
 #include "../common/value_operations.h"
 
 #include <catch2/matchers/catch_matchers.hpp>
+#include <sstream>
+#include <utility>
 
 namespace accessor_tests_common {
 using namespace sycl_cts;
@@ -30,6 +32,103 @@ enum class accessor_type {
                      // spec)
   local_accessor,
   host_accessor,
+};
+}  // namespace accessor_tests_common
+
+namespace Catch {
+template <>
+struct StringMaker<accessor_tests_common::accessor_type> {
+  using type = accessor_tests_common::accessor_type;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::generic_accessor:
+        return "sycl::accessor";
+      case type::local_accessor:
+        return "sycl::local_accessor";
+      case type::host_accessor:
+        return "sycl::host_accessor";
+      default:
+        return "unknown accessor type";
+    }
+  }
+};
+
+template <>
+struct StringMaker<sycl::access_mode> {
+  using type = sycl::access_mode;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::read:
+        return "access_mode::read";
+      case type::write:
+        return "access_mode::write";
+      case type::read_write:
+        return "access_mode::read_write";
+      default:
+        // no stringification for deprecated ones
+        return "unknown access mode";
+    }
+  }
+};
+
+template <>
+struct StringMaker<sycl::target> {
+  using type = sycl::target;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::device:
+        return "target::device";
+      case type::host_task:
+        return "target::host_task";
+      default:
+        // no stringification for deprecated ones
+        return "unknown target";
+    }
+  }
+};
+}  // namespace Catch
+
+namespace accessor_tests_common {
+/**
+ * @brief Builder for a section name with the fluent interface
+ * @details Be aware that Catch2 doesn't support nested sections with the same
+ *          name, see https://github.com/catchorg/Catch2/issues/816 for details.
+ *          So if you see
+ *              Assertion `m_parent' failed.
+ *          that's probably the case.
+ */
+class section_name {
+  std::string m_description;
+  std::ostringstream m_parameters;
+
+ public:
+  section_name(const section_name& other)
+      : m_description(other.m_description),
+        m_parameters(other.m_parameters.str()) {}
+
+  // Avoid implicit move constructor removal
+  section_name(section_name&& other) = default;
+
+  section_name(const std::string& description) : m_description(description) {}
+
+  template <typename T>
+  section_name& with(const std::string& name, T&& value) {
+    m_parameters << ' ' << name << ": "
+                 << Catch::StringMaker<T>::convert(std::forward<T>(value))
+                 << ',';
+    return *this;
+  }
+
+  std::string create() const {
+    std::string result(m_description);
+
+    const auto parameters = m_parameters.str();
+    if (!parameters.empty()) {
+      // remove last comma and re-use first space from parameters
+      result += " with" + parameters + "\b \b";
+    }
+    return result;
+  }
 };
 
 /**
@@ -48,17 +147,12 @@ inline std::string get_section_name(const std::string& type_name,
                                     const std::string& access_mode_name,
                                     const std::string& target_name,
                                     const std::string& section_description) {
-  std::string name = "Test ";
-  name += section_description;
-  name += " with parameters: <";
-  name += type_name;
-  name += "><";
-  name += access_mode_name;
-  name += "><";
-  name += target_name;
-  name += "><";
-  name += std::to_string(Dimension) + ">";
-  return name;
+  return section_name(section_description)
+      .with("T", type_name)
+      .with("access mode", access_mode_name)
+      .with("target", target_name)
+      .with("dimension", Dimension)
+      .create();
 }
 
 /**
@@ -76,15 +170,11 @@ template <int Dimension>
 inline std::string get_section_name(const std::string& type_name,
                                     const std::string& access_mode_name,
                                     const std::string& section_description) {
-  std::string name = "Test ";
-  name += section_description;
-  name += " with parameters: <";
-  name += type_name;
-  name += "><";
-  name += access_mode_name;
-  name += "><";
-  name += std::to_string(Dimension) + ">";
-  return name;
+  return section_name(section_description)
+      .with("T", type_name)
+      .with("access mode", access_mode_name)
+      .with("dimension", Dimension)
+      .create();
 }
 
 /**
@@ -99,14 +189,10 @@ inline std::string get_section_name(const std::string& type_name,
 template <int Dimension>
 inline std::string get_section_name(const std::string& type_name,
                                     const std::string& section_description) {
-  using namespace sycl_cts::get_cts_string;
-
-  std::string name = "Test ";
-  name += section_description;
-  name += " with parameters: <";
-  name += type_name + "><";
-  name += std::to_string(Dimension) + ">";
-  return name;
+  return section_name(section_description)
+      .with("T", type_name)
+      .with("dimension", Dimension)
+      .create();
 }
 
 /**
@@ -155,11 +241,10 @@ inline auto get_lightweight_type_pack() {
  * @brief Factory function for getting type_pack with access modes values
  */
 inline auto get_access_modes() {
-  static const auto access_modes = value_pack<
-      sycl::access_mode, sycl::access_mode::read, sycl::access_mode::write,
-      sycl::access_mode::read_write>::generate_named("access_mode::read",
-                                                     "access_mode::write",
-                                                     "access_mode::read_write");
+  static const auto access_modes =
+      value_pack<sycl::access_mode, sycl::access_mode::read,
+                 sycl::access_mode::write,
+                 sycl::access_mode::read_write>::generate_named();
   return access_modes;
 }
 
@@ -177,8 +262,7 @@ inline auto get_dimensions() {
 inline auto get_targets() {
   static const auto targets =
       value_pack<sycl::target, sycl::target::device,
-                 sycl::target::host_task>::generate_named("target::device",
-                                                          "target::host_task");
+                 sycl::target::host_task>::generate_named();
   return targets;
 }
 

--- a/tests/accessor/accessor_implicit_conversions.hpp
+++ b/tests/accessor/accessor_implicit_conversions.hpp
@@ -1,0 +1,389 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for SYCL accessor implicit conversions
+//  The main idea is to:
+//  - check if source accessor is convertible to destination accessor
+//  - and re-use generic checks for accessor constructors to verify data remains
+//    valid
+//
+*******************************************************************************/
+#ifndef SYCL_CTS_ACCESSOR_IMPLICIT_CONVERSIONS_H
+#define SYCL_CTS_ACCESSOR_IMPLICIT_CONVERSIONS_H
+
+#include "accessor_common.h"
+
+#include <type_traits>
+
+namespace accessor_implicit_conversions {
+using namespace accessor_tests_common;
+
+namespace detail {
+template <typename SrcAccT, typename DstAccT>
+struct invoke_implicit_conversion {
+  auto operator()(const SrcAccT& srcAcc) const {
+    // We might safely go with returning `srcAcc` parameter as `DstAccT` type,
+    // still better to make it explicit
+    const DstAccT result = srcAcc;
+    return result;
+  }
+};
+
+template <typename AccT>
+struct avoid_implicit_conversion {
+  const AccT& operator()(const AccT& srcAcc) const {
+    // Just forward parameter further with no copy/move constructor call
+    return srcAcc;
+  }
+};
+
+/**
+ * @brief Provide section name builder prototype
+ */
+template <accessor_type AccType, int Dimension>
+struct section_name_prototype {
+  static auto get(const std::string& type_name) {
+    return section_name("implicit conversion for " +
+                        Catch::StringMaker<accessor_type>::convert(AccType))
+        .with("T", type_name)
+        .with("dim", Dimension);
+  }
+};
+}  // namespace detail
+
+/**
+ * @brief Validates implicit conversion within command
+ */
+template <typename DataT, typename DimensionT, typename TargetT>
+class check_conversion_generic {
+  // TODO: refactor into `check_conversion<AccessorT, ...>` with separate
+  // specialization for local accesor once `accessor_tests_common` refactoring
+  // is done
+  static constexpr auto AccType = accessor_type::generic_accessor;
+  static constexpr sycl::target Target = TargetT::value;
+  static constexpr int Dimension = DimensionT::value;
+
+  static_assert(!std::is_const_v<DataT>, "No need to pass const type here");
+  static_assert((Target == sycl::target::host_task) ||
+                    (Target == sycl::target::device),
+                "Unsupported target");
+
+  template <typename SrcDataT, sycl::access_mode SrcAccessMode,
+            typename DstDataT, sycl::access_mode DstAccessMode>
+  void run_check() const {
+    constexpr int BufferDimension = (Dimension == 0) ? 1 : Dimension;
+    using src_accessor_t =
+        sycl::accessor<SrcDataT, Dimension, SrcAccessMode, Target>;
+    using dst_accessor_t =
+        sycl::accessor<DstDataT, Dimension, DstAccessMode, Target>;
+    using src_buffer_t = sycl::buffer<SrcDataT, BufferDimension>;
+
+    constexpr bool has_implicit_conversion_available =
+        std::is_convertible_v<src_accessor_t, dst_accessor_t>;
+
+    // We don't want to fail compilation of entire test every time conversion
+    // is not available for some of accessor template instantiations
+    // So first we check precodition, and only in case of conversion
+    // availability we try to go on with functionality check
+    REQUIRE(has_implicit_conversion_available);
+    // Execution would never pass the 'REQUIRE' call in case there is no
+    // implicit conversion available; still it's better to switch off only
+    // the minimal part of compilation path for better test support
+    using invoke_implicit_conversion_t = std::conditional_t<
+        has_implicit_conversion_available,
+        detail::invoke_implicit_conversion<src_accessor_t, dst_accessor_t>,
+        detail::avoid_implicit_conversion<src_accessor_t>>;
+
+    // We should create source accessor on the host side
+    const auto get_acc_functor = [](src_buffer_t& data_buf,
+                                    sycl::handler& cgh) {
+      const src_accessor_t src_acc(data_buf, cgh);
+      return src_acc;
+    };
+    // Implicit conversion should be verified within command
+    const invoke_implicit_conversion_t modify_acc_functor;
+
+    if constexpr (Dimension == 0) {
+      check_zero_dim_constructor<AccType, SrcDataT, DstAccessMode, Target>(
+          get_acc_functor, modify_acc_functor);
+    } else {
+      const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
+      check_common_constructor<AccType, SrcDataT, Dimension, DstAccessMode,
+                               Target>(r, get_acc_functor, modify_acc_functor);
+    }
+  }
+
+ public:
+  void operator()(const std::string& type_name,
+                  const std::string& target_name) const {
+    const auto make_section_name = [&](sycl::access_mode SrcAccessMode,
+                                       sycl::access_mode DstAccessMode,
+                                       const std::string& details) {
+      return detail::section_name_prototype<AccType, Dimension>::get(type_name)
+          .with("target", Target)
+          .with("source access", SrcAccessMode)
+          .with("destination access", DstAccessMode)
+          .with("case", details)
+          .create();
+    };
+
+    // From read-only accessor to read-only accessor
+    {
+      constexpr auto AccessMode = sycl::access_mode::read;
+
+      SECTION((
+          make_section_name(AccessMode, AccessMode, "from 'T' to 'const T'"))) {
+        using SrcDataT = DataT;
+        using DstDataT = const DataT;
+        run_check<SrcDataT, AccessMode, DstDataT, AccessMode>();
+      }
+      SECTION((
+          make_section_name(AccessMode, AccessMode, "from 'const T' to 'T'"))) {
+        using SrcDataT = const DataT;
+        using DstDataT = DataT;
+        run_check<SrcDataT, AccessMode, DstDataT, AccessMode>();
+      }
+    }
+    // From read-write accessor to read-only accessor
+    {
+      constexpr auto SrcAccessMode = sycl::access_mode::read_write;
+      constexpr auto DstAccessMode = sycl::access_mode::read;
+
+      SECTION((make_section_name(SrcAccessMode, DstAccessMode,
+                                 "from 'T' to 'const T'"))) {
+        using SrcDataT = DataT;
+        using DstDataT = const DataT;
+        run_check<SrcDataT, SrcAccessMode, DstDataT, DstAccessMode>();
+      }
+      SECTION((make_section_name(SrcAccessMode, DstAccessMode,
+                                 "from 'const T' to 'T'"))) {
+        using SrcDataT = const DataT;
+        using DstDataT = DataT;
+        run_check<SrcDataT, SrcAccessMode, DstDataT, DstAccessMode>();
+      }
+    }
+  }
+};
+
+/**
+ * @brief Validates implicit conversion for local accessor
+ */
+template <typename DataT, typename DimensionT>
+class check_conversion_local {
+  static constexpr auto AccType = accessor_type::local_accessor;
+  static constexpr int Dimension = DimensionT::value;
+
+  static_assert(!std::is_const_v<DataT>, "No need to pass const type here");
+
+  template <typename SrcDataT, typename DstDataT>
+  inline void run_check() const {
+    // Workarounds to use generic algorithm
+    constexpr auto Target = sycl::target::device;
+    constexpr auto DstAccessMode = std::is_const_v<DstDataT>
+                                       ? sycl::access_mode::read
+                                       : sycl::access_mode::read_write;
+    constexpr int BufferDimension = (Dimension == 0) ? 1 : Dimension;
+    using src_buffer_t = sycl::buffer<SrcDataT, BufferDimension>;
+    // TODO: Make `check_common_constructor` more generic.
+    // (1) May use `AccType` instead of `Target` to trigger either host_task or
+    // device-side kernel creation within `check_common_constructor`
+    // (2) May use partial specialization of templated class
+    // `check_common_constructor`
+    // (3) May move zero dimension constexpr check into the
+    // `check_common_constructor`
+
+    using src_accessor_t = sycl::local_accessor<SrcDataT, Dimension>;
+    using dst_accessor_t = sycl::local_accessor<DstDataT, Dimension>;
+
+    constexpr bool has_implicit_conversion_available =
+        std::is_convertible_v<src_accessor_t, dst_accessor_t>;
+
+    // Ensure we don't go further in runtime if conversion is unavailable
+    REQUIRE(has_implicit_conversion_available);
+
+    // Still go on with the further compilation to make sure test compiles
+    using invoke_implicit_conversion_t = std::conditional_t<
+        has_implicit_conversion_available,
+        detail::invoke_implicit_conversion<src_accessor_t, dst_accessor_t>,
+        detail::avoid_implicit_conversion<src_accessor_t>>;
+
+    // Implicit conversion should be verified within command
+    const invoke_implicit_conversion_t modify_acc_functor;
+
+    if constexpr (Dimension == 0) {
+      const auto get_acc_functor = [](src_buffer_t&, sycl::handler& cgh) {
+        const src_accessor_t src_acc(cgh);
+        return src_acc;
+      };
+      check_zero_dim_constructor<AccType, SrcDataT, DstAccessMode, Target>(
+          get_acc_functor, modify_acc_functor);
+    } else {
+      const auto get_acc_functor = [](src_buffer_t&, sycl::handler& cgh) {
+        // TODO: Align with `check_common_constructor` API changes in #326
+        const auto range = util::get_cts_object::range<Dimension>::get(1, 1, 1);
+        const src_accessor_t src_acc(range, cgh);
+        return src_acc;
+      };
+      check_common_constructor<AccType, SrcDataT, Dimension, DstAccessMode,
+                               Target>(get_acc_functor, modify_acc_functor);
+    }
+  }
+
+ public:
+  void operator()(const std::string& type_name) const {
+    const auto section_name =
+        detail::section_name_prototype<AccType, Dimension>::get(type_name)
+            .with("case", "conversion from 'T' to 'const T'")
+            .create();
+    SECTION(section_name) { run_check<DataT, const DataT>(); }
+  }
+};
+
+/**
+ * @brief Validates implicit conversion for host accessor
+ */
+template <typename DataT, typename DimensionT>
+class check_conversion_host {
+  static constexpr auto AccType = accessor_type::host_accessor;
+  static constexpr int Dimension = DimensionT::value;
+
+  static_assert(!std::is_const_v<DataT>, "No need to pass const type here");
+
+  template <typename SrcDataT, sycl::access_mode SrcAccessMode,
+            typename DstDataT, sycl::access_mode DstAccessMode>
+  void run_check() const {
+    constexpr int BufferDimension = (Dimension == 0) ? 1 : Dimension;
+    using src_accessor_t =
+        sycl::host_accessor<SrcDataT, Dimension, SrcAccessMode>;
+    using dst_accessor_t =
+        sycl::host_accessor<DstDataT, Dimension, DstAccessMode>;
+    using src_buffer_t = sycl::buffer<SrcDataT, BufferDimension>;
+
+    constexpr bool has_implicit_conversion_available =
+        std::is_convertible_v<src_accessor_t, dst_accessor_t>;
+
+    // We don't want to fail compilation of entire test every time conversion
+    // is not available for some of accessor template instantiations
+    // So first we check precodition, and only in case of conversion
+    // availability we try to go on with functionality check
+    REQUIRE(has_implicit_conversion_available);
+    // Execution would never pass the 'REQUIRE' call in case there is no
+    // implicit conversion available; still it's better to switch off only
+    // the minimal part of compilation path for better test support
+    using invoke_implicit_conversion_t = std::conditional_t<
+        has_implicit_conversion_available,
+        detail::invoke_implicit_conversion<src_accessor_t, dst_accessor_t>,
+        detail::avoid_implicit_conversion<src_accessor_t>>;
+
+    // We should create source accessor on the host side
+    const auto get_acc_functor = [](src_buffer_t& data_buf) {
+      const src_accessor_t src_acc(data_buf);
+      return src_acc;
+    };
+    // Implicit conversion should be verified within command
+    const invoke_implicit_conversion_t modify_acc_functor;
+
+    if constexpr (Dimension == 0) {
+      check_zero_dim_constructor<AccType, SrcDataT, DstAccessMode>(
+          get_acc_functor, modify_acc_functor);
+    } else {
+      const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
+      check_common_constructor<AccType, SrcDataT, Dimension, DstAccessMode>(
+          r, get_acc_functor, modify_acc_functor);
+    }
+  }
+
+ public:
+  void operator()(const std::string& type_name) const {
+    const auto make_section_name = [&](sycl::access_mode SrcAccessMode,
+                                       sycl::access_mode DstAccessMode,
+                                       const std::string& details) {
+      return detail::section_name_prototype<AccType, Dimension>::get(type_name)
+          .with("source access", SrcAccessMode)
+          .with("destination access", DstAccessMode)
+          .with("case", details)
+          .create();
+    };
+
+    // From read-only accessor to read-only accessor
+    {
+      constexpr auto AccessMode = sycl::access_mode::read;
+
+      SECTION((
+          make_section_name(AccessMode, AccessMode, "from 'T' to 'const T'"))) {
+        using SrcDataT = DataT;
+        using DstDataT = const DataT;
+        run_check<SrcDataT, AccessMode, DstDataT, AccessMode>();
+      }
+      SECTION((
+          make_section_name(AccessMode, AccessMode, "from 'const T' to 'T'"))) {
+        using SrcDataT = const DataT;
+        using DstDataT = DataT;
+        run_check<SrcDataT, AccessMode, DstDataT, AccessMode>();
+      }
+    }
+    // From read-write accessor to read-only accessor
+    {
+      constexpr auto SrcAccessMode = sycl::access_mode::read_write;
+      constexpr auto DstAccessMode = sycl::access_mode::read;
+
+      SECTION((make_section_name(SrcAccessMode, DstAccessMode,
+                                 "from 'T' to 'const T'"))) {
+        using SrcDataT = DataT;
+        using DstDataT = const DataT;
+        run_check<SrcDataT, SrcAccessMode, DstDataT, DstAccessMode>();
+      }
+      SECTION((make_section_name(SrcAccessMode, DstAccessMode,
+                                 "from 'const T' to 'T'"))) {
+        using SrcDataT = const DataT;
+        using DstDataT = DataT;
+        run_check<SrcDataT, SrcAccessMode, DstDataT, DstAccessMode>();
+      }
+    }
+  }
+};
+
+/**
+ * @brief Run tests for generic sycl::accessor
+ * @detail A wrapper around for_all_combinations call to make possible extended
+ *         type coverage - e.g. vectors and marrays
+ */
+template <typename DataT>
+struct run_test_generic {
+  void operator()(const std::string& type_name) {
+    // TODO: make for_all_combinations recognize non-const type packs
+    const auto dimensions = get_dimensions();
+    const auto targets = get_targets();
+
+    for_all_combinations<check_conversion_generic, DataT>(dimensions, targets,
+                                                          type_name);
+  }
+};
+
+/**
+ * @brief Run tests for sycl::local_accessor
+ */
+template <typename DataT>
+struct run_test_local {
+  void operator()(const std::string& type_name) {
+    const auto dimensions = get_dimensions();
+
+    for_all_combinations<check_conversion_local, DataT>(dimensions, type_name);
+  }
+};
+
+/**
+ * @brief Run tests for sycl::host_accessor
+ */
+template <typename DataT>
+struct run_test_host {
+  void operator()(const std::string& type_name) {
+    const auto dimensions = get_dimensions();
+
+    for_all_combinations<check_conversion_host, DataT>(dimensions, type_name);
+  }
+};
+
+}  // namespace accessor_implicit_conversions
+#endif  // SYCL_CTS_ACCESSOR_IMPLICIT_CONVERSIONS_H

--- a/tests/accessor/accessor_implicit_conversions_core.cpp
+++ b/tests/accessor/accessor_implicit_conversions_core.cpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for accessor implicit conversions for core types
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "accessor_implicit_conversions.hpp"
+
+namespace accessor_implicit_conversions_core {
+using namespace accessor_implicit_conversions;
+}  // namespace accessor_implicit_conversions_core
+
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace accessor_implicit_conversions_core {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("Generic sycl::accessor implicit conversion. core types",
+ "[accessor][generic_accessor][conversion][core]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  const auto types = get_lightweight_type_pack();
+#else
+  const auto types = get_full_conformance_type_pack();
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+
+  for_all_types_vectors_marray<run_test_generic>(types);
+});
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("The sycl::local_accessor implicit conversion. core types",
+ "[accessor][local_accessor][conversion][core]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  const auto types = get_lightweight_type_pack();
+#else
+  const auto types = get_full_conformance_type_pack();
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+
+  for_all_types_vectors_marray<run_test_local>(types);
+});
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("The sycl::host_accessor implicit conversion. core types",
+ "[accessor][host_accessor][conversion][core]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  const auto types = get_lightweight_type_pack();
+#else
+  const auto types = get_full_conformance_type_pack();
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+
+  for_all_types_vectors_marray<run_test_host>(types);
+});
+
+}  // namespace accessor_implicit_conversions_core

--- a/tests/accessor/accessor_implicit_conversions_fp16.cpp
+++ b/tests/accessor/accessor_implicit_conversions_fp16.cpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for accessor implicit conversions for the sycl::half type
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "accessor_implicit_conversions.hpp"
+
+namespace accessor_implicit_conversions_fp16 {
+using namespace accessor_implicit_conversions;
+}  // namespace accessor_implicit_conversions_fp16
+
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace accessor_implicit_conversions_fp16 {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("Generic sycl::accessor implicit conversion. fp16 type",
+ "[accessor][generic_accessor][conversion][fp16]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    WARN("Device does not support half precision floating point operations");
+    return;
+  }
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  run_test_generic<sycl::half>{}("sycl::half");
+#else
+  // TODO: implement factory functions for extending type packs and remove
+  //       for_all_types/for_type_and_vectors/for_all_types_and_vectors/
+  //       for_type_vectors_marray/for_all_types_vectors_marray/
+  //       for_type_and_marrays/for_all_types_and_marrays/etc.
+  // As result, it would be possible to use for_all_combinations once per test
+  // with no wrappers at all, providing any combination of type coverage
+  // Specifically for this use case:
+  //  - there would be no need in run_implicit_conversion_test wrapper
+  //  - we could easily provide coverage for any additional fp16 type with no
+  //    need in further wrappers
+  //  - we could easily enable additional dependant types coverage with no
+  //    need in further wrappers
+  // For example:
+  //    enum class tcov : unsigned long long { ...
+  //
+  //    const auto types = get_fp16_types<tcov::scalar | tcov::marray |
+  //                                      tcov::vector | tcov::variant>();
+  //    for_all_combinations<test_conversion_within_command>(
+  //        types, targets, dimensions);
+  //
+  for_type_vectors_marray<run_test_generic, sycl::half>("sycl::half");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+});
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("The sycl::local_accessor implicit conversion. fp16 type",
+ "[accessor][local_accessor][conversion][fp16]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    WARN("Device does not support half precision floating point operations");
+    return;
+  }
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  run_test_local<sycl::half>{}("sycl::half");
+#else
+  for_type_vectors_marray<run_test_local, sycl::half>("sycl::half");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+});
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("The sycl::host_accessor implicit conversion. fp16 type",
+ "[accessor][host_accessor][conversion][fp16]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    WARN("Device does not support half precision floating point operations");
+    return;
+  }
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  run_test_host<sycl::half>{}("sycl::half");
+#else
+  for_type_vectors_marray<run_test_host, sycl::half>("sycl::half");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+});
+
+}  // namespace accessor_implicit_conversions_fp16

--- a/tests/accessor/accessor_implicit_conversions_fp64.cpp
+++ b/tests/accessor/accessor_implicit_conversions_fp64.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for accessor implicit conversions for the double type
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "accessor_implicit_conversions.hpp"
+
+namespace accessor_implicit_conversions_fp64 {
+using namespace accessor_implicit_conversions;
+}  // namespace accessor_implicit_conversions_fp64
+
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace accessor_implicit_conversions_fp64 {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("Generic sycl::accessor implicit conversion. fp64 type",
+ "[accessor][generic_accessor][conversion][fp64]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    WARN("Device does not support double precision floating point operations");
+    return;
+  }
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  run_test_generic<double>{}("double");
+#else
+  for_type_vectors_marray<run_test_generic, double>("double");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+});
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("The sycl::local_accessor implicit conversion. fp64 type",
+ "[accessor][local_accessor][conversion][fp64]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    WARN("Device does not support double precision floating point operations");
+    return;
+  }
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  run_test_local<double>{}("double");
+#else
+  for_type_vectors_marray<run_test_local, double>("double");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+});
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("The sycl::host_accessor implicit conversion. fp64 type",
+ "[accessor][host_accessor][conversion][fp64]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    WARN("Device does not support double precision floating point operations");
+    return;
+  }
+
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  run_test_host<double>{}("double");
+#else
+  for_type_vectors_marray<run_test_host, double>("double");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+});
+
+}  // namespace accessor_implicit_conversions_fp64

--- a/tests/accessor/generic_accessor_constructors.hpp
+++ b/tests/accessor/generic_accessor_constructors.hpp
@@ -69,7 +69,7 @@ void test_common_buffer_constructors(const std::string& type_name,
                                                                   cgh);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name =
@@ -83,7 +83,7 @@ void test_common_buffer_constructors(const std::string& type_name,
                                                                   r);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name =
@@ -97,7 +97,7 @@ void test_common_buffer_constructors(const std::string& type_name,
                                                                   r, offset);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 }
 
@@ -120,7 +120,7 @@ void test_common_buffer_constructors_tag_t_deduction(
       return sycl::accessor(data_buf, cgh, tag);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -133,7 +133,7 @@ void test_common_buffer_constructors_tag_t_deduction(
       return sycl::accessor(data_buf, cgh, r, tag);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name =
@@ -148,7 +148,7 @@ void test_common_buffer_constructors_tag_t_deduction(
       return sycl::accessor(data_buf, cgh, r, offset, tag);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 }
 
@@ -170,7 +170,7 @@ void test_placeholder_constructors(const std::string& type_name,
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -183,7 +183,7 @@ void test_placeholder_constructors(const std::string& type_name,
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, r);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -197,7 +197,7 @@ void test_placeholder_constructors(const std::string& type_name,
                                                                   offset);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode, Target>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 }
 
@@ -218,7 +218,7 @@ void test_placeholder_accessors_exception(const std::string& type_name,
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf);
     };
     check_placeholder_accessor_exception<AccType, DataT, Dimension, AccessMode,
-                                         Target>(get_acc_functor, r);
+                                         Target>(r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -230,7 +230,7 @@ void test_placeholder_accessors_exception(const std::string& type_name,
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, r);
     };
     check_placeholder_accessor_exception<AccType, DataT, Dimension, AccessMode,
-                                         Target>(get_acc_functor, r);
+                                         Target>(r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -244,7 +244,7 @@ void test_placeholder_accessors_exception(const std::string& type_name,
                                                                   offset);
     };
     check_placeholder_accessor_exception<AccType, DataT, Dimension, AccessMode,
-                                         Target>(get_acc_functor, r);
+                                         Target>(r, get_acc_functor);
   }
 }
 

--- a/tests/accessor/host_accessor_constructors.h
+++ b/tests/accessor/host_accessor_constructors.h
@@ -60,7 +60,7 @@ void test_common_buffer_constructors(const std::string& access_mode_name,
       return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -71,7 +71,7 @@ void test_common_buffer_constructors(const std::string& access_mode_name,
       return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -84,7 +84,7 @@ void test_common_buffer_constructors(const std::string& access_mode_name,
                                                                offset);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 }
 
@@ -103,7 +103,7 @@ void test_common_buffer_constructors_tag_t_deduction(
       return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, tagT);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -115,7 +115,7 @@ void test_common_buffer_constructors_tag_t_deduction(
       return sycl::host_accessor(data_buf, r, tagT);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 
   section_name =
@@ -129,7 +129,7 @@ void test_common_buffer_constructors_tag_t_deduction(
       return sycl::host_accessor(data_buf, r, offset, tagT);
     };
     check_common_constructor<AccType, DataT, Dimension, AccessMode>(
-        get_acc_functor, r);
+        r, get_acc_functor);
   }
 }
 

--- a/tests/accessor/host_accessor_constructors.h
+++ b/tests/accessor/host_accessor_constructors.h
@@ -1,0 +1,179 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::host_accessor constructors
+//
+*******************************************************************************/
+#ifndef SYCL_CTS_HOST_ACCESSOR_CONSTRUCTORS_H
+#define SYCL_CTS_HOST_ACCESSOR_CONSTRUCTORS_H
+#include "catch2/catch_test_macros.hpp"
+
+#include "accessor_common.h"
+
+namespace host_accessor_constructors {
+using namespace sycl_cts;
+using namespace accessor_tests_common;
+
+constexpr accessor_type AccType = accessor_type::host_accessor;
+
+template <typename DataT, int Dimension, sycl::access_mode AccessMode>
+void test_default_constructor(const std::string& access_mode_name,
+                              const std::string& type_name) {
+  const auto section_name = get_section_name<Dimension>(
+      type_name, access_mode_name, "Default constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = []() {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>();
+    };
+    check_def_constructor<AccType, DataT, Dimension, AccessMode>(
+        get_acc_functor);
+  }
+}
+
+template <typename DataT, sycl::access_mode AccessMode>
+void test_zero_dimension_buffer_constructor(const std::string& access_mode_name,
+                                            const std::string& type_name) {
+  const auto section_name = get_section_name<0>(type_name, access_mode_name,
+                                                "Zero dimension constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [](sycl::buffer<DataT, 1> data_buf) {
+      return sycl::host_accessor<DataT, 0, AccessMode>(data_buf);
+    };
+    check_zero_dim_constructor<AccType, DataT, AccessMode>(get_acc_functor);
+  }
+}
+
+template <typename DataT, int Dimension, sycl::access_mode AccessMode>
+void test_common_buffer_constructors(const std::string& access_mode_name,
+                                     const std::string& type_name) {
+  const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
+  const auto offset = sycl::id<Dimension>();
+
+  auto section_name = get_section_name<Dimension>(type_name, access_mode_name,
+                                                  "From buffer constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [](sycl::buffer<DataT, Dimension> data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf);
+    };
+    check_common_constructor<AccType, DataT, Dimension, AccessMode>(
+        get_acc_functor, r);
+  }
+
+  section_name = get_section_name<Dimension>(
+      type_name, access_mode_name, "From buffer and range constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [r](sycl::buffer<DataT, Dimension> data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r);
+    };
+    check_common_constructor<AccType, DataT, Dimension, AccessMode>(
+        get_acc_functor, r);
+  }
+
+  section_name = get_section_name<Dimension>(
+      type_name, access_mode_name, "From buffer,range and offset constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [r,
+                            offset](sycl::buffer<DataT, Dimension> data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r,
+                                                               offset);
+    };
+    check_common_constructor<AccType, DataT, Dimension, AccessMode>(
+        get_acc_functor, r);
+  }
+}
+
+template <typename DataT, int Dimension, sycl::access_mode AccessMode>
+void test_common_buffer_constructors_tag_t_deduction(
+    const std::string& access_mode_name, const std::string& type_name) {
+  const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
+  const auto offset = sycl::id<Dimension>();
+  auto tagT = tag_factory<AccType>::get_tag<AccessMode>();
+
+  auto section_name = get_section_name<Dimension>(
+      type_name, access_mode_name, "TagT deduction from buffer constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [tagT](sycl::buffer<DataT, Dimension> data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, tagT);
+    };
+    check_common_constructor<AccType, DataT, Dimension, AccessMode>(
+        get_acc_functor, r);
+  }
+
+  section_name = get_section_name<Dimension>(
+      type_name, access_mode_name,
+      "TagT deduction from buffer and range constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [r, tagT](sycl::buffer<DataT, Dimension> data_buf) {
+      return sycl::host_accessor(data_buf, r, tagT);
+    };
+    check_common_constructor<AccType, DataT, Dimension, AccessMode>(
+        get_acc_functor, r);
+  }
+
+  section_name =
+      get_section_name<Dimension>(type_name, access_mode_name,
+                                  "TagT deduction from buffer,range and "
+                                  "offset constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [r, offset,
+                            tagT](sycl::buffer<DataT, Dimension> data_buf) {
+      return sycl::host_accessor(data_buf, r, offset, tagT);
+    };
+    check_common_constructor<AccType, DataT, Dimension, AccessMode>(
+        get_acc_functor, r);
+  }
+}
+
+template <typename T, typename AccessModeT, typename DimensionT>
+class run_tests_constructors {
+  static constexpr sycl::access_mode AccessMode = AccessModeT::value;
+  static constexpr int Dimension = DimensionT::value;
+
+ public:
+  void operator()(const std::string& type_name,
+                  const std::string& access_mode_name) {
+    test_zero_dimension_buffer_constructor<T, AccessMode>(access_mode_name,
+                                                          type_name);
+    test_default_constructor<T, Dimension, AccessMode>(access_mode_name,
+                                                       type_name);
+    test_common_buffer_constructors<T, Dimension, AccessMode>(access_mode_name,
+                                                              type_name);
+    test_common_buffer_constructors_tag_t_deduction<T, Dimension, AccessMode>(
+        access_mode_name, type_name);
+  }
+};
+
+template <typename T>
+class run_host_constructors_test {
+ public:
+  void operator()(const std::string& type_name) {
+    // Type packs instances have to be const, otherwise for_all_combination will
+    // not compile
+    const auto access_modes = get_access_modes();
+    const auto dimensions = get_dimensions();
+
+    for_all_combinations<run_tests_constructors, T>(access_modes, dimensions,
+                                                    type_name);
+
+    // For covering const types
+    const auto const_type_name = std::string("const ") + type_name;
+    // const T can be only with access_mode::read
+    const auto read_only_acc_mode =
+        value_pack<sycl::access_mode, sycl::access_mode::read>::generate_named(
+            "access_mode::read");
+    for_all_combinations<run_tests_constructors, const T>(
+        read_only_acc_mode, dimensions, const_type_name);
+  }
+};
+}  // namespace host_accessor_constructors
+
+#endif  // SYCL_CTS_HOST_ACCESSOR_CONSTRUCTORS_H

--- a/tests/accessor/host_accessor_constructors_core.cpp
+++ b/tests/accessor/host_accessor_constructors_core.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides host_accessor constructors test for generic types
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::host_accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "host_accessor_constructors.h"
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace host_accessor_constructors_core {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("sycl::host_accessor constructors. core types", "[accessor]")({
+  using namespace host_accessor_constructors;
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  const auto types = get_lightweight_type_pack();
+#else
+  const auto types = get_full_conformance_type_pack();
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  for_all_types_vectors_marray<run_host_constructors_test>(types);
+});
+
+}  // namespace host_accessor_constructors_core

--- a/tests/accessor/host_accessor_constructors_fp16.cpp
+++ b/tests/accessor/host_accessor_constructors_fp16.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides host_accessor constructors test for the sycl::half type
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::host_accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "host_accessor_constructors.h"
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace host_accessor_constructors_fp16 {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("sycl::host_accessor constructors. fp16 type", "[accessor]")({
+  using namespace host_accessor_constructors;
+  auto queue = sycl_cts::util::get_cts_object::queue();
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  run_host_constructors_test<sycl::half>{}("sycl::half");
+#else
+  for_type_vectors_marray<run_host_constructors_test, sycl::half>("sycl::half");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+});
+}  // namespace host_accessor_constructors_fp16

--- a/tests/accessor/host_accessor_constructors_fp64.cpp
+++ b/tests/accessor/host_accessor_constructors_fp64.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides host_accessor constructors test for the double type
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::host_accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "host_accessor_constructors.h"
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace host_accessor_constructors_fp64 {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("sycl::host_accessor constructors. fp64 type", "[accessor]")({
+  using namespace host_accessor_constructors;
+  auto queue = sycl_cts::util::get_cts_object::queue();
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  run_host_constructors_test<double>{}("double");
+#else
+  for_type_vectors_marray<run_host_constructors_test, double>("double");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+})
+}  // namespace host_accessor_constructors_fp64

--- a/tests/accessor/local_accessor_constructors.h
+++ b/tests/accessor/local_accessor_constructors.h
@@ -1,0 +1,114 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for sycl::local_accessor constructors
+//
+*******************************************************************************/
+#ifndef SYCL_CTS_LOCAL_ACCESSOR_H
+#define SYCL_CTS_LOCAL_ACCESSOR_H
+#include "catch2/catch_test_macros.hpp"
+
+#include "accessor_common.h"
+
+namespace local_accessor_constructors {
+using namespace sycl_cts;
+using namespace accessor_tests_common;
+
+constexpr accessor_type AccType = accessor_type::local_accessor;
+
+template <typename DataT, int Dimension>
+void test_default_constructor(const std::string& type_name) {
+  const auto section_name =
+      get_section_name<Dimension>(type_name, "Default constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [] {
+      return sycl::local_accessor<DataT, Dimension>();
+    };
+    if constexpr (std::is_const_v<DataT>) {
+      check_def_constructor<AccType, DataT, Dimension, sycl::access_mode::read,
+                            sycl::target::device>(get_acc_functor);
+    } else {
+      check_def_constructor<AccType, DataT, Dimension,
+                            sycl::access_mode::read_write,
+                            sycl::target::device>(get_acc_functor);
+    }
+  }
+}
+
+template <typename DataT>
+void test_zero_dimension_buffer_constructor(const std::string& type_name) {
+  const auto section_name =
+      get_section_name<0>(type_name, "Zero dimension constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [](sycl::buffer<DataT, 1>& data_buf,
+                              sycl::handler& cgh) {
+      return sycl::local_accessor<DataT, 0>(cgh);
+    };
+    if constexpr (std::is_const_v<DataT>) {
+      check_zero_dim_constructor<AccType, DataT, sycl::access_mode::read,
+                                 sycl::target::device>(get_acc_functor);
+    } else {
+      check_zero_dim_constructor<AccType, DataT, sycl::access_mode::read_write,
+                                 sycl::target::device>(get_acc_functor);
+    }
+  }
+}
+
+template <typename DataT, int Dimension>
+void test_common_constructors(const std::string& type_name) {
+  const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
+  const auto offset = sycl::id<Dimension>();
+
+  auto section_name =
+      get_section_name<Dimension>(type_name, "From sycl::range constructor");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [r](sycl::buffer<DataT, Dimension>& data_buf,
+                               sycl::handler& cgh) {
+      return sycl::local_accessor<DataT, Dimension>(r, cgh);
+    };
+    if constexpr (std::is_const_v<DataT>) {
+      check_common_constructor<AccType, DataT, Dimension,
+                               sycl::access_mode::read, sycl::target::device>(
+          get_acc_functor, r);
+    } else {
+      check_common_constructor<AccType, DataT, Dimension,
+                               sycl::access_mode::read_write,
+                               sycl::target::device>(get_acc_functor, r);
+    }
+  }
+}
+
+template <typename T, typename DimensionT>
+class run_tests_constructors {
+  static constexpr int Dimension = DimensionT::value;
+
+ public:
+  void operator()(const std::string& type_name) {
+    test_zero_dimension_buffer_constructor<T>(type_name);
+    test_default_constructor<T, Dimension>(type_name);
+    test_common_constructors<T, Dimension>(type_name);
+  }
+};
+
+template <typename T>
+class run_local_constructors_test {
+ public:
+  void operator()(const std::string& type_name) {
+    // Type packs instances have to be const, otherwise for_all_combination will
+    // not compile
+    const auto dimensions = get_dimensions();
+
+    for_all_combinations<run_tests_constructors, T>(dimensions, type_name);
+
+    // For covering const types
+    const auto const_type_name = std::string("const ") + type_name;
+    for_all_combinations<run_tests_constructors, const T>(dimensions,
+                                                          const_type_name);
+  }
+};
+}  // namespace local_accessor_constructors
+#endif  // SYCL_CTS_LOCAL_ACCESSOR_H

--- a/tests/accessor/local_accessor_constructors.h
+++ b/tests/accessor/local_accessor_constructors.h
@@ -73,11 +73,11 @@ void test_common_constructors(const std::string& type_name) {
     if constexpr (std::is_const_v<DataT>) {
       check_common_constructor<AccType, DataT, Dimension,
                                sycl::access_mode::read, sycl::target::device>(
-          get_acc_functor, r);
+          r, get_acc_functor);
     } else {
       check_common_constructor<AccType, DataT, Dimension,
                                sycl::access_mode::read_write,
-                               sycl::target::device>(get_acc_functor, r);
+                               sycl::target::device>(r, get_acc_functor);
     }
   }
 }

--- a/tests/accessor/local_accessor_constructors_core.cpp
+++ b/tests/accessor/local_accessor_constructors_core.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides sycl::local_accessor constructors test for generic types
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::local_accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "local_accessor_constructors.h"
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace local_accessor_constructors_core {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("sycl::local_accessor constructors. core types", "[accessor]")({
+  using namespace local_accessor_constructors;
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  const auto types = get_lightweight_type_pack();
+#else
+  const auto types = get_full_conformance_type_pack();
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  for_all_types_vectors_marray<run_local_constructors_test>(types);
+});
+}  // namespace local_accessor_constructors_core

--- a/tests/accessor/local_accessor_constructors_fp16.cpp
+++ b/tests/accessor/local_accessor_constructors_fp16.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides sycl::local_accessor test for the sycl::half type
+//
+*******************************************************************************/
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::local_accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "local_accessor_constructors.h"
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace local_accessor_constructors_fp16 {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("sycl::local_accessor constructors. fp16 type", "[accessor]")({
+  using namespace local_accessor_constructors;
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+    run_local_constructors_test<sycl::half>{}("sycl::half");
+#else
+    for_type_vectors_marray<run_local_constructors_test, sycl::half>(
+        "sycl::half");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  } else {
+    WARN("Device does not support half precision floating point operations");
+    return;
+  }
+});
+}  // namespace local_accessor_constructors_fp16

--- a/tests/accessor/local_accessor_constructors_fp64.cpp
+++ b/tests/accessor/local_accessor_constructors_fp64.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides sycl::local_accessor test for the double type
+//
+*******************************************************************************/
+#include "../common/common.h"
+
+// FIXME: re-enable when sycl::local_accessor is implemented
+#if !defined(__HIPSYCL__) && !defined(__COMPUTECPP__) && \
+    !defined(__SYCL_COMPILER_VERSION)
+#include "accessor_common.h"
+#include "local_accessor_constructors.h"
+#endif
+
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+namespace local_accessor_constructors_fp64 {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+("sycl::local_accessor constructors. fp64 type", "[accessor]")({
+  using namespace local_accessor_constructors;
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+    run_local_constructors_test<double>{}("double");
+#else
+    for_type_vectors_marray<run_local_constructors_test, double>("double");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  } else {
+    WARN("Device does not support double precision floating point operations");
+    return;
+  }
+});
+}  // namespace local_accessor_constructors_fp64


### PR DESCRIPTION
The main idea is to:

- check if source accessor is convertible to destination accessor
- and re-use generic checks for accessor constructors to verify data remains valid

PR depends on:

- https://github.com/KhronosGroup/SYCL-CTS/pull/325
- https://github.com/KhronosGroup/SYCL-CTS/pull/326
- https://github.com/KhronosGroup/SYCL-CTS/pull/337