### PR TITLE
Add test on multi_ptr arithmetic operators

### DIFF
--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -56,7 +56,7 @@ class run_multi_ptr_arithmetic_op_test {
   T m_arr[m_array_size];
   size_t m_middle_elem_index = m_array_size / 2;
 
-  sycl::range m_r = sycl::range(1);
+  sycl::range m_r(1);
 
   template <typename TestActionT>
   void run_test(sycl::queue &queue, TestActionT test_action,
@@ -67,7 +67,7 @@ class run_multi_ptr_arithmetic_op_test {
 
     {
       sycl::buffer<detail::test_results<T>> test_result_buffer(&test_results,
-                                                               sycl::range(1));
+                                                               m_r);
 
       sycl::buffer<T> buffer_for_mptr(m_arr, sycl::range(m_array_size));
       queue.submit([&](sycl::handler &cgh) {

--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -16,7 +16,26 @@
 
 namespace multi_ptr_prefetch_member {
 
-constexpr int expected_val = 42;
+namespace detail {
+
+/**
+ * @brief Structure that combines variables used to validate test results
+ * @tparam T Data type that will be used in test
+ */
+template <typename T>
+struct test_results {
+  // Value that will be used to initialze variables with random values to avoid
+  // false positive test result
+  constexpr int value_to_init = 49;
+  // Expected value that will be returned after multi_ptr's operator will be
+  // called
+  T op_return_result_val = value_to_init;
+  // Expected value that will be stored into multi_ptr after
+  // multi_ptr's operator will be called
+  T op_calling_val = value_to_init;
+};
+
+}  // namespace detail
 
 /**
  * @brief Provides functor for verification on multi_ptr arithmetic operators
@@ -30,6 +49,55 @@ class run_multi_ptr_arithmetic_op_test {
   static constexpr sycl::access::decorated decorated = IsDecoratedT::value;
   using multi_ptr_t = sycl::multi_ptr<T, space, decorated>;
 
+  constexpr size_t m_array_size = 10;
+  // Array that will be used in multi_ptr
+  T m_arr[m_array_size];
+  size_t m_middle_elem_index = m_array_size / 2;
+
+  sycl::range m_r = sycl::range(1);
+  T m_default_expected_val = 55;
+
+  template <typename TestActionT>
+  void run_test(sycl::queue &queue, TestActionT test_action,
+                detail::test_results<T> &expected_results) {
+    // Variable that contains all variables that will be used to verify test
+    // result
+    detail::test_results<T> test_results;
+
+    {
+      sycl::buffer<detail::test_results<T>> test_result_buffer(&test_results,
+                                                               sycl::range(1));
+
+      sycl::buffer<T> buffer_for_mptr(m_arr, sycl::range(m_array_size));
+      queue.submit([&](sycl::handler &cgh) {
+        auto test_result_acc =
+            test_result_buffer.template get_access<sycl::access_mode::write>(
+                cgh);
+        auto acc_for_mptr =
+            buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+
+        if constexpr (space == sycl::access::address_space::global_space) {
+          cgh.single_task([=] { test_action(acc_for_mptr, test_result_acc); });
+        } else {
+          cgh.parallel_for(sycl::nd_range(m_r, m_r), [=](sycl::nd_item item) {
+            test_action(acc_for_mptr, test_result_acc);
+          });
+        }
+      });
+    }
+    // If expected value is equal to default value, then verification should be
+    // skipped
+    if (expected_results.op_return_result_val != m_default_expected_val) {
+      CHECK(expected_results.op_return_result_val ==
+            test_results.op_return_result_val);
+    }
+    // If expected value is equal to default value, then verification should be
+    // skipped
+    if (expected_results.op_calling_val != m_default_expected_val) {
+      CHECK(expected_results.op_calling_val == test_results.op_calling_val);
+    }
+  }
+
  public:
   /**
    * @param type_name Current data type string representation
@@ -41,264 +109,173 @@ class run_multi_ptr_arithmetic_op_test {
   void operator()(const std::string &type_name,
                   const std::string &address_space_name,
                   const std::string &is_decorated_name) {
-    constexpr size_t array_size = 10;
-    // Array that will be used in multi_ptr
-    T arr[array_size];
-    for (size_t i = 0; i < array_size; ++i) {
-      arr[i] = i;
-    }
-    size_t middle_elem_index = array_size / 2;
-    // Expected value that will be returned after multi_ptr's operator will be
-    // called
-    T op_return_result_expected_val;
-    // Expected value that will be stored into multi_ptr after
-    // multi_ptr's operator will be called
-    T op_calling_expected_val;
-
     auto queue = sycl_cts::util::get_cts_object::queue();
+
+    for (size_t i = 0; i < m_array_size; ++i) {
+      m_arr[i] = i;
+    }
+
     SECTION(section_name("Check multi_ptr operator++(multi_ptr& mp)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_return_result_expected_val = arr[1];
-      op_calling_expected_val = arr[1];
-      // Variable that will be used to store the value that will be returned
-      // after calling multi_ptr's operator
-      T op_calling_result_val;
-      // Variable that will be used to store the multi_ptr's value after
-      // multi_ptr's operator will be called
-      T op_calling_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
-                                                 sycl::range(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the value that will be returned
-          // after calling multi_ptr's operator
-          auto op_return_res_val_acc =
-              op_return_res_val_buffer
-                  .template get_access<sycl::access_mode::write>(cgh);
-          // Accessor that will be used to store the multi_ptr's value after
-          // multi_ptr's operator will be called
-          auto op_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            multi_ptr_t mptr(acc_for_mptr);
-            multi_ptr_t result_mptr = ++mptr;
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that will be returned after calling multi_ptr's operator
+      verification_points.op_return_result_val = m_arr[1];
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_calling_val = m_arr[1];
 
-            op_return_res_val_acc[0] = *result_mptr;
-            op_res_val_acc[0] = *mptr;
-          });
-        });
-      }
-      CHECK(op_calling_result_val == op_return_result_expected_val);
-      CHECK(op_calling_val == op_calling_expected_val);
+      const auto run_test_action = [](auto acc_for_mptr, auto test_result_acc) {
+        multi_ptr_t mptr(acc_for_mptr);
+        multi_ptr_t result_mptr = ++mptr;
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+
+        test_result.op_return_result_val = *result_mptr;
+        test_result.op_calling_val = *mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
     SECTION(section_name("Check multi_ptr operator++(multi_ptr&, int)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_return_result_expected_val = arr[0];
-      op_calling_expected_val = arr[1];
-     // Variable that will be used to store the value that will be returned
-      // after calling multi_ptr's operator
-      T op_calling_result_val;
-      // Variable that will be used to store the multi_ptr's value after
-      // multi_ptr's operator will be called
-      T op_calling_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
-                                                 sycl::range(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the value that will be returned
-          // after calling multi_ptr's operator
-          auto op_return_res_val_acc =
-              op_return_res_val_buffer
-                  .template get_access<sycl::access_mode::write>(cgh);
-          // Accessor that will be used to store the multi_ptr's value after
-          // multi_ptr's operator will be called
-          auto op_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            multi_ptr_t mptr(acc_for_mptr);
-            multi_ptr_t result_mptr = mptr++;
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that will be returned after calling multi_ptr's operator
+      verification_points.op_return_result_val = m_arr[0];
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_calling_val = m_arr[1];
 
-            op_return_res_val_acc[0] = *result_mptr;
-            op_res_val_acc[0] = *mptr;
-          });
-        });
-      }
-      CHECK(op_calling_result_val == op_return_result_expected_val);
-      CHECK(op_calling_val == op_calling_expected_val);
+      const auto run_test_action = [](auto acc_for_mptr, auto test_result_acc) {
+        multi_ptr_t mptr(acc_for_mptr);
+        multi_ptr_t result_mptr = mptr++;
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+        test_result.op_return_result_val = *result_mptr;
+        test_result.op_calling_val = *mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
     SECTION(section_name("Check multi_ptr operator--(multi_ptr&)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_return_result_expected_val = arr[middle_elem_index - 1];
-      op_calling_expected_val = arr[middle_elem_index - 1];
-      // Variable that will be used to store the value that will be returned
-      // after calling multi_ptr's operator
-      T op_calling_result_val;
-      // Variable that will be used to store the multi_ptr's value after
-      // multi_ptr's operator will be called
-      T op_calling_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
-                                                 sycl::range(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the value that will be returned
-          // after calling multi_ptr's operator
-          auto op_return_res_val_acc =
-              op_return_res_val_buffer
-                  .template get_access<sycl::access_mode::write>(cgh);
-          // Accessor that will be used to store the multi_ptr's value after
-          // multi_ptr's operator will be called
-          auto op_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            multi_ptr_t mptr(acc_for_mptr);
-            // Shift multi_ptr that he is pointed to the middle element, to have
-            // possibe decrease pointed value index
-            mptr += middle_elem_index;
-            multi_ptr_t result_mptr = --mptr;
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that will be returned after calling multi_ptr's operator
+      verification_points.op_return_result_val = m_arr[m_middle_elem_index - 1];
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_calling_val = m_arr[m_middle_elem_index - 1];
 
-            op_return_res_val_acc[0] = *result_mptr;
-            op_res_val_acc[0] = *mptr;
-          });
-        });
-      }
-      CHECK(op_calling_result_val == op_return_result_expected_val);
-      CHECK(op_calling_val == op_calling_expected_val);
+      const auto run_test_action = [=](auto acc_for_mptr,
+                                       auto test_result_acc) {
+        multi_ptr_t mptr(acc_for_mptr);
+        // Shift multi_ptr that he is pointed to the middle element, to have
+        // possibe decrease pointed value index
+        mptr += m_middle_elem_index;
+
+        multi_ptr_t result_mptr = --mptr;
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+        test_result.op_return_result_val = *result_mptr;
+        test_result.op_calling_val = *mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
     SECTION(section_name("Check multi_ptr operator--(multi_ptr&, int)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_return_result_expected_val = arr[middle_elem_index];
-      op_calling_expected_val = arr[middle_elem_index - 1];
-      // Variable that will be used to store the value that will be returned
-      // after calling multi_ptr's operator
-      T op_calling_result_val;
-      // Variable that will be used to store the multi_ptr's value after
-      // multi_ptr's operator will be called
-      T op_calling_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
-                                                 sycl::range(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the value that will be returned
-          // after calling multi_ptr's operator
-          auto op_return_res_val_acc =
-              op_return_res_val_buffer
-                  .template get_access<sycl::access_mode::write>(cgh);
-          // Accessor that will be used to store the multi_ptr's value after
-          // multi_ptr's operator will be called
-          auto op_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            multi_ptr_t mptr(acc_for_mptr);
-            // Shift multi_ptr that he is pointed to the middle element, to have
-            // possibe decrease pointed value index
-            mptr += middle_elem_index;
-            multi_ptr_t result_mptr = mptr--;
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that will be returned after calling multi_ptr's operator
+      verification_points.op_return_result_val = m_arr[m_middle_elem_index];
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_calling_val = m_arr[m_middle_elem_index - 1];
 
-            op_return_res_val_acc[0] = *result_mptr;
-            op_res_val_acc[0] = *mptr;
-          });
-        });
-      }
-      CHECK(op_calling_result_val == op_return_result_expected_val);
-      CHECK(op_calling_val == op_calling_expected_val);
+      const auto run_test_action = [=](auto acc_for_mptr,
+                                       auto test_result_acc) {
+        multi_ptr_t mptr(acc_for_mptr);
+        // Shift multi_ptr that he is pointed to the middle element, to have
+        // possibe decrease pointed value index
+        mptr += m_middle_elem_index;
+
+        multi_ptr_t result_mptr = mptr--;
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+        test_result.op_return_result_val = *result_mptr;
+        test_result.op_calling_val = *mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
 
     using diff_t = multi_ptr_t::difference_type;
-    diff_t shift = array_size / 3;
+    diff_t shift = m_array_size / 3;
     SECTION(section_name("Check multi_ptr operator+=(multi_ptr&, diff_type)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_calling_expected_val = arr[shift];
-      // Variable that will be used to store the multi_ptr's value after
-      // multi_ptr's operator will be called
-      T op_calling_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the multi_ptr's value after
-          // multi_ptr's operator will be called
-          auto op_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            multi_ptr_t mptr(acc_for_mptr);
-            mptr += shift;
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_calling_val = m_arr[shift];
+      // Assing m_default_expected_val to skip verification of this value
+      verification_points.op_return_result_val = m_default_expected_val;
 
-            op_res_val_acc[0] = *mptr;
-          });
-        });
-      }
-      CHECK(op_calling_val == op_calling_expected_val);
+      const auto run_test_action = [=](auto acc_for_mptr,
+                                       auto test_result_acc) {
+        multi_ptr_t mptr(acc_for_mptr);
+        mptr += shift;
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+        test_result.op_calling_val = *mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
     SECTION(section_name("Check multi_ptr operator-=(multi_ptr&, diff_type)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_calling_expected_val = arr[middle_elem_index - shift];
-      // Variable that will be used to store the multi_ptr's value after
-      // multi_ptr's operator will be called
-      T op_calling_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the multi_ptr's value after
-          // multi_ptr's operator will be called
-          auto op_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            multi_ptr_t mptr(acc_for_mptr);
-            // Shift multi_ptr that he is pointed to the middle element, to have
-            // possibe decrease pointed value index
-            mptr += middle_elem_index;
-            mptr -= shift;
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_calling_val = m_arr[m_middle_elem_index - shift];
+      // Assing m_default_expected_val to skip verification of this value
+      verification_points.op_return_result_val = m_default_expected_val;
 
-            op_res_val_acc[0] = *mptr;
-          });
-        });
-      }
-      CHECK(op_calling_val == op_calling_expected_val);
+      const auto run_test_action = [=](auto acc_for_mptr,
+                                       auto test_result_acc) {
+        multi_ptr_t mptr(acc_for_mptr);
+        // Shift multi_ptr that he is pointed to the middle element, to have
+        // possibe decrease pointed value index
+        mptr += m_middle_elem_index;
+
+        mptr -= shift;
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+        test_result.op_calling_val = *mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
     SECTION(
         section_name("Check multi_ptr operator+(const multi_ptr&, diff_type)")
@@ -306,31 +283,24 @@ class run_multi_ptr_arithmetic_op_test {
             .with("address_space", "access::address_space::global_space")
             .with("decorated", is_decorated_name)
             .create()) {
-      op_return_result_expected_val = arr[shift];
-      // Variable that will be used to store the value that will be returned
-      // after calling multi_ptr's operator
-      T op_calling_result_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
-                                          sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the value that will be returned
-          // after calling multi_ptr's operator
-          auto op_return_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            const multi_ptr_t mptr(acc_for_mptr);
-            multi_ptr_t result_mptr = mptr + shift;
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_return_result_val = m_arr[shift];
+      // Assing m_default_expected_val to skip verification of this value
+      verification_points.op_calling_val = m_default_expected_val;
 
-            op_return_res_val_acc[0] = *result_mptr;
-          });
-        });
-      }
-      CHECK(op_calling_result_val == op_return_result_expected_val);
+      const auto run_test_action = [=](auto acc_for_mptr,
+                                       auto test_result_acc) {
+        const multi_ptr_t mptr(acc_for_mptr);
+        multi_ptr_t result_mptr = mptr + shift;
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+        test_result.op_return_result_val = *result_mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
     SECTION(
         section_name("Check multi_ptr operator-(const multi_ptr&, diff_type)")
@@ -338,64 +308,51 @@ class run_multi_ptr_arithmetic_op_test {
             .with("address_space", "access::address_space::global_space")
             .with("decorated", is_decorated_name)
             .create()) {
-      op_return_result_expected_val = arr[middle_elem_index - shift];
-      // Variable that will be used to store the value that will be returned
-      // after calling multi_ptr's operator
-      T op_calling_result_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
-                                          sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the value that will be returned
-          // after calling multi_ptr's operator
-          auto op_return_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            const multi_ptr_t mptr(acc_for_mptr);
-            // Shift multi_ptr that he is pointed to the middle element, to have
-            // possibe decrease pointed value index
-            mptr += middle_elem_index;
-            multi_ptr_t result_mptr = mptr - shift;
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_return_result_val =
+          m_arr[m_middle_elem_index - shift];
+      // Assing m_default_expected_val to skip verification of this value
+      verification_points.op_calling_val = m_default_expected_val;
 
-            op_return_res_val_acc[0] = *result_mptr;
-          });
-        });
-      }
-      CHECK(op_calling_result_val == op_return_result_expected_val);
+      const auto run_test_action = [=](auto acc_for_mptr,
+                                       auto test_result_acc) {
+        multi_ptr_t mptr(acc_for_mptr);
+        // Shift multi_ptr that he is pointed to the middle element, to have
+        // possibe decrease pointed value index
+        mptr += m_middle_elem_index;
+
+        multi_ptr_t result_mptr = mptr - shift;
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+        test_result.op_return_result_val = *result_mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
     SECTION(section_name("Check multi_ptr operator*(const multi_ptr&)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_return_result_expected_val = arr[0];
-      // Variable that will be used to store the value that will be returned
-      // after calling multi_ptr's operator
-      T op_calling_result_val;
-      {
-        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
-                                          sycl::range(1));
-        queue.submit([&](sycl::handler &cgh) {
-          auto acc_for_mptr =
-              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
-          // Accessor that will be used to store the value that will be returned
-          // after calling multi_ptr's operator
-          auto op_return_res_val_acc =
-              op_res_val_buffer.template get_access<sycl::access_mode::write>(
-                  cgh);
-          cgh.single_task([=] {
-            const multi_ptr_t mptr(acc_for_mptr);
+      // Variable that contains all variables that will be used to verify test
+      // result
+      detail::test_results<T> verification_points;
+      // Expected value that be contained into multi_ptr after multi_ptr's
+      // operator will be called
+      verification_points.op_return_result_val = m_arr[0];
+      // Assing m_default_expected_val to skip verification of this value
+      verification_points.op_calling_val = m_default_expected_val;
 
-            op_return_res_val_acc[0] = *mptr;
-          });
-        });
-      }
-      CHECK(op_calling_result_val == op_return_result_expected_val);
+      const auto run_test_action = [](auto acc_for_mptr, auto test_result_acc) {
+        const multi_ptr_t mptr(acc_for_mptr);
+
+        detail::test_results<T> &test_result = test_result_acc[0];
+        test_result.op_return_result_val = *mptr;
+      };
+      run_test(queue, run_test_action, verification_points);
     }
   }
 };

--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -1,0 +1,350 @@
+
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides code for multi_ptr arithmetic operators
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_MULTI_PTR_ARITHMETIC_OP_H
+#define __SYCLCTS_TESTS_MULTI_PTR_ARITHMETIC_OP_H
+
+#include "../common/common.h"
+
+#include "../common/section_name_builder.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_prefetch_member {
+
+constexpr int expected_val = 42;
+
+/**
+ * @brief Provides functor for verification on multi_ptr arithmetic operators
+ * @tparam T Current data type
+ * @tparam AddrSpaceT sycl::access::address_space enumeration's field
+ * @tparam IsDecoratedT sycl::access::decorated enumeration's field
+ */
+template <typename T, typename AddrSpaceT, typename IsDecoratedT>
+class run_multi_ptr_arithmetic_op_test {
+  static constexpr sycl::access::address_space space = AddrSpaceT::value;
+  static constexpr sycl::access::decorated decorated = IsDecoratedT::value;
+  using multi_ptr_t = sycl::multi_ptr<T, space, decorated>;
+
+ public:
+  /**
+   * @param type_name Current data type string representation
+   * @param address_space_name Current sycl::access::address_space string
+   *        representation
+   * @param is_decorated_name Current sycl::access::decorated string
+   *        representation
+   */
+  void operator()(const std::string &type_name,
+                  const std::string &address_space_name,
+                  const std::string &is_decorated_name) {
+    constexpr size_t array_size = 10;
+    // Array that will be used in multi_ptr
+    T arr[array_size];
+    for (size_t i = 0; i < array_size; ++i) {
+      arr[i] = i;
+    }
+    size_t middle_elem_index = array_size / 2;
+    T op_return_result_expected_val;
+    T op_calling_expected_val;
+
+    auto queue = sycl_cts::util::get_cts_object::queue();
+    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    SECTION(section_name("Check multi_ptr preincrement operator")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_return_result_expected_val = arr[middle_elem_index + 1];
+      op_calling_expected_val = arr[middle_elem_index + 1];
+      T op_calling_result_val;
+      T op_calling_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
+                                                 sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_return_res_val_acc =
+              op_return_res_val_buffer
+                  .template get_access<sycl::access_mode::write>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            multi_ptr_t mptr(acc_for_mptr);
+            multi_ptr_t result_mptr = ++mptr;
+
+            op_return_res_val_acc[0] = result_mptr[0];
+            op_res_val_acc[0] = mptr[0];
+          });
+        });
+      }
+      CHECK(op_calling_result_val == op_return_result_expected_val);
+      CHECK(op_calling_val == op_calling_expected_val);
+    }
+    SECTION(section_name("Check multi_ptr postincrement operator")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_return_result_expected_val = arr[middle_elem_index];
+      op_calling_expected_val = arr[middle_elem_index + 1];
+      T op_calling_result_val;
+      T op_calling_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
+                                                 sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_return_res_val_acc =
+              op_return_res_val_buffer
+                  .template get_access<sycl::access_mode::write>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            multi_ptr_t mptr(acc_for_mptr);
+            multi_ptr_t result_mptr = mptr++;
+
+            op_return_res_val_acc[0] = result_mptr[0];
+            op_res_val_acc[0] = mptr[0];
+          });
+        });
+      }
+      CHECK(op_calling_result_val == op_return_result_expected_val);
+      CHECK(op_calling_val == op_calling_expected_val);
+    }
+    SECTION(section_name("Check multi_ptr predecrement operator")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_return_result_expected_val = arr[middle_elem_index - 1];
+      op_calling_expected_val = arr[middle_elem_index - 1];
+      T op_calling_result_val;
+      T op_calling_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
+                                                 sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_return_res_val_acc =
+              op_return_res_val_buffer
+                  .template get_access<sycl::access_mode::write>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            multi_ptr_t mptr(acc_for_mptr);
+            multi_ptr_t result_mptr = --mptr;
+
+            op_return_res_val_acc[0] = result_mptr[0];
+            op_res_val_acc[0] = mptr[0];
+          });
+        });
+      }
+      CHECK(op_calling_result_val == op_return_result_expected_val);
+      CHECK(op_calling_val == op_calling_expected_val);
+    }
+    SECTION(section_name("Check multi_ptr postdecrement operator")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_return_result_expected_val = arr[middle_elem_index];
+      op_calling_expected_val = arr[middle_elem_index - 1];
+      T op_calling_result_val;
+      T op_calling_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
+                                                 sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_return_res_val_acc =
+              op_return_res_val_buffer
+                  .template get_access<sycl::access_mode::write>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            multi_ptr_t mptr(acc_for_mptr);
+            multi_ptr_t result_mptr = mptr--;
+
+            op_return_res_val_acc[0] = result_mptr[0];
+            op_res_val_acc[0] = mptr[0];
+          });
+        });
+      }
+      CHECK(op_calling_result_val == op_return_result_expected_val);
+      CHECK(op_calling_val == op_calling_expected_val);
+    }
+
+    using diff_t = multi_ptr_t::difference_type;
+    diff_t shift = array_size / 3;
+
+    SECTION(section_name("Check multi_ptr operator+=")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_calling_expected_val = arr[middle_elem_index + shift];
+      T op_calling_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            multi_ptr_t mptr(acc_for_mptr);
+            mptr += shift;
+
+            op_res_val_acc[0] = mptr[0];
+          });
+        });
+      }
+      CHECK(op_calling_val == op_calling_expected_val);
+    }
+    SECTION(section_name("Check multi_ptr operator-=")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_calling_expected_val = arr[middle_elem_index - shift];
+      T op_calling_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            multi_ptr_t mptr(acc_for_mptr);
+            mptr -= shift;
+
+            op_res_val_acc[0] = mptr[0];
+          });
+        });
+      }
+      CHECK(op_calling_val == op_calling_expected_val);
+    }
+    SECTION(section_name("Check multi_ptr operator+")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_return_result_expected_val = arr[middle_elem_index + shift];
+      T op_calling_result_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
+                                          sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            const multi_ptr_t mptr(acc_for_mptr);
+            multi_ptr_t result_mptr = mptr + shift;
+
+            op_res_val_acc[0] = *result_mptr;
+          });
+        });
+      }
+      CHECK(op_calling_result_val == op_return_result_expected_val);
+    }
+    SECTION(section_name("Check multi_ptr operator-")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_return_result_expected_val = arr[middle_elem_index - shift];
+      T op_calling_result_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
+                                          sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            const multi_ptr_t mptr(acc_for_mptr);
+            multi_ptr_t result_mptr = mptr - shift;
+
+            op_res_val_acc[0] = *result_mptr;
+          });
+        });
+      }
+      CHECK(op_calling_result_val == op_return_result_expected_val);
+    }
+    SECTION(section_name("Check multi_ptr dereference operator")
+                .with("T", type_name)
+                .with("address_space", "access::address_space::global_space")
+                .with("decorated", is_decorated_name)
+                .create()) {
+      op_return_result_expected_val = arr[middle_elem_index];
+      T op_calling_result_val;
+      {
+        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
+                                          sycl::range<1>(1));
+        queue.submit([&](sycl::handler &cgh) {
+          auto acc_for_mptr =
+              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto op_res_val_acc =
+              op_res_val_buffer.template get_access<sycl::access_mode::write>(
+                  cgh);
+          cgh.single_task([=] {
+            const multi_ptr_t mptr(acc_for_mptr);
+
+            op_res_val_acc[0] = *mptr;
+          });
+        });
+      }
+      CHECK(op_calling_result_val == op_return_result_expected_val);
+    }
+  }
+};
+
+template <typename T>
+class check_multi_ptr_arithmetic_op_for_type {
+ public:
+  void operator()(const std::string &type_name) {
+    const auto address_spaces = multi_ptr_common::get_address_spaces();
+    const auto is_decorated = multi_ptr_common::get_decorated();
+    // Run test
+    for_all_combinations<run_multi_ptr_arithmetic_op_test, T>(
+        address_spaces, is_decorated, type_name);
+  }
+};
+
+}  // namespace multi_ptr_prefetch_member
+
+#endif  // __SYCLCTS_TESTS_MULTI_PTR_ARITHMETIC_OP_H

