### PR TITLE
Add test on multi_ptr prefetch member

### DIFF
--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -47,8 +47,8 @@ class run_prefetch_test {
                 .create()) {
       bool res = false;
       {
-        sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
-        sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
+        sycl::buffer<bool> res_buf(&res, sycl::range(1));
+        sycl::buffer<T> val_buffer(&value, sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
               res_buf.template get_access<sycl::access_mode::write>(cgh);

--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -1,0 +1,84 @@
+
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides code for multi_ptr prefetch member
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_MULTI_PTR_PREFETCH_FUNC_H
+#define __SYCLCTS_TESTS_MULTI_PTR_PREFETCH_FUNC_H
+
+#include "../common/common.h"
+
+#include "../common/section_name_builder.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_prefetch_member {
+
+constexpr int expected_val = 42;
+
+/**
+ * @brief Provides functions for verification multi_ptr prefetch member
+ * @tparam T Current data type
+ * @tparam IsDecoratedT sycl::access::decorated enumeration's field
+ */
+template <typename T, typename IsDecoratedT>
+class run_prefetch_test {
+  static constexpr sycl::access::decorated decorated = IsDecoratedT::value;
+  using multi_ptr_t =
+      sycl::multi_ptr<T, sycl::access::address_space::global_space, decorated>;
+
+ public:
+  /**
+   * @param type_name Current data type string representation
+   * @param is_decorated_name Current sycl::access::decorated string
+   *        representation
+   */
+  void operator()(const std::string &type_name,
+                  const std::string &is_decorated_name) {
+    auto queue = sycl_cts::util::get_cts_object::queue();
+    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    SECTION(section_name("Check multi_ptr::prefetch")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      bool res = false;
+      {
+        sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
+        sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto res_acc =
+              res_buf.template get_access<sycl::access_mode::write>(cgh);
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          cgh.single_task([=] {
+            const multi_ptr_t mptr(acc_for_mptr);
+
+            // Check call and const correctness for multi_ptr::prefetch, then
+            // verify that multi_ptr contained expected value
+            mptr_in.prefetch(0);
+            res_acc[0] = mptr_in[0] == acc_for_mptr[0];
+          });
+        });
+      }
+      CHECK(res);
+    }
+  }
+};
+
+template <typename T>
+class check_multi_ptr_prefetch_for_type {
+ public:
+  void operator()(const std::string &type_name) {
+    const auto is_decorated = multi_ptr_common::get_decorated();
+    // Run test
+    for_all_combinations<run_prefetch_test, T>(is_decorated, type_name);
+  }
+};
+
+}  // namespace multi_ptr_prefetch_member
+
+#endif  // __SYCLCTS_TESTS_MULTI_PTR_PREFETCH_FUNC_H

--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -59,9 +59,9 @@ class run_prefetch_test {
 
             // Check call and const correctness for multi_ptr::prefetch(), then
             // verify that multi_ptr contained expected value
-            mptr_in.prefetch(0);
+            mptr.prefetch(0);
             // Check that data is not corrupted
-            res_acc[0] = mptr_in[0] == acc_for_mptr[0];
+            res_acc[0] = mptr[0] == acc_for_mptr[0];
           });
         });
       }

--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -40,7 +40,7 @@ class run_prefetch_test {
                   const std::string &is_decorated_name) {
     auto queue = sycl_cts::util::get_cts_object::queue();
     T value = user_def_types::get_init_value_helper<T>(expected_val);
-    SECTION(section_name("Check multi_ptr::prefetch")
+    SECTION(section_name("Check multi_ptr::prefetch()")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
@@ -57,7 +57,7 @@ class run_prefetch_test {
           cgh.single_task([=] {
             const multi_ptr_t mptr(acc_for_mptr);
 
-            // Check call and const correctness for multi_ptr::prefetch, then
+            // Check call and const correctness for multi_ptr::prefetch(), then
             // verify that multi_ptr contained expected value
             mptr_in.prefetch(0);
             res_acc[0] = mptr_in[0] == acc_for_mptr[0];

--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -15,6 +15,8 @@
 #include "../common/section_name_builder.h"
 #include "multi_ptr_common.h"
 
+#include <type_traits>  // for std::is_same
+
 namespace multi_ptr_prefetch_member {
 
 constexpr int expected_val = 42;
@@ -38,6 +40,9 @@ class run_prefetch_test {
    */
   void operator()(const std::string &type_name,
                   const std::string &is_decorated_name) {
+    static_assert(!std::is_same_v<T, void>,
+                  "Data type shouldn't be is same to void type");
+
     auto queue = sycl_cts::util::get_cts_object::queue();
     T value = user_def_types::get_init_value_helper<T>(expected_val);
     SECTION(section_name("Check multi_ptr::prefetch()")

--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -60,10 +60,12 @@ class run_prefetch_test {
             // Check call and const correctness for multi_ptr::prefetch(), then
             // verify that multi_ptr contained expected value
             mptr_in.prefetch(0);
+            // Check that data is not corrupted
             res_acc[0] = mptr_in[0] == acc_for_mptr[0];
           });
         });
       }
+      // Check that data in multi_ptr is not corrupted
       CHECK(res);
     }
   }

--- a/tests/multi_ptr/multi_ptr_prefetch_member_core.cpp
+++ b/tests/multi_ptr/multi_ptr_prefetch_member_core.cpp
@@ -1,0 +1,23 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr prefetch member for core types
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_prefetch_member.h"
+
+namespace multi_ptr_prefetch_member_core {
+
+TEST_CASE("Prefetch member. core types", "[multi_ptr]") {
+  using namespace multi_ptr_prefetch_member;
+  auto types = multi_ptr_convert::get_types();
+  auto composite_types = multi_ptr_convert::get_composite_types();
+  for_all_types<check_multi_ptr_prefetch_for_type>(types);
+  for_all_types<check_multi_ptr_prefetch_for_type>(composite_types);
+}
+
+}  // namespace multi_ptr_prefetch_member_core

--- a/tests/multi_ptr/multi_ptr_prefetch_member_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_prefetch_member_fp16.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr prefetch member for sycl::half type
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_prefetch_member.h"
+
+namespace multi_ptr_prefetch_member_fp16 {
+
+TEST_CASE("Prefetch member. fp16 type", "[multi_ptr]") {
+  using namespace multi_ptr_prefetch_member;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    WARN(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+  check_multi_ptr_prefetch_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace multi_ptr_prefetch_member_fp16

--- a/tests/multi_ptr/multi_ptr_prefetch_member_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_prefetch_member_fp64.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr prefetch member for double type
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_prefetch_member.h"
+
+namespace multi_ptr_prefetch_member_fp64 {
+
+TEST_CASE("Prefetch member. fp64 type", "[multi_ptr]") {
+  using namespace multi_ptr_prefetch_member;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    WARN(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+  check_multi_ptr_prefetch_for_type<double>{}("double");
+}
+
+}  // namespace multi_ptr_prefetch_member_fp64


### PR DESCRIPTION
The test provides verification for `multi_ptr::prefetch` member, that it could be called with const `multi_ptr` and it is contains expected value

________

This PR depends on https://github.com/KhronosGroup/SYCL-CTS/pull/346