### PR TITLE
Bump dpcpp version in ci

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -59,7 +59,7 @@ jobs:
           # - sycl-impl: computecpp
           # version: 2.8.0
           - sycl-impl: dpcpp
-            version: 977f22d
+            version: caa696f
           - sycl-impl: hipsycl
             version: 3d8b1cd
     steps:
@@ -98,7 +98,7 @@ jobs:
           - sycl-impl: computecpp
             version: 2.8.0
           - sycl-impl: dpcpp
-            version: 977f22d
+            version: caa696f
           - sycl-impl: hipsycl
             version: 3d8b1cd
     env:


### PR DESCRIPTION
This version of the DPCPP contains a fix for get_native_mem() return
type.