### PR TITLE
Remove stub from accessor tests

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -609,11 +609,11 @@ void check_no_init_prop(GetAccFunctorT get_accessor_functor,
 
           auto acc = get_accessor_functor(data_buf, cgh);
 
-          if (Target == sycl_stub::target::host_task) {
+          if (Target == sycl::target::host_task) {
             cgh.host_task([=] {
               write_read_acc<DataT, Dimension, AccessMode>(acc, res_acc);
             });
-          } else if (Target == sycl_stub::target::device) {
+          } else if (Target == sycl::target::device) {
             cgh.parallel_for_work_group(sycl::range(1), [=](sycl::group<1>) {
               write_read_acc<DataT, Dimension, AccessMode>(acc, res_acc);
             });

--- a/tests/accessor/host_accessor_properties.h
+++ b/tests/accessor/host_accessor_properties.h
@@ -28,8 +28,8 @@ void test_constructor_with_no_init(const std::string& type_name,
 
   SECTION(section_name) {
     auto construct_acc = [&prop_list](sycl::buffer<DataT, Dimension> data_buf) {
-      return sycl_stub::host_accessor<DataT, Dimension, AccessMode>(data_buf,
-                                                                    prop_list);
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf,
+                                                               prop_list);
     };
 
     check_no_init_prop<AccType, DataT, Dimension, AccessMode>(construct_acc, r);
@@ -42,8 +42,8 @@ void test_constructor_with_no_init(const std::string& type_name,
   SECTION(section_name) {
     auto construct_acc = [&prop_list,
                           r](sycl::buffer<DataT, Dimension> data_buf) {
-      return sycl_stub::host_accessor<DataT, Dimension, AccessMode>(data_buf, r,
-                                                                    prop_list);
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r,
+                                                               prop_list);
     };
 
     check_no_init_prop<AccType, DataT, Dimension, AccessMode>(construct_acc, r);
@@ -56,7 +56,7 @@ void test_constructor_with_no_init(const std::string& type_name,
   SECTION(section_name) {
     auto construct_acc = [&prop_list, r,
                           offset](sycl::buffer<DataT, Dimension> data_buf) {
-      return sycl_stub::host_accessor<DataT, Dimension, AccessMode>(
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(
           data_buf, r, offset, prop_list);
     };
 
@@ -76,8 +76,8 @@ void test_exception(const std::string& type_name) {
       "with no_init property and access_mode::read");
   SECTION(section_name) {
     auto construct_acc = [&prop_list](sycl::buffer<DataT, Dimension> data_buf) {
-      sycl_stub::host_accessor<DataT, Dimension, sycl::access_mode::read>(
-          data_buf, prop_list);
+      sycl::host_accessor<DataT, Dimension, sycl::access_mode::read>(data_buf,
+                                                                     prop_list);
     };
     check_no_init_prop_exception<AccType, DataT, Dimension>(construct_acc, r);
   }
@@ -89,7 +89,7 @@ void test_exception(const std::string& type_name) {
   SECTION(section_name) {
     auto construct_acc = [&prop_list,
                           r](sycl::buffer<DataT, Dimension> data_buf) {
-      sycl_stub::host_accessor<DataT, Dimension, sycl::access_mode::read>(
+      sycl::host_accessor<DataT, Dimension, sycl::access_mode::read>(
           data_buf, r, prop_list);
     };
     check_no_init_prop_exception<AccType, DataT, Dimension>(construct_acc, r);
@@ -102,7 +102,7 @@ void test_exception(const std::string& type_name) {
   SECTION(section_name) {
     auto construct_acc = [&prop_list, r,
                           offset](sycl::buffer<DataT, Dimension> data_buf) {
-      sycl_stub::host_accessor<DataT, Dimension, sycl::access_mode::read>(
+      sycl::host_accessor<DataT, Dimension, sycl::access_mode::read>(
           data_buf, r, offset, prop_list);
     };
     check_no_init_prop_exception<AccType, DataT, Dimension>(construct_acc, r);
@@ -118,8 +118,8 @@ void test_property_member_functions(const std::string& type_name,
 
   const auto construct_acc =
       [&prop_list](sycl::buffer<DataT, Dimension> data_buf) {
-        return sycl_stub::host_accessor<DataT, Dimension, AccessMode>(
-            data_buf, prop_list);
+        return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf,
+                                                                 prop_list);
       };
 
   auto section_name = get_section_name<Dimension>(


### PR DESCRIPTION
This removes using of `stub` classes from accessor tests.

As SYCL 2020 `accessors` were not ready at the moment of tests development, stub classes with the same api as `sycl::accessor` were used for the verification that tests can be compiled successfully. There is no need for the stub classes in future lifetime of tests, so they were removed.