### PR TITLE
Add tests for multi_ptr explicit conversions

### DIFF
--- a/tests/common/section_name_builder.h
+++ b/tests/common/section_name_builder.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Builder for a section name with the fluent interface
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_COMMON_SECTION_NAME_BUILDER_H
+#define __SYCLCTS_TESTS_COMMON_SECTION_NAME_BUILDER_H
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace {
+/**
+ * @brief Builder for a section name with the fluent interface
+ * @details Be aware that Catch2 doesn't support nested sections with the same
+ *          name, see https://github.com/catchorg/Catch2/issues/816 for details.
+ *          So if you see
+ *              Assertion `m_parent' failed.
+ *          that's probably the case.
+ */
+class section_name {
+  std::string m_description;
+  std::ostringstream m_parameters;
+
+ public:
+  section_name(const section_name& other)
+      : m_description(other.m_description),
+        m_parameters(other.m_parameters.str()) {}
+
+  // Avoid implicit move constructor removal
+  section_name(section_name&& other) = default;
+
+  section_name(const std::string& description) : m_description(description) {}
+
+  template <typename T>
+  section_name& with(const std::string& name, T&& value) {
+    m_parameters << ' ' << name << ": "
+                 << Catch::StringMaker<T>::convert(std::forward<T>(value))
+                 << ',';
+    return *this;
+  }
+
+  std::string create() const {
+    std::string result(m_description);
+
+    const auto parameters = m_parameters.str();
+    if (!parameters.empty()) {
+      // remove last comma and re-use first space from parameters
+      result += " with" + parameters + "\b \b";
+    }
+    return result;
+  }
+};
+}  // namespace
+
+#endif  // __SYCLCTS_TESTS_COMMON_SECTION_NAME_BUILDER_H

--- a/tests/multi_ptr/multi_ptr_common.h
+++ b/tests/multi_ptr/multi_ptr_common.h
@@ -11,6 +11,29 @@
 
 #include "../common/common.h"
 #include "../common/type_coverage.h"
+#include "../common/type_list.h"
+
+namespace Catch {
+template <>
+struct StringMaker<sycl::access::address_space> {
+  using type = sycl::access::address_space;
+  static std::string convert(type value) {
+    switch (value) {
+      case type::global_space:
+        return "access::address_space::global_space";
+      case type::local_space:
+        return "access::address_space::local_space";
+      case type::private_space:
+        return "access::address_space::private_space";
+      case type::generic_space:
+        return "access::address_space::generic_space";
+      default:
+        // no stringification for deprecated ones
+        return "unknown address_space";
+    }
+  }
+};
+}  // namespace Catch
 
 namespace multi_ptr_common {
 

--- a/tests/multi_ptr/multi_ptr_common.h
+++ b/tests/multi_ptr/multi_ptr_common.h
@@ -29,7 +29,7 @@ struct StringMaker<sycl::access::address_space> {
         return "access::address_space::generic_space";
       default:
         // no stringification for deprecated ones
-        return "unknown address_space";
+        return "unknown or deprecated address_space";
     }
   }
 };