--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
 //
 //  SYCL 2020 Conformance Test Suite
@@ -49,31 +48,42 @@ class run_multi_ptr_arithmetic_op_test {
       arr[i] = i;
     }
     size_t middle_elem_index = array_size / 2;
+    // Expected value that will be returned after multi_ptr's operator will be
+    // called
     T op_return_result_expected_val;
+    // Expected value that will be stored into multi_ptr after
+    // multi_ptr's operator will be called
     T op_calling_expected_val;
 
     auto queue = sycl_cts::util::get_cts_object::queue();
-    T value = user_def_types::get_init_value_helper<T>(expected_val);
-    SECTION(section_name("Check multi_ptr preincrement operator")
+    SECTION(section_name("Check multi_ptr operator++(multi_ptr& mp)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_return_result_expected_val = arr[middle_elem_index + 1];
-      op_calling_expected_val = arr[middle_elem_index + 1];
+      op_return_result_expected_val = arr[1];
+      op_calling_expected_val = arr[1];
+      // Variable that will be used to store the value that will be returned
+      // after calling multi_ptr's operator
       T op_calling_result_val;
+      // Variable that will be used to store the multi_ptr's value after
+      // multi_ptr's operator will be called
       T op_calling_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
         sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
-                                                 sycl::range<1>(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+                                                 sycl::range(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the value that will be returned
+          // after calling multi_ptr's operator
           auto op_return_res_val_acc =
               op_return_res_val_buffer
                   .template get_access<sycl::access_mode::write>(cgh);
+          // Accessor that will be used to store the multi_ptr's value after
+          // multi_ptr's operator will be called
           auto op_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
@@ -81,34 +91,42 @@ class run_multi_ptr_arithmetic_op_test {
             multi_ptr_t mptr(acc_for_mptr);
             multi_ptr_t result_mptr = ++mptr;
 
-            op_return_res_val_acc[0] = result_mptr[0];
-            op_res_val_acc[0] = mptr[0];
+            op_return_res_val_acc[0] = *result_mptr;
+            op_res_val_acc[0] = *mptr;
           });
         });
       }
       CHECK(op_calling_result_val == op_return_result_expected_val);
       CHECK(op_calling_val == op_calling_expected_val);
     }
