### PR TITLE
Streamline handling of CTS options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON) # Required for hex floats in C++11 mode on gcc 6+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-include(AddSYCLExecutable)
-include(AddCTSOption)
-
 find_package(Threads REQUIRED)
 find_package(OpenCL REQUIRED)
 find_package(PythonInterp 3 REQUIRED)
@@ -28,6 +24,10 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
    ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_compile_options(-Wall -Wno-unused-variable)
 endif()
+
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+include(AddSYCLExecutable)
+include(AddCTSOption)
 
 add_cts_option(SYCL_CTS_ENABLE_FULL_CONFORMANCE
     "Enable full conformance with extensive tests" OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_CXX_EXTENSIONS ON) # Required for hex floats in C++11 mode on gcc 6+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+include(AddSYCLExecutable)
+include(AddCTSOption)
 
 find_package(Threads REQUIRED)
 find_package(OpenCL REQUIRED)
@@ -27,92 +29,36 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
     add_compile_options(-Wall -Wno-unused-variable)
 endif()
 
+add_cts_option(SYCL_CTS_ENABLE_FULL_CONFORMANCE
+    "Enable full conformance with extensive tests" OFF
+    WARN_IF_OFF "Full conformance mode (SYCL_CTS_ENABLE_FULL_CONFORMANCE) should be used for conformance submission")
 
-include(AddSYCLExecutable)
+add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_PROPERTIES_TESTS
+    "Enable extension oneAPI compile-time property list tests" OFF)
 
-# ------------------
-# Extensive mode for full coverage
-option(SYCL_CTS_ENABLE_FULL_CONFORMANCE
-       "Enable full conformance mode with extensive tests" OFF)
-if(SYCL_CTS_ENABLE_FULL_CONFORMANCE)
-    message(STATUS "Full conformance mode: ON")
-    add_host_and_device_compiler_definitions(-DSYCL_CTS_ENABLE_FULL_CONFORMANCE)
-else()
-    message(STATUS "Full conformance mode: OFF")
-    message(WARNING
-            "Full conformance mode should be used for conformance submission")
-endif()
-# ------------------
+# TODO: Should SYCL_CTS_ENABLE_FULL_CONFORMANCE=ON imply this?
+add_cts_option(SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+    "Enable tests for deprecated SYCL features" ON
+    WARN_IF_OFF "Tests for deprecated SYCL features should be enabled for conformance submission")
 
-# ------------------
-# Extensive mode for running extension oneAPI compile-time property list tests
-option(SYCL_CTS_ENABLE_EXT_ONEAPI_PROPERTIES_TESTS
-       "Enable extension oneAPI compile-time property list tests" OFF)
-if(SYCL_CTS_ENABLE_EXT_ONEAPI_PROPERTIES_TESTS)
-    message(STATUS "oneAPI extension compile-time property list tests mode: ON")
-endif()
-# ------------------
+add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_SUB_GROUP_MASK_TESTS
+    "Enable extension oneAPI sub_group_mask tests" OFF)
 
-# ------------------
-# Extensive mode for running legacy tests
-option(SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
-       "Enable tests for the deprecated SYCL features" ON)
-if(SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS)
-    message(STATUS "Tests for the deprecated SYCL features are enabled")
-    add_definitions(-DSYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS)
-else()
-    message(STATUS "Tests for the deprecated SYCL features are disabled")
-    message(WARNING
-            "Tests for the deprecated SYCL features should be enabled for conformance submission")
-endif()
-# ------------------
+add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_DEVICE_GLOBAL_TESTS
+    "Enable extension oneAPI device_global tests" OFF)
 
-# ------------------
-# Extensive mode for running extension oneAPI sub_group_mask tests
-option(SYCL_CTS_ENABLE_EXT_ONEAPI_SUB_GROUP_MASK_TESTS
-       "Enable extension oneAPI sub_group_mask tests" OFF)
-if(SYCL_CTS_ENABLE_EXT_ONEAPI_SUB_GROUP_MASK_TESTS)
-    message(STATUS "oneAPI extension sub_group_mask tests mode: ON")
-endif()
-# ------------------
+# TODO: Deprecated - remove
+add_cts_option(SYCL_CTS_ENABLE_VERBOSE_LOG
+    "Enable debug-level logs (deprecated)" OFF)
 
-# ------------------
-# Extensive mode for running extension oneAPI device_global tests
-option(SYCL_CTS_ENABLE_EXT_ONEAPI_DEVICE_GLOBAL_TESTS
-       "Enable extension oneAPI device_global tests" OFF)
-if(SYCL_CTS_ENABLE_EXT_ONEAPI_DEVICE_GLOBAL_TESTS)
-    message(STATUS "oneAPI extension device_global tests mode: ON")
-endif()
-# ------------------
+add_cts_option(SYCL_CTS_ENABLE_DOUBLE_TESTS
+    "Enable tests that require double precision floating point capabilities" ON)
 
-# ------------------
-# Debug-level verbose logging
-option(SYCL_CTS_ENABLE_VERBOSE_LOG "Enable debug-level logs" OFF)
-if(SYCL_CTS_ENABLE_VERBOSE_LOG)
-    add_definitions(-DSYCL_CTS_VERBOSE_LOG)
-endif()
-# ------------------
+add_cts_option(SYCL_CTS_ENABLE_HALF_TESTS
+    "Enable tests that require half precision floating point capabilities" ON)
 
-# ------------------
-# Double and Half variables
-option(SYCL_CTS_ENABLE_DOUBLE_TESTS "Enable Double tests." ON)
-option(SYCL_CTS_ENABLE_HALF_TESTS "Enable Half tests." ON)
-if(SYCL_CTS_ENABLE_DOUBLE_TESTS)
-    add_host_and_device_compiler_definitions(-DSYCL_CTS_TEST_DOUBLE)
-endif()
-if(SYCL_CTS_ENABLE_HALF_TESTS)
-    add_host_and_device_compiler_definitions(-DSYCL_CTS_TEST_HALF)
-endif()
-# ------------------
-
-# ------------------
-# OpenCL interoperability
-option(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-       "Enable OpenCL interoperability tests." ON)
-if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS)
-    add_host_and_device_compiler_definitions(-DSYCL_CTS_TEST_OPENCL_INTEROP)
-endif()
-# ------------------
+add_cts_option(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    "Enable OpenCL interoperability tests" ON)
 
 # ------------------
 # Device used for running with CTest (e.g. during conformance report generation)
@@ -141,3 +87,6 @@ enable_testing()
 add_subdirectory(util)
 add_subdirectory(tests)
 add_subdirectory(oclmath)
+
+# This should be the last line
+print_cts_config_summary()

