### PR TITLE
Align include path with SYCL 2020 spec

### DIFF
--- a/tests/host_task/host_task_interop_api.cpp
+++ b/tests/host_task/host_task_interop_api.cpp
@@ -10,7 +10,7 @@
 #include "../common/common.h"
 
 #ifdef SYCL_BACKEND_OPENCL
-#include <CL/sycl/backend/opencl.hpp>
+#include <sycl/backend/opencl.hpp>
 #endif  // SYCL_BACKEND_OPENCL
 
 #define TEST_NAME host_task_interop_api


### PR DESCRIPTION
Backend interoperability header file location and name must follow the pattern specified in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:headers-and-namespaces.

"sycl/backend/<backend_name>.hpp"