### PR TITLE
Add test on multi_ptr comparison operators

### DIFF
--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -33,15 +33,15 @@ struct mptr_mptr_test_results {
   // Use std::optional to disable verification if some member hasn't been
   // initialised by some value
 
-  // Expected value that will be returned after "lower_mptr *current operator*
-  // lower_mptr" operator will be called
-  std::optional<bool> lower_lower_mptr_result_val;
-  // Expected value that will be returned after "greater_mptr *current operator*
-  // lower_mptr" operator will be called
-  std::optional<bool> greater_lower_mptr_result_val;
-  // Expected value that will be returned after "lower_mptr *current operator*
-  // greater_mptr" operator will be called
-  std::optional<bool> lower_greater_mptr_result_val;
+  // Expected value that will be returned after "first_mptr *current operator*
+  // first_mptr" operator will be called
+  std::optional<bool> first_first_mptr_result_val;
+  // Expected value that will be returned after "second_mptr *current operator*
+  // first_mptr" operator will be called
+  std::optional<bool> second_first_mptr_result_val;
+  // Expected value that will be returned after "first_mptr *current operator*
+  // second_mptr" operator will be called
+  std::optional<bool> first_second_mptr_result_val;
 
   /**
    * @brief Verified test result. The object's data, that will call this
@@ -51,21 +51,21 @@ struct mptr_mptr_test_results {
   void verify_resuts(const mptr_mptr_test_results<T> &retreived_results) const {
     // If expected value isn't initialized, then this verification should be
     // skipped
-    if (lower_lower_mptr_result_val) {
-      CHECK(lower_lower_mptr_result_val ==
-            retreived_results.lower_lower_mptr_result_val);
+    if (first_first_mptr_result_val) {
+      CHECK(first_first_mptr_result_val ==
+            retreived_results.first_first_mptr_result_val);
     }
     // If expected value isn't initialized, then this verification should be
     // skipped
-    if (greater_lower_mptr_result_val) {
-      CHECK(greater_lower_mptr_result_val ==
-            retreived_results.greater_lower_mptr_result_val);
+    if (second_first_mptr_result_val) {
+      CHECK(second_first_mptr_result_val ==
+            retreived_results.second_first_mptr_result_val);
     }
     // If expected value isn't initialized, then this verification should be
     // skipped
-    if (lower_greater_mptr_result_val) {
-      CHECK(lower_greater_mptr_result_val ==
-            retreived_results.lower_greater_mptr_result_val);
+    if (first_second_mptr_result_val) {
+      CHECK(first_second_mptr_result_val ==
+            retreived_results.first_second_mptr_result_val);
     }
   }
 };
@@ -155,8 +155,7 @@ class run_multi_ptr_comparison_op_test {
     ExpectedTestResultT test_results;
     {
       sycl::buffer<T> array_buffer(values_arr, std::size(values_arr));
-      sycl::buffer<ExpectedTestResultT> test_result_buffer(&test_results,
-                                                           m_r);
+      sycl::buffer<ExpectedTestResultT> test_result_buffer(&test_results, m_r);
       queue.submit([&](sycl::handler &cgh) {
         auto array_acc =
             array_buffer.template get_access<sycl::access_mode::read>(cgh);
@@ -198,12 +197,12 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "lower_mptr == lower_mptr"
+      // Expected value that will be returned after "first_mptr == first_mptr"
       // operator will be called
-      expected_results.lower_lower_mptr_result_val = true;
-      // Expected value that will be returned after "lower_mptr == greater_mptr"
+      expected_results.first_first_mptr_result_val = true;
+      // Expected value that will be returned after "first_mptr == second_mptr"
       // operator will be called
-      expected_results.lower_greater_mptr_result_val = false;
+      expected_results.first_second_mptr_result_val = false;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t arr_mptr(arr_acc);
@@ -214,8 +213,8 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.lower_lower_mptr_result_val = mptr_1 == mptr_1;
-        test_result.lower_greater_mptr_result_val = mptr_1 == mptr_2;
+        test_result.first_first_mptr_result_val = mptr_1 == mptr_1;
+        test_result.first_second_mptr_result_val = mptr_1 == mptr_2;
       };
 
       run_test(queue, run_test_action, expected_results);
@@ -230,12 +229,12 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "lower_mptr != lower_mptr"
+      // Expected value that will be returned after "first_mptr != first_mptr"
       // operator will be called
-      expected_results.lower_lower_mptr_result_val = false;
-      // Expected value that will be returned after "lower_mptr != greater_mptr"
+      expected_results.first_first_mptr_result_val = false;
+      // Expected value that will be returned after "first_mptr != second_mptr"
       // operator will be called
-      expected_results.lower_greater_mptr_result_val = true;
+      expected_results.first_second_mptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t arr_mptr(arr_acc);
@@ -246,8 +245,8 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.lower_lower_mptr_result_val = mptr_1 != mptr_1;
-        test_result.lower_greater_mptr_result_val = mptr_1 != mptr_2;
+        test_result.first_first_mptr_result_val = mptr_1 != mptr_1;
+        test_result.first_second_mptr_result_val = mptr_1 != mptr_2;
       };
 
       run_test(queue, run_test_action, expected_results);
@@ -261,12 +260,12 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "lower_mptr < lower_mptr"
+      // Expected value that will be returned after "first_mptr < first_mptr"
       // operator will be called
-      expected_results.lower_lower_mptr_result_val = false;
-      // Expected value that will be returned after "lower_mptr < greater_mptr"
+      expected_results.first_first_mptr_result_val = false;
+      // Expected value that will be returned after "first_mptr < second_mptr"
       // operator will be called
-      expected_results.lower_greater_mptr_result_val = true;
+      expected_results.first_second_mptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t arr_mptr(arr_acc);
@@ -277,8 +276,8 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.lower_lower_mptr_result_val = mptr_1 < mptr_1;
-        test_result.lower_greater_mptr_result_val = mptr_1 < mptr_2;
+        test_result.first_first_mptr_result_val = mptr_1 < mptr_1;
+        test_result.first_second_mptr_result_val = mptr_1 < mptr_2;
       };
 
       run_test(queue, run_test_action, expected_results);
@@ -292,12 +291,12 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "lower_mptr > greater_mptr"
+      // Expected value that will be returned after "first_mptr > second_mptr"
       // operator will be called
-      expected_results.lower_lower_mptr_result_val = false;
-      // Expected value that will be returned after "greater_mptr > lower_mptr"
+      expected_results.first_first_mptr_result_val = false;
+      // Expected value that will be returned after "second_mptr > first_mptr"
       // operator will be called
-      expected_results.lower_greater_mptr_result_val = true;
+      expected_results.first_second_mptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t arr_mptr(arr_acc);
@@ -308,8 +307,8 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.lower_lower_mptr_result_val = mptr_1 > mptr_2;
-        test_result.lower_greater_mptr_result_val = mptr_2 > mptr_1;
+        test_result.first_first_mptr_result_val = mptr_1 > mptr_2;
+        test_result.first_second_mptr_result_val = mptr_2 > mptr_1;
       };
 
       run_test(queue, run_test_action, expected_results);
@@ -324,15 +323,15 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "lower_mptr <= lower_mptr"
+      // Expected value that will be returned after "first_mptr <= first_mptr"
       // operator will be called
-      expected_results.lower_lower_mptr_result_val = true;
-      // Expected value that will be returned after "lower_mptr <= greater_mptr"
+      expected_results.first_first_mptr_result_val = true;
+      // Expected value that will be returned after "first_mptr <= second_mptr"
       // operator will be called
-      expected_results.lower_greater_mptr_result_val = true;
-      // Expected value that will be returned after "greater_mptr <= lower_mptr"
+      expected_results.first_second_mptr_result_val = true;
+      // Expected value that will be returned after "second_mptr <= first_mptr"
       // operator will be called
-      expected_results.greater_lower_mptr_result_val = false;
+      expected_results.second_first_mptr_result_val = false;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t arr_mptr(arr_acc);
@@ -343,9 +342,9 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.lower_lower_mptr_result_val = mptr_1 <= mptr_1;
-        test_result.lower_greater_mptr_result_val = mptr_1 <= mptr_2;
-        test_result.greater_lower_mptr_result_val = mptr_2 <= mptr_1;
+        test_result.first_first_mptr_result_val = mptr_1 <= mptr_1;
+        test_result.first_second_mptr_result_val = mptr_1 <= mptr_2;
+        test_result.second_first_mptr_result_val = mptr_2 <= mptr_1;
       };
 
       run_test(queue, run_test_action, expected_results);
@@ -360,15 +359,15 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "lower_mptr >= lower_mptr"
+      // Expected value that will be returned after "first_mptr >= first_mptr"
       // operator will be called
-      expected_results.lower_lower_mptr_result_val = true;
-      // Expected value that will be returned after "greater_mptr >= lower_mptr"
+      expected_results.first_first_mptr_result_val = true;
+      // Expected value that will be returned after "second_mptr >= first_mptr"
       // operator will be called
-      expected_results.lower_greater_mptr_result_val = true;
-      // Expected value that will be returned after "lower_mptr >= greater_mptr"
+      expected_results.first_second_mptr_result_val = true;
+      // Expected value that will be returned after "first_mptr >= second_mptr"
       // operator will be called
-      expected_results.greater_lower_mptr_result_val = false;
+      expected_results.second_first_mptr_result_val = false;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t arr_mptr(arr_acc);
@@ -379,9 +378,9 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.lower_lower_mptr_result_val = mptr_1 >= mptr_1;
-        test_result.lower_greater_mptr_result_val = mptr_2 >= mptr_1;
-        test_result.greater_lower_mptr_result_val = mptr_1 >= mptr_2;
+        test_result.first_first_mptr_result_val = mptr_1 >= mptr_1;
+        test_result.first_second_mptr_result_val = mptr_2 >= mptr_1;
+        test_result.second_first_mptr_result_val = mptr_1 >= mptr_2;
       };
 
       run_test(queue, run_test_action, expected_results);

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -79,9 +79,6 @@ struct mptr_mptr_test_results {
  */
 template <typename T>
 struct mptr_nullptr_mptr_test_results {
-  // Use std::optional to disable verification if some member hasn't been
-  // initialised by some value
-
   // Expected value that will be returned after "nullptr *current operator*
   // nullptr_mptr" operator will be called
   bool nullptr_nullptr_mptr_result_val = true;
@@ -453,7 +450,7 @@ class run_multi_ptr_comparison_op_test {
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
-      // result
+      // result. We expect that all of them will be true.
       detail::mptr_nullptr_mptr_test_results<T> expected_results;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
@@ -485,7 +482,7 @@ class run_multi_ptr_comparison_op_test {
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
-      // result
+      // result. We expect that all of them will be true.
       detail::mptr_nullptr_mptr_test_results<T> expected_results;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
@@ -517,7 +514,7 @@ class run_multi_ptr_comparison_op_test {
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
-      // result
+      // result. We expect that all of them will be true.
       detail::mptr_nullptr_mptr_test_results<T> expected_results;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
@@ -549,7 +546,7 @@ class run_multi_ptr_comparison_op_test {
                 .with("decorated", is_decorated_name)
                 .create()) {
       // Variable that contains all variables that will be used to verify test
-      // result
+      // result. We expect that all of them will be true.
       detail::mptr_nullptr_mptr_test_results<T> expected_results;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -126,7 +126,7 @@ class run_multi_ptr_comparison_op_test {
 
   const T m_small_value = 1;
   const T m_great_value = 2;
-  // Use an array to be sure that we have two elements that has subsequence
+  // Use an array to be sure that we have two elements that has consecutive
   // memory addresses
   const T m_values_arr[2] = {m_small_value, m_great_value};
   sycl::range m_r(1);

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
 //
 //  SYCL 2020 Conformance Test Suite
@@ -125,11 +124,11 @@ class run_multi_ptr_comparison_op_test {
 
   using multi_ptr_t = sycl::multi_ptr<T, space, decorated>;
 
-  const T m_low_value = 1;
+  const T m_small_value = 1;
   const T m_great_value = 2;
   // Use an array to be sure that we have two elements that has subsequence
   // memory addresses
-  const T m_values_arr[2] = {m_low_value, m_great_value};
+  const T m_values_arr[2] = {m_small_value, m_great_value};
   sycl::range m_r(1);
 
   template <typename TestActionT, typename ExpectedTestResultT>
@@ -148,13 +147,9 @@ class run_multi_ptr_comparison_op_test {
             test_result_buffer.template get_access<sycl::access_mode::write>(
                 cgh);
 
-        if constexpr (space == sycl::access::address_space::global_space) {
-          cgh.single_task([=] { test_action(array_acc, test_result_acc); });
-        } else {
-          cgh.parallel_for(sycl::nd_range(m_r, m_r), [=](sycl::nd_item item) {
-            test_action(array_acc, test_result_acc);
-          });
-        }
+        cgh.parallel_for(sycl::nd_range(m_r, m_r), [=](sycl::nd_item item) {
+          test_action(array_acc, test_result_acc);
+        });
       });
     }
     expected_results.verify_results(test_results);
@@ -278,10 +273,10 @@ class run_multi_ptr_comparison_op_test {
       detail::mptr_mptr_test_results<T> expected_results;
       // Expected value that will be returned after "first_mptr > second_mptr"
       // operator will be called
-      expected_results.first_first_mptr_result_val = false;
+      expected_results.first_second_mptr_result_val = false;
       // Expected value that will be returned after "second_mptr > first_mptr"
       // operator will be called
-      expected_results.first_second_mptr_result_val = true;
+      expected_results.second_first_mptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t arr_mptr(arr_acc);
@@ -292,8 +287,8 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.first_first_mptr_result_val = mptr_1 > mptr_2;
-        test_result.first_second_mptr_result_val = mptr_2 > mptr_1;
+        test_result.first_second_mptr_result_val = mptr_1 > mptr_2;
+        test_result.second_first_mptr_result_val = mptr_2 > mptr_1;
       };
 
       run_test(queue, run_test_action, expected_results);

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -47,26 +47,27 @@ struct mptr_mptr_test_results {
   /**
    * @brief Verified test result. The object's data, that will call this
    *        function, will used as expected results
-   * @param retreived_results Retreived test results
+   * @param retrieved_results Retrieved test results
    */
-  void verify_resuts(const mptr_mptr_test_results<T> &retreived_results) const {
+  void verify_results(
+      const mptr_mptr_test_results<T> &retrieved_results) const {
     // If expected value isn't initialized, then this verification should be
     // skipped
     if (first_first_mptr_result_val) {
       CHECK(first_first_mptr_result_val ==
-            retreived_results.first_first_mptr_result_val);
+            retrieved_results.first_first_mptr_result_val);
     }
     // If expected value isn't initialized, then this verification should be
     // skipped
     if (second_first_mptr_result_val) {
       CHECK(second_first_mptr_result_val ==
-            retreived_results.second_first_mptr_result_val);
+            retrieved_results.second_first_mptr_result_val);
     }
     // If expected value isn't initialized, then this verification should be
     // skipped
     if (first_second_mptr_result_val) {
       CHECK(first_second_mptr_result_val ==
-            retreived_results.first_second_mptr_result_val);
+            retrieved_results.first_second_mptr_result_val);
     }
   }
 };
@@ -83,48 +84,32 @@ struct mptr_nullptr_mptr_test_results {
 
   // Expected value that will be returned after "nullptr *current operator*
   // nullptr_mptr" operator will be called
-  std::optional<bool> nullptr_nullptr_mptr_result_val;
+  bool nullptr_nullptr_mptr_result_val = true;
   // Expected value that will be returned after "nullptr_mptr *current operator*
   // nullptr" operator will be called
-  std::optional<bool> nullptr_mptr_nullptr_result_val;
+  bool nullptr_mptr_nullptr_result_val = true;
   // Expected value that will be returned after "nullptr *current operator*
   // value_mptr" operator will be called
-  std::optional<bool> nullptr_value_mptr_result_val;
+  bool nullptr_value_mptr_result_val = true;
   // Expected value that will be returned after "value_mptr *current operator*
   // nullptr" operator will be called
-  std::optional<bool> value_mptr_nullptr_result_val;
+  bool value_mptr_nullptr_result_val = true;
 
   /**
    * @brief Verified test result. The object's data, that will call this
    *        function, will used as expected results
-   * @param retreived_results Retreived test results
+   * @param retrieved_results Retrieved test results
    */
-  void verify_resuts(
-      const mptr_nullptr_mptr_test_results<T> &retreived_results) const {
-    // If expected value isn't initialized, then this verification should be
-    // skipped
-    if (nullptr_nullptr_mptr_result_val) {
-      CHECK(nullptr_nullptr_mptr_result_val ==
-            retreived_results.nullptr_nullptr_mptr_result_val);
-    }
-    // If expected value isn't initialized, then this verification should be
-    // skipped
-    if (nullptr_mptr_nullptr_result_val) {
-      CHECK(nullptr_mptr_nullptr_result_val ==
-            retreived_results.nullptr_mptr_nullptr_result_val);
-    }
-    // If expected value isn't initialized, then this verification should be
-    // skipped
-    if (nullptr_value_mptr_result_val) {
-      CHECK(nullptr_value_mptr_result_val ==
-            retreived_results.nullptr_value_mptr_result_val);
-    }
-    // If expected value isn't initialized, then this verification should be
-    // skipped
-    if (value_mptr_nullptr_result_val) {
-      CHECK(value_mptr_nullptr_result_val ==
-            retreived_results.value_mptr_nullptr_result_val);
-    }
+  void verify_results(
+      const mptr_nullptr_mptr_test_results<T> &retrieved_results) const {
+    CHECK(nullptr_nullptr_mptr_result_val ==
+          retrieved_results.nullptr_nullptr_mptr_result_val);
+    CHECK(nullptr_mptr_nullptr_result_val ==
+          retrieved_results.nullptr_mptr_nullptr_result_val);
+    CHECK(nullptr_value_mptr_result_val ==
+          retrieved_results.nullptr_value_mptr_result_val);
+    CHECK(value_mptr_nullptr_result_val ==
+          retrieved_results.value_mptr_nullptr_result_val);
   }
 };
 
@@ -146,7 +131,7 @@ class run_multi_ptr_comparison_op_test {
   const T m_low_value = 1;
   const T m_great_value = 2;
   // Use an array to be sure that we have two elements that has subsequence
-  // memory addereses
+  // memory addresses
   const T m_values_arr[2] = {m_low_value, m_great_value};
   sycl::range m_r(1);
 
@@ -175,7 +160,7 @@ class run_multi_ptr_comparison_op_test {
         }
       });
     }
-    expected_results.verify_resuts(test_results);
+    expected_results.verify_results(test_results);
   }
 
  public:
@@ -470,18 +455,6 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_nullptr_mptr_test_results<T> expected_results;
-      // We expect that "nullptr < nullptr_mptr" result should be equal to
-      // std::less<multi_ptr_t<()(nullptr, nullptr_mptr) result
-      expected_results.nullptr_nullptr_mptr_result_val = true;
-      // We expect that "nullptr_mptr < nullptr" result should be equal to
-      // std::less<multi_ptr_t<()(nullptr_mptr, nullptr) result
-      expected_results.nullptr_mptr_nullptr_result_val = true;
-      // We expect that "nullptr < value_mptr" result should be equal to
-      // std::less<multi_ptr_t<()(nullptr, value_mptr) result
-      expected_results.nullptr_value_mptr_result_val = true;
-      // We expect that "value_mptr < nullptr" result should be equal to
-      // std::less<multi_ptr_t<()(value_mptr, nullptr) result
-      expected_results.value_mptr_nullptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t nullptr_mptr(nullptr);
@@ -514,18 +487,6 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_nullptr_mptr_test_results<T> expected_results;
-      // We expect that "nullptr > nullptr_mptr" result should be equal to
-      // std::greater<multi_ptr_t>()(nullptr, nullptr_mptr) result
-      expected_results.nullptr_nullptr_mptr_result_val = true;
-      // We expect that "nullptr_mptr > nullptr" result should be equal to
-      // std::greater<multi_ptr_t>()(nullptr_mptr, nullptr) result
-      expected_results.nullptr_mptr_nullptr_result_val = true;
-      // We expect that "nullptr > value_mptr" result should be equal to
-      // std::greater<multi_ptr_t>()(nullptr, value_mptr) result
-      expected_results.nullptr_value_mptr_result_val = true;
-      // We expect that "value_mptr > nullptr" result should be equal to
-      // std::greater<multi_ptr_t>()(value_mptr, nullptr) result
-      expected_results.value_mptr_nullptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t nullptr_mptr(nullptr);
@@ -558,18 +519,6 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_nullptr_mptr_test_results<T> expected_results;
-      // We expect that "nullptr <= nullptr_mptr" result should be equal to
-      // std::less_equal<multi_ptr_t>()(nullptr, nullptr_mptr) result
-      expected_results.nullptr_nullptr_mptr_result_val = true;
-      // We expect that "nullptr_mptr <= nullptr" result should be equal to
-      // std::less_equal<multi_ptr_t>()(nullptr_mptr, nullptr) result
-      expected_results.nullptr_mptr_nullptr_result_val = true;
-      // We expect that "nullptr <= value_mptr" result should be equal to
-      // std::less_equal<multi_ptr_t>()(nullptr, value_mptr) result
-      expected_results.nullptr_value_mptr_result_val = true;
-      // We expect that "value_mptr <= nullptr" result should be equal to
-      // std::less_equal<multi_ptr_t>()(value_mptr, nullptr) result
-      expected_results.value_mptr_nullptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t nullptr_mptr(nullptr);
@@ -602,18 +551,6 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_nullptr_mptr_test_results<T> expected_results;
-      // We expect that "nullptr >= nullptr_mptr" result should be equal to
-      // std::greater_equal<multi_ptr_t>()(nullptr, nullptr_mptr) result
-      expected_results.nullptr_nullptr_mptr_result_val = true;
-      // We expect that "nullptr_mptr >= nullptr" result should be equal to
-      // std::greater_equal<multi_ptr_t>()(nullptr_mptr, nullptr) result
-      expected_results.nullptr_mptr_nullptr_result_val = true;
-      // We expect that "nullptr >= value_mptr" result should be equal to
-      // std::greater_equal<multi_ptr_t>()(nullptr, value_mptr) result
-      expected_results.nullptr_value_mptr_result_val = true;
-      // We expect that "value_mptr >= nullptr" result should be equal to
-      // std::greater_equal<multi_ptr_t>()(value_mptr, nullptr) result
-      expected_results.value_mptr_nullptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t nullptr_mptr(nullptr);

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -77,7 +77,7 @@ struct mptr_mptr_test_results {
  * @tparam T Data type that will be used in test
  */
 template <typename T>
-struct mptr_nillptr_mptr_test_results {
+struct mptr_nullptr_mptr_test_results {
   // Use std::optional to disable verification if some member hasn't been
   // initialised by some value
 
@@ -100,7 +100,7 @@ struct mptr_nillptr_mptr_test_results {
    * @param retreived_results Retreived test results
    */
   void verify_resuts(
-      const mptr_nillptr_mptr_test_results<T> &retreived_results) const {
+      const mptr_nullptr_mptr_test_results<T> &retreived_results) const {
     // If expected value isn't initialized, then this verification should be
     // skipped
     if (nullptr_nullptr_mptr_result_val) {
@@ -397,7 +397,7 @@ class run_multi_ptr_comparison_op_test {
             .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
-      detail::mptr_nillptr_mptr_test_results<T> expected_results;
+      detail::mptr_nullptr_mptr_test_results<T> expected_results;
       // Expected value that will be returned after "nullptr_mptr == nullptr"
       // operator will be called
       expected_results.nullptr_nullptr_mptr_result_val = true;
@@ -433,7 +433,7 @@ class run_multi_ptr_comparison_op_test {
                 .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
-      detail::mptr_nillptr_mptr_test_results<T> expected_results;
+      detail::mptr_nullptr_mptr_test_results<T> expected_results;
       // Expected value that will be returned after "nullptr != nullptr_mptr"
       // operator will be called
       expected_results.nullptr_nullptr_mptr_result_val = false;
@@ -469,7 +469,7 @@ class run_multi_ptr_comparison_op_test {
                 .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
-      detail::mptr_nillptr_mptr_test_results<T> expected_results;
+      detail::mptr_nullptr_mptr_test_results<T> expected_results;
       // We expect that "nullptr < nullptr_mptr" result should be equal to
       // std::less<multi_ptr_t<()(nullptr, nullptr_mptr) result
       expected_results.nullptr_nullptr_mptr_result_val = true;
@@ -513,7 +513,7 @@ class run_multi_ptr_comparison_op_test {
                 .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
-      detail::mptr_nillptr_mptr_test_results<T> expected_results;
+      detail::mptr_nullptr_mptr_test_results<T> expected_results;
       // We expect that "nullptr > nullptr_mptr" result should be equal to
       // std::greater<multi_ptr_t>()(nullptr, nullptr_mptr) result
       expected_results.nullptr_nullptr_mptr_result_val = true;
@@ -557,7 +557,7 @@ class run_multi_ptr_comparison_op_test {
                 .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
-      detail::mptr_nillptr_mptr_test_results<T> expected_results;
+      detail::mptr_nullptr_mptr_test_results<T> expected_results;
       // We expect that "nullptr <= nullptr_mptr" result should be equal to
       // std::less_equal<multi_ptr_t>()(nullptr, nullptr_mptr) result
       expected_results.nullptr_nullptr_mptr_result_val = true;
@@ -601,7 +601,7 @@ class run_multi_ptr_comparison_op_test {
                 .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
-      detail::mptr_nillptr_mptr_test_results<T> expected_results;
+      detail::mptr_nullptr_mptr_test_results<T> expected_results;
       // We expect that "nullptr >= nullptr_mptr" result should be equal to
       // std::greater_equal<multi_ptr_t>()(nullptr, nullptr_mptr) result
       expected_results.nullptr_nullptr_mptr_result_val = true;

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -139,12 +139,14 @@ template <typename T, typename AddrSpaceT, typename IsDecoratedT>
 class run_multi_ptr_comparison_op_test {
   static constexpr sycl::access::address_space space = AddrSpaceT::value;
   static constexpr sycl::access::decorated decorated = IsDecoratedT::value;
-  const T low_value = 1;
-  const T great_value = 2;
+
+  using multi_ptr_t = sycl::multi_ptr<T, space, decorated>;
+
+  const T m_low_value = 1;
+  const T m_great_value = 2;
   // Use an array to be sure that we have two elements that has subsequence
   // memory addereses
-  const T values_arr[2] = {low_value, great_value};
-  using multi_ptr_t = sycl::multi_ptr<T, space, decorated>;
+  const T m_values_arr[2] = {m_low_value, m_great_value};
   sycl::range m_r(1);
 
   template <typename TestActionT, typename ExpectedTestResultT>
@@ -154,7 +156,7 @@ class run_multi_ptr_comparison_op_test {
     // result
     ExpectedTestResultT test_results;
     {
-      sycl::buffer<T> array_buffer(values_arr, std::size(values_arr));
+      sycl::buffer<T> array_buffer(m_values_arr, std::size(m_values_arr));
       sycl::buffer<ExpectedTestResultT> test_result_buffer(&test_results, m_r);
       queue.submit([&](sycl::handler &cgh) {
         auto array_acc =

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -15,9 +15,10 @@
 #include "../common/section_name_builder.h"
 #include "multi_ptr_common.h"
 
-#include <array>     // for std::array
-#include <cstddef>   // for std::size_t
-#include <optional>  // for std::optional
+#include <array>       // for std::array
+#include <cstddef>     // for std::size_t
+#include <functional>  // for std::less/greater/less_equal/greater_equal
+#include <optional>    // for std::optional
 
 namespace multi_ptr_comparison_op {
 
@@ -469,18 +470,18 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_nillptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "nullptr < nullptr_mptr"
-      // operator will be called
-      expected_results.nullptr_nullptr_mptr_result_val = false;
-      // Expected value that will be returned after "nullptr_mptr < nullptr"
-      // operator will be called
-      expected_results.nullptr_mptr_nullptr_result_val = false;
-      // Expected value that will be returned after "nullptr < value_mptr"
-      // operator will be called
+      // We expect that "nullptr < nullptr_mptr" result should be equal to
+      // std::less<multi_ptr_t<()(nullptr, nullptr_mptr) result
+      expected_results.nullptr_nullptr_mptr_result_val = true;
+      // We expect that "nullptr_mptr < nullptr" result should be equal to
+      // std::less<multi_ptr_t<()(nullptr_mptr, nullptr) result
+      expected_results.nullptr_mptr_nullptr_result_val = true;
+      // We expect that "nullptr < value_mptr" result should be equal to
+      // std::less<multi_ptr_t<()(nullptr, value_mptr) result
       expected_results.nullptr_value_mptr_result_val = true;
-      // Expected value that will be returned after "value_mptr < nullptr"
-      // operator will be called
-      expected_results.value_mptr_nullptr_result_val = false;
+      // We expect that "value_mptr < nullptr" result should be equal to
+      // std::less<multi_ptr_t<()(value_mptr, nullptr) result
+      expected_results.value_mptr_nullptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t nullptr_mptr(nullptr);
@@ -488,10 +489,18 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.nullptr_nullptr_mptr_result_val = nullptr < nullptr_mptr;
-        test_result.nullptr_mptr_nullptr_result_val = nullptr_mptr < nullptr;
-        test_result.nullptr_value_mptr_result_val = nullptr < value_mptr;
-        test_result.value_mptr_nullptr_result_val = value_mptr < nullptr;
+        test_result.nullptr_nullptr_mptr_result_val =
+            std::less < multi_ptr_t < ()(nullptr, nullptr_mptr.get()) ==
+            nullptr < nullptr_mptr;
+        test_result.nullptr_mptr_nullptr_result_val =
+            std::less < multi_ptr_t < ()(nullptr_mptr.get(), nullptr) ==
+            nullptr_mptr < nullptr;
+        test_result.nullptr_value_mptr_result_val =
+            std::less < multi_ptr_t < ()(nullptr, value_mptr.get()) ==
+            nullptr < value_mptr;
+        test_result.value_mptr_nullptr_result_val =
+            std::less < multi_ptr_t < ()(value_mptr.get(), nullptr) ==
+            value_mptr < nullptr;
       };
 
       run_test(queue, run_test_action, expected_results);
@@ -505,17 +514,17 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_nillptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "nullptr > nullptr_mptr"
-      // operator will be called
-      expected_results.nullptr_nullptr_mptr_result_val = false;
-      // Expected value that will be returned after "nullptr_mptr > nullptr"
-      // operator will be called
-      expected_results.nullptr_mptr_nullptr_result_val = false;
-      // Expected value that will be returned after "nullptr > value_mptr"
-      // operator will be called
-      expected_results.nullptr_value_mptr_result_val = false;
-      // Expected value that will be returned after "value_mptr > nullptr"
-      // operator will be called
+      // We expect that "nullptr > nullptr_mptr" result should be equal to
+      // std::greater<multi_ptr_t>()(nullptr, nullptr_mptr) result
+      expected_results.nullptr_nullptr_mptr_result_val = true;
+      // We expect that "nullptr_mptr > nullptr" result should be equal to
+      // std::greater<multi_ptr_t>()(nullptr_mptr, nullptr) result
+      expected_results.nullptr_mptr_nullptr_result_val = true;
+      // We expect that "nullptr > value_mptr" result should be equal to
+      // std::greater<multi_ptr_t>()(nullptr, value_mptr) result
+      expected_results.nullptr_value_mptr_result_val = true;
+      // We expect that "value_mptr > nullptr" result should be equal to
+      // std::greater<multi_ptr_t>()(value_mptr, nullptr) result
       expected_results.value_mptr_nullptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
@@ -524,10 +533,18 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.nullptr_nullptr_mptr_result_val = nullptr > nullptr_mptr;
-        test_result.nullptr_mptr_nullptr_result_val = nullptr_mptr > nullptr;
-        test_result.nullptr_value_mptr_result_val = nullptr > value_mptr;
-        test_result.value_mptr_nullptr_result_val = value_mptr > nullptr;
+        test_result.nullptr_nullptr_mptr_result_val =
+            std::greater<multi_ptr_t>()(nullptr, nullptr_mptr) ==
+            nullptr > nullptr_mptr;
+        test_result.nullptr_mptr_nullptr_result_val =
+            std::greater<multi_ptr_t>()(nullptr_mptr, nullptr) ==
+            nullptr_mptr > nullptr;
+        test_result.nullptr_value_mptr_result_val =
+            std::greater<multi_ptr_t>()(nullptr, value_mptr) ==
+            nullptr > value_mptr;
+        test_result.value_mptr_nullptr_result_val =
+            std::greater<multi_ptr_t>()(value_mptr, nullptr) ==
+            value_mptr > nullptr;
       };
 
       run_test(queue, run_test_action, expected_results);
@@ -541,18 +558,18 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_nillptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "nullptr <= nullptr_mptr"
-      // operator will be called
+      // We expect that "nullptr <= nullptr_mptr" result should be equal to
+      // std::less_equal<multi_ptr_t>()(nullptr, nullptr_mptr) result
       expected_results.nullptr_nullptr_mptr_result_val = true;
-      // Expected value that will be returned after "nullptr_mptr <= nullptr"
-      // operator will be called
+      // We expect that "nullptr_mptr <= nullptr" result should be equal to
+      // std::less_equal<multi_ptr_t>()(nullptr_mptr, nullptr) result
       expected_results.nullptr_mptr_nullptr_result_val = true;
-      // Expected value that will be returned after "nullptr <= value_mptr"
-      // operator will be called
-      expected_results.nullptr_value_mptr_result_val = false;
-      // Expected value that will be returned after "value_mptr <= nullptr"
-      // operator will be called
-      expected_results.value_mptr_nullptr_result_val = false;
+      // We expect that "nullptr <= value_mptr" result should be equal to
+      // std::less_equal<multi_ptr_t>()(nullptr, value_mptr) result
+      expected_results.nullptr_value_mptr_result_val = true;
+      // We expect that "value_mptr <= nullptr" result should be equal to
+      // std::less_equal<multi_ptr_t>()(value_mptr, nullptr) result
+      expected_results.value_mptr_nullptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
         multi_ptr_t nullptr_mptr(nullptr);
@@ -560,10 +577,18 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.nullptr_nullptr_mptr_result_val = nullptr <= nullptr_mptr;
-        test_result.nullptr_mptr_nullptr_result_val = nullptr_mptr <= nullptr;
-        test_result.nullptr_value_mptr_result_val = nullptr <= value_mptr;
-        test_result.value_mptr_nullptr_result_val = value_mptr <= nullptr;
+        test_result.nullptr_nullptr_mptr_result_val =
+            std::less_equal<multi_ptr_t>()(nullptr, nullptr_mptr) ==
+            nullptr <= nullptr_mptr;
+        test_result.nullptr_mptr_nullptr_result_val =
+            std::less_equal<multi_ptr_t>()(nullptr_mptr, nullptr) ==
+            nullptr_mptr <= nullptr;
+        test_result.nullptr_value_mptr_result_val =
+            std::less_equal<multi_ptr_t>()(nullptr, value_mptr) ==
+            nullptr <= value_mptr;
+        test_result.value_mptr_nullptr_result_val =
+            std::less_equal<multi_ptr_t>()(value_mptr, nullptr) ==
+            value_mptr <= nullptr;
       };
 
       run_test(queue, run_test_action, expected_results);
@@ -577,17 +602,17 @@ class run_multi_ptr_comparison_op_test {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::mptr_nillptr_mptr_test_results<T> expected_results;
-      // Expected value that will be returned after "nullptr >= nullptr_mptr"
-      // operator will be called
+      // We expect that "nullptr >= nullptr_mptr" result should be equal to
+      // std::greater_equal<multi_ptr_t>()(nullptr, nullptr_mptr) result
       expected_results.nullptr_nullptr_mptr_result_val = true;
-      // Expected value that will be returned after "nullptr_mptr >= nullptr"
-      // operator will be called
+      // We expect that "nullptr_mptr >= nullptr" result should be equal to
+      // std::greater_equal<multi_ptr_t>()(nullptr_mptr, nullptr) result
       expected_results.nullptr_mptr_nullptr_result_val = true;
-      // Expected value that will be returned after "nullptr >= value_mptr"
-      // operator will be called
-      expected_results.nullptr_value_mptr_result_val = false;
-      // Expected value that will be returned after "value_mptr >= nullptr"
-      // operator will be called
+      // We expect that "nullptr >= value_mptr" result should be equal to
+      // std::greater_equal<multi_ptr_t>()(nullptr, value_mptr) result
+      expected_results.nullptr_value_mptr_result_val = true;
+      // We expect that "value_mptr >= nullptr" result should be equal to
+      // std::greater_equal<multi_ptr_t>()(value_mptr, nullptr) result
       expected_results.value_mptr_nullptr_result_val = true;
 
       const auto run_test_action = [](auto arr_acc, auto result_acc) {
@@ -596,10 +621,18 @@ class run_multi_ptr_comparison_op_test {
 
         auto &test_result = result_acc[0];
 
-        test_result.nullptr_nullptr_mptr_result_val = nullptr >= nullptr_mptr;
-        test_result.nullptr_mptr_nullptr_result_val = nullptr_mptr >= nullptr;
-        test_result.nullptr_value_mptr_result_val = nullptr >= value_mptr;
-        test_result.value_mptr_nullptr_result_val = value_mptr >= nullptr;
+        test_result.nullptr_nullptr_mptr_result_val =
+            std::greater_equal<multi_ptr_t>()(nullptr, nullptr_mptr) ==
+            nullptr >= nullptr_mptr;
+        test_result.nullptr_mptr_nullptr_result_val =
+            std::greater_equal<multi_ptr_t>()(nullptr_mptr, nullptr) ==
+            nullptr_mptr >= nullptr;
+        test_result.nullptr_value_mptr_result_val =
+            std::greater_equal<multi_ptr_t>()(nullptr, value_mptr) ==
+            nullptr >= value_mptr;
+        test_result.value_mptr_nullptr_result_val =
+            std::greater_equal<multi_ptr_t>()(value_mptr, nullptr) ==
+            value_mptr >= nullptr;
       };
 
       run_test(queue, run_test_action, expected_results);

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -1,0 +1,586 @@
+
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides code for multi_ptr comparison operators
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_MULTI_PTR_COMPARISON_OP_H
+#define __SYCLCTS_TESTS_MULTI_PTR_COMPARISON_OP_H
+
+#include "../common/common.h"
+
+#include "../common/section_name_builder.h"
+#include "multi_ptr_common.h"
+
+#include <array>    // for std::array
+#include <cstddef>  // for std::size_t
+
+namespace multi_ptr_comparison_op {
+
+/**
+ * @brief Provides functor for verification on multi_ptr comparison operators
+ * @tparam T Current data type
+ * @tparam AddrSpaceT sycl::access::address_space enumeration's field
+ * @tparam IsDecoratedT sycl::access::decorated enumeration's field
+ */
+template <typename T, typename AddrSpaceT, typename IsDecoratedT>
+class run_multi_ptr_comparison_op_test {
+  static constexpr sycl::access::address_space space = AddrSpaceT::value;
+  static constexpr sycl::access::decorated decorated = IsDecoratedT::value;
+  T low_value = 1;
+  T great_value = 2;
+  using multi_ptr_t = sycl::multi_ptr<T, space, decorated>;
+  sycl::range m_r = sycl::range(1);
+
+  template <typename TestActionA, std::size_t N>
+  void run_test(sycl::queue &queue, TestActionA test_action,
+                std::array<bool, N> &test_results) {
+    sycl::buffer<T> low_value_buffer(&low_value, m_r);
+    sycl::buffer<T> great_value_buffer(&great_value, m_r);
+    sycl::buffer<bool> nullptr_nullptr_res_buffer(test_results.data(),
+                                                  sycl::range(N));
+    queue.submit([&](sycl::handler &cgh) {
+      auto low_value_acc =
+          low_value_buffer.template get_access<sycl::access_mode::read>(cgh);
+      auto great_value_acc =
+          great_value_buffer.template get_access<sycl::access_mode::read>(cgh);
+      auto nullptr_nullptr_res_acc =
+          nullptr_nullptr_res_buffer
+              .template get_access<sycl::access_mode::write>(cgh);
+
+      if constexpr (space == sycl::access::address_space::global_space) {
+        cgh.single_task([=] {
+          test_action(low_value_acc, great_value_acc, nullptr_nullptr_res_acc);
+        });
+      } else {
+        cgh.parallel_for(sycl::nd_range(r, r), [=](sycl::nd_item item) {
+          test_action(low_value_acc, great_value_acc, nullptr_nullptr_res_acc);
+        });
+      }
+    });
+  }
+
+ public:
+  /**
+   * @param type_name Current data type string representation
+   * @param address_space_name Current sycl::access::address_space string
+   *        representation
+   * @param is_decorated_name Current sycl::access::decorated string
+   *        representation
+   */
+  void operator()(const std::string &type_name,
+                  const std::string &address_space_name,
+                  const std::string &is_decorated_name) {
+    auto queue = sycl_cts::util::get_cts_object::queue();
+    SECTION(
+        section_name(
+            "Check multi_ptr operator==(const multi_ptr&, const multi_ptr&)")
+            .with("T", type_name)
+            .with("address_space", address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
+      // Expected value that will be returned after "lower_mptr == lower_mptr"
+      // operator will be called
+      bool first_first_mptr_expected_val = true;
+      // Expected value that will be returned after "lower_mptr == greater_mptr"
+      // operator will be called
+      bool first_second_mptr_expected_val = false;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "lower_mptr == lower_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "lower_mptr == greater_mptr" operator will be called
+      std::array<bool, 2> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t mptr_1(low_value_acc);
+        multi_ptr_t mptr_2(great_value_acc);
+
+        result_acc[0] = mptr_1 == mptr_1;
+        result_acc[1] = mptr_1 == mptr_2;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == first_first_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == first_second_mptr_expected_val);
+    }
+
+    SECTION(
+        section_name(
+            "Check multi_ptr operator!=(const multi_ptr&, const multi_ptr&)")
+            .with("T", type_name)
+            .with("address_space", address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
+      // Expected value that will be returned after "lower_mptr != lower_mptr"
+      // operator will be called
+      bool first_first_mptr_expected_val = false;
+      // Expected value that will be returned after "lower_mptr != greater_mptr"
+      // operator will be called
+      bool first_second_mptr_expected_val = true;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "lower_mptr != lower_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "lower_mptr != greater_mptr" operator will be called
+      std::array<bool, 2> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t mptr_1(low_value_acc);
+        multi_ptr_t mptr_2(great_value_acc);
+
+        result_acc[0] = mptr_1 != mptr_1;
+        result_acc[1] = mptr_1 != mptr_2;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == first_first_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == first_second_mptr_expected_val);
+    }
+    SECTION(section_name(
+                "Check multi_ptr operator<(const multi_ptr&, const multi_ptr&)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      // Expected value that will be returned after "lower_mptr < lower_mptr"
+      // operator will be called
+      bool first_first_mptr_expected_val = false;
+      // Expected value that will be returned after "lower_mptr < greater_mptr"
+      // operator will be called
+      bool first_second_mptr_expected_val = true;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "lower_mptr < lower_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "lower_mptr < greater_mptr" operator will be called
+      std::array<bool, 2> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t mptr_1(low_value_acc);
+        multi_ptr_t mptr_2(great_value_acc);
+
+        result_acc[0] = mptr_1 < mptr_1;
+        result_acc[1] = mptr_1 < mptr_2;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == first_first_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == first_second_mptr_expected_val);
+    }
+
+    SECTION(section_name(
+                "Check multi_ptr operator>(const multi_ptr&, const multi_ptr&)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      // Expected value that will be returned after "lower_mptr > greater_mptr"
+      // operator will be called
+      bool first_first_mptr_expected_val = false;
+      // Expected value that will be returned after "greater_mptr > lower_mptr"
+      // operator will be called
+      bool first_second_mptr_expected_val = true;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "lower_mptr > greater_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "greater_mptr > lower_mptr" operator will be called
+      std::array<bool, 2> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t mptr_1(low_value_acc);
+        multi_ptr_t mptr_2(great_value_acc);
+
+        result_acc[0] = mptr_1 > mptr_2;
+        result_acc[1] = mptr_2 > mptr_1;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == first_first_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == first_second_mptr_expected_val);
+    }
+
+    SECTION(
+        section_name(
+            "Check multi_ptr operator<=(const multi_ptr&, const multi_ptr&)")
+            .with("T", type_name)
+            .with("address_space", address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
+      // Expected value that will be returned after "lower_mptr <= lower_mptr"
+      // operator will be called
+      bool first_first_mptr_expected_val = true;
+      // Expected value that will be returned after "lower_mptr <= greater_mptr"
+      // operator will be called
+      bool first_second_mptr_expected_val = true;
+      // Expected value that will be returned after "greater_mptr <= lower_mptr"
+      // operator will be called
+      bool second_first_mptr_expected_val = false;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "lower_mptr <= lower_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "lower_mptr <= greater_mptr" operator will be called
+      //   - At the third position will contains value that will be returned
+      //     after "greater_mptr <= lower_mptr" operator will be called
+      std::array<bool, 3> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t mptr_1(low_value_acc);
+        multi_ptr_t mptr_2(great_value_acc);
+
+        result_acc[0] = mptr_1 <= mptr_1;
+        result_acc[1] = mptr_1 <= mptr_2;
+        result_acc[2] = mptr_2 <= mptr_1;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == first_first_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == first_second_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[2] == second_first_mptr_expected_val);
+    }
+    SECTION(
+        section_name(
+            "Check multi_ptr operator>=(const multi_ptr&, const multi_ptr&)")
+            .with("T", type_name)
+            .with("address_space", address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
+      // Expected value that will be returned after "lower_mptr >= lower_mptr"
+      // operator will be called
+      bool first_first_mptr_expected_val = true;
+      // Expected value that will be returned after "greater_mptr >= lower_mptr"
+      // operator will be called
+      bool second_first_mptr_expected_val = true;
+      // Expected value that will be returned after "lower_mptr >= greater_mptr"
+      // operator will be called
+      bool first_second_mptr_expected_val = false;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "lower_mptr >= lower_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "greater_mptr >= lower_mptr" operator will be called
+      //   - At the third position will contains value that will be returned
+      //     after "lower_mptr >= greater_mptr" operator will be called
+      std::array<bool, 3> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t mptr_1(low_value_acc);
+        multi_ptr_t mptr_2(great_value_acc);
+
+        result_acc[0] = mptr_1 >= mptr_1;
+        result_acc[1] = mptr_2 >= mptr_1;
+        result_acc[2] = mptr_1 >= mptr_2;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == first_first_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == second_first_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[2] == first_second_mptr_expected_val);
+    }
+
+    SECTION(
+        section_name(
+            "Check multi_ptr operator==(const multi_ptr& lhs, std::nullptr_t)")
+            .with("T", type_name)
+            .with("address_space", address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
+      // Expected value that will be returned after "nullptr_mptr == nullptr"
+      // operator will be called
+      bool nullptr_nullptr_mptr_expected_val = true;
+      // Expected value that will be returned after "nullptr == nullptr_mptr"
+      // operator will be called
+      bool mptr_nullptr_nullptr_expected_val = true;
+      // Expected value that will be returned after "nullptr == value_mptr"
+      // operator will be called
+      bool nullptr_value_expected_val = false;
+      // Expected value that will be returned after "value_mptr == nullptr"
+      // operator will be called
+      bool value_nullptr_expected_val = false;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "nullptr_mptr == nullptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "value_mptr == nullptr" operator will be called
+      std::array<bool, 4> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t nullptr_mptr(nullptr);
+        multi_ptr_t value_mptr(low_value_acc);
+
+        result_acc[0] = nullptr_mptr == nullptr;
+        result_acc[1] = nullptr == nullptr_mptr;
+        result_acc[2] = value_mptr == nullptr;
+        result_acc[3] = nullptr == value_mptr;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == nullptr_nullptr_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == mptr_nullptr_nullptr_expected_val);
+      CHECK(mpr_comparison_ops_results[2] == nullptr_value_expected_val);
+      CHECK(mpr_comparison_ops_results[3] == value_nullptr_expected_val);
+    }
+    SECTION(section_name(
+                "Check multi_ptr operator!=(std::nullptr_t, const multi_ptr&)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      // Expected value that will be returned after "nullptr_mptr != nullptr"
+      // operator will be called
+      bool nullptr_nullptr_mptr_expected_val = false;
+      // Expected value that will be returned after "nullptr != nullptr_mptr"
+      // operator will be called
+      bool mptr_nullptr_nullptr_expected_val = false;
+      // Expected value that will be returned after "nullptr != value_mptr"
+      // operator will be called
+      bool nullptr_value_expected_val = true;
+      // Expected value that will be returned after "value_mptr != nullptr"
+      // operator will be called
+      bool value_nullptr_expected_val = false;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "nullptr_mptr != nullptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "nullptr != value_mptr" operator will be called
+      std::array<bool, 4> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t nullptr_mptr(nullptr);
+        multi_ptr_t value_mptr(low_value_acc);
+
+        result_acc[0] = nullptr != nullptr_mptr;
+        result_acc[1] = nullptr_mptr != nullptr;
+        result_acc[3] = nullptr != value_mptr;
+        result_acc[2] = value_mptr != nullptr;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == nullptr_nullptr_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == mptr_nullptr_nullptr_expected_val);
+      CHECK(mpr_comparison_ops_results[2] == nullptr_value_expected_val);
+      CHECK(mpr_comparison_ops_results[3] == value_nullptr_expected_val);
+    }
+
+    SECTION(section_name(
+                "Check multi_ptr operator<(std::nullptr_t, const multi_ptr&)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      // Expected value that will be returned after "nullptr < nullptr_mptr"
+      // operator will be called
+      bool nullptr_nullptr_mptr_expected_val = false;
+      // Expected value that will be returned after "nullptr_mptr < nullptr"
+      // operator will be called
+      bool nullptr_mptr_nullptr_expected_val = true;
+      // Expected value that will be returned after "nullptr < value_mptr"
+      // operator will be called
+      bool nullptr_value_expected_val = false;
+      // Expected value that will be returned after "value_mptr < nullptr"
+      // operator will be called
+      bool value_nullptr_expected_val = false;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "nullptr < nullptr_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "nullptr < value_mptr" operator will be called
+      //   - At the third position will contains value that will be returned
+      //     after "value_mptr < nullptr" operator will be called
+      std::array<bool, 4> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t nullptr_mptr(nullptr);
+        multi_ptr_t value_mptr(low_value_acc);
+
+        result_acc[0] = nullptr < nullptr_mptr;
+        result_acc[0] = nullptr_mptr < nullptr;
+        result_acc[1] = nullptr < value_mptr;
+        result_acc[2] = value_mptr < nullptr;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == nullptr_nullptr_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == nullptr_mptr_nullptr_expected_val);
+      CHECK(mpr_comparison_ops_results[2] == nullptr_value_expected_val);
+      CHECK(mpr_comparison_ops_results[3] == value_nullptr_expected_val);
+    }
+    SECTION(section_name(
+                "Check multi_ptr operator>(std::nullptr_t, const multi_ptr&)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      // Expected value that will be returned after "nullptr < nullptr_mptr"
+      // operator will be called
+      bool nullptr_nullptr_mptr_expected_val = false;
+      // Expected value that will be returned after "nullptr_mptr < nullptr"
+      // operator will be called
+      bool nullptr_mptr_nullptr_expected_val = false;
+      // Expected value that will be returned after "nullptr < value_mptr"
+      // operator will be called
+      bool nullptr_value_expected_val = true;
+      // Expected value that will be returned after "value_mptr < nullptr"
+      // operator will be called
+      bool value_nullptr_expected_val = false;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "nullptr > nullptr_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "nullptr > value_mptr" operator will be called
+      //   - At the third position will contains value that will be returned
+      //     after "value_mptr > nullptr" operator will be called
+      std::array<bool, 4> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t nullptr_mptr(nullptr);
+        multi_ptr_t value_mptr(low_value_acc);
+
+        result_acc[0] = nullptr > nullptr_mptr;
+        result_acc[0] = nullptr_mptr > nullptr;
+        result_acc[1] = nullptr > value_mptr;
+        result_acc[2] = value_mptr > nullptr;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == nullptr_nullptr_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == nullptr_mptr_nullptr_expected_val);
+      CHECK(mpr_comparison_ops_results[2] == nullptr_value_expected_val);
+      CHECK(mpr_comparison_ops_results[3] == value_nullptr_expected_val);
+    }
+    SECTION(section_name(
+                "Check multi_ptr operator<=(std::nullptr_t, const multi_ptr&)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      // Expected value that will be returned after "nullptr <= nullptr_mptr"
+      // operator will be called
+      bool nullptr_nullptr_mptr_expected_val = true;
+      // Expected value that will be returned after "nullptr_mptr <= nullptr"
+      // operator will be called
+      bool nullptr_mptr_nullptr_expected_val = true;
+      // Expected value that will be returned after "nullptr <= value_mptr"
+      // operator will be called
+      bool nullptr_value_expected_val = false;
+      // Expected value that will be returned after "value_mptr <= nullptr"
+      // operator will be called
+      bool value_nullptr_expected_val = false;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "nullptr <= nullptr_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "nullptr <= value_mptr" operator will be called
+      //   - At the third position will contains value that will be returned
+      //     after "value_mptr <= nullptr" operator will be called
+      std::array<bool, 4> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t nullptr_mptr(nullptr);
+        multi_ptr_t value_mptr(low_value_acc);
+
+        result_acc[0] = nullptr <= nullptr_mptr;
+        result_acc[1] = nullptr_mptr <= nullptr;
+        result_acc[2] = nullptr <= value_mptr;
+        result_acc[3] = value_mptr <= nullptr;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == nullptr_nullptr_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == nullptr_mptr_nullptr_expected_val);
+      CHECK(mpr_comparison_ops_results[2] == nullptr_value_expected_val);
+      CHECK(mpr_comparison_ops_results[3] == value_nullptr_expected_val);
+    }
+
+    SECTION(section_name(
+                "Check multi_ptr operator>=(std::nullptr_t, const multi_ptr&)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
+      // Expected value that will be returned after "nullptr >= nullptr_mptr"
+      // operator will be called
+      bool nullptr_nullptr_mptr_expected_val = true;
+      // Expected value that will be returned after "nullptr_mptr >= nullptr"
+      // operator will be called
+      bool nullptr_mptr_nullptr_expected_val = true;
+      // Expected value that will be returned after "nullptr >= value_mptr"
+      // operator will be called
+      bool nullptr_value_expected_val = false;
+      // Expected value that will be returned after "value_mptr >= nullptr"
+      // operator will be called
+      bool value_nullptr_expected_val = true;
+
+      // Array that contained operator calling result:
+      //   - At the first position will contains value that will be returned
+      //     after "nullptr >= nullptr_mptr" operator will be called
+      //   - At the second position will contains value that will be returned
+      //     after "nullptr_mptr >= nullptr" operator will be called
+      //   - At the third position will contains value that will be returned
+      //     after "nullptr >= value_mptr" operator will be called
+      //   - At the fourth position will contains value that will be returned
+      //     after "value_mptr >= nullptr" operator will be called
+      std::array<bool, 4> mpr_comparison_ops_results;
+      const auto run_test_action = [](auto low_value_acc, auto great_value_acc,
+                                      auto result_acc) {
+        multi_ptr_t nullptr_mptr(nullptr);
+        multi_ptr_t value_mptr(low_value_acc);
+
+        result_acc[0] = nullptr >= nullptr_mptr;
+        result_acc[1] = nullptr_mptr >= nullptr;
+        result_acc[2] = nullptr >= value_mptr;
+        result_acc[3] = value_mptr >= nullptr;
+      };
+
+      run_test(queue, run_test_action, mpr_comparison_ops_results);
+
+      CHECK(mpr_comparison_ops_results[0] == nullptr_nullptr_mptr_expected_val);
+      CHECK(mpr_comparison_ops_results[0] == nullptr_mptr_nullptr_expected_val);
+      CHECK(mpr_comparison_ops_results[1] == nullptr_value_expected_val);
+      CHECK(mpr_comparison_ops_results[2] == value_nullptr_expected_val);
+    }
+  }
+};
+
+template <typename T>
+class check_multi_ptr_comparison_op_for_type {
+ public:
+  void operator()(const std::string &type_name) {
+    const auto address_spaces = multi_ptr_common::get_address_spaces();
+    const auto is_decorated = multi_ptr_common::get_decorated();
+    // Run test
+    for_all_combinations<run_multi_ptr_comparison_op_test, T>(
+        address_spaces, is_decorated, type_name);
+  }
+};
+
+}  // namespace multi_ptr_comparison_op
+
+#endif  // __SYCLCTS_TESTS_MULTI_PTR_COMPARISON_OP_H

--- a/tests/multi_ptr/multi_ptr_comparison_op_core.cpp
+++ b/tests/multi_ptr/multi_ptr_comparison_op_core.cpp
@@ -1,0 +1,24 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr comparison operators for core types
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_comparison_op.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_comparison_op_core {
+
+TEST_CASE("multi_ptr comparison operators. Core types", "[multi_ptr]") {
+  using namespace multi_ptr_comparison_op;
+  auto types = multi_ptr_convert::get_types();
+  auto composite_types = multi_ptr_convert::get_composite_types();
+
+  for_all_types<check_multi_ptr_comparison_op_for_type>(types);
+  for_all_types<check_multi_ptr_comparison_op_for_type>(composite_types);
+}
+
+}  // namespace multi_ptr_comparison_op_core

--- a/tests/multi_ptr/multi_ptr_comparison_op_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_comparison_op_fp16.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr comparison operators for sycl::half type
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_comparison_op.h"
+
+namespace multi_ptr_comparison_op_fp16 {
+
+TEST_CASE("multi_ptr comparison operators. fp16 type", "[multi_ptr]") {
+  using namespace multi_ptr_comparison_op;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    WARN(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+
+  check_multi_ptr_comparison_op_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace multi_ptr_comparison_op_fp16

--- a/tests/multi_ptr/multi_ptr_comparison_op_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_comparison_op_fp64.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests multi_ptr comparison operators for double type
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "multi_ptr_common.h"
+#include "multi_ptr_comparison_op.h"
+
+namespace multi_ptr_comparison_op_fp64 {
+
+TEST_CASE("multi_ptr comparison operators. fp64 type", "[multi_ptr]") {
+  using namespace multi_ptr_comparison_op;
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    WARN(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+    return;
+  }
+
+  check_multi_ptr_comparison_op_for_type<double>{}("double");
+}
+
+}  // namespace multi_ptr_comparison_op_fp64


### PR DESCRIPTION
The test provides verification for the following comparison operators:
- `multi_ptr& operator==(const multi_ptr&, const multi_ptr&)`
- `multi_ptr operator!=(const multi_ptr&, const multi_ptr&)`
- `multi_ptr& operator<(const multi_ptr&, const multi_ptr&)`
- `multi_ptr operator>(const multi_ptr&, const multi_ptr&)`
- `multi_ptr& operator<=(const multi_ptr&, const multi_ptr&)`
- `multi_ptr& operator>=(const multi_ptr&, const multi_ptr&)`
- `bool operator<=(const multi_ptr& lhs, std::nullptr_t)`
- `bool operator<=(std::nullptr_t, const multi_ptr& rhs)`
- `bool operator>=(const multi_ptr& lhs, std::nullptr_t)`
- `bool operator>=(std::nullptr_t, const multi_ptr& rhs)`
- `bool operator==(const multi_ptr& rhs, std::nullptr_t)`
- `bool operator==(std::nullptr_t, const multi_ptr& rhs)`
- `bool operator!=(const multi_ptr& rhs, std::nullptr_t)`
- `bool operator!=(std::nullptr_t, const multi_ptr& rhs)`
- `bool operator<(const multi_ptr& rhs, std::nullptr_t)`
- `bool operator<(std::nullptr_t, const multi_ptr& rhs)`
- `bool operator>(const multi_ptr& rhs, std::nullptr_t)`
- `bool operator>(std::nullptr_t, const multi_ptr& rhs)`