-    SECTION(section_name("Check multi_ptr postincrement operator")
+    SECTION(section_name("Check multi_ptr operator++(multi_ptr&, int)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_return_result_expected_val = arr[middle_elem_index];
-      op_calling_expected_val = arr[middle_elem_index + 1];
+      op_return_result_expected_val = arr[0];
+      op_calling_expected_val = arr[1];
+     // Variable that will be used to store the value that will be returned
+      // after calling multi_ptr's operator
       T op_calling_result_val;
+      // Variable that will be used to store the multi_ptr's value after
+      // multi_ptr's operator will be called
       T op_calling_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
         sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
-                                                 sycl::range<1>(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+                                                 sycl::range(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the value that will be returned
+          // after calling multi_ptr's operator
           auto op_return_res_val_acc =
               op_return_res_val_buffer
                   .template get_access<sycl::access_mode::write>(cgh);
+          // Accessor that will be used to store the multi_ptr's value after
+          // multi_ptr's operator will be called
           auto op_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
@@ -116,78 +134,100 @@ class run_multi_ptr_arithmetic_op_test {
             multi_ptr_t mptr(acc_for_mptr);
             multi_ptr_t result_mptr = mptr++;
 
-            op_return_res_val_acc[0] = result_mptr[0];
-            op_res_val_acc[0] = mptr[0];
+            op_return_res_val_acc[0] = *result_mptr;
+            op_res_val_acc[0] = *mptr;
           });
         });
       }
       CHECK(op_calling_result_val == op_return_result_expected_val);
       CHECK(op_calling_val == op_calling_expected_val);
     }
