### PR TITLE
Update copyright notices to Khronos copyright

### DIFF
--- a/tests/accessor_legacy/accessor_api_buffer_common.h
+++ b/tests/accessor_legacy/accessor_api_buffer_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 #ifndef SYCL_1_2_1_TESTS_ACCESSOR_ACCESSOR_API_BUFFER_COMMON_H

--- a/tests/accessor_legacy/accessor_api_buffer_core.cpp
+++ b/tests/accessor_legacy/accessor_api_buffer_core.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_api_buffer_fp16.cpp
+++ b/tests/accessor_legacy/accessor_api_buffer_fp16.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_api_buffer_fp64.cpp
+++ b/tests/accessor_legacy/accessor_api_buffer_fp64.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_api_common_all.h
+++ b/tests/accessor_legacy/accessor_api_common_all.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  This file is a common header for implementing buffer, local, and image
 //  accessor tests

--- a/tests/accessor_legacy/accessor_api_common_buffer_local.h
+++ b/tests/accessor_legacy/accessor_api_common_buffer_local.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  This file is a common header for implementing buffer and local accessor
 //  tests

--- a/tests/accessor_legacy/accessor_api_image_common.h
+++ b/tests/accessor_legacy/accessor_api_image_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 #ifndef SYCL_1_2_1_TESTS_ACCESSOR_ACCESSOR_API_IMAGE_COMMON_H

--- a/tests/accessor_legacy/accessor_api_image_core.cpp
+++ b/tests/accessor_legacy/accessor_api_image_core.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_api_image_fp16.cpp
+++ b/tests/accessor_legacy/accessor_api_image_fp16.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_api_local_common.h
+++ b/tests/accessor_legacy/accessor_api_local_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 #ifndef SYCL_1_2_1_TESTS_ACCESSOR_ACCESSOR_API_LOCAL_COMMON_H

--- a/tests/accessor_legacy/accessor_api_local_core.cpp
+++ b/tests/accessor_legacy/accessor_api_local_core.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_api_local_fp16.cpp
+++ b/tests/accessor_legacy/accessor_api_local_fp16.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_api_local_fp64.cpp
+++ b/tests/accessor_legacy/accessor_api_local_fp64.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_api_utility.h
+++ b/tests/accessor_legacy/accessor_api_utility.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  This file is a common utility for the implementation of
 //  accessor_api.cpp.

--- a/tests/accessor_legacy/accessor_constructors_buffer.cpp
+++ b/tests/accessor_legacy/accessor_constructors_buffer.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_constructors_buffer_placeholder.cpp
+++ b/tests/accessor_legacy/accessor_constructors_buffer_placeholder.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_constructors_buffer_utility.h
+++ b/tests/accessor_legacy/accessor_constructors_buffer_utility.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  This file is a common utility for the implementation of
 //  accessor_constructors.cpp and accessor_api.cpp.

--- a/tests/accessor_legacy/accessor_constructors_fp16.cpp
+++ b/tests/accessor_legacy/accessor_constructors_fp16.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_constructors_fp64.cpp
+++ b/tests/accessor_legacy/accessor_constructors_fp64.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_constructors_image.cpp
+++ b/tests/accessor_legacy/accessor_constructors_image.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_constructors_image_utility.h
+++ b/tests/accessor_legacy/accessor_constructors_image_utility.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  This file is a common utility for the implementation of
 //  accessor_constructors.cpp and accessor_api.cpp.

--- a/tests/accessor_legacy/accessor_constructors_local.cpp
+++ b/tests/accessor_legacy/accessor_constructors_local.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/accessor_legacy/accessor_constructors_local_utility.h
+++ b/tests/accessor_legacy/accessor_constructors_local_utility.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  This file is a common utility for the implementation of
 //  accessor_constructors.cpp and accessor_api.cpp.

--- a/tests/accessor_legacy/accessor_constructors_utility.h
+++ b/tests/accessor_legacy/accessor_constructors_utility.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  This file is a common utility for the implementation of
 //  accessor_constructors.cpp and accessor_api.cpp.

