### PR TITLE
Switch to struct information descriptors

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -59,7 +59,7 @@ jobs:
           # - sycl-impl: computecpp
           # version: 2.8.0
           - sycl-impl: dpcpp
-            version: 7ee07ba
+            version: b3cbda5
           - sycl-impl: hipsycl
             version: 3d8b1cd
     steps:
@@ -98,7 +98,7 @@ jobs:
           - sycl-impl: computecpp
             version: 2.8.0
           - sycl-impl: dpcpp
-            version: 7ee07ba
+            version: b3cbda5
           - sycl-impl: hipsycl
             version: 3d8b1cd
     env:

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -148,25 +148,23 @@ void check_enum_underlying_type(sycl_cts::util::logger& log) {
 /**
  * @brief Helper function to check an info parameter.
  */
-template <typename enumT, typename returnT, enumT kValue, typename objectT>
+template <typename infoDesc, typename returnT, typename objectT>
 void check_get_info_param(const objectT& object) {
-  // Check param_traits return type
-  using paramTraitsType =
-      typename sycl::info::param_traits<enumT, kValue>::return_type;
-  INFO("param_traits specialization has incorrect return type");
-  CHECK(std::is_same_v<paramTraitsType, returnT>);
+  // Check return_type specified in the descriptor
+  INFO("Information descriptor has incorrect return_type");
+  CHECK(std::is_same_v<typename infoDesc::return_type, returnT>);
 
   // Check get_info return type
-  auto returnValue = object.template get_info<kValue>();
+  auto returnValue = object.template get_info<infoDesc>();
   check_return_type<returnT>(returnValue, "object::get_info()");
 }
 
 /**
  * @deprecated Use overload without logger.
  */
-template <typename enumT, typename returnT, enumT kValue, typename objectT>
+template <typename infoDesc, typename returnT, typename objectT>
 void check_get_info_param(sycl_cts::util::logger& log, const objectT& object) {
-  check_get_info_param<enumT, returnT, kValue>(object);
+  check_get_info_param<infoDesc, returnT>(object);
 }
 
 /**
@@ -319,18 +317,6 @@ bool check_equal_values(const sycl::marray<T, numElements>& lhs,
   });
 }
 #endif
-
-#define TEST_TYPE_TRAIT(syclType, param, syclObject)                    \
-  if (typeid(sycl::info::param_traits<                              \
-             sycl::info::syclType,                                  \
-             sycl::info::syclType::param>::return_type) !=          \
-      typeid(syclObject.get_info<sycl::info::syclType::param>())) { \
-    FAIL(log, #syclType                                                 \
-         ".get_info<sycl::info::" #syclType "::" #param             \
-         ">() does not return "                                         \
-         "sycl::info::param_traits<sycl::info::" #syclType      \
-         ", sycl::info::" #syclType "::" #param ">::return_type");  \
-  }
 
 /** Enables concept checking ahead of the Concepts TS
  *  Idea for macro taken from Eric Niebler's range-v3

--- a/tests/context/context_info.cpp
+++ b/tests/context/context_info.cpp
@@ -46,16 +46,22 @@ class TEST_NAME : public util::test_base {
        */
       {
         auto platform = context.get_info<sycl::info::context::platform>();
+        // FIXME: Reenable when struct information descriptors are implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
         check_get_info_param<sycl::info::context::platform, sycl::platform>(
             log, context);
+#endif
       }
 
       /** check get_info for info::context::devices
        */
       {
         auto devs = context.get_info<sycl::info::context::devices>();
+        // FIXME: Reenable when struct information descriptors are implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
         check_get_info_param<sycl::info::context::devices,
                              std::vector<sycl::device>>(log, context);
+#endif
       }
     }
   }