-    SECTION(section_name("Check multi_ptr predecrement operator")
+    SECTION(section_name("Check multi_ptr operator--(multi_ptr&)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
       op_return_result_expected_val = arr[middle_elem_index - 1];
       op_calling_expected_val = arr[middle_elem_index - 1];
+      // Variable that will be used to store the value that will be returned
+      // after calling multi_ptr's operator
       T op_calling_result_val;
+      // Variable that will be used to store the multi_ptr's value after
+      // multi_ptr's operator will be called
       T op_calling_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
         sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
-                                                 sycl::range<1>(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+                                                 sycl::range(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the value that will be returned
+          // after calling multi_ptr's operator
           auto op_return_res_val_acc =
               op_return_res_val_buffer
                   .template get_access<sycl::access_mode::write>(cgh);
+          // Accessor that will be used to store the multi_ptr's value after
+          // multi_ptr's operator will be called
           auto op_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
           cgh.single_task([=] {
             multi_ptr_t mptr(acc_for_mptr);
+            // Shift multi_ptr that he is pointed to the middle element, to have
+            // possibe decrease pointed value index
+            mptr += middle_elem_index;
             multi_ptr_t result_mptr = --mptr;
 
-            op_return_res_val_acc[0] = result_mptr[0];
-            op_res_val_acc[0] = mptr[0];
+            op_return_res_val_acc[0] = *result_mptr;
+            op_res_val_acc[0] = *mptr;
           });
         });
       }
       CHECK(op_calling_result_val == op_return_result_expected_val);
       CHECK(op_calling_val == op_calling_expected_val);
     }
-    SECTION(section_name("Check multi_ptr postdecrement operator")
+    SECTION(section_name("Check multi_ptr operator--(multi_ptr&, int)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
       op_return_result_expected_val = arr[middle_elem_index];
       op_calling_expected_val = arr[middle_elem_index - 1];
+      // Variable that will be used to store the value that will be returned
+      // after calling multi_ptr's operator
       T op_calling_result_val;
+      // Variable that will be used to store the multi_ptr's value after
+      // multi_ptr's operator will be called
       T op_calling_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
         sycl::buffer<T> op_return_res_val_buffer(&op_calling_result_val,
-                                                 sycl::range<1>(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+                                                 sycl::range(1));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the value that will be returned
+          // after calling multi_ptr's operator
           auto op_return_res_val_acc =
               op_return_res_val_buffer
                   .template get_access<sycl::access_mode::write>(cgh);
+          // Accessor that will be used to store the multi_ptr's value after
+          // multi_ptr's operator will be called
           auto op_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
           cgh.single_task([=] {
             multi_ptr_t mptr(acc_for_mptr);
+            // Shift multi_ptr that he is pointed to the middle element, to have
+            // possibe decrease pointed value index
+            mptr += middle_elem_index;
             multi_ptr_t result_mptr = mptr--;
 
-            op_return_res_val_acc[0] = result_mptr[0];
-            op_res_val_acc[0] = mptr[0];
+            op_return_res_val_acc[0] = *result_mptr;
+            op_res_val_acc[0] = *mptr;
           });
         });
       }
@@ -197,20 +237,23 @@ class run_multi_ptr_arithmetic_op_test {
 
     using diff_t = multi_ptr_t::difference_type;
     diff_t shift = array_size / 3;
-
-    SECTION(section_name("Check multi_ptr operator+=")
+    SECTION(section_name("Check multi_ptr operator+=(multi_ptr&, diff_type)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_calling_expected_val = arr[middle_elem_index + shift];
+      op_calling_expected_val = arr[shift];
+      // Variable that will be used to store the multi_ptr's value after
+      // multi_ptr's operator will be called
       T op_calling_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the multi_ptr's value after
+          // multi_ptr's operator will be called
           auto op_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
@@ -218,113 +261,137 @@ class run_multi_ptr_arithmetic_op_test {
             multi_ptr_t mptr(acc_for_mptr);
             mptr += shift;
 
-            op_res_val_acc[0] = mptr[0];
+            op_res_val_acc[0] = *mptr;
           });
         });
       }
       CHECK(op_calling_val == op_calling_expected_val);
     }
-    SECTION(section_name("Check multi_ptr operator-=")
+    SECTION(section_name("Check multi_ptr operator-=(multi_ptr&, diff_type)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
       op_calling_expected_val = arr[middle_elem_index - shift];
+      // Variable that will be used to store the multi_ptr's value after
+      // multi_ptr's operator will be called
       T op_calling_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
-        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
+        sycl::buffer<T> op_res_val_buffer(&op_calling_val, sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the multi_ptr's value after
+          // multi_ptr's operator will be called
           auto op_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
           cgh.single_task([=] {
             multi_ptr_t mptr(acc_for_mptr);
+            // Shift multi_ptr that he is pointed to the middle element, to have
+            // possibe decrease pointed value index
+            mptr += middle_elem_index;
             mptr -= shift;
 
-            op_res_val_acc[0] = mptr[0];
+            op_res_val_acc[0] = *mptr;
           });
         });
       }
       CHECK(op_calling_val == op_calling_expected_val);
     }
-    SECTION(section_name("Check multi_ptr operator+")
-                .with("T", type_name)
-                .with("address_space", "access::address_space::global_space")
-                .with("decorated", is_decorated_name)
-                .create()) {
-      op_return_result_expected_val = arr[middle_elem_index + shift];
+    SECTION(
+        section_name("Check multi_ptr operator+(const multi_ptr&, diff_type)")
+            .with("T", type_name)
+            .with("address_space", "access::address_space::global_space")
+            .with("decorated", is_decorated_name)
+            .create()) {
+      op_return_result_expected_val = arr[shift];
+      // Variable that will be used to store the value that will be returned
+      // after calling multi_ptr's operator
       T op_calling_result_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
         sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
-                                          sycl::range<1>(1));
+                                          sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
-          auto op_res_val_acc =
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the value that will be returned
+          // after calling multi_ptr's operator
+          auto op_return_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
           cgh.single_task([=] {
             const multi_ptr_t mptr(acc_for_mptr);
             multi_ptr_t result_mptr = mptr + shift;
 
-            op_res_val_acc[0] = *result_mptr;
+            op_return_res_val_acc[0] = *result_mptr;
           });
         });
       }
       CHECK(op_calling_result_val == op_return_result_expected_val);
     }