--- a/tests/atomic/atomic_api_32.cpp
+++ b/tests/atomic/atomic_api_32.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/atomic/atomic_api_64_base.cpp
+++ b/tests/atomic/atomic_api_64_base.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/atomic/atomic_api_64_extended.cpp
+++ b/tests/atomic/atomic_api_64_extended.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/atomic/atomic_api_common.h
+++ b/tests/atomic/atomic_api_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/atomic/atomic_constructors_32.cpp
+++ b/tests/atomic/atomic_constructors_32.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/atomic/atomic_constructors_64.cpp
+++ b/tests/atomic/atomic_constructors_64.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/atomic/atomic_constructors_common.h
+++ b/tests/atomic/atomic_constructors_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/buffer/buffer_constructors_common.h
+++ b/tests/buffer/buffer_constructors_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/buffer/buffer_destructors.cpp
+++ b/tests/buffer/buffer_destructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/buffer/buffer_storage_common.h
+++ b/tests/buffer/buffer_storage_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2020-2022 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/common/common_python_vec.py
+++ b/tests/common/common_python_vec.py
@@ -2,7 +2,21 @@
 #
 #   SYCL Conformance Test Suite
 #
-#   Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 # ************************************************************************
 

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -2,7 +2,21 @@
 //
 //  SYCL Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 **************************************************************************/
 

--- a/tests/common/cts_async_handler.h
+++ b/tests/common/cts_async_handler.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/common/cts_selector.h
+++ b/tests/common/cts_selector.h
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2021 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2021-2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/common/get_cts_object.h
+++ b/tests/common/get_cts_object.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/common/macros.h
+++ b/tests/common/macros.h
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2020-2022 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/common/value_operations.h
+++ b/tests/common/value_operations.h
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2020-2022 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  This file contains helper functions for modifying and comparing values,
 //  arrays, and objects that implements operator[]

--- a/tests/common/vector.template
+++ b/tests/common/vector.template
@@ -2,7 +2,21 @@
 //
 //  SYCL Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 **************************************************************************/
 

--- a/tests/common/vector_swizzles.template
+++ b/tests/common/vector_swizzles.template
@@ -2,7 +2,21 @@
 //
 //  SYCL Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 **************************************************************************/
 $IFDEF

--- a/tests/context/context_api.cpp
+++ b/tests/context/context_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/context/context_constructors.cpp
+++ b/tests/context/context_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/context/context_info.cpp
+++ b/tests/context/context_info.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/device/device_api.cpp
+++ b/tests/device/device_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/device/device_info.cpp
+++ b/tests/device/device_info.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/device_event/device_event_api.cpp
+++ b/tests/device_event/device_event_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/device_selector/device_selector_api.cpp
+++ b/tests/device_selector/device_selector_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/device_selector/device_selector_constructors.cpp
+++ b/tests/device_selector/device_selector_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/device_selector/device_selector_custom.cpp
+++ b/tests/device_selector/device_selector_custom.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/device_selector/device_selector_predefined.cpp
+++ b/tests/device_selector/device_selector_predefined.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/error/error_types.cpp
+++ b/tests/error/error_types.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2022 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/exception_handling/asynchronous_exceptions.cpp
+++ b/tests/exception_handling/asynchronous_exceptions.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/exception_handling/synchronous_exceptions.cpp
+++ b/tests/exception_handling/synchronous_exceptions.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/group/group_api.cpp
+++ b/tests/group/group_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/group/group_constructors.cpp
+++ b/tests/group/group_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/group/group_equality.cpp
+++ b/tests/group/group_equality.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/group/group_wait_for.cpp
+++ b/tests/group/group_wait_for.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/h_item/h_item_api.cpp
+++ b/tests/h_item/h_item_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 #include "../common/common.h"

--- a/tests/h_item/h_item_constructors.cpp
+++ b/tests/h_item/h_item_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/h_item/h_item_equality.cpp
+++ b/tests/h_item/h_item_equality.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/handler/handler_api.cpp
+++ b/tests/handler/handler_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/handler/handler_copy_common.h
+++ b/tests/handler/handler_copy_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 #ifndef __SYCLCTS_TESTS_HANDLER_COPY_COMMON_H

--- a/tests/handler/handler_invoke_api.cpp
+++ b/tests/handler/handler_invoke_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/header/header_test.cpp
+++ b/tests/header/header_test.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/hierarchical/hierarchical_functor.cpp
+++ b/tests/hierarchical/hierarchical_functor.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/hierarchical/hierarchical_id.cpp
+++ b/tests/hierarchical/hierarchical_id.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/hierarchical/hierarchical_implicit_barriers.cpp
+++ b/tests/hierarchical/hierarchical_implicit_barriers.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/hierarchical/hierarchical_implicit_conditional.cpp
+++ b/tests/hierarchical/hierarchical_implicit_conditional.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/hierarchical/hierarchical_implicit_reduce.cpp
+++ b/tests/hierarchical/hierarchical_implicit_reduce.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/hierarchical/hierarchical_lambda.cpp
+++ b/tests/hierarchical/hierarchical_lambda.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/hierarchical/hierarchical_non_uniform_local_range.cpp
+++ b/tests/hierarchical/hierarchical_non_uniform_local_range.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Test description:
 //

