### PR TITLE
Substitute deprecated feature kernel::get_work_group_info with kernel::get_info

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -635,8 +635,8 @@ inline bool kernel_supports_wg_size(sycl_cts::util::logger& log,
   program.build_with_kernel_type<kernelT>("");
   auto kernel = program.get_kernel<kernelT>();
 #endif
-  auto maxKernelWorkGroupSize = kernel.template get_info<
-      sycl::info::kernel_device_specific::work_group_size>(device);
+  auto maxKernelWorkGroupSize =
+      device.template get_info<sycl::info::device::max_work_group_size>();
 
   const bool supports = maxKernelWorkGroupSize >= wgSize;
   if (!supports) {

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -635,8 +635,8 @@ inline bool kernel_supports_wg_size(sycl_cts::util::logger& log,
   program.build_with_kernel_type<kernelT>("");
   auto kernel = program.get_kernel<kernelT>();
 #endif
-  auto maxKernelWorkGroupSize = kernel.template get_work_group_info<
-      sycl::info::kernel_work_group::work_group_size>(device);
+  auto maxKernelWorkGroupSize = kernel.template get_info<
+      sycl::info::kernel_device_specific::work_group_size>(device);
 
   const bool supports = maxKernelWorkGroupSize >= wgSize;
   if (!supports) {

--- a/tests/group/group_api.cpp
+++ b/tests/group/group_api.cpp
@@ -383,8 +383,8 @@ bool reduce_size(sycl::queue& queue) {
   auto kernel = kb.get_kernel(sycl::get_kernel_id<k_name>());
   auto device = queue.get_device();
 
-  auto work_group_size_limit = kernel.template get_info<
-      sycl::info::kernel_device_specific::work_group_size>(device);
+  auto work_group_size_limit =
+      device.template get_info<sycl::info::device::max_work_group_size>();
 
   size_t default_wg_size = 1;
   for (size_t dim = 0; dim < dimensions; ++dim) {

--- a/tests/group/group_api.cpp
+++ b/tests/group/group_api.cpp
@@ -383,8 +383,8 @@ bool reduce_size(sycl::queue& queue) {
   auto kernel = kb.get_kernel(sycl::get_kernel_id<k_name>());
   auto device = queue.get_device();
 
-  auto work_group_size_limit = kernel.template get_work_group_info<
-      sycl::info::kernel_work_group::work_group_size>(device);
+  auto work_group_size_limit = kernel.template get_info<
+      sycl::info::kernel_device_specific::work_group_size>(device);
 
   size_t default_wg_size = 1;
   for (size_t dim = 0; dim < dimensions; ++dim) {

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -98,6 +98,9 @@ class TEST_NAME : public sycl_cts::util::test_base {
 };
 
 // register this test with the test_collection
+
+#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
 util::test_proxy<TEST_NAME> proxy;
+#endif
 
 } /* namespace kernel_info__ */

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -71,19 +71,21 @@ class TEST_NAME : public sycl_cts::util::test_base {
       auto dev = util::get_cts_object::device();
       if (dev.get_info<sycl::info::device::device_type>() ==
           sycl::info::device_type::custom) {
-        range3Ret = kernel.get_work_group_info<
-            sycl::info::kernel_work_group::global_work_size>(dev);
+        range3Ret =
+            kernel
+                .get_info<sycl::info::kernel_device_specific::global_work_size>(
+                    dev);
       }
-      range3Ret = kernel.get_work_group_info<
-          sycl::info::kernel_work_group::compile_work_group_size>(dev);
-      sizeTRet =
-          kernel.get_work_group_info<sycl::info::kernel_work_group::
-                                          preferred_work_group_size_multiple>(
+      range3Ret = kernel.get_info<
+          sycl::info::kernel_device_specific::compile_work_group_size>(dev);
+      sizeTRet = kernel.get_info<sycl::info::kernel_device_specific::
+                                     preferred_work_group_size_multiple>(dev);
+      clUlongRet =
+          kernel.get_info<sycl::info::kernel_device_specific::private_mem_size>(
               dev);
-      clUlongRet = kernel.get_work_group_info<
-          sycl::info::kernel_work_group::private_mem_size>(dev);
-      sizeTRet = kernel.get_work_group_info<
-          sycl::info::kernel_work_group::work_group_size>(dev);
+      sizeTRet =
+          kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
+              dev);
 
       TEST_TYPE_TRAIT(kernel, reference_count, kernel);
       TEST_TYPE_TRAIT(kernel, function_name, kernel);

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -8,6 +8,10 @@
 
 #include "../common/common.h"
 
+// Disable test when compiling with ComputeCpp
+// ComputeCpp doesn't fully support kernel::get_info of SYCL 2020 spec
+#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
 #define TEST_NAME kernel_info
 
 namespace kernel_info__ {
@@ -98,11 +102,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
 };
 
 // register this test with the test_collection
-
-// Disable test when compiling with ComputeCpp
-// doesn't fully support kernel::get_info of SYCL 2020 spec
-#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
 util::test_proxy<TEST_NAME> proxy;
-#endif
 
 } /* namespace kernel_info__ */
+#endif // SYCL_CTS_COMPILING_WITH_COMPUTECPP

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -99,6 +99,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
 // register this test with the test_collection
 
+// Disable test when compiling with ComputeCpp
+// doesn't fully support kernel::get_info of SYCL 2020 spec
 #ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
 util::test_proxy<TEST_NAME> proxy;
 #endif


### PR DESCRIPTION
SYCL 2020 specification doesn't include kernel::get_work_group_info, thus calls to such methods in the tests are replaced with kernel::get_info