### PR TITLE
Require size member function for assign and are_equal

### DIFF
--- a/tests/common/value_operations.h
+++ b/tests/common/value_operations.h
@@ -40,8 +40,8 @@ inline void assign(ArrayT<LeftArrT, LeftArrN>& left,
 }
 
 template <typename LeftArrT, typename RightNonArrT>
-inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
-                                 !has_subscript_operator_v<RightNonArrT>>
+inline typename std::enable_if_t<has_subscript_and_size_v<LeftArrT> &&
+                                 !has_subscript_and_size_v<RightNonArrT>>
 assign(LeftArrT& left, const RightNonArrT& right) {
   for (size_t i = 0; i < left.size(); ++i) {
     left[i] = right;
@@ -49,8 +49,8 @@ assign(LeftArrT& left, const RightNonArrT& right) {
 }
 
 template <typename LeftArrT, typename RightArrT>
-inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
-                                 has_subscript_operator_v<RightArrT>>
+inline typename std::enable_if_t<has_subscript_and_size_v<LeftArrT> &&
+                                 has_subscript_and_size_v<RightArrT>>
 assign(LeftArrT& left, const RightArrT& right) {
   assert((left.size() == right.size()) && "Arrays have to be the same size");
   for (size_t i = 0; i < left.size(); ++i) {
@@ -59,8 +59,8 @@ assign(LeftArrT& left, const RightArrT& right) {
 }
 
 template <typename LeftNonArrT, typename RightNonArrT = LeftNonArrT>
-inline typename std::enable_if_t<!has_subscript_operator_v<LeftNonArrT> &&
-                                 !has_subscript_operator_v<RightNonArrT>>
+inline typename std::enable_if_t<!has_subscript_and_size_v<LeftNonArrT> &&
+                                 !has_subscript_and_size_v<RightNonArrT>>
 assign(LeftNonArrT& left, const RightNonArrT& right) {
   left = right;
 }
@@ -87,8 +87,8 @@ inline bool are_equal(const ArrayT<LeftArrT, LeftArrN>& left,
 }
 
 template <typename LeftArrT, typename RightNonArrT>
-inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
-                                     !has_subscript_operator_v<RightNonArrT>,
+inline typename std::enable_if_t<has_subscript_and_size_v<LeftArrT> &&
+                                     !has_subscript_and_size_v<RightNonArrT>,
                                  bool>
 are_equal(const LeftArrT& left, const RightNonArrT& right) {
   for (size_t i = 0; i < left.size(); ++i) {
@@ -98,8 +98,8 @@ are_equal(const LeftArrT& left, const RightNonArrT& right) {
 }
 
 template <typename LeftArrT, typename RightArrT>
-inline typename std::enable_if_t<has_subscript_operator_v<LeftArrT> &&
-                                     has_subscript_operator_v<RightArrT>,
+inline typename std::enable_if_t<has_subscript_and_size_v<LeftArrT> &&
+                                     has_subscript_and_size_v<RightArrT>,
                                  bool>
 are_equal(const LeftArrT& left, const RightArrT& right) {
   assert((left.size() == right.size()) && "Arrays have to be the same size");
@@ -110,8 +110,8 @@ are_equal(const LeftArrT& left, const RightArrT& right) {
 }
 
 template <typename LeftNonArrT, typename RightNonArrT = LeftNonArrT>
-inline typename std::enable_if_t<!has_subscript_operator_v<LeftNonArrT> &&
-                                     !has_subscript_operator_v<RightNonArrT>,
+inline typename std::enable_if_t<!has_subscript_and_size_v<LeftNonArrT> &&
+                                     !has_subscript_and_size_v<RightNonArrT>,
                                  bool>
 are_equal(const LeftNonArrT& left, const RightNonArrT& right) {
   return (left == right);

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -101,6 +101,42 @@ template <typename T>
 inline constexpr bool has_subscript_operator_v =
     has_subscript_operator_t<T>::value;
 
+/**
+ * @brief Verify \c T has size member function
+ */
+template <typename T, typename = void>
+struct has_size : std::false_type {};
+
+template <typename T>
+struct has_size<
+    T, std::void_t<decltype(std::declval<T>().size())>>
+    : std::true_type {};
+
+/**
+ * @brief Shortcut for has_size::type
+ */
+template <typename T>
+using has_size_t = typename has_size<T>::type;
+
+/**
+ * @brief Shortcut for has_size::value
+ */
+template <typename T>
+constexpr bool has_size_v = has_size_t<T>::value;
+
+/**
+ * @brief Verify \c T has both subscript operator and size member function
+ */
+template <typename T> struct has_subscript_and_size {
+    static constexpr bool value = has_subscript_operator_v<T> && has_size_v<T>;
+};
+
+/**
+ * @brief Shortcut for has_subscript_and_size::value
+ */
+template <typename T>
+constexpr bool has_subscript_and_size_v = has_subscript_and_size<T>::value;
+
 }  // namespace
 
 #endif  // __SYCLCTS_UTIL_TYPE_TRAITS_H

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -122,20 +122,19 @@ using has_size_t = typename has_size<T>::type;
  * @brief Shortcut for has_size::value
  */
 template <typename T>
-constexpr bool has_size_v = has_size_t<T>::value;
+constexpr inline bool has_size_v = has_size_t<T>::value;
 
 /**
  * @brief Verify \c T has both subscript operator and size member function
  */
-template <typename T> struct has_subscript_and_size {
-    static constexpr bool value = has_subscript_operator_v<T> && has_size_v<T>;
-};
+template <typename T>
+using has_subscript_and_size = std::conjunction<has_subscript_operator<T>, has_size<T>>;
 
 /**
  * @brief Shortcut for has_subscript_and_size::value
  */
 template <typename T>
-constexpr bool has_subscript_and_size_v = has_subscript_and_size<T>::value;
+constexpr inline bool has_subscript_and_size_v = has_subscript_and_size<T>::value;
 
 }  // namespace
 


### PR DESCRIPTION
Overloads of `value_operations::assign` and `value_operations::are_equal` for types with subscript operator uses the `size` member function for iterating the members. However it only checks for the subscript operator. This can cause compile-time errors when using these with types such as `user_struct` that define the subscript operator and a comparison operator but not the `size` member function.

This commit further restricts the aforementioned overloads by requiring the `size` member function. This is done through adding a new type trait for checking a type for the `size` member function, namely `has_size`, and a shortcut trait `has_subscript_and_size` for the conjunction of `has_subscript_operator` and `has_size`.