--- a/tests/hierarchical/hierarchical_private_memory.cpp
+++ b/tests/hierarchical/hierarchical_private_memory.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/id/id_constructors.cpp
+++ b/tests/id/id_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/image/image_api.cpp
+++ b/tests/image/image_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/image/image_common.h
+++ b/tests/image/image_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/image/image_constructors.cpp
+++ b/tests/image/image_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/invoke/invoke_kernel_param_sizes.cpp
+++ b/tests/invoke/invoke_kernel_param_sizes.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/invoke/invoke_kernel_params.cpp
+++ b/tests/invoke/invoke_kernel_params.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/invoke/invoke_template_kernels_common.h
+++ b/tests/invoke/invoke_template_kernels_common.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/item/item_1d.cpp
+++ b/tests/item/item_1d.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/item/item_2d.cpp
+++ b/tests/item/item_2d.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/item/item_3d.cpp
+++ b/tests/item/item_3d.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 #include "../common/common.h"

--- a/tests/item/item_constructors.cpp
+++ b/tests/item/item_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/item/item_equality.cpp
+++ b/tests/item/item_equality.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/kernel/kernel_api.cpp
+++ b/tests/kernel/kernel_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/kernel/kernel_constructors.cpp
+++ b/tests/kernel/kernel_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/kernel_args/kernel_args.cpp
+++ b/tests/kernel_args/kernel_args.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/math_builtin_api/generate_math_builtin.py
+++ b/tests/math_builtin_api/generate_math_builtin.py
@@ -3,7 +3,21 @@
 ##
 ##  SYCL 2020 Conformance Test Suite
 ##
-##  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 ##
 ################################################################################
 

--- a/tests/math_builtin_api/math_builtin.h
+++ b/tests/math_builtin_api/math_builtin.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/math_builtin_api/math_builtin.template
+++ b/tests/math_builtin_api/math_builtin.template
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/multi_ptr/multi_ptr_legacy_api_core.cpp
+++ b/tests/multi_ptr/multi_ptr_legacy_api_core.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests for multi_ptr legacy API
 //

--- a/tests/multi_ptr/multi_ptr_legacy_constructors_core.cpp
+++ b/tests/multi_ptr/multi_ptr_legacy_constructors_core.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests for legacy multi_ptr constructors
 //

--- a/tests/nd_item/nd_item_api.cpp
+++ b/tests/nd_item/nd_item_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_async_work_group_copy.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_combined_barrier.cpp
+++ b/tests/nd_item/nd_item_combined_barrier.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_constructors.cpp
+++ b/tests/nd_item/nd_item_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_default_barrier.cpp
+++ b/tests/nd_item/nd_item_default_barrier.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_equality.cpp
+++ b/tests/nd_item/nd_item_equality.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_global_barrier.cpp
+++ b/tests/nd_item/nd_item_global_barrier.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_local_barrier.cpp
+++ b/tests/nd_item/nd_item_local_barrier.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_item/nd_item_wait_for.cpp
+++ b/tests/nd_item/nd_item_wait_for.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_range/nd_range_api.cpp
+++ b/tests/nd_range/nd_range_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_range/nd_range_constructors.cpp
+++ b/tests/nd_range/nd_range_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/nd_range/nd_range_equality.cpp
+++ b/tests/nd_range/nd_range_equality.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/opencl_interop/opencl_interop_get.cpp
+++ b/tests/opencl_interop/opencl_interop_get.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/opencl_interop/opencl_interop_kernel.cpp
+++ b/tests/opencl_interop/opencl_interop_kernel.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/platform/platform_api.cpp
+++ b/tests/platform/platform_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/platform/platform_constructors.cpp
+++ b/tests/platform/platform_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/platform/platform_info.cpp
+++ b/tests/platform/platform_info.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/pointers/kernel_pointers.cpp
+++ b/tests/pointers/kernel_pointers.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/queue/queue_api.cpp
+++ b/tests/queue/queue_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/queue/queue_constructors.cpp
+++ b/tests/queue/queue_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/queue/queue_info.cpp
+++ b/tests/queue/queue_info.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/queue/queue_properties.cpp
+++ b/tests/queue/queue_properties.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/range/range_api.cpp
+++ b/tests/range/range_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/range/range_constructors.cpp
+++ b/tests/range/range_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/sampler/sampler_api.cpp
+++ b/tests/sampler/sampler_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/sampler/sampler_constructors.cpp
+++ b/tests/sampler/sampler_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/scalars/scalars_interopability_types.cpp
+++ b/tests/scalars/scalars_interopability_types.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/scalars/scalars_sycl_types.cpp
+++ b/tests/scalars/scalars_sycl_types.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/std_classes/std_classes.cpp
+++ b/tests/std_classes/std_classes.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/stream/stream_api.cpp
+++ b/tests/stream/stream_api.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/stream/stream_api_fp16.cpp
+++ b/tests/stream/stream_api_fp16.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/stream/stream_constructors.cpp
+++ b/tests/stream/stream_constructors.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/tests/vector_alias/generate_vector_alias.py
+++ b/tests/vector_alias/generate_vector_alias.py
@@ -3,7 +3,21 @@
 #
 #   SYCL Conformance Test Suite
 #