--- a/tests/multi_ptr/multi_ptr_common.h
+++ b/tests/multi_ptr/multi_ptr_common.h
@@ -37,6 +37,27 @@ struct StringMaker<sycl::access::address_space> {
 
 namespace multi_ptr_common {
 
+/**
+ * @brief Factory function for getting type_pack with fields of
+ *        sycl::access::address_space enums
+ */
+inline auto get_address_spaces() {
+  return value_pack<
+      sycl::access::address_space, sycl::access::address_space::global_space,
+      sycl::access::address_space::local_space,
+      sycl::access::address_space::private_space,
+      sycl::access::address_space::generic_space>::generate_named();
+}
+
+/**
+ * @brief Factory function for getting type_pack with fields of
+ *        sycl::access::address_space enums
+ */
+inline auto get_decorated() {
+  return value_pack<sycl::access::decorated, sycl::access::decorated::yes,
+                    sycl::access::decorated::no>::generate_named();
+}
+
 /** @brief Legacy multi_ptr alias to enforce the access::decorated::legacy
  *         usage with no dependency on default multi_ptr template parameter
  *         values

--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -1,0 +1,162 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides code for tests for multi_ptr explicit conversions
+//
+*******************************************************************************/
+#ifndef __SYCLCTS_TESTS_MULTI_PTR_EXPLICIT_CONVERSIONS_H
+#define __SYCLCTS_TESTS_MULTI_PTR_EXPLICIT_CONVERSIONS_H
+
+#include "../common/common.h"
+
+#include "../common/section_name_builder.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_explicit_conversions {
+
+constexpr int expected_val = 42;
+template <typename T, typename AddrSpaceT, typename IsDecorated>
+class run_explicit_convert_tests {
+  static constexpr sycl::access::address_space source_space = AddrSpaceT::value;
+  static constexpr sycl::access::decorated decorated = IsDecorated::value;
+  using multi_ptr_t =
+      sycl::multi_ptr<T, sycl::access::address_space::generic_space, decorated>;
+
+ public:
+  void operator()(const std::string &type_name,
+                  const std::string &source_address_space_name,
+                  const std::string &is_decorated_name) {
+    auto queue = sycl_cts::util::get_cts_object::queue();
+    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    SECTION(
+        section_name("Check multi_ptr<T, source_address_space, IsDecorated>()")
+            .with("T", type_name)
+            .with("source address_space", source_address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
+      bool res = false;
+      {
+        sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
+        sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto res_acc =
+              res_buf.template get_access<sycl::access_mode::write>(cgh);
+          auto val_acc =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          cgh.single_task([=] {
+            multi_ptr_t mptr_in(val_acc);
+            auto mptr_out =
+                sycl::multi_ptr<T, source_space, decorated>(mptr_in);
+
+            // Check that second mptr has the same value as first mptr
+            res_acc[0] = *(mptr_out.get_raw()) == val_acc[0];
+          });
+        });
+      }
+      CHECK(res);
+    }
+
+    SECTION(section_name("Check multi_ptr<const T, source_address_space, "
+                         "IsDecorated>() const")
+                .with("T", type_name)
+                .with("source address_space", source_address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      bool res = false;
+      {
+        sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
+        sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto res_acc =
+              res_buf.template get_access<sycl::access_mode::write>(cgh);
+          auto val_acc =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          cgh.single_task([=] {
+            const multi_ptr_t mptr_in(val_acc);
+            auto mptr_out =
+                sycl::multi_ptr<const T, source_space, decorated>(mptr_in);
+
+            // Check that second mptr has the same value as first mptr
+            res_acc[0] = *(mptr_out.get_raw()) == val_acc[0];
+          });
+        });
+      }
+      CHECK(res);
+    }
+  }
+};
+
+template <typename T>
+bool check_pointer_aliases(const std::string &type_name) {
+  SECTION(section_name("Check explicit pointer aliases")
+              .with("T", type_name)
+              .create()) {
+    {
+      INFO("raw_global_ptr");
+      STATIC_CHECK(std::is_same_v<
+                   sycl::raw_global_ptr<T>,
+                   sycl::multi_ptr<T, sycl::access::address_space::global_space,
+                                   sycl::access::decorated::no>>);
+    }
+    {
+      INFO("raw_local_ptr");
+      STATIC_CHECK(std::is_same_v<
+                   sycl::raw_local_ptr<T>,
+                   sycl::multi_ptr<T, sycl::access::address_space::local_space,
+                                   sycl::access::decorated::no>>);
+    }
+    {
+      INFO("raw_private_ptr");
+      STATIC_CHECK(
+          std::is_same_v<
+              sycl::raw_private_ptr<T>,
+              sycl::multi_ptr<T, sycl::access::address_space::private_space,
+                              sycl::access::decorated::no>>);
+    }
+    {
+      INFO("decorated_global_ptr");
+      STATIC_CHECK(std::is_same_v<
+                   sycl::decorated_global_ptr<T>,
+                   sycl::multi_ptr<T, sycl::access::address_space::global_space,
+                                   sycl::access::decorated::yes>>);
+    }
+    {
+      INFO("decorated_local_ptr");
+      STATIC_CHECK(std::is_same_v<
+                   sycl::decorated_local_ptr<T>,
+                   sycl::multi_ptr<T, sycl::access::address_space::local_space,
+                                   sycl::access::decorated::yes>>);
+    }
+    {
+      INFO("decorated_private_ptr");
+      STATIC_CHECK(
+          std::is_same_v<
+              sycl::decorated_private_ptr<T>,
+              sycl::multi_ptr<T, sycl::access::address_space::private_space,
+                              sycl::access::decorated::yes>>);
+    }
+  }
+}
+
+template <typename T>
+class check_multi_ptr_explicit_convert_for_type {
+ public:
+  void operator()(const std::string &type_name) {
+    check_pointer_aliases<T>(type_name);
+
+    const auto source_address_spaces = value_pack<
+        sycl::access::address_space, sycl::access::address_space::global_space,
+        sycl::access::address_space::local_space,
+        sycl::access::address_space::private_space>::generate_named();
+    ;
+    const auto is_decorated = multi_ptr_common::get_decorated();
+
+    for_all_combinations<run_explicit_convert_tests, T>(
+        source_address_spaces, is_decorated, type_name);
+  }
+};
+
+}  // namespace multi_ptr_explicit_conversions
+
+#endif  // __SYCLCTS_TESTS_MULTI_PTR_EXPLICIT_CONVERSIONS_H

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_core.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_core.cpp
@@ -1,0 +1,23 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multi_ptr explicit conversions
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_explicit_conversions.h"
+
+namespace multi_ptr_explicit_conversions_core {
+
+TEST_CASE("multi_ptr explicit conversions. core types", "[multi_ptr]") {
+  using namespace multi_ptr_explicit_conversions;
+  auto types = multi_ptr_common::get_types();
+  auto composite_types = multi_ptr_common::get_composite_types();
+  for_all_types<check_multi_ptr_explicit_convert_for_type>(types);
+  for_all_types<check_multi_ptr_explicit_convert_for_type>(composite_types);
+}
+
+}  // namespace multi_ptr_explicit_conversions_core

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_fp16.cpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multi_ptr explicit conversions for sycl::half type
+//
+*******************************************************************************/
+
+#include "multi_ptr_explicit_conversions.h"
+
+namespace multi_ptr_explicit_conversions_fp16 {
+
+TEST_CASE("multi_ptr explicit conversions. fp16 type", "[multi_ptr]") {
+  using namespace multi_ptr_explicit_conversions;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    WARN(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+  check_multi_ptr_explicit_convert_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace multi_ptr_explicit_conversions_fp16

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_fp64.cpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for multi_ptr explicit conversions for dpuble type
+//
+*******************************************************************************/
+
+#include "multi_ptr_explicit_conversions.h"
+
+namespace multi_ptr_explicit_conversions_fp64 {
+
+TEST_CASE("multi_ptr explicit conversions. fp64 type", "[multi_ptr]") {
+  using namespace multi_ptr_explicit_conversions;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    WARN(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+  check_multi_ptr_explicit_convert_for_type<double>{}("double");
+}
+
+}  // namespace multi_ptr_explicit_conversions_fp64


### PR DESCRIPTION
Tests for cases
[3.2.8. Explicit conversions to private_ptr](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/multi_ptr_test_plan.asciidoc#328-explicit-conversions-to-private_ptr)
[3.2.9. Explicit conversions to global_ptr](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/multi_ptr_test_plan.asciidoc#329-explicit-conversions-to-global_ptr)
[3.2.10. Explicit conversions to local_ptr](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/multi_ptr_test_plan.asciidoc#3210-explicit-conversions-to-local_ptr)