### PR TITLE
Fix usages of CHECK_THROWS_MATCHES macro

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -641,7 +641,7 @@ void check_placeholder_accessor_exception(const sycl::range<Dimension>& r,
         "sycl::errc::kernel_argument when a placeholder accessor is passed to "
         "the command");
     CHECK_THROWS_MATCHES(
-        action, sycl::exception,
+        action(), sycl::exception,
         sycl_cts::util::equals_exception(sycl::errc::kernel_argument));
   }
 }
@@ -736,12 +736,12 @@ void check_no_init_prop_exception(GetAccFunctorT construct_acc,
     if constexpr (AccType != accessor_type::host_accessor) {
       auto action = [&] { construct_acc(queue, data_buf); };
       CHECK_THROWS_MATCHES(
-          action, sycl::exception,
+          action(), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
     } else {
       auto action = [&] { construct_acc(data_buf); };
       CHECK_THROWS_MATCHES(
-          action, sycl::exception,
+          action(), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
     }
   }

--- a/tests/accessor/accessor_exceptions.h
+++ b/tests/accessor/accessor_exceptions.h
@@ -55,20 +55,20 @@ void check_exception(GetAccFunctorT construct_acc) {
             .wait_and_throw();
       };
       CHECK_THROWS_MATCHES(
-          action, sycl::exception,
+          action(), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
     } else if constexpr (AccType ==
                          accessor_tests_common::accessor_type::host_accessor) {
       auto action = [&] { construct_acc(data_buf); };
       CHECK_THROWS_MATCHES(
-          action, sycl::exception,
+          action(), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
     } else if constexpr (AccType ==
                          accessor_tests_common::accessor_type::local_accessor) {
       static_cast<void>(data_buf);
       auto action = [&] { construct_acc(queue); };
       CHECK_THROWS_MATCHES(
-          action, sycl::exception,
+          action(), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::kernel_argument));
     } else {
       static_assert(AccType != AccType, "Unexpected accessor type.");

--- a/tests/exceptions/exceptions_constructors.cpp
+++ b/tests/exceptions/exceptions_constructors.cpp
@@ -27,7 +27,7 @@ inline void check_exception(sycl::exception e, const std::error_code errcode,
   CHECK(e.category() == errcat);
   CHECK(e.what() != nullptr);
   CHECK(e.has_context() == false);
-  CHECK_THROWS_MATCHES([&e] { e.get_context(); }, sycl::exception,
+  CHECK_THROWS_MATCHES([&e] { e.get_context(); }(), sycl::exception,
                        sycl_cts::util::equals_exception(sycl::errc::invalid));
 }
 
@@ -48,7 +48,7 @@ inline void check_exception(sycl::exception e, const std::error_code errcode,
   CHECK(e.category() == errcat);
   CHECK(e.what() == what_arg);
   CHECK(e.has_context() == false);
-  CHECK_THROWS_MATCHES([&e] { e.get_context(); }, sycl::exception,
+  CHECK_THROWS_MATCHES([&e] { e.get_context(); }(), sycl::exception,
                        sycl_cts::util::equals_exception(sycl::errc::invalid));
 }
 

--- a/tests/exceptions/exceptions_constructors.cpp
+++ b/tests/exceptions/exceptions_constructors.cpp
@@ -27,7 +27,7 @@ inline void check_exception(sycl::exception e, const std::error_code errcode,
   CHECK(e.category() == errcat);
   CHECK(e.what() != nullptr);
   CHECK(e.has_context() == false);
-  CHECK_THROWS_MATCHES([&e] { e.get_context(); }(), sycl::exception,
+  CHECK_THROWS_MATCHES(e.get_context(), sycl::exception,
                        sycl_cts::util::equals_exception(sycl::errc::invalid));
 }
 
@@ -48,7 +48,7 @@ inline void check_exception(sycl::exception e, const std::error_code errcode,
   CHECK(e.category() == errcat);
   CHECK(e.what() == what_arg);
   CHECK(e.has_context() == false);
-  CHECK_THROWS_MATCHES([&e] { e.get_context(); }(), sycl::exception,
+  CHECK_THROWS_MATCHES(e.get_context(), sycl::exception,
                        sycl_cts::util::equals_exception(sycl::errc::invalid));
 }
 

--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -301,19 +301,19 @@ void execute_tasks_and_check_exception(
   if (is_exception_expected) {
     {
       INFO(single_task_desc);
-      CHECK_THROWS_MATCHES(single_task_action, sycl::exception,
+      CHECK_THROWS_MATCHES(single_task_action(), sycl::exception,
                            sycl_cts::util::equals_exception(errc_expected));
       check_async_exception(queue, false);
     }
     {
       INFO(parallel_for_desc);
-      CHECK_THROWS_MATCHES(parallel_for_action, sycl::exception,
+      CHECK_THROWS_MATCHES(parallel_for_action(), sycl::exception,
                            sycl_cts::util::equals_exception(errc_expected));
       check_async_exception(queue, false);
     }
     {
       INFO(parallel_for_wg_desc);
-      CHECK_THROWS_MATCHES(parallel_for_wg_action, sycl::exception,
+      CHECK_THROWS_MATCHES(parallel_for_wg_action(), sycl::exception,
                            sycl_cts::util::equals_exception(errc_expected));
       check_async_exception(queue, false);
     }


### PR DESCRIPTION
Added `()` to actually trigger execution of lambdas passed to the macro
or otherwise the macro didn't invoke anything. Apparently,
`static_cast<void>` on lambda compiles just fine.