-#   Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 # ************************************************************************
 

--- a/tests/vector_api/generate_vector_api.py
+++ b/tests/vector_api/generate_vector_api.py
@@ -3,7 +3,21 @@
 #
 #   SYCL Conformance Test Suite
 #
-#   Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 # ************************************************************************
 

--- a/tests/vector_constructors/generate_vector_constructors.py
+++ b/tests/vector_constructors/generate_vector_constructors.py
@@ -3,7 +3,21 @@
 #
 #   SYCL Conformance Test Suite
 #
-#   Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 # ************************************************************************
 

--- a/tests/vector_load_store/generate_vector_load_store.py
+++ b/tests/vector_load_store/generate_vector_load_store.py
@@ -3,7 +3,21 @@
 #
 #   SYCL Conformance Test Suite
 #
-#   Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 # ************************************************************************
 

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -3,7 +3,21 @@
 #
 #   SYCL Conformance Test Suite
 #
-#   Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 # ************************************************************************
 

--- a/tests/vector_swizzle_assignment/generate_vector_swizzle_assignment.py
+++ b/tests/vector_swizzle_assignment/generate_vector_swizzle_assignment.py
@@ -3,7 +3,21 @@
 #
 #   SYCL Conformance Test Suite
 #
-#   Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 # ************************************************************************
 

--- a/tests/vector_swizzles/generate_vector_swizzles.py
+++ b/tests/vector_swizzles/generate_vector_swizzles.py
@@ -3,7 +3,21 @@
 #
 #   SYCL Conformance Test Suite
 #
-#   Copyright:	(c) 2018 by Codeplay Software LTD. All Rights Reserved.
+#
+#   Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
+#   Copyright (c) 2022 The Khronos Group Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 #
 # ************************************************************************
 

--- a/util/device_manager.cpp
+++ b/util/device_manager.cpp
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2021 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2021-2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/device_manager.h
+++ b/util/device_manager.h
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2020-2021 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2020-2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/logger.cpp
+++ b/util/logger.cpp
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2020-2021 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2020-2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/logger.h
+++ b/util/logger.h
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2021 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2021-2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/math_helper.cpp
+++ b/util/math_helper.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/math_helper.h
+++ b/util/math_helper.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/math_reference.cpp
+++ b/util/math_reference.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/math_vector.h
+++ b/util/math_vector.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/proxy.h
+++ b/util/proxy.h
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2021 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2021-2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/singleton.h
+++ b/util/singleton.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/stl.h
+++ b/util/stl.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/test_base.h
+++ b/util/test_base.h
@@ -2,8 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2021 The Khronos Group Inc.
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2021-2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/test_base_opencl.cpp
+++ b/util/test_base_opencl.cpp
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/test_base_opencl.h
+++ b/util/test_base_opencl.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 

--- a/util/type_names.h
+++ b/util/type_names.h
@@ -2,7 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright:	(c) 2017 by Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 *******************************************************************************/
 


### PR DESCRIPTION
This patch updates all the copyright notices to reflect that the CTS is
no longer under Codeplay copyright but under Khronos copyright, and adds
the relevant Khronos Copyright notice.