--- a/tests/context/context_info.cpp
+++ b/tests/context/context_info.cpp
@@ -42,33 +42,20 @@ class TEST_NAME : public util::test_base {
     {
       auto context = util::get_cts_object::context();
 
-      /** check get_info for info::context::reference_count
-       */
-      {
-        auto ref_count =
-            context.get_info<sycl::info::context::reference_count>();
-        check_return_type<cl_uint>(
-            log, ref_count,
-            "get_info<sycl::info::context::reference_count>()");
-        TEST_TYPE_TRAIT(context, reference_count, context);
-      }
-
       /** check get_info for info::context::platform
        */
       {
         auto platform = context.get_info<sycl::info::context::platform>();
-        check_return_type<sycl::platform>(
-            log, platform, "get_info<sycl::info::context::platform>()");
-        TEST_TYPE_TRAIT(context, platform, context);
+        check_get_info_param<sycl::info::context::platform, sycl::platform>(
+            log, context);
       }
 
       /** check get_info for info::context::devices
        */
       {
         auto devs = context.get_info<sycl::info::context::devices>();
-        check_return_type<std::vector<sycl::device>>(
-            log, devs, "get_info<sycl::info::context::devices>()");
-        TEST_TYPE_TRAIT(context, devices, context);
+        check_get_info_param<sycl::info::context::devices,
+                             std::vector<sycl::device>>(log, context);
       }
     }
   }