-    SECTION(section_name("Check multi_ptr operator-")
-                .with("T", type_name)
-                .with("address_space", "access::address_space::global_space")
-                .with("decorated", is_decorated_name)
-                .create()) {
+    SECTION(
+        section_name("Check multi_ptr operator-(const multi_ptr&, diff_type)")
+            .with("T", type_name)
+            .with("address_space", "access::address_space::global_space")
+            .with("decorated", is_decorated_name)
+            .create()) {
       op_return_result_expected_val = arr[middle_elem_index - shift];
+      // Variable that will be used to store the value that will be returned
+      // after calling multi_ptr's operator
       T op_calling_result_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
         sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
-                                          sycl::range<1>(1));
+                                          sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
-          auto op_res_val_acc =
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the value that will be returned
+          // after calling multi_ptr's operator
+          auto op_return_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
           cgh.single_task([=] {
             const multi_ptr_t mptr(acc_for_mptr);
+            // Shift multi_ptr that he is pointed to the middle element, to have
+            // possibe decrease pointed value index
+            mptr += middle_elem_index;
             multi_ptr_t result_mptr = mptr - shift;
 
-            op_res_val_acc[0] = *result_mptr;
+            op_return_res_val_acc[0] = *result_mptr;
           });
         });
       }
       CHECK(op_calling_result_val == op_return_result_expected_val);
     }
