### PR TITLE
Add test on multi_ptr convert assignment operators

### DIFF
--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
@@ -22,20 +22,19 @@ constexpr int expected_val = 42;
 template <typename T, typename SrcAddrSpaceT, typename SrcIsDecorated,
           typename DstIsDecorated>
 class run_convert_assignment_operators_tests {
-  static constexpr sycl::access::address_space target_space =
-      SrcAddrSpaceT::value;
+  static constexpr sycl::access::address_space src_space = SrcAddrSpaceT::value;
   static constexpr sycl::access::decorated src_decorated =
       SrcIsDecorated::value;
   static constexpr sycl::access::decorated dst_decorated =
       DstIsDecorated::value;
-  using src_multi_ptr_t = sycl::multi_ptr<T, target_space, src_decorated>;
+  using src_multi_ptr_t = sycl::multi_ptr<T, src_space, src_decorated>;
   using dst_multi_ptr_t =
       sycl::multi_ptr<T, sycl::access::address_space::generic_space,
                       src_decorated>;
 
  public:
   void operator()(const std::string &type_name,
-                  const std::string &target_address_space_name,
+                  const std::string &src_address_space_name,
                   const std::string &src_is_decorated_name,
                   const std::string &dst_is_decorated_name) {
     auto queue = sycl_cts::util::get_cts_object::queue();
@@ -45,7 +44,7 @@ class run_convert_assignment_operators_tests {
         section_name(
             "Check &operator=(const multi_ptr<value_type, ASP, IsDecorated>&)")
             .with("T", type_name)
-            .with("src address_space", target_address_space_name)
+            .with("src address_space", src_address_space_name)
             .with("src decorated", src_is_decorated_name)
             .with("dst address_space", "access::address_space::generic_space")
             .with("dst decorated", dst_is_decorated_name)
@@ -60,7 +59,7 @@ class run_convert_assignment_operators_tests {
           auto acc_for_mptr =
               val_buffer.template get_access<sycl::access_mode::read>(cgh);
 
-          if constexpr (target_space ==
+          if constexpr (src_space ==
                         sycl::access::address_space::global_space) {
             auto val_acc =
                 val_buffer.template get_access<sycl::access_mode::read>(cgh);
@@ -77,7 +76,7 @@ class run_convert_assignment_operators_tests {
             sycl::local_accessor<T> local_acc(r, cgh);
             cgh.parallel_for(
                 sycl::nd_range<1>(r, r), [=](sycl::nd_item<1> item) {
-                  if constexpr (target_space ==
+                  if constexpr (src_space ==
                                 sycl::access::address_space::local_space) {
                     auto ref = local_acc[0];
                     value_operations::assign(ref, expected_val);
@@ -114,7 +113,7 @@ class run_convert_assignment_operators_tests {
         section_name(
             "Check &operator=(multi_ptr<value_type, AS, IsDecorated>&&)")
             .with("T", type_name)
-            .with("src address_space", target_address_space_name)
+            .with("src address_space", src_address_space_name)
             .with("src decorated", src_is_decorated_name)
             .with("dst address_space", "access::address_space::generic_space")
             .with("dst decorated", dst_is_decorated_name)
@@ -129,7 +128,7 @@ class run_convert_assignment_operators_tests {
           auto acc_for_mptr =
               val_buffer.template get_access<sycl::access_mode::read>(cgh);
 
-          if constexpr (target_space ==
+          if constexpr (src_space ==
                         sycl::access::address_space::global_space) {
             auto val_acc =
                 val_buffer.template get_access<sycl::access_mode::read>(cgh);
@@ -146,7 +145,7 @@ class run_convert_assignment_operators_tests {
             sycl::local_accessor<T> local_acc(r, cgh);
             cgh.parallel_for(
                 sycl::nd_range<1>(r, r), [=](sycl::nd_item<1> item) {
-                  if constexpr (target_space ==
+                  if constexpr (src_space ==
                                 sycl::access::address_space::local_space) {
                     auto ref = local_acc[0];
                     value_operations::assign(ref, expected_val);

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
 //
 //  SYCL 2020 Conformance Test Suite
@@ -51,8 +50,8 @@ class run_convert_assignment_operators_tests {
             .create()) {
       bool res = false;
       {
-        sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
-        sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
+        sycl::buffer<bool> res_buf(&res, r);
+        sycl::buffer<T> val_buffer(&value, r);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
               res_buf.template get_access<sycl::access_mode::write>(cgh);
@@ -120,8 +119,8 @@ class run_convert_assignment_operators_tests {
             .create()) {
       bool res = false;
       {
-        sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
-        sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
+        sycl::buffer<bool> res_buf(&res, r);
+        sycl::buffer<T> val_buffer(&value, r);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
               res_buf.template get_access<sycl::access_mode::write>(cgh);

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
@@ -1,0 +1,124 @@
+
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides code for multi_ptr convert assignment operators
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_MULTI_PTR_CONVERT_ASSIGN_OPS_H
+#define __SYCLCTS_TESTS_MULTI_PTR_CONVERT_ASSIGN_OPS_H
+
+#include "../common/common.h"
+
+#include "../common/section_name_builder.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_convert_assignment_ops {
+
+constexpr int expected_val = 42;
+
+template <typename T, typename SrcAddrSpaceT, typename SrcIsDecorated,
+          typename DstAddrSpaceT, typename DstIsDecorated>
+class run_convert_assignment_operators_tests {
+  static constexpr sycl::access::address_space src_space = SrcAddrSpaceT::value;
+  static constexpr sycl::access::decorated src_decorated =
+      SrcIsDecorated::value;
+  static constexpr sycl::access::address_space dst_space = DstAddrSpaceT::value;
+  static constexpr sycl::access::decorated dst_decorated =
+      DstIsDecorated::value;
+  using src_multi_ptr_t = sycl::multi_ptr<T, src_space, src_decorated>;
+  using dst_multi_ptr_t = sycl::multi_ptr<T, dst_space, dst_decorated>;
+
+ public:
+  void operator()(const std::string &type_name,
+                  const std::string &src_address_space_name,
+                  const std::string &src_is_decorated_name,
+                  const std::string &dst_address_space_name,
+                  const std::string &dst_is_decorated_name) {
+    auto queue = sycl_cts::util::get_cts_object::queue();
+    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    SECTION(
+        section_name(
+            "Check &operator=(const multi_ptr<value_type, ASP, IsDecorated>&)")
+            .with("T", type_name)
+            .with("src address_space", src_address_space_name)
+            .with("src decorated", src_is_decorated_name)
+            .with("dst address_space", dst_address_space_name)
+            .with("dst decorated", dst_is_decorated_name)
+            .create()) {
+      bool res = false;
+      {
+        sycl::buffer<bool, 1> res_buf(&res, sycl::range<1>(1));
+        sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto res_acc =
+              res_buf.template get_access<sycl::access_mode::write>(cgh);
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          cgh.single_task([=] {
+            const src_multi_ptr_t mptr_in(acc_for_mptr);
+            dst_multi_ptr_t mptr_out;
+
+            mptr_out = mptr_in;
+
+            // Check that second mptr has the same value as first mptr
+            res_acc[0] = *(mptr_out.get_raw()) == acc_for_mptr[0];
+          });
+        });
+      }
+      CHECK(res);
+    }
+
+    SECTION(
+        section_name(
+            "Check &operator=(multi_ptr<value_type, ASP, IsDecorated>&)")
+            .with("T", type_name)
+            .with("src address_space", src_address_space_name)
+            .with("src decorated", src_is_decorated_name)
+            .with("dst address_space", dst_address_space_name)
+            .with("dst decorated", dst_is_decorated_name)
+            .create()) {
+      bool res = false;
+      {
+        sycl::buffer<bool, 1> res_buf(&res, sycl::range<1>(1));
+        sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto res_acc =
+              res_buf.template get_access<sycl::access_mode::write>(cgh);
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          cgh.single_task([=] {
+            src_multi_ptr_t mptr_in(acc_for_mptr);
+            dst_multi_ptr_t mptr_out;
+
+            mptr_out = mptr_in;
+
+            // Check that second mptr has the same value as first mptr
+            res_acc[0] = *(mptr_out.get_raw()) == acc_for_mptr[0];
+          });
+        });
+      }
+      CHECK(res);
+    }
+    }
+};
+
+template <typename T>
+class check_multi_ptr_convert_assign_for_type {
+ public:
+  void operator()(const std::string &type_name) {
+    const auto address_spaces = multi_ptr_common::get_address_spaces();
+    const auto is_decorated = multi_ptr_common::get_decorated();
+
+    // Run test with address_space and decorated for source multi_ptr type and
+    // with address_space and decorated for destination  multi_ptr type
+    for_all_combinations<run_convert_assignment_operators_tests, T>(
+        address_spaces, is_decorated, address_spaces, is_decorated, type_name);
+  }
+};
+
+}  // namespace multi_ptr_convert_assignment_ops
+
+#endif  // __SYCLCTS_TESTS_MULTI_PTR_CONVERT_ASSIGN_OPS_H

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
@@ -20,22 +20,22 @@ namespace multi_ptr_convert_assignment_ops {
 constexpr int expected_val = 42;
 
 template <typename T, typename SrcAddrSpaceT, typename SrcIsDecorated,
-          typename DstAddrSpaceT, typename DstIsDecorated>
+          typename DstIsDecorated>
 class run_convert_assignment_operators_tests {
   static constexpr sycl::access::address_space src_space = SrcAddrSpaceT::value;
   static constexpr sycl::access::decorated src_decorated =
       SrcIsDecorated::value;
-  static constexpr sycl::access::address_space dst_space = DstAddrSpaceT::value;
   static constexpr sycl::access::decorated dst_decorated =
       DstIsDecorated::value;
   using src_multi_ptr_t = sycl::multi_ptr<T, src_space, src_decorated>;
-  using dst_multi_ptr_t = sycl::multi_ptr<T, dst_space, dst_decorated>;
+  using dst_multi_ptr_t =
+      sycl::multi_ptr<T, sycl::access::address_space::generic_space,
+                      src_decorated>;
 
  public:
   void operator()(const std::string &type_name,
                   const std::string &src_address_space_name,
                   const std::string &src_is_decorated_name,
-                  const std::string &dst_address_space_name,
                   const std::string &dst_is_decorated_name) {
     auto queue = sycl_cts::util::get_cts_object::queue();
     T value = user_def_types::get_init_value_helper<T>(expected_val);
@@ -45,12 +45,12 @@ class run_convert_assignment_operators_tests {
             .with("T", type_name)
             .with("src address_space", src_address_space_name)
             .with("src decorated", src_is_decorated_name)
-            .with("dst address_space", dst_address_space_name)
+            .with("dst address_space", "access::address_space::generic_space")
             .with("dst decorated", dst_is_decorated_name)
             .create()) {
       bool res = false;
       {
-        sycl::buffer<bool, 1> res_buf(&res, sycl::range<1>(1));
+        sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
         sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -73,16 +73,16 @@ class run_convert_assignment_operators_tests {
 
     SECTION(
         section_name(
-            "Check &operator=(multi_ptr<value_type, ASP, IsDecorated>&)")
+            "Check &operator=(multi_ptr<value_type, AS, IsDecorated>&&)")
             .with("T", type_name)
             .with("src address_space", src_address_space_name)
             .with("src decorated", src_is_decorated_name)
-            .with("dst address_space", dst_address_space_name)
+            .with("dst address_space", "access::address_space::generic_space")
             .with("dst decorated", dst_is_decorated_name)
             .create()) {
       bool res = false;
       {
-        sycl::buffer<bool, 1> res_buf(&res, sycl::range<1>(1));
+        sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
         sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -93,7 +93,7 @@ class run_convert_assignment_operators_tests {
             src_multi_ptr_t mptr_in(acc_for_mptr);
             dst_multi_ptr_t mptr_out;
 
-            mptr_out = mptr_in;
+            mptr_out = std::move(mptr_in);
 
             // Check that second mptr has the same value as first mptr
             res_acc[0] = *(mptr_out.get_raw()) == acc_for_mptr[0];
@@ -102,7 +102,7 @@ class run_convert_assignment_operators_tests {
       }
       CHECK(res);
     }
-    }
+  }
 };
 
 template <typename T>
@@ -113,9 +113,9 @@ class check_multi_ptr_convert_assign_for_type {
     const auto is_decorated = multi_ptr_common::get_decorated();
 
     // Run test with address_space and decorated for source multi_ptr type and
-    // with address_space and decorated for destination  multi_ptr type
+    // with decorated for destination multi_ptr type
     for_all_combinations<run_convert_assignment_operators_tests, T>(
-        address_spaces, is_decorated, address_spaces, is_decorated, type_name);
+        address_spaces, is_decorated, is_decorated, type_name);
   }
 };
 

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops_core.cpp
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops_core.cpp
@@ -1,0 +1,23 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr convert assignment operators for core types
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_convert_assignment_ops.h"
+
+namespace multi_ptr_convert_assignment_ops_core {
+
+TEST_CASE("Convert assignment operators. core types", "[multi_ptr]") {
+  using namespace multi_ptr_convert_assignment_ops;
+  auto types = multi_ptr_convert::get_types();
+  auto composite_types = multi_ptr_convert::get_composite_types();
+  for_all_types<check_multi_ptr_convert_assign_for_type>(types);
+  for_all_types<check_multi_ptr_convert_assign_for_type>(composite_types);
+}
+
+}  // namespace multi_ptr_convert_assignment_ops_core

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops_fp16.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr convert assignment operators for sycl::half type
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_convert_assignment_ops.h"
+
+namespace multi_ptr_convert_assignment_ops_fp16 {
+
+TEST_CASE("Convert assignment operators. fp16 type", "[multi_ptr]") {
+  using namespace multi_ptr_convert_assignment_ops;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    WARN(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+  check_multi_ptr_convert_assign_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace multi_ptr_convert_assignment_ops_fp16

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops_fp64.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr convert assignment operators for double type
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_convert_assignment_ops.h"
+
+namespace multi_ptr_convert_assignment_ops_fp64 {
+
+TEST_CASE("Convert assignment operators. fp64 type", "[multi_ptr]") {
+  using namespace multi_ptr_convert_assignment_ops;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    WARN(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+  check_multi_ptr_convert_assign_for_type<double>{}("double");
+}
+
+}  // namespace multi_ptr_convert_assignment_ops_fp64


### PR DESCRIPTION
The test constructs destination `multi_ptr` with destination `address_space` and
`decorated` types and then calls convert assignment operator from `multi_ptr`
with source `address_space` and `decorated` types. Then verify that destination
`multi_ptr` refers to the target value

________

This PR depends on https://github.com/KhronosGroup/SYCL-CTS/pull/346