--- a/cmake/AddCTSOption.cmake
+++ b/cmake/AddCTSOption.cmake
@@ -1,0 +1,51 @@
+set(SYCL_CTS_DETAIL_AVAILABLE_OPTIONS "")
+
+#
+# Adds a new CTS option with the given name, description and default value.
+#
+# The option is made available both as a CMake variable (either OFF or ON)
+# and as a preprocessor definition with the same name (either 0 or 1).
+#
+# Important: The preprocessor macro is always set, regardless of its value.
+#            Use `#if <OPTION>` instead of `#ifdef <OPTION>`.
+#
+# Optional parameters:
+#  - WARN_IF_OFF <msg>     Print a warning message if this option is set to OFF.
+#
+function(add_cts_option option_name option_description option_default)
+    cmake_parse_arguments(PARSE_ARGV 3 args "" "WARN_IF_OFF" "")
+
+    option(${option_name} ${option_description} ${option_default})
+    list(APPEND SYCL_CTS_DETAIL_AVAILABLE_OPTIONS ${option_name})
+    set(SYCL_CTS_DETAIL_AVAILABLE_OPTIONS ${SYCL_CTS_DETAIL_AVAILABLE_OPTIONS} PARENT_SCOPE)
+
+    set("${option_name}_DESCRIPTION" ${option_description} PARENT_SCOPE)
+
+    if(args_WARN_IF_OFF)
+        set("${option_name}_WARN_IF_OFF" ${args_WARN_IF_OFF} PARENT_SCOPE)
+    endif()
+
+    add_host_and_device_compiler_definitions("-D${option_name}=$<BOOL:${${option_name}}>")
+endfunction()
+
+function(print_cts_config_summary)
+    set(MSG_STR "\n")
+    string(APPEND MSG_STR "====================================\n")
+    string(APPEND MSG_STR "  SYCL 2020 Conformance Test Suite\n")
+    string(APPEND MSG_STR "       Configuration summary\n")
+    string(APPEND MSG_STR "====================================\n\n")
+
+    foreach(opt ${SYCL_CTS_DETAIL_AVAILABLE_OPTIONS})
+        string(APPEND MSG_STR " * ${opt}\n   ${${opt}_DESCRIPTION}: ${${opt}}\n\n")
+    endforeach()
+
+    message(STATUS ${MSG_STR})
+
+    # Print warnings for disabled options
+    foreach(opt ${SYCL_CTS_DETAIL_AVAILABLE_OPTIONS})
+        if(NOT ${${opt}} AND ${opt}_WARN_IF_OFF)
+            message(WARNING ${${opt}_WARN_IF_OFF})
+        endif()
+    endforeach()
+
+endfunction()

--- a/cmake/AddCTSOption.cmake
+++ b/cmake/AddCTSOption.cmake
@@ -1,4 +1,5 @@
 set(SYCL_CTS_DETAIL_AVAILABLE_OPTIONS "")
+set(SYCL_CTS_DETAIL_OPTION_COMPILE_DEFINITIONS "")
 
 #
 # Adds a new CTS option with the given name, description and default value.
@@ -25,7 +26,8 @@ function(add_cts_option option_name option_description option_default)
         set("${option_name}_WARN_IF_OFF" ${args_WARN_IF_OFF} PARENT_SCOPE)
     endif()
 
-    add_host_and_device_compiler_definitions("-D${option_name}=$<BOOL:${${option_name}}>")
+    list(APPEND SYCL_CTS_DETAIL_OPTION_COMPILE_DEFINITIONS "${option_name}=$<BOOL:${${option_name}}>")
+    set(SYCL_CTS_DETAIL_OPTION_COMPILE_DEFINITIONS ${SYCL_CTS_DETAIL_OPTION_COMPILE_DEFINITIONS} PARENT_SCOPE)
 endfunction()
 
 function(print_cts_config_summary)

--- a/cmake/AddSYCLExecutable.cmake
+++ b/cmake/AddSYCLExecutable.cmake
@@ -58,18 +58,3 @@ function(add_sycl_executable)
         OBJECT_LIBRARY "${args_OBJECT_LIBRARY}"
         TESTS          "${args_TESTS}")
 endfunction()
-
-# Adds preprocessor definitions to the device compiler,
-# to mimic the add_definitions CMake function, but only for the device compiler
-# If the implementation uses a single compiler for host and device code,
-# then this function is expected to be a no-op
-# because add_definitions should take care of everything
-function(add_device_compiler_definitions)
-    add_device_compiler_definitions_implementation(${ARGN})
-endfunction()
-
-# Adds preprocessor definitions to both host and device compilers
-function(add_host_and_device_compiler_definitions)
-    add_definitions(${ARGN})
-    add_device_compiler_definitions(${ARGN})
-endfunction()

--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -97,8 +97,3 @@ function(add_sycl_executable_implementation)
 
     target_link_libraries(${exe_name} PUBLIC DPCPP::Runtime)
 endfunction()
-
-# Adds device compiler definitions
-# This functions is a no-op because add_definitions should take care of it
-function(add_device_compiler_definitions_implementation)
-endfunction()

--- a/cmake/FindhipSYCL.cmake
+++ b/cmake/FindhipSYCL.cmake
@@ -33,8 +33,3 @@ function(add_sycl_executable_implementation)
         POSITION_INDEPENDENT_CODE ON)
 
 endfunction()