-    SECTION(section_name("Check multi_ptr dereference operator")
+    SECTION(section_name("Check multi_ptr operator*(const multi_ptr&)")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)
                 .create()) {
-      op_return_result_expected_val = arr[middle_elem_index];
+      op_return_result_expected_val = arr[0];
+      // Variable that will be used to store the value that will be returned
+      // after calling multi_ptr's operator
       T op_calling_result_val;
       {
-        sycl::buffer<T> val_buffer(&arr[middle_elem_index], sycl::range<1>(1));
+        sycl::buffer<T> buffer_for_mptr(arr, sycl::range(array_size));
         sycl::buffer<T> op_res_val_buffer(&op_calling_result_val,
-                                          sycl::range<1>(1));
+                                          sycl::range(1));
         queue.submit([&](sycl::handler &cgh) {
           auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
-          auto op_res_val_acc =
+              buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+          // Accessor that will be used to store the value that will be returned
+          // after calling multi_ptr's operator
+          auto op_return_res_val_acc =
               op_res_val_buffer.template get_access<sycl::access_mode::write>(
                   cgh);
           cgh.single_task([=] {
             const multi_ptr_t mptr(acc_for_mptr);
 
-            op_res_val_acc[0] = *mptr;
+            op_return_res_val_acc[0] = *mptr;
           });
         });
       }