--- a/tests/device/device_info.cpp
+++ b/tests/device/device_info.cpp
@@ -41,96 +41,6 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     {
-      /** check info::device
-       */
-      check_enum_class_value(sycl::info::device::device_type);
-      check_enum_class_value(sycl::info::device::vendor_id);
-      check_enum_class_value(sycl::info::device::max_compute_units);
-      check_enum_class_value(sycl::info::device::max_work_item_dimensions);
-      check_enum_class_value(sycl::info::device::max_work_item_sizes);
-      check_enum_class_value(sycl::info::device::max_work_group_size);
-      check_enum_class_value(
-          sycl::info::device::preferred_vector_width_char);
-      check_enum_class_value(
-          sycl::info::device::preferred_vector_width_short);
-      check_enum_class_value(
-          sycl::info::device::preferred_vector_width_int);
-      check_enum_class_value(
-          sycl::info::device::preferred_vector_width_long);
-      check_enum_class_value(
-          sycl::info::device::preferred_vector_width_float);
-      check_enum_class_value(
-          sycl::info::device::preferred_vector_width_double);
-      check_enum_class_value(
-          sycl::info::device::preferred_vector_width_half);
-      check_enum_class_value(sycl::info::device::native_vector_width_char);
-      check_enum_class_value(sycl::info::device::native_vector_width_short);
-      check_enum_class_value(sycl::info::device::native_vector_width_int);
-      check_enum_class_value(sycl::info::device::native_vector_width_long);
-      check_enum_class_value(sycl::info::device::native_vector_width_float);
-      check_enum_class_value(
-          sycl::info::device::native_vector_width_double);
-      check_enum_class_value(sycl::info::device::native_vector_width_half);
-      check_enum_class_value(sycl::info::device::max_clock_frequency);
-      check_enum_class_value(sycl::info::device::address_bits);
-      check_enum_class_value(sycl::info::device::max_mem_alloc_size);
-      check_enum_class_value(sycl::info::device::image_support);
-      check_enum_class_value(sycl::info::device::max_read_image_args);
-      check_enum_class_value(sycl::info::device::max_write_image_args);
-      check_enum_class_value(sycl::info::device::image2d_max_height);
-      check_enum_class_value(sycl::info::device::image2d_max_width);
-      check_enum_class_value(sycl::info::device::image3d_max_height);
-      check_enum_class_value(sycl::info::device::image3d_max_width);
-      check_enum_class_value(sycl::info::device::image3d_max_depth);
-      check_enum_class_value(sycl::info::device::image_max_buffer_size);
-      check_enum_class_value(sycl::info::device::image_max_array_size);
-      check_enum_class_value(sycl::info::device::max_samplers);
-      check_enum_class_value(sycl::info::device::max_parameter_size);
-      check_enum_class_value(sycl::info::device::mem_base_addr_align);
-      check_enum_class_value(sycl::info::device::half_fp_config);
-      check_enum_class_value(sycl::info::device::single_fp_config);
-      check_enum_class_value(sycl::info::device::double_fp_config);
-      check_enum_class_value(sycl::info::device::global_mem_cache_type);
-      check_enum_class_value(
-          sycl::info::device::global_mem_cache_line_size);
-      check_enum_class_value(sycl::info::device::global_mem_cache_size);
-      check_enum_class_value(sycl::info::device::global_mem_size);
-      check_enum_class_value(sycl::info::device::max_constant_buffer_size);
-      check_enum_class_value(sycl::info::device::max_constant_args);
-      check_enum_class_value(sycl::info::device::local_mem_type);
-      check_enum_class_value(sycl::info::device::local_mem_size);
-      check_enum_class_value(sycl::info::device::error_correction_support);
-      check_enum_class_value(sycl::info::device::host_unified_memory);
-      check_enum_class_value(
-          sycl::info::device::profiling_timer_resolution);
-      check_enum_class_value(sycl::info::device::is_endian_little);
-      check_enum_class_value(sycl::info::device::is_available);
-      check_enum_class_value(sycl::info::device::is_compiler_available);
-      check_enum_class_value(sycl::info::device::is_linker_available);
-      check_enum_class_value(sycl::info::device::execution_capabilities);
-      check_enum_class_value(sycl::info::device::queue_profiling);
-      check_enum_class_value(sycl::info::device::built_in_kernels);
-      check_enum_class_value(sycl::info::device::platform);
-      check_enum_class_value(sycl::info::device::name);
-      check_enum_class_value(sycl::info::device::vendor);
-      check_enum_class_value(sycl::info::device::driver_version);
-      check_enum_class_value(sycl::info::device::profile);
-      check_enum_class_value(sycl::info::device::version);
-      check_enum_class_value(sycl::info::device::opencl_c_version);
-      check_enum_class_value(sycl::info::device::extensions);
-      check_enum_class_value(sycl::info::device::printf_buffer_size);
-      check_enum_class_value(
-          sycl::info::device::preferred_interop_user_sync);
-      check_enum_class_value(sycl::info::device::parent_device);
-      check_enum_class_value(sycl::info::device::partition_max_sub_devices);
-      check_enum_class_value(sycl::info::device::partition_properties);
-      check_enum_class_value(
-          sycl::info::device::partition_affinity_domains);
-      check_enum_class_value(sycl::info::device::partition_type_property);
-      check_enum_class_value(
-          sycl::info::device::partition_type_affinity_domain);
-      check_enum_class_value(sycl::info::device::reference_count);
-
       /** check info::device_type
        */
       check_enum_class_value(sycl::info::device_type::cpu);
@@ -202,198 +112,141 @@ class TEST_NAME : public util::test_base {
       {
         cts_selector selector;
         auto dev = util::get_cts_object::device(selector);
-        check_get_info_param<sycl::info::device,
-                             sycl::info::device_type,
-                             sycl::info::device::device_type>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::vendor_id>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::max_compute_units>(log,
-                                                                        dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::max_work_item_dimensions>(
-            log, dev);
-        check_get_info_param<sycl::info::device, sycl::id<3>,
-                             sycl::info::device::max_work_item_sizes>(log,
-                                                                          dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::max_work_group_size>(log,
-                                                                          dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::preferred_vector_width_char>(log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::preferred_vector_width_short>(log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::preferred_vector_width_int>(log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::preferred_vector_width_long>(log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::preferred_vector_width_float>(log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::preferred_vector_width_double>(log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::preferred_vector_width_half>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::native_vector_width_char>(
-            log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::native_vector_width_short>(
-            log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::native_vector_width_int>(
-            log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::native_vector_width_long>(
-            log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::native_vector_width_float>(
-            log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::native_vector_width_double>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::native_vector_width_half>(
-            log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::max_clock_frequency>(log,
-                                                                          dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::address_bits>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_ulong,
-                             sycl::info::device::max_mem_alloc_size>(log,
-                                                                         dev);
-        check_get_info_param<sycl::info::device, bool,
-                             sycl::info::device::image_support>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::max_read_image_args>(log,
-                                                                          dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::max_write_image_args>(log,
+        check_get_info_param<sycl::info::device::device_type,
+                             sycl::info::device_type>(log, dev);
+        check_get_info_param<sycl::info::device::vendor_id, sycl::cl_uint>(log,
                                                                            dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::image2d_max_height>(log,
-                                                                         dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::image2d_max_width>(log,
-                                                                        dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::image3d_max_height>(log,
-                                                                         dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::image3d_max_width>(log,
-                                                                        dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::image3d_max_depth>(log,
-                                                                        dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::image_max_buffer_size>(
+        check_get_info_param<sycl::info::device::max_compute_units,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::max_work_item_dimensions,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::max_work_item_sizes<1>,
+                             sycl::id<1>>(log, dev);
+        check_get_info_param<sycl::info::device::max_work_item_sizes<2>,
+                             sycl::id<2>>(log, dev);
+        check_get_info_param<sycl::info::device::max_work_item_sizes<3>,
+                             sycl::id<3>>(log, dev);
+        check_get_info_param<sycl::info::device::max_work_group_size, size_t>(
             log, dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::image_max_array_size>(log,
+        check_get_info_param<sycl::info::device::preferred_vector_width_char,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::preferred_vector_width_short,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::preferred_vector_width_int,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::preferred_vector_width_long,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::preferred_vector_width_float,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::preferred_vector_width_double,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::preferred_vector_width_half,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::native_vector_width_char,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::native_vector_width_short,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::native_vector_width_int,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::native_vector_width_long,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::native_vector_width_float,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::native_vector_width_double,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::native_vector_width_half,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::max_clock_frequency,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::address_bits, sycl::cl_uint>(
+            log, dev);
+        check_get_info_param<sycl::info::device::max_mem_alloc_size,
+                             sycl::cl_ulong>(log, dev);
+        check_get_info_param<sycl::info::device::image_support, bool>(log, dev);
+        check_get_info_param<sycl::info::device::max_read_image_args,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::max_write_image_args,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::image2d_max_height, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::image2d_max_width, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::image3d_max_height, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::image3d_max_width, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::image3d_max_depth, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::image_max_buffer_size, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::image_max_array_size, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::max_samplers, sycl::cl_uint>(
+            log, dev);
+        check_get_info_param<sycl::info::device::max_parameter_size, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::mem_base_addr_align,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::half_fp_config,
+                             std::vector<sycl::info::fp_config>>(log, dev);
+        check_get_info_param<sycl::info::device::single_fp_config,
+                             std::vector<sycl::info::fp_config>>(log, dev);
+        check_get_info_param<sycl::info::device::double_fp_config,
+                             std::vector<sycl::info::fp_config>>(log, dev);
+        check_get_info_param<sycl::info::device::global_mem_cache_type,
+                             sycl::info::global_mem_cache_type>(log, dev);
+        check_get_info_param<sycl::info::device::global_mem_cache_line_size,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::global_mem_cache_size,
+                             sycl::cl_ulong>(log, dev);
+        check_get_info_param<sycl::info::device::global_mem_size,
+                             sycl::cl_ulong>(log, dev);
+        check_get_info_param<sycl::info::device::max_constant_buffer_size,
+                             sycl::cl_ulong>(log, dev);
+        check_get_info_param<sycl::info::device::max_constant_args,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::local_mem_type,
+                             sycl::info::local_mem_type>(log, dev);
+        check_get_info_param<sycl::info::device::local_mem_size,
+                             sycl::cl_ulong>(log, dev);
+        check_get_info_param<sycl::info::device::error_correction_support,
+                             bool>(log, dev);
+        check_get_info_param<sycl::info::device::host_unified_memory, bool>(
+            log, dev);
+        check_get_info_param<sycl::info::device::profiling_timer_resolution,
+                             size_t>(log, dev);
+        check_get_info_param<sycl::info::device::is_endian_little, bool>(log,
+                                                                         dev);
+        check_get_info_param<sycl::info::device::is_available, bool>(log, dev);
+        check_get_info_param<sycl::info::device::is_compiler_available, bool>(
+            log, dev);
+        check_get_info_param<sycl::info::device::is_linker_available, bool>(
+            log, dev);
+        check_get_info_param<sycl::info::device::execution_capabilities,
+                             std::vector<sycl::info::execution_capability>>(
+            log, dev);
+        check_get_info_param<sycl::info::device::queue_profiling, bool>(log,
+                                                                        dev);
+        check_get_info_param<sycl::info::device::built_in_kernels,
+                             std::vector<std::string>>(log, dev);
+        check_get_info_param<sycl::info::device::platform, sycl::platform>(log,
                                                                            dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::max_samplers>(log, dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::max_parameter_size>(log,
-                                                                         dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::mem_base_addr_align>(log,
-                                                                          dev);
-        check_get_info_param<sycl::info::device,
-                             std::vector<sycl::info::fp_config>,
-                             sycl::info::device::half_fp_config>(log, dev);
-        check_get_info_param<sycl::info::device,
-                             std::vector<sycl::info::fp_config>,
-                             sycl::info::device::single_fp_config>(log,
-                                                                       dev);
-        check_get_info_param<sycl::info::device,
-                             std::vector<sycl::info::fp_config>,
-                             sycl::info::device::double_fp_config>(log,
-                                                                       dev);
-        check_get_info_param<sycl::info::device,
-                             sycl::info::global_mem_cache_type,
-                             sycl::info::device::global_mem_cache_type>(
+        check_get_info_param<sycl::info::device::name, std::string>(log, dev);
+        check_get_info_param<sycl::info::device::vendor, std::string>(log, dev);
+        check_get_info_param<sycl::info::device::driver_version, std::string>(
             log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::cl_uint,
-            sycl::info::device::global_mem_cache_line_size>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_ulong,
-                             sycl::info::device::global_mem_cache_size>(
-            log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_ulong,
-                             sycl::info::device::global_mem_size>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_ulong,
-                             sycl::info::device::max_constant_buffer_size>(
-            log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::max_constant_args>(log,
-                                                                        dev);
-        check_get_info_param<sycl::info::device,
-                             sycl::info::local_mem_type,
-                             sycl::info::device::local_mem_type>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_ulong,
-                             sycl::info::device::local_mem_size>(log, dev);
-        check_get_info_param<sycl::info::device, bool,
-                             sycl::info::device::error_correction_support>(
-            log, dev);
-        check_get_info_param<sycl::info::device, bool,
-                             sycl::info::device::host_unified_memory>(log,
-                                                                          dev);
-        check_get_info_param<
-            sycl::info::device, size_t,
-            sycl::info::device::profiling_timer_resolution>(log, dev);
-        check_get_info_param<sycl::info::device, bool,
-                             sycl::info::device::is_endian_little>(log,
+        check_get_info_param<sycl::info::device::profile, std::string>(log,
                                                                        dev);
-        check_get_info_param<sycl::info::device, bool,
-                             sycl::info::device::is_available>(log, dev);
-        check_get_info_param<sycl::info::device, bool,
-                             sycl::info::device::is_compiler_available>(
+        check_get_info_param<sycl::info::device::version, std::string>(log,
+                                                                       dev);
+        check_get_info_param<sycl::info::device::opencl_c_version, std::string>(
             log, dev);
-        check_get_info_param<sycl::info::device, bool,
-                             sycl::info::device::is_linker_available>(log,
-                                                                          dev);
-        check_get_info_param<
-            sycl::info::device,
-            std::vector<sycl::info::execution_capability>,
-            sycl::info::device::execution_capabilities>(log, dev);
-        check_get_info_param<sycl::info::device, bool,
-                             sycl::info::device::queue_profiling>(log, dev);
-        check_get_info_param<sycl::info::device,
-                             std::vector<std::string>,
-                             sycl::info::device::built_in_kernels>(log,
-                                                                       dev);
-        check_get_info_param<sycl::info::device, sycl::platform,
-                             sycl::info::device::platform>(log, dev);
-        check_get_info_param<sycl::info::device, std::string,
-                             sycl::info::device::name>(log, dev);
-        check_get_info_param<sycl::info::device, std::string,
-                             sycl::info::device::vendor>(log, dev);
-        check_get_info_param<sycl::info::device, std::string,
-                             sycl::info::device::driver_version>(log, dev);
-        check_get_info_param<sycl::info::device, std::string,
-                             sycl::info::device::profile>(log, dev);
-        check_get_info_param<sycl::info::device, std::string,
-                             sycl::info::device::version>(log, dev);
-        check_get_info_param<sycl::info::device, std::string,
-                             sycl::info::device::opencl_c_version>(log,
-                                                                       dev);
-        check_get_info_param<sycl::info::device,
-                             std::vector<std::string>,
-                             sycl::info::device::extensions>(log, dev);
-        check_get_info_param<sycl::info::device, size_t,
-                             sycl::info::device::printf_buffer_size>(log,
-                                                                         dev);
-        check_get_info_param<
-            sycl::info::device, bool,
-            sycl::info::device::preferred_interop_user_sync>(log, dev);
+        check_get_info_param<sycl::info::device::extensions,
+                             std::vector<std::string>>(log, dev);
+        check_get_info_param<sycl::info::device::printf_buffer_size, size_t>(
+            log, dev);
+        check_get_info_param<sycl::info::device::preferred_interop_user_sync,
+                             bool>(log, dev);
         auto SupportedProperties =
             dev.get_info<sycl::info::device::partition_properties>();
         if (std::find(SupportedProperties.begin(), SupportedProperties.end(),
@@ -403,30 +256,21 @@ class TEST_NAME : public util::test_base {
           auto sub_device_partition_equal = dev.create_sub_devices<
               sycl::info::partition_property::partition_equally>(1);
 
-          check_get_info_param<sycl::info::device, sycl::device,
-                               sycl::info::device::parent_device>(
+          check_get_info_param<sycl::info::device::parent_device, sycl::device>(
               log, sub_device_partition_equal[0]);
         }
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::partition_max_sub_devices>(
-            log, dev);
+        check_get_info_param<sycl::info::device::partition_max_sub_devices,
+                             sycl::cl_uint>(log, dev);
+        check_get_info_param<sycl::info::device::partition_properties,
+                             std::vector<sycl::info::partition_property>>(log,
+                                                                          dev);
         check_get_info_param<
-            sycl::info::device,
-            std::vector<sycl::info::partition_property>,
-            sycl::info::device::partition_properties>(log, dev);
-        check_get_info_param<
-            sycl::info::device,
-            std::vector<sycl::info::partition_affinity_domain>,
-            sycl::info::device::partition_affinity_domains>(log, dev);
-        check_get_info_param<sycl::info::device,
-                             sycl::info::partition_property,
-                             sycl::info::device::partition_type_property>(
-            log, dev);
-        check_get_info_param<
-            sycl::info::device, sycl::info::partition_affinity_domain,
-            sycl::info::device::partition_type_affinity_domain>(log, dev);
-        check_get_info_param<sycl::info::device, sycl::cl_uint,
-                             sycl::info::device::reference_count>(log, dev);
+            sycl::info::device::partition_affinity_domains,
+            std::vector<sycl::info::partition_affinity_domain>>(log, dev);
+        check_get_info_param<sycl::info::device::partition_type_property,
+                             sycl::info::partition_property>(log, dev);
+        check_get_info_param<sycl::info::device::partition_type_affinity_domain,
+                             sycl::info::partition_affinity_domain>(log, dev);
       }
     }
   }

--- a/tests/device/device_info.cpp
+++ b/tests/device/device_info.cpp
@@ -109,6 +109,8 @@ class TEST_NAME : public util::test_base {
 
       /** check get_info parameters
        */
+      // FIXME: Reenable when struct information descriptors are implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
       {
         cts_selector selector;
         auto dev = util::get_cts_object::device(selector);
@@ -272,6 +274,7 @@ class TEST_NAME : public util::test_base {
         check_get_info_param<sycl::info::device::partition_type_affinity_domain,
                              sycl::info::partition_affinity_domain>(log, dev);
       }
+#endif
     }
   }
 };

--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -444,7 +444,9 @@ static void check_get_profiling_info_return_type() {
         uint64_t>);
 }
 
-TEST_CASE("event::get_profiling_info works as expected", "[event]") {
+// FIXME: reenable when struct information descriptors are implemented
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCPP)
+("event::get_profiling_info works as expected", "[event]")({
   // Check that queries return the expected type.
   check_get_profiling_info_return_type<
       sycl::info::event_profiling::command_submit>();
@@ -478,4 +480,4 @@ TEST_CASE("event::get_profiling_info works as expected", "[event]") {
   // perform some basic sanity checks.
   CHECK(submit_time <= start_time);
   CHECK(start_time <= end_time);
-}
+});

--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -394,9 +394,8 @@ TEST_CASE("event::wait_and_throw only reports unconsumed asynchronous errors",
 TEST_CASE("event::get_info returns correct command execution status",
           "[event]") {
   // First check that return value is of expected type
-  check_get_info_param<sycl::info::event, sycl::info::event_command_status,
-                       sycl::info::event::command_execution_status>(
-      make_device_event());
+  check_get_info_param<sycl::info::event::command_execution_status,
+                       sycl::info::event_command_status>(make_device_event());
 
   SECTION("for host_task event") {
     resolvable_host_event rhe;
@@ -435,12 +434,9 @@ TEST_CASE("event::get_info returns correct command execution status",
 TODO_TEST_CASE("event::get_backend_info returns backend-specific information",
                "[event]");
 
-template <sycl::info::event_profiling descriptor>
+template <typename descriptor>
 static void check_get_profiling_info_return_type() {
-  using paramTraitsType =
-      typename sycl::info::param_traits<sycl::info::event_profiling,
-                                        descriptor>::return_type;
-  CHECK(std::is_same<paramTraitsType, uint64_t>::value);
+  CHECK(std::is_same<typename descriptor::return_type, uint64_t>::value);
   CHECK(std::is_same_v<
         decltype(std::declval<sycl::event>().get_profiling_info<descriptor>()),
         uint64_t>);

--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
 
 using namespace sycl_cts;
 
@@ -391,8 +392,9 @@ TEST_CASE("event::wait_and_throw only reports unconsumed asynchronous errors",
   CHECK(teh.has("another-error"));
 }
 
-TEST_CASE("event::get_info returns correct command execution status",
-          "[event]") {
+// FIXME: reenable when struct information descriptors are implemented
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+("event::get_info returns correct command execution status", "[event]")({
   // First check that return value is of expected type
   check_get_info_param<sycl::info::event::command_execution_status,
                        sycl::info::event_command_status>(make_device_event());
@@ -425,7 +427,7 @@ TEST_CASE("event::get_info returns correct command execution status",
         e1.get_info<sycl::info::event::command_execution_status>();
     CHECK(status == sycl::info::event_command_status::complete);
   }
-}
+});
 
 // TODO: Figure out if/how we want to test this.
 // => Must throw exception w/ errc::backend_mismatch if querying a parameter

--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -445,7 +445,7 @@ static void check_get_profiling_info_return_type() {
 }
 
 // FIXME: reenable when struct information descriptors are implemented
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCPP)
+DISABLED_FOR_TEST_CASE(ComputeCPP)
 ("event::get_profiling_info works as expected", "[event]")({
   // Check that queries return the expected type.
   check_get_profiling_info_return_type<

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -95,9 +95,12 @@ class TEST_NAME : public sycl_cts::util::test_base {
           kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
               dev);
 
+      // FIXME: Reenable when struct information descriptors are implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
       check_get_info_param<sycl::info::kernel::num_args, uint32_t>(log, kernel);
       check_get_info_param<sycl::info::kernel::attributes, std::string>(log,
                                                                         kernel);
+#endif
 
       queue.wait_and_throw();
     }

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -59,10 +59,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
         cgh.single_task<k_name>([=]() {});
       });
 
-      /** check types
-       */
-      check_type_existence<sycl::info::kernel>();
-
       /** initialize return values
        */
       cl_uint clUintRet;
@@ -78,11 +74,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
       /** check program info parameters
        */
-      if (!queue.is_host()) {
-        clUintRet =
-            kernel.get_info<sycl::info::kernel::reference_count>();
-      }
-      stringRet = kernel.get_info<sycl::info::kernel::function_name>();
       clUintRet = kernel.get_info<sycl::info::kernel::num_args>();
       stringRet = kernel.get_info<sycl::info::kernel::attributes>();
       auto dev = util::get_cts_object::device();
@@ -104,10 +95,9 @@ class TEST_NAME : public sycl_cts::util::test_base {
           kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
               dev);
 
-      TEST_TYPE_TRAIT(kernel, reference_count, kernel);
-      TEST_TYPE_TRAIT(kernel, function_name, kernel);
-      TEST_TYPE_TRAIT(kernel, num_args, kernel);
-      TEST_TYPE_TRAIT(kernel, attributes, kernel);
+      check_get_info_param<sycl::info::kernel::num_args, uint32_t>(log, kernel);
+      check_get_info_param<sycl::info::kernel::attributes, std::string>(log,
+                                                                        kernel);
 
       queue.wait_and_throw();
     }

--- a/tests/platform/platform_info.cpp
+++ b/tests/platform/platform_info.cpp
@@ -40,30 +40,20 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     {
-      /** check info::platform
-       */
-      check_enum_class_value(sycl::info::platform::profile);
-      check_enum_class_value(sycl::info::platform::version);
-      check_enum_class_value(sycl::info::platform::name);
-      check_enum_class_value(sycl::info::platform::vendor);
-      check_enum_class_value(sycl::info::platform::extensions);
-
       /** check get_info parameters
        */
       {
         cts_selector selector;
         auto plt = util::get_cts_object::platform(selector);
-        check_get_info_param<sycl::info::platform, std::string,
-                             sycl::info::platform::profile>(log, plt);
-        check_get_info_param<sycl::info::platform, std::string,
-                             sycl::info::platform::version>(log, plt);
-        check_get_info_param<sycl::info::platform, std::string,
-                             sycl::info::platform::name>(log, plt);
-        check_get_info_param<sycl::info::platform, std::string,
-                             sycl::info::platform::vendor>(log, plt);
-        check_get_info_param<sycl::info::platform,
-                             std::vector<std::string>,
-                             sycl::info::platform::extensions>(log, plt);
+        check_get_info_param<sycl::info::platform::profile, std::string>(log,
+                                                                         plt);
+        check_get_info_param<sycl::info::platform::version, std::string>(log,
+                                                                         plt);
+        check_get_info_param<sycl::info::platform::name, std::string>(log, plt);
+        check_get_info_param<sycl::info::platform::vendor, std::string>(log,
+                                                                        plt);
+        check_get_info_param<sycl::info::platform::extensions,
+                             std::vector<std::string>>(log, plt);
       }
     }
   }

--- a/tests/platform/platform_info.cpp
+++ b/tests/platform/platform_info.cpp
@@ -40,6 +40,8 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     {
+      // FIXME: Reenable when struct information descriptors are implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
       /** check get_info parameters
        */
       {
@@ -55,6 +57,7 @@ class TEST_NAME : public util::test_base {
         check_get_info_param<sycl::info::platform::extensions,
                              std::vector<std::string>>(log, plt);
       }
+#endif
     }
   }
 };

--- a/tests/queue/queue_info.cpp
+++ b/tests/queue/queue_info.cpp
@@ -41,8 +41,10 @@ class TEST_NAME : public util::test_base {
   */
   void run(util::logger &log) override {
     {
+      // FIXME: Reenable when struct information descriptors are implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
       /** check get_info parameters
-      */
+       */
       {
         cts_selector selector;
         auto queue = util::get_cts_object::queue(selector);
@@ -51,6 +53,7 @@ class TEST_NAME : public util::test_base {
         check_get_info_param<sycl::info::queue::device, sycl::device>(log,
                                                                       queue);
       }
+#endif
     }
   }
 };

--- a/tests/queue/queue_info.cpp
+++ b/tests/queue/queue_info.cpp
@@ -41,24 +41,15 @@ class TEST_NAME : public util::test_base {
   */
   void run(util::logger &log) override {
     {
-      /** check sycl::info::queue
-      */
-      check_enum_class_value(sycl::info::queue::reference_count);
-      check_enum_class_value(sycl::info::queue::context);
-      check_enum_class_value(sycl::info::queue::device);
-
       /** check get_info parameters
       */
       {
         cts_selector selector;
         auto queue = util::get_cts_object::queue(selector);
-        check_get_info_param<sycl::info::queue, sycl::cl_uint,
-                             sycl::info::queue::reference_count>(log,
-                                                                     queue);
-        check_get_info_param<sycl::info::queue, sycl::context,
-                             sycl::info::queue::context>(log, queue);
-        check_get_info_param<sycl::info::queue, sycl::device,
-                             sycl::info::queue::device>(log, queue);
+        check_get_info_param<sycl::info::queue::context, sycl::context>(log,
+                                                                        queue);
+        check_get_info_param<sycl::info::queue::device, sycl::device>(log,
+                                                                      queue);
       }
     }
   }


### PR DESCRIPTION
Change information descriptors from enum class elements to structs in
accordance with SYCL 2020. Additionally, drop some outdated descriptors
and bump the DPC++ version.