-
-# Adds device compiler definitions
-# This functions is a no-op because add_definitions should take care of it
-function(add_device_compiler_definitions_implementation)
-endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -165,6 +165,7 @@ function(add_cts_test_helper)
                       TESTS          ${test_cases_list})
 
   target_include_directories(${test_exe_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+  target_compile_definitions(${test_exe_name} PUBLIC ${SYCL_CTS_DETAIL_OPTION_COMPILE_DEFINITIONS})
 
   set(info_dump_dir "${CMAKE_BINARY_DIR}/Testing")
   add_test(NAME ${test_exe_name}

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -189,7 +189,7 @@ inline auto get_lightweight_type_pack() {
  * @return lightweight or full named_type_pack
  */
 inline auto get_conformance_type_pack() {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   return get_lightweight_type_pack();
 #else
   return get_full_conformance_type_pack();

--- a/tests/accessor/accessor_exceptions_fp16.cpp
+++ b/tests/accessor/accessor_exceptions_fp16.cpp
@@ -26,7 +26,7 @@ using namespace sycl_cts;
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("Generic sycl::accessor constructor exceptions test.", "[accessor]")({
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_tests_with_types<sycl::half, generic_accessor>{}("sycl::half");
 #else
   for_type_vectors_marray<run_tests_with_types, sycl::half, generic_accessor>(
@@ -36,7 +36,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::local_accessor  constructor exceptions test.", "[accessor]")({
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_tests_with_types<sycl::half, local_accessor>{}("sycl::half");
 #else
   for_type_vectors_marray<run_tests_with_types, sycl::half, local_accessor>(
@@ -46,7 +46,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::host_accessor constructor exceptions test.", "[accessor]")({
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_tests_with_types<sycl::half, host_accessor>{}("sycl::half");
 #else
   for_type_vectors_marray<run_tests_with_types, sycl::half, host_accessor>(

--- a/tests/accessor/accessor_exceptions_fp64.cpp
+++ b/tests/accessor/accessor_exceptions_fp64.cpp
@@ -26,7 +26,7 @@ using namespace sycl_cts;
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("Generic sycl::accessor constructor exceptions test.", "[accessor]")({
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_tests_with_types<double, generic_accessor>{}("double");
 #else
   for_type_vectors_marray<run_tests_with_types, double, generic_accessor>(
@@ -36,7 +36,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::local_accessor  constructor exceptions test.", "[accessor]")({
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_tests_with_types<double, local_accessor>{}("double");
 #else
   for_type_vectors_marray<run_tests_with_types, double, local_accessor>(
@@ -46,7 +46,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::host_accessor constructor exceptions test.", "[accessor]")({
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_tests_with_types<double, host_accessor>{}("double");
 #else
   for_type_vectors_marray<run_tests_with_types, double, host_accessor>(

--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -30,7 +30,7 @@ void test_accessor_methods(const AccT &accessor,
     CHECK(acc_isPlaceholder == expected_isPlaceholder);
   }
 
-#ifdef SYCL_CTS_TEST_DEPRECATED_FEATURES
+#if SYCL_CTS_TEST_DEPRECATED_FEATURES
   {
     INFO("check get_size() method");
     auto acc_get_size = accessor.get_size();

--- a/tests/accessor/generic_accessor_api_fp16.cpp
+++ b/tests/accessor/generic_accessor_api_fp16.cpp
@@ -28,7 +28,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         "Skipping the test case.");
     return;
   }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_generic_api_for_type<sycl::half>{}("sycl::half");
 #else
   for_type_vectors_marray<run_generic_api_for_type, sycl::half>("sycl::half");

--- a/tests/accessor/generic_accessor_api_fp64.cpp
+++ b/tests/accessor/generic_accessor_api_fp64.cpp
@@ -28,7 +28,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         "Skipping the test case.");
     return;
   }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_generic_api_for_type<double>{}("double");
 #else
   for_type_vectors_marray<run_generic_api_for_type, double>("double");

--- a/tests/accessor/generic_accessor_constructors_fp16.cpp
+++ b/tests/accessor/generic_accessor_constructors_fp16.cpp
@@ -25,7 +25,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     run_generic_constructors_test<sycl::half>{}("sycl::half");
 #else
     for_type_vectors_marray<run_generic_constructors_test, sycl::half>(

--- a/tests/accessor/generic_accessor_constructors_fp64.cpp
+++ b/tests/accessor/generic_accessor_constructors_fp64.cpp
@@ -25,7 +25,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     run_generic_constructors_test<double>{}("double");
 #else
     for_type_vectors_marray<run_generic_constructors_test, double>("double");

--- a/tests/accessor/generic_accessor_properties_fp16.cpp
+++ b/tests/accessor/generic_accessor_properties_fp16.cpp
@@ -26,7 +26,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
     const auto types = get_fp16_type();
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     run_generic_properties_tests<sycl::half>{}("sycl::half");
 #else
     for_type_vectors_marray<run_generic_properties_tests, sycl::half>(

--- a/tests/accessor/generic_accessor_properties_fp64.cpp
+++ b/tests/accessor/generic_accessor_properties_fp64.cpp
@@ -26,7 +26,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
     const auto types = get_fp16_type();
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     run_generic_properties_tests<sycl::half>{}("double");
 #else
     for_type_vectors_marray<run_generic_properties_tests, double>("double");

--- a/tests/accessor/host_accessor_api_fp16.cpp
+++ b/tests/accessor/host_accessor_api_fp16.cpp
@@ -28,7 +28,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         "Skipping the test case.");
     return;
   }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_host_accessor_api_for_type<sycl::half>{}("sycl::half");
 #else
   for_type_vectors_marray<run_host_accessor_api_for_type, sycl::half>(

--- a/tests/accessor/host_accessor_api_fp64.cpp
+++ b/tests/accessor/host_accessor_api_fp64.cpp
@@ -28,7 +28,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         "Skipping the test case.");
     return;
   }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_host_accessor_api_for_type<double>{}("double");
 #else
   for_type_vectors_marray<run_host_accessor_api_for_type, double>("double");

--- a/tests/accessor/host_accessor_constructors_fp16.cpp
+++ b/tests/accessor/host_accessor_constructors_fp16.cpp
@@ -24,7 +24,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::host_accessor constructors. fp16 type", "[accessor]")({
   using namespace host_accessor_constructors;
   auto queue = sycl_cts::util::get_cts_object::queue();
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_host_constructors_test<sycl::half>{}("sycl::half");
 #else
   for_type_vectors_marray<run_host_constructors_test, sycl::half>("sycl::half");

--- a/tests/accessor/host_accessor_constructors_fp64.cpp
+++ b/tests/accessor/host_accessor_constructors_fp64.cpp
@@ -24,7 +24,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::host_accessor constructors. fp64 type", "[accessor]")({
   using namespace host_accessor_constructors;
   auto queue = sycl_cts::util::get_cts_object::queue();
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_host_constructors_test<double>{}("double");
 #else
   for_type_vectors_marray<run_host_constructors_test, double>("double");

--- a/tests/accessor/host_accessor_properties_fp16.cpp
+++ b/tests/accessor/host_accessor_properties_fp16.cpp
@@ -24,7 +24,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::host_accessor properties. fp16 type", "[accessor]")({
   using namespace host_accessor_properties;
   auto queue = sycl_cts::util::get_cts_object::queue();
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_host_properties_tests<sycl::half>{}("sycl::half");
 #else
   for_type_vectors_marray<run_host_properties_tests, sycl::half>("sycl::half");

--- a/tests/accessor/host_accessor_properties_fp64.cpp
+++ b/tests/accessor/host_accessor_properties_fp64.cpp
@@ -24,7 +24,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::host_accessor properties. fp64 type", "[accessor]")({
   using namespace host_accessor_properties;
   auto queue = sycl_cts::util::get_cts_object::queue();
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_host_properties_tests<double>{}("double");
 #else
   for_type_vectors_marray<run_host_properties_tests, double>("double");

--- a/tests/accessor/local_accessor_api_core.cpp
+++ b/tests/accessor/local_accessor_api_core.cpp
@@ -20,7 +20,7 @@ namespace local_accessor_api_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::local_accessor api. core types", "[accessor]")({
   using namespace local_accessor_api_common;
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   const auto types = get_lightweight_type_pack();
 #else
   const auto types = get_full_conformance_type_pack();

--- a/tests/accessor/local_accessor_api_fp16.cpp
+++ b/tests/accessor/local_accessor_api_fp16.cpp
@@ -28,7 +28,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         "Skipping the test case.");
     return;
   }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_local_api_for_type<sycl::half>{}("sycl::half");
 #else
   for_type_vectors_marray<run_local_api_for_type, sycl::half>("sycl::half");

--- a/tests/accessor/local_accessor_api_fp64.cpp
+++ b/tests/accessor/local_accessor_api_fp64.cpp
@@ -28,7 +28,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         "Skipping the test case.");
     return;
   }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
   run_local_api_for_type<double>{}("double");
 #else
   for_type_vectors_marray<run_local_api_for_type, double>("double");

--- a/tests/accessor/local_accessor_constructors_fp16.cpp
+++ b/tests/accessor/local_accessor_constructors_fp16.cpp
@@ -24,7 +24,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   using namespace local_accessor_constructors;
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     run_local_constructors_test<sycl::half>{}("sycl::half");
 #else
     for_type_vectors_marray<run_local_constructors_test, sycl::half>(

--- a/tests/accessor/local_accessor_constructors_fp64.cpp
+++ b/tests/accessor/local_accessor_constructors_fp64.cpp
@@ -24,7 +24,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   using namespace local_accessor_constructors;
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     run_local_constructors_test<double>{}("double");
 #else
     for_type_vectors_marray<run_local_constructors_test, double>("double");

--- a/tests/accessor_legacy/accessor_api_buffer_common.h
+++ b/tests/accessor_legacy/accessor_api_buffer_common.h
@@ -42,10 +42,10 @@ class check_buffer_accessor_api_methods {
   void operator()(util::logger &log, sycl::queue &queue,
                   const sycl_range_t<dims> &range,
                   const std::string& typeName) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target, placeholder>(
         "check_buffer_accessor_api_methods", typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
     auto data = get_buffer_input_data<T>(count, dims);
     buffer_t<T, dims> buffer(data.data(), range);
@@ -135,10 +135,10 @@ class check_buffer_accessor_api_methods {
   void check_get_pointer(util::logger &log, const std::string& typeName,
                          const sycl_id_t<dims> &accessOffset,
                          const acc_t &accessor) const {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target, placeholder>(
         "check_buffer_accessor_api_methods::get_pointer::host", typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
     static constexpr auto errorTarget = sycl::target::host_buffer;
 
     auto errors = get_error_data(2);
@@ -179,10 +179,10 @@ class check_buffer_accessor_api_methods {
                          const sycl_id_t<dims> &accessOffset,
                          sycl::queue& queue,
                          accLambdaT makeAccessor) const {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target, placeholder>(
         "check_buffer_accessor_api_methods::get_pointer::device", typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
     static constexpr auto errorTarget = sycl::target::device;
 
     auto errors = get_error_data(2);
@@ -391,10 +391,10 @@ class check_buffer_accessor_api {
   void operator()(util::logger &log, sycl::queue &queue,
                   sycl_range_t<dims> range, const std::string& typeName,
                   acc_mode_tag::read_only) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target, placeholder>(
         "check_buffer_accessor_api::reads", typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
     auto dataIdSyntax = get_buffer_input_data<T>(count, dims);
     auto dataMultiDimSyntax = get_buffer_input_data<T>(count, dims);
@@ -566,10 +566,10 @@ class check_buffer_accessor_api {
   void operator()(util::logger &log, sycl::queue &queue,
                   sycl_range_t<dims> range, const std::string& typeName,
                   acc_mode_tag::write_only) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target, placeholder>(
         "check_buffer_accessor_api::writes", typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
     static constexpr bool useIndexes = false;
     auto dataIdSyntax = get_buffer_input_data<T>(count, dims, useIndexes);
@@ -710,10 +710,10 @@ class check_buffer_accessor_api {
   void operator()(util::logger &log, sycl::queue &queue,
                   sycl_range_t<dims> range, const std::string& typeName,
                   acc_mode_tag::generic) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target, placeholder>(
         "check_buffer_accessor_api::reads_and_writes", typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
     // In case of dims == 0, there will be a read from dataIdSyntax
     // and a write to dataMultiDimSyntax
@@ -940,7 +940,7 @@ void check_buffer_accessor_api_mode(util::logger &log,
                                     size_t count, size_t size,
                                     sycl::queue &queue,
                                     sycl_range_t<dims> range) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
   log_accessor<T, dims, mode, target, placeholder>("", typeName, log);
 #endif
 
@@ -1055,14 +1055,14 @@ struct check_buffer_accessor_api_target<generic_path_t> {
   static void run(acc_target_tag::atomic64<accTagT>,
                   util::logger &log, const std::string& typeName, argsT&& ...) {
     // Do not run atomic64 checks
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     constexpr auto mode = sycl::access_mode::atomic;
     log_accessor<T, dims, mode, target, placeholder>(
         "skip_buffer_accessor_atomic64", typeName, log);
 #else
     static_cast<void>(log);
     static_cast<void>(typeName);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
   }
 
   /**

--- a/tests/accessor_legacy/accessor_api_common_all.h
+++ b/tests/accessor_legacy/accessor_api_common_all.h
@@ -28,12 +28,12 @@ template <typename T, int dims, sycl::access_mode mode,
               sycl::access::placeholder::false_t>
 void check_accessor_members(sycl_cts::util::logger &log,
                             const std::string& typeName) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
   log_accessor<T, dims, mode, target, placeholder>("check_accessor_members",
                                                    typeName, log);
 #else
   static_cast<void>(typeName);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
   using acc_t = sycl::accessor<T, dims, mode, target, placeholder>;
 

--- a/tests/accessor_legacy/accessor_api_image_common.h
+++ b/tests/accessor_legacy/accessor_api_image_common.h
@@ -1189,10 +1189,10 @@ class check_image_accessor_api_methods {
   void operator()(util::logger &log, sycl::queue &queue,
                   image_range_t<dims, target> range,
                   const std::string& typeName) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target>("check_image_accessor_api_methods",
                                         typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
     auto data = get_image_input_data<T>(size);
     auto image = image_t(data.data(), image_format_channel<T>::order,
@@ -1239,9 +1239,9 @@ class check_image_accessor_api_methods {
     {
       // check get_range() method
       auto accessorRange = accessor.get_range();
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
       log.note("Checking get_range");
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
       check_acc_return_type<image_range_t<dims, target>>(
           log, accessor.get_range(), "get_range()", typeName);
       if (accessorRange != range) {
@@ -1317,10 +1317,10 @@ class check_image_accessor_api_reads {
   void operator()(util::logger &log, sycl::queue &queue,
                   image_range_t<dims, target> range,
                   const std::string& typeName) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target>("check_image_accessor_api_reads",
                                         typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
     const auto tag = acc_type_tag::get<target, acc_placeholder::image>();
     image_accessor_samplers samplers;
@@ -1512,10 +1512,10 @@ class check_image_accessor_api_writes {
   void operator()(util::logger &log, sycl::queue &queue,
                   image_range_t<dims, target> range,
                   const std::string typeName) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target>("check_image_accessor_api_writes",
                                         typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
     static constexpr bool initialize = false;
     auto dataCoordsSyntax = get_image_input_data<T>(size, initialize);
@@ -1651,7 +1651,7 @@ void check_image_accessor_api_mode(util::logger &log,
                                    size_t count, size_t size,
                                    sycl::queue &queue,
                                    image_range_t<dims, target> range) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
   log_accessor<T, dims, mode, target>("", typeName, log);
 #endif
 

--- a/tests/accessor_legacy/accessor_api_local_common.h
+++ b/tests/accessor_legacy/accessor_api_local_common.h
@@ -42,10 +42,10 @@ class check_local_accessor_api_methods {
 
   void operator()(util::logger &log, sycl::queue &queue,
                   sycl_range_t<dims> range, const std::string& typeName) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target>("check_local_accessor_api_methods",
                                         typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
     static constexpr auto errorTarget = sycl::target::device;
 
     auto errors = get_error_data(2);
@@ -163,10 +163,10 @@ class check_local_accessor_api_reads_and_writes {
 
   void operator()(util::logger &log, sycl::queue &queue,
                   sycl_range_t<dims> range, const std::string& typeName) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     log_accessor<T, dims, mode, target>(
         "check_local_accessor_api_reads_and_writes", typeName, log);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
 
     auto errors = get_error_data(4);
 
@@ -243,7 +243,7 @@ void check_local_accessor_api_mode(util::logger &log,
                                    size_t count, size_t size,
                                    sycl::queue &queue,
                                    sycl_range_t<dims> range) {
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
   log_accessor<T, dims, mode, target>("", typeName, log);
 #endif
 
@@ -324,14 +324,14 @@ struct check_local_accessor_api_dim<generic_path_t> {
   static void run(acc_target_tag::atomic64<accTagT>,
                   util::logger &log, const std::string& typeName, argsT&& ...) {
     // Do not run atomic64 checks
-#ifdef VERBOSE_LOG
+#if SYCL_CTS_ENABLE_VERBOSE_LOG
     constexpr auto mode = sycl::access_mode::atomic;
     log_accessor<T, kernelName, dims, mode, target>(
         "skip_local_accessor_atomic64", typeName, log);
 #else
     static_cast<void>(log);
     static_cast<void>(typeName);
-#endif  // VERBOSE_LOG
+#endif  // SYCL_CTS_ENABLE_VERBOSE_LOG
   }
 };
 

--- a/tests/accessor_legacy/accessor_types_core.h
+++ b/tests/accessor_legacy/accessor_types_core.h
@@ -52,7 +52,7 @@ public:
     if (!availability::check(queue, log))
       return;
 
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     // Specific set of types to cover during ordinary compilation
 
     const auto vector_types = named_type_pack<int>::generate("int");

--- a/tests/accessor_legacy/accessor_types_fp16.h
+++ b/tests/accessor_legacy/accessor_types_fp16.h
@@ -42,7 +42,7 @@ public:
     if (!availability::check(queue, log))
       return;
 
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     // Specific set of types to cover during ordinary compilation
 
     /** check specific accessor api for half

--- a/tests/accessor_legacy/accessor_types_fp64.h
+++ b/tests/accessor_legacy/accessor_types_fp64.h
@@ -47,7 +47,7 @@ public:
     if (!availability::check(queue, log))
       return;
 
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     // Specific set of types to cover during ordinary compilation
 
     /** check specific accessor api for double

--- a/tests/buffer/buffer_api_core.cpp
+++ b/tests/buffer/buffer_api_core.cpp
@@ -30,7 +30,7 @@ public:
   /** execute the test
    */
   void run(util::logger &log) override {
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types_and_vectors<buffer_api_common::check_buffer_api_for_type>(
         get_cts_types::vector_types, log);
 #ifdef INT8_MAX

--- a/tests/buffer/buffer_api_fp16.cpp
+++ b/tests/buffer/buffer_api_fp16.cpp
@@ -36,7 +36,7 @@ public:
     }
     for_type_and_vectors<buffer_api_common::check_buffer_api_for_type,
                          sycl::half>(log, "sycl::half");
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_api_common::check_buffer_api_for_type,
                          sycl::cl_half>(log, "sycl::cl_half");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE

--- a/tests/buffer/buffer_api_fp64.cpp
+++ b/tests/buffer/buffer_api_fp64.cpp
@@ -36,7 +36,7 @@ public:
     }
     for_type_and_vectors<buffer_api_common::check_buffer_api_for_type, double>(
         log, "double");
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_api_common::check_buffer_api_for_type,
                          sycl::cl_double>(log, "sycl::cl_double");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE

--- a/tests/buffer/buffer_constructors_common.h
+++ b/tests/buffer/buffer_constructors_common.h
@@ -47,7 +47,7 @@ bool check_buffer_constructor(sycl::buffer<T, dims, allocT> buf,
                               sycl::range<dims> r,
                               bool data_verify = false) {
   bool res = buf.get_range() == r;
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   if (data_verify) {
     res &= check_data(buf, r);
   }

--- a/tests/buffer/buffer_constructors_core.cpp
+++ b/tests/buffer/buffer_constructors_core.cpp
@@ -31,7 +31,7 @@ public:
    */
   void run(util::logger &log) override {
     {
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types_and_vectors<
           buffer_constructors_common::check_buffer_ctors_for_type>(
           get_cts_types::vector_types, log);

--- a/tests/buffer/buffer_constructors_fp16.cpp
+++ b/tests/buffer/buffer_constructors_fp16.cpp
@@ -37,7 +37,7 @@ public:
     for_type_and_vectors<
         buffer_constructors_common::check_buffer_ctors_for_type,
         sycl::half>(log, "sycl::half");
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<
         buffer_constructors_common::check_buffer_ctors_for_type,
         sycl::cl_half>(log, "sycl::cl_half");

--- a/tests/buffer/buffer_constructors_fp64.cpp
+++ b/tests/buffer/buffer_constructors_fp64.cpp
@@ -37,7 +37,7 @@ public:
     for_type_and_vectors<
         buffer_constructors_common::check_buffer_ctors_for_type, double>(
         log, "double");
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<
         buffer_constructors_common::check_buffer_ctors_for_type,
         sycl::cl_double>(log, "sycl::cl_double");

--- a/tests/buffer/buffer_storage_core.cpp
+++ b/tests/buffer/buffer_storage_core.cpp
@@ -32,7 +32,7 @@ public:
    */
   void run(util::logger &log) override {
     {
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types_and_vectors<
           buffer_storage_common::check_buffer_storage_for_type>(
           get_cts_types::vector_types, log);

--- a/tests/buffer/buffer_storage_fp16.cpp
+++ b/tests/buffer/buffer_storage_fp16.cpp
@@ -37,7 +37,7 @@ public:
     }
     for_type_and_vectors<buffer_storage_common::check_buffer_storage_for_type,
                          sycl::half>(log, "sycl::half");
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_storage_common::check_buffer_storage_for_type,
                          sycl::cl_half>(log, "sycl::cl_half");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE

--- a/tests/buffer/buffer_storage_fp64.cpp
+++ b/tests/buffer/buffer_storage_fp64.cpp
@@ -36,7 +36,7 @@ public:
     }
     for_type_and_vectors<buffer_storage_common::check_buffer_storage_for_type,
                          double>(log, "double");
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_storage_common::check_buffer_storage_for_type,
                          sycl::cl_double>(log, "sycl::cl_double");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE

--- a/tests/common/common_python_vec.py
+++ b/tests/common/common_python_vec.py
@@ -383,7 +383,7 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(swizzledVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(swizzledVec)) {
                 resAcc[0] = false;
             }
@@ -431,7 +431,7 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(inOrderSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(inOrderSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
@@ -451,7 +451,7 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(reverseOrderSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(reverseOrderSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
@@ -471,7 +471,7 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(inOrderReversedPairSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(inOrderReversedPairSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
@@ -491,7 +491,7 @@ class SwizzleData:
             if (!check_vector_size_byte_size<${type}, ${size}>(reverseOrderReversedPairSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
             if (!check_convert_as_all_types<${type}, ${size}>(reverseOrderReversedPairSwizzleFunctionVec)) {
                 resAcc[0] = false;
             }

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -282,7 +282,7 @@ bool check_vector_convert_modes(sycl::vec<vecType, N> inputVec) {
   flag &=
       check_vector_convert_result<vecType, N, convertType,
                                   sycl::rounding_mode::automatic>(inputVec);
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   flag &= check_vector_convert_result<vecType, N, convertType,
                                       sycl::rounding_mode::rte>(inputVec);
   flag &= check_vector_convert_result<vecType, N, convertType,
@@ -502,7 +502,7 @@ bool check_convert_as_all_types(sycl::vec<vecType, N> inputVec) {
   result +=
       check_convert_as_all_dims<vecType, N, unsigned long long int>(inputVec);
   result += check_convert_as_all_dims<vecType, N, float>(inputVec);
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   result += check_convert_as_all_dims<vecType, N, sycl::byte>(inputVec);
 
 #ifdef INT8_MAX
@@ -529,7 +529,7 @@ bool check_convert_as_all_types(sycl::vec<vecType, N> inputVec) {
 #ifdef UINT64_MAX
   result += check_convert_as_all_dims<vecType, N, std::uint64_t>(inputVec);
 #endif
-#endif  // ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#endif  // if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   return result;
 }
 

--- a/tests/common/macros.h
+++ b/tests/common/macros.h
@@ -91,7 +91,7 @@ inline void set_test_info(sycl_cts::util::test_base::info& out,
     FAIL("This test case is not yet implemented.");           \
   }
 
-#if defined(SYCL_CTS_TEST_OPENCL_INTEROP)
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
 #define CHECK_CL_SUCCESS(log, error) \
   ([&] {                             \
     CHECK(error == CL_SUCCESS);      \

--- a/tests/exceptions/exceptions_constructors.cpp
+++ b/tests/exceptions/exceptions_constructors.cpp
@@ -94,7 +94,7 @@ inline void check_exception(sycl::exception e, const std::error_code errcode,
 
 TEST_CASE("Constructors for sycl::exception with sycl::errc error codes",
           "[exception]") {
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   std::array testing_errs = get_err_codes();
 #else
   std::array testing_errs{sycl::errc::success};

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_common.h
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_common.h
@@ -15,7 +15,7 @@
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 namespace {
 
-#ifdef SYCL_CTS_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
 static const auto types =
     named_type_pack<char, signed char, unsigned char, short, unsigned short,
                     int, unsigned int, long, unsigned long, long long,
@@ -26,7 +26,7 @@ static const auto types =
 #else
 static const auto types =
     named_type_pack<char, int>::generate("char", "int");
-#endif  // SYCL_CTS_FULL_CONFORMANCE
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 
 template <typename funT, typename PredT, typename T, size_t SGSize>
 class test_kernel;
@@ -75,7 +75,7 @@ inline auto get_result_array() {
 }
 
 inline bool if_check(const sycl::sub_group &sub_group) {
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   return true;
 #else
   return sub_group.leader();

--- a/tests/handler/handler_copy_core.cpp
+++ b/tests/handler/handler_copy_core.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Tests the API for sycl::handler::copy", "[handler]") {
 
   test_all_variants<int>(lh, queue);
 
-#if defined(SYCL_CTS_ENABLE_FULL_CONFORMANCE)
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   test_all_variants<char>(lh, queue);
   test_all_variants<short>(lh, queue);
   test_all_variants<long>(lh, queue);

--- a/tests/multi_ptr/multi_ptr_common.h
+++ b/tests/multi_ptr/multi_ptr_common.h
@@ -41,7 +41,7 @@ using constant_ptr_legacy =
 /** @brief Factory method to enforce the same coverage for constructors and API
  */
 inline auto get_types() {
-#ifdef SYCL_CTS_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   return named_type_pack<bool, float, double, char,   // types grouped
                          signed char, unsigned char,  // by sign
                          short, unsigned short,       //
@@ -57,18 +57,18 @@ inline auto get_types() {
       "long long",   "unsigned long long");
 #else
   return named_type_pack<int, float>::generate("int", "float");
-#endif  // SYCL_CTS_FULL_CONFORMANCE
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 }
 
 // custom data types that will be used in type coverage
 inline auto get_composite_types() {
-#ifdef SYCL_CTS_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   return named_type_pack<user_def_types::no_cnstr, user_def_types::def_cnstr,
                          user_def_types::no_def_cnstr>::generate(
       "no_cnstr", "def_cnstr", "no_def_cnstr");
 #else
   return named_type_pack<user_def_types::def_cnstr>::generate("def_cnstr");
-#endif  // SYCL_CTS_FULL_CONFORMANCE
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 }
 
 template <typename... argsT>

--- a/tests/multi_ptr/multi_ptr_legacy_api_core.cpp
+++ b/tests/multi_ptr/multi_ptr_legacy_api_core.cpp
@@ -33,7 +33,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-#ifdef SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     auto queue = util::get_cts_object::queue();
 
     const auto types = get_types();

--- a/tests/multi_ptr/multi_ptr_legacy_api_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_legacy_api_fp16.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-#ifdef SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     auto queue = util::get_cts_object::queue();
 
     if (!queue.get_device().has(sycl::aspect::fp16)) {

--- a/tests/multi_ptr/multi_ptr_legacy_constructors_core.cpp
+++ b/tests/multi_ptr/multi_ptr_legacy_constructors_core.cpp
@@ -33,7 +33,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-#ifdef SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     auto queue = util::get_cts_object::queue();
 
     const auto types = get_types();

--- a/tests/multi_ptr/multi_ptr_legacy_constructors_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_legacy_constructors_fp16.cpp
@@ -30,7 +30,7 @@ class TEST_NAME : public util::test_base {
   /** execute this test
    */
   void run(util::logger &log) override {
-#ifdef SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     auto queue = util::get_cts_object::queue();
 
     if (!queue.get_device().has(sycl::aspect::fp16)) {

--- a/tests/specialization_constants/specialization_constants_defined_various_ways.h
+++ b/tests/specialization_constants/specialization_constants_defined_various_ways.h
@@ -164,7 +164,7 @@ template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_defined_various_ways;
   {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_defined_various_ways_for_type,
                   via_kb>(get_spec_const::testing_types::types, log);
 #else
@@ -188,7 +188,7 @@ static void sc_run_test_fp16(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_defined_various_ways_for_type<sycl::half,
                                                                  via_kb>
         fp16_test{};
@@ -212,7 +212,7 @@ static void sc_run_test_fp64(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_defined_various_ways_for_type<double, via_kb>
         fp64_test{};
     fp64_test(log, "double");

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_core.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_core.cpp
@@ -29,7 +29,7 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<check_spec_constant_exception_throw_for_type>(
           get_spec_const::testing_types::types, log);
 #else

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_fp16.cpp
@@ -38,7 +38,7 @@ class TEST_NAME : public util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_spec_constant_exception_throw_for_type<sycl::half> fp16_test{};
       fp16_test(log, "sycl::half");
 #else

--- a/tests/specialization_constants/specialization_constants_exceptions_throwing_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_exceptions_throwing_fp64.cpp
@@ -38,7 +38,7 @@ class TEST_NAME : public util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_spec_constant_exception_throw_for_type<double> fp64_test{};
       fp64_test(log, "double");
 #else

--- a/tests/specialization_constants/specialization_constants_external.h
+++ b/tests/specialization_constants/specialization_constants_external.h
@@ -30,7 +30,7 @@ inline constexpr sycl::specialization_id<T> spec_const_external(
       sycl::kernel_handler h, TYPE);
 
 #ifdef TEST_CORE
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
 CORE_TYPES(FUNC_DECLARE)
 #else
 CORE_TYPES_PARAM(SYCL_VECTORS_MARRAYS, FUNC_DECLARE)
@@ -41,7 +41,7 @@ FUNC_DECLARE(user_def_types::no_def_cnstr)
 #endif  // TEST_CORE
 
 #ifdef TEST_FP64
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
 FUNC_DECLARE(double)
 #else
 SYCL_VECTORS_MARRAYS(double, FUNC_DECLARE)
@@ -49,7 +49,7 @@ SYCL_VECTORS_MARRAYS(double, FUNC_DECLARE)
 #endif  // TEST_FP64
 
 #ifdef TEST_FP16
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
 FUNC_DECLARE(sycl::half)
 #else
 SYCL_VECTORS_MARRAYS(sycl::half, FUNC_DECLARE)

--- a/tests/specialization_constants/specialization_constants_external_core.cpp
+++ b/tests/specialization_constants/specialization_constants_external_core.cpp
@@ -37,7 +37,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using namespace specialization_constants_external;
     {
 
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<check_specialization_constants_external>(
           get_spec_const::testing_types::types, log);
 #else

--- a/tests/specialization_constants/specialization_constants_external_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_external_fp16.cpp
@@ -44,7 +44,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_specialization_constants_external<sycl::half> fp16_test{};
       fp16_test(log, "sycl::half");
 #else

--- a/tests/specialization_constants/specialization_constants_external_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_external_fp64.cpp
@@ -44,7 +44,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_specialization_constants_external<double> fp64_test{};
       fp64_test(log, "double");
 #else

--- a/tests/specialization_constants/specialization_constants_multiple.h
+++ b/tests/specialization_constants/specialization_constants_multiple.h
@@ -132,7 +132,7 @@ template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_multiple;
   {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_multiple_for_type, via_kb>(
         get_spec_const::testing_types::types, log);
 #else
@@ -156,7 +156,7 @@ static void sc_run_test_fp16(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_multiple_for_type<sycl::half, via_kb>
         fp16_test{};
     fp16_test(log, "sycl::half");
@@ -178,7 +178,7 @@ static void sc_run_test_fp64(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_multiple_for_type<double, via_kb>
         fp64_test{};
     fp64_test(log, "double");

--- a/tests/specialization_constants/specialization_constants_same_command_group_core.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_core.cpp
@@ -31,7 +31,7 @@ public:
   void run(util::logger &log) override {
     using namespace specialization_constants_same_command_group_common;
     {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<
           check_specialization_constants_same_command_group>(
           get_spec_const::testing_types::types, log);

--- a/tests/specialization_constants/specialization_constants_same_command_group_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_fp16.cpp
@@ -37,7 +37,7 @@ public:
                  "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_specialization_constants_same_command_group<sycl::half> fp16_test{};
       fp16_test(log, "sycl::half");
 #else

--- a/tests/specialization_constants/specialization_constants_same_command_group_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_same_command_group_fp64.cpp
@@ -37,7 +37,7 @@ public:
                  "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_specialization_constants_same_command_group<double> fp64_test{};
       fp64_test(log, "double");
 #else

--- a/tests/specialization_constants/specialization_constants_same_name_inter_link.h
+++ b/tests/specialization_constants/specialization_constants_same_name_inter_link.h
@@ -115,7 +115,7 @@ template <int tu_num, typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace spec_const_help;
   {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_same_name_inter_link_for_type,
                   sc_sn_il_config<tu_num>, via_kb>(
         get_spec_const::testing_types::types, log);
@@ -143,7 +143,7 @@ static void sc_run_test_fp16(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_same_name_inter_link_for_type<
         sycl::half, sc_sn_il_config<tu_num>, via_kb>
         fp16_test{};
@@ -168,7 +168,7 @@ static void sc_run_test_fp64(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_same_name_inter_link_for_type<
         double, sc_sn_il_config<tu_num>, via_kb>
         fp64_test{};

--- a/tests/specialization_constants/specialization_constants_same_name_stress.h
+++ b/tests/specialization_constants/specialization_constants_same_name_stress.h
@@ -182,7 +182,7 @@ template <typename via_kb>
 static void sc_run_test_core(util::logger &log) {
   using namespace specialization_constants_same_name_stress;
   {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types<check_specialization_constants_same_name_stress_for_type,
                   via_kb>(get_spec_const::testing_types::types, log);
 #else
@@ -206,7 +206,7 @@ static void sc_run_test_fp16(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_same_name_stress_for_type<sycl::half, via_kb>
         fp16_test{};
     fp16_test(log, "sycl::half");
@@ -229,7 +229,7 @@ static void sc_run_test_fp64(util::logger &log) {
           "operations");
       return;
     }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
     check_specialization_constants_same_name_stress_for_type<double, via_kb>
         fp64_test{};
     fp64_test(log, "double");

--- a/tests/specialization_constants/specialization_constants_separate_unit.cpp
+++ b/tests/specialization_constants/specialization_constants_separate_unit.cpp
@@ -60,7 +60,7 @@ bool check_kernel_handler_by_value_external(sycl::kernel_handler h,
         TYPE, test_cases_external::by_value_via_bundle>(h, expected);          \
   }
 
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
 CORE_TYPES(FUNC_DEFINE)
 #else
 CORE_TYPES_PARAM(SYCL_VECTORS_MARRAYS, FUNC_DEFINE)
@@ -70,18 +70,18 @@ FUNC_DEFINE(user_def_types::no_cnstr)
 FUNC_DEFINE(user_def_types::def_cnstr)
 FUNC_DEFINE(user_def_types::no_def_cnstr)
 
-#ifdef SYCL_CTS_TEST_DOUBLE
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_DOUBLE_TESTS
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
 FUNC_DEFINE(double)
 #else
 SYCL_VECTORS_MARRAYS(double, FUNC_DEFINE)
 #endif
-#endif  // SYCL_CTS_TEST_DOUBLE
+#endif  // SYCL_CTS_ENABLE_DOUBLE_TESTS
 
-#ifdef SYCL_CTS_TEST_HALF
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_HALF_TESTS
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
 FUNC_DEFINE(sycl::half)
 #else
 SYCL_VECTORS_MARRAYS(sycl::half, FUNC_DEFINE)
 #endif
-#endif  // SYCL_CTS_TEST_HALF
+#endif  // SYCL_CTS_ENABLE_HALF_TESTS

--- a/tests/specialization_constants/specialization_constants_via_handler_core.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_core.cpp
@@ -30,7 +30,7 @@ public:
   void run(util::logger &log) override {
     using namespace specialization_constants_via_handler_common;
     {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<check_spec_constant_with_handler_for_type>(
           get_spec_const::testing_types::types, log);
 #else

--- a/tests/specialization_constants/specialization_constants_via_handler_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_fp16.cpp
@@ -36,7 +36,7 @@ public:
                  "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_spec_constant_with_handler_for_type<sycl::half> fp16_test{};
       fp16_test(log, "sycl::half");
 #else

--- a/tests/specialization_constants/specialization_constants_via_handler_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_via_handler_fp64.cpp
@@ -36,7 +36,7 @@ public:
                  "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_spec_constant_with_handler_for_type<double> fp64_test{};
       fp64_test(log, "double");
 #else

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_core.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_core.cpp
@@ -31,7 +31,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger &log) override {
     {
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types<check_all>(get_spec_const::testing_types::types, log);
 #else
       for_all_types_vectors_marray<check_all>(

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp16.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp16.cpp
@@ -37,7 +37,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
             "Device does not support half precision floating point operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_all<sycl::half>{}(log, "sycl::half");
 #else
       for_type_vectors_marray<check_all, sycl::half>(log, "sycl::half");

--- a/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp64.cpp
+++ b/tests/specialization_constants/specialization_constants_via_kernel_bundle_fp64.cpp
@@ -38,7 +38,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
             "operations");
         return;
       }
-#ifndef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
       check_all<double>{}(log, "double");
 #else
       for_type_vectors_marray<check_all, double>(log, "double");

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -7,4 +7,5 @@ endif()
 
 add_library(util ${source_files} ${util_headers})
 add_library(CTS::util ALIAS util)
+target_compile_definitions(util PUBLIC ${SYCL_CTS_DETAIL_OPTION_COMPILE_DEFINITIONS})
 target_link_libraries(util PUBLIC OpenCL::OpenCL SYCL::SYCL Catch2::Catch2)


### PR DESCRIPTION
This adds a new CMake function `add_cts_option` that replaces all manual handling of `SYCL_CTS_ENABLE_*` options.

For each option, a corresponding preprocessor definition is automatically created. This macro is set regardless of the option's
value, which means that `#if <OPTION>` should be used instead of e.g. `#ifdef <OPTION>` going forward. All relevant locations in existing tests have been updated.

All remaining options that used different names for CMake option and preprocessor macro have been unified to use a single name.

An overview of all CTS option values is now printed at the end of CMake configuration:

```
====================================
  SYCL 2020 Conformance Test Suite
       Configuration summary
====================================

 * SYCL_CTS_ENABLE_FULL_CONFORMANCE
   Enable full conformance with extensive tests: OFF

 * SYCL_CTS_ENABLE_EXT_ONEAPI_PROPERTIES_TESTS
   Enable extension oneAPI compile-time property list tests: OFF

 * SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
   Enable tests for deprecated SYCL features: ON

 * SYCL_CTS_ENABLE_EXT_ONEAPI_SUB_GROUP_MASK_TESTS
   Enable extension oneAPI sub_group_mask tests: OFF

 * SYCL_CTS_ENABLE_EXT_ONEAPI_DEVICE_GLOBAL_TESTS
   Enable extension oneAPI device_global tests: OFF

 * SYCL_CTS_ENABLE_VERBOSE_LOG
   Enable debug-level logs (deprecated): OFF

 * SYCL_CTS_ENABLE_DOUBLE_TESTS
   Enable tests that require double precision floating point capabilities: ON

 * SYCL_CTS_ENABLE_HALF_TESTS
   Enable tests that require half precision floating point capabilities: ON

 * SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
   Enable OpenCL interoperability tests: ON

CMake Warning at cmake/AddCTSOption.cmake:49 (message):
  Full conformance mode (SYCL_CTS_ENABLE_FULL_CONFORMANCE) should be used for
  conformance submission
Call Stack (most recent call first):
  CMakeLists.txt:92 (print_cts_config_summary)
```

Additionally, this removes the `add_host_and_device_compiler_definitions` function as it modified global state (through `compile_definitions` and the `computecpp_device_compiler_defs` cache variable), which makes it susceptible to containing stale/duplicate definitions upon reconfiguration.

Device compiler options for ComputeCpp (which is the only SYCL implementation with a separate device compiler pass at this time) are now instead inferred from the test executable through generator expressions. This is a prerequisite for fixing the issues I've encountered in #331.