--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -14,6 +14,8 @@
 #include "../common/section_name_builder.h"
 #include "multi_ptr_common.h"
 
+#include <optional>  // for std::optional
+
 namespace multi_ptr_arithmetic_op {
 
 namespace detail {
@@ -24,15 +26,15 @@ namespace detail {
  */
 template <typename T>
 struct test_results {
-  // Value that will be used to initialze variables with random values to avoid
-  // false positive test result
-  constexpr int value_to_init = 49;
+  // Use std::optional to disable verification if some member hasn't been
+  // initialised by some value
+
   // Expected value that will be returned after multi_ptr's operator will be
   // called
-  T op_return_result_val = value_to_init;
+  std::optional<T> op_return_result_val;
   // Expected value that will be stored into multi_ptr after
   // multi_ptr's operator will be called
-  T op_calling_val = value_to_init;
+  std::optional<T> op_calling_val;
 };
 
 }  // namespace detail
@@ -55,7 +57,6 @@ class run_multi_ptr_arithmetic_op_test {
   size_t m_middle_elem_index = m_array_size / 2;
 
   sycl::range m_r = sycl::range(1);
-  T m_default_expected_val = 55;
 
   template <typename TestActionT>
   void run_test(sycl::queue &queue, TestActionT test_action,
@@ -85,15 +86,15 @@ class run_multi_ptr_arithmetic_op_test {
         }
       });
     }
-    // If expected value is equal to default value, then verification should be
+    // If expected value isn't initialized, then this verification should be
     // skipped
-    if (expected_results.op_return_result_val != m_default_expected_val) {
+    if (expected_results.op_return_result_val) {
       CHECK(expected_results.op_return_result_val ==
             test_results.op_return_result_val);
     }
-    // If expected value is equal to default value, then verification should be
+    // If expected value isn't initialized, then this verification should be
     // skipped
-    if (expected_results.op_calling_val != m_default_expected_val) {
+    if (expected_results.op_calling_val) {
       CHECK(expected_results.op_calling_val == test_results.op_calling_val);
     }
   }
@@ -236,8 +237,6 @@ class run_multi_ptr_arithmetic_op_test {
       // Expected value that be contained into multi_ptr after multi_ptr's
       // operator will be called
       verification_points.op_calling_val = m_arr[shift];
-      // Assing m_default_expected_val to skip verification of this value
-      verification_points.op_return_result_val = m_default_expected_val;
 
       const auto run_test_action = [=](auto acc_for_mptr,
                                        auto test_result_acc) {
@@ -260,8 +259,6 @@ class run_multi_ptr_arithmetic_op_test {
       // Expected value that be contained into multi_ptr after multi_ptr's
       // operator will be called
       verification_points.op_calling_val = m_arr[m_middle_elem_index - shift];
-      // Assing m_default_expected_val to skip verification of this value
-      verification_points.op_return_result_val = m_default_expected_val;
 
       const auto run_test_action = [=](auto acc_for_mptr,
                                        auto test_result_acc) {
@@ -289,8 +286,6 @@ class run_multi_ptr_arithmetic_op_test {
       // Expected value that be contained into multi_ptr after multi_ptr's
       // operator will be called
       verification_points.op_return_result_val = m_arr[shift];
-      // Assing m_default_expected_val to skip verification of this value
-      verification_points.op_calling_val = m_default_expected_val;
 
       const auto run_test_action = [=](auto acc_for_mptr,
                                        auto test_result_acc) {
@@ -315,8 +310,6 @@ class run_multi_ptr_arithmetic_op_test {
       // operator will be called
       verification_points.op_return_result_val =
           m_arr[m_middle_elem_index - shift];
-      // Assing m_default_expected_val to skip verification of this value
-      verification_points.op_calling_val = m_default_expected_val;
 
       const auto run_test_action = [=](auto acc_for_mptr,
                                        auto test_result_acc) {
@@ -343,8 +336,6 @@ class run_multi_ptr_arithmetic_op_test {
       // Expected value that be contained into multi_ptr after multi_ptr's
       // operator will be called
       verification_points.op_return_result_val = m_arr[0];
-      // Assing m_default_expected_val to skip verification of this value
-      verification_points.op_calling_val = m_default_expected_val;
 
       const auto run_test_action = [](auto acc_for_mptr, auto test_result_acc) {
         const multi_ptr_t mptr(acc_for_mptr);

--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -142,7 +142,7 @@ class run_multi_ptr_arithmetic_op_test {
     }
     SECTION(section_name("Check multi_ptr operator++(multi_ptr&, int)")
                 .with("T", type_name)
-                .with("address_space", "access::address_space::global_space")
+                .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
@@ -166,7 +166,7 @@ class run_multi_ptr_arithmetic_op_test {
     }
     SECTION(section_name("Check multi_ptr operator--(multi_ptr&)")
                 .with("T", type_name)
-                .with("address_space", "access::address_space::global_space")
+                .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
@@ -195,7 +195,7 @@ class run_multi_ptr_arithmetic_op_test {
     }
     SECTION(section_name("Check multi_ptr operator--(multi_ptr&, int)")
                 .with("T", type_name)
-                .with("address_space", "access::address_space::global_space")
+                .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
@@ -227,7 +227,7 @@ class run_multi_ptr_arithmetic_op_test {
     diff_t shift = m_array_size / 3;
     SECTION(section_name("Check multi_ptr operator+=(multi_ptr&, diff_type)")
                 .with("T", type_name)
-                .with("address_space", "access::address_space::global_space")
+                .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
@@ -251,7 +251,7 @@ class run_multi_ptr_arithmetic_op_test {
     }
     SECTION(section_name("Check multi_ptr operator-=(multi_ptr&, diff_type)")
                 .with("T", type_name)
-                .with("address_space", "access::address_space::global_space")
+                .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
@@ -280,7 +280,7 @@ class run_multi_ptr_arithmetic_op_test {
     SECTION(
         section_name("Check multi_ptr operator+(const multi_ptr&, diff_type)")
             .with("T", type_name)
-            .with("address_space", "access::address_space::global_space")
+            .with("address_space", address_space_name)
             .with("decorated", is_decorated_name)
             .create()) {
       // Variable that contains all variables that will be used to verify test
@@ -305,7 +305,7 @@ class run_multi_ptr_arithmetic_op_test {
     SECTION(
         section_name("Check multi_ptr operator-(const multi_ptr&, diff_type)")
             .with("T", type_name)
-            .with("address_space", "access::address_space::global_space")
+            .with("address_space", address_space_name)
             .with("decorated", is_decorated_name)
             .create()) {
       // Variable that contains all variables that will be used to verify test
@@ -334,7 +334,7 @@ class run_multi_ptr_arithmetic_op_test {
     }
     SECTION(section_name("Check multi_ptr operator*(const multi_ptr&)")
                 .with("T", type_name)
-                .with("address_space", "access::address_space::global_space")
+                .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test

--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -14,7 +14,7 @@
 #include "../common/section_name_builder.h"
 #include "multi_ptr_common.h"
 
-namespace multi_ptr_prefetch_member {
+namespace multi_ptr_arithmetic_op {
 
 namespace detail {
 
@@ -369,6 +369,6 @@ class check_multi_ptr_arithmetic_op_for_type {
   }
 };
 
-}  // namespace multi_ptr_prefetch_member
+}  // namespace multi_ptr_arithmetic_op
 
 #endif  // __SYCLCTS_TESTS_MULTI_PTR_ARITHMETIC_OP_H

--- a/tests/multi_ptr/multi_ptr_arithmetic_op_core.cpp
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op_core.cpp
@@ -12,7 +12,7 @@
 
 namespace multi_ptr_arithmetic_op_core {
 
-TEST_CASE("Arithmetic operators. core types", "[multi_ptr]") {
+TEST_CASE("Arithmetic operators. Core types.", "[multi_ptr]") {
   using namespace multi_ptr_arithmetic_op;
   auto types = multi_ptr_convert::get_types();
   auto composite_types = multi_ptr_convert::get_composite_types();

--- a/tests/multi_ptr/multi_ptr_arithmetic_op_core.cpp
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op_core.cpp
@@ -1,0 +1,24 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr arithmetic operators for core types
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_arithmetic_op.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_arithmetic_op_core {
+
+TEST_CASE("Arithmetic operators. core types", "[multi_ptr]") {
+  using namespace multi_ptr_arithmetic_op;
+  auto types = multi_ptr_convert::get_types();
+  auto composite_types = multi_ptr_convert::get_composite_types();
+
+  for_all_types<check_multi_ptr_arithmetic_op_for_type>(types);
+  for_all_types<check_multi_ptr_arithmetic_op_for_type>(composite_types);
+}
+
+}  // namespace multi_ptr_arithmetic_op_core

--- a/tests/multi_ptr/multi_ptr_arithmetic_op_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op_fp16.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr arithmetic operators for sycl::half type
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_arithmetic_op.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_arithmetic_op_fp16 {
+
+TEST_CASE("Arithmetic operators. fp16 type", "[multi_ptr]") {
+  using namespace multi_ptr_arithmetic_op;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    WARN(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+  check_multi_ptr_arithmetic_op_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace multi_ptr_arithmetic_op_fp16

--- a/tests/multi_ptr/multi_ptr_arithmetic_op_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op_fp64.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr arithmetic operators for double type
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_arithmetic_op.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_arithmetic_op_fp64 {
+
+TEST_CASE("Arithmetic operators. fp64 type", "[multi_ptr]") {
+  using namespace multi_ptr_arithmetic_op;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    WARN(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+  check_multi_ptr_arithmetic_op_for_type<double>{}("double");
+}
+
+}  // namespace multi_ptr_arithmetic_op_fp64


### PR DESCRIPTION
The test provides verification for the following arithmetic operators:
- `multi_ptr& operator++(multi_ptr& mp)`
- `multi_ptr operator++(multi_ptr& mp, int)`
- `multi_ptr& operator--(multi_ptr& mp)`
- `multi_ptr operator--(multi_ptr& mp, int)`
- `multi_ptr& operator+=(multi_ptr& lhs, difference_type r)`
- `multi_ptr& operator-=(multi_ptr& lhs, difference_type r)`
- `multi_ptr operator+(const multi_ptr& lhs, difference_type r)`
- `multi_ptr operator-(const multi_ptr& lhs, difference_type r)`
- `reference operator*(const multi_ptr& lhs)`