### PR TITLE
Remove use of is_host and fix default device constructor check

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -174,10 +174,10 @@ void check_get_info_param(sycl_cts::util::logger& log, const objectT& object) {
  */
 template <typename T>
 void check_equality(T& a, T& b) {
-  /** check is_host
+  /** check get_backend
    */
-  if (a.is_host() != b.is_host()) {
-    FAIL("two objects are not equal (is_host)");
+  if (a.get_backend() != b.get_backend()) {
+    FAIL("two objects are not equal (get_backend)");
   }
 
 #ifdef SYCL_BACKEND_OPENCL

--- a/tests/context/context_api.cpp
+++ b/tests/context/context_api.cpp
@@ -42,13 +42,6 @@ class TEST_NAME : public util::test_base {
     {
       auto context = util::get_cts_object::context();
 
-      /** check is_host() method
-       */
-      {
-        auto isHost = context.is_host();
-        check_return_type<bool>(log, isHost, "is_host()");
-      }
-
       /** check get_devices() method
        */
       {

--- a/tests/context/context_constructors.cpp
+++ b/tests/context/context_constructors.cpp
@@ -35,6 +35,35 @@ class TEST_NAME : public util::test_base {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
+  void check_context_after_ctor(sycl::context &context,
+                                sycl::device &expectedDevice,
+                                util::logger &log) {
+    if (context.get_devices().size() != 1) {
+      FAIL(log, "context was not constructed correctly (get_devices size)");
+    }
+
+    if (context.get_devices()[0] != expectedDevice) {
+      FAIL(log, "context was not constructed correctly (device equality)");
+    }
+  }
+
+  void check_context_after_ctor(sycl::context &context,
+                                std::vector<sycl::device> &expectedDevices,
+                                util::logger &log) {
+    if (context.get_devices().size() != expectedDevices.size()) {
+      FAIL(log, "context was not constructed correctly (get_devices size)");
+    }
+
+    for (auto &device : context.get_devices()) {
+      if (std::find(expectedDevices.begin(), expectedDevices.end(), device) ==
+          expectedDevices.end()) {
+        FAIL(log,
+             "context was not constructed correctly (device not in passed "
+             "device list)");
+      }
+    }
+  }
+
   /** execute the test
    */
   void run(util::logger &log) override {
@@ -60,13 +89,7 @@ class TEST_NAME : public util::test_base {
         auto device = util::get_cts_object::device(selector);
         sycl::context context(device);
 
-        if (context.get_devices().size() != 1) {
-          FAIL(log, "context was not constructed correctly (get_devices size)");
-        }
-
-        if (context.get_devices()[0] != device) {
-          FAIL(log, "context was not constructed correctly (device equality)");
-        }
+        check_context_after_ctor(context, device, log);
       }
 
       /** check (device, async_handler) constructor
@@ -77,13 +100,7 @@ class TEST_NAME : public util::test_base {
         auto device = util::get_cts_object::device(selector);
         sycl::context context(device, asyncHandler);
 
-        if (context.get_devices().size() != 1) {
-          FAIL(log, "context was not constructed correctly (get_devices size)");
-        }
-
-        if (context.get_devices()[0] != device) {
-          FAIL(log, "context was not constructed correctly (device equality)");
-        }
+        check_context_after_ctor(context, device, log);
       }
 
       /** check (std::vector<device>) constructor
@@ -94,24 +111,7 @@ class TEST_NAME : public util::test_base {
         auto deviceList = platform.get_devices();
         sycl::context context(deviceList);
 
-        if (context.get_devices().size() != deviceList.size()) {
-          FAIL(log, "context was not constructed correctly (get_devices size)");
-        }
-
-        for (auto &device : context.get_devices()) {
-          if (std::find(deviceList.begin(), deviceList.end(), device) ==
-              deviceList.end()) {
-            FAIL(log,
-                 "context was not constructed correctly (device not in passed "
-                 "device list)");
-          }
-
-          if (std::count(context.get_devices().begin(),
-                         context.get_devices().end(), device) != 1) {
-            FAIL(log,
-                 "context was not constructed correctly (duplicate devices)");
-          }
-        }
+        check_context_after_ctor(context, deviceList, log);
       }
 
       /** check (std::vector<device>, async_handler) constructor
@@ -123,24 +123,7 @@ class TEST_NAME : public util::test_base {
         auto deviceList = platform.get_devices();
         sycl::context context(deviceList, asyncHandler);
 
-        if (context.get_devices().size() != deviceList.size()) {
-          FAIL(log, "context was not constructed correctly (get_devices size)");
-        }
-
-        for (auto &device : context.get_devices()) {
-          if (std::find(deviceList.begin(), deviceList.end(), device) ==
-              deviceList.end()) {
-            FAIL(log,
-                 "context was not constructed correctly (device not in passed "
-                 "device list)");
-          }
-
-          if (std::count(context.get_devices().begin(),
-                         context.get_devices().end(), device) != 1) {
-            FAIL(log,
-                 "context was not constructed correctly (duplicate devices)");
-          }
-        }
+        check_context_after_ctor(context, deviceList, log);
       }
 
       /** check (platform) constructor
@@ -148,27 +131,10 @@ class TEST_NAME : public util::test_base {
       {
         cts_selector selector;
         auto platform = util::get_cts_object::platform(selector);
+        auto deviceList = platform.get_devices();
         sycl::context context(platform);
 
-        if (context.get_devices().size() != platform.get_devices().size()) {
-          FAIL(log, "context was not constructed correctly (get_devices size)");
-        }
-
-        for (auto &device : context.get_devices()) {
-          if (std::find(platform.get_devices().begin(),
-                        platform.get_devices().end(),
-                        device) == platform.get_devices().end()) {
-            FAIL(log,
-                 "context was not constructed correctly (device not in "
-                 "platform)");
-          }
-
-          if (std::count(context.get_devices().begin(),
-                         context.get_devices().end(), device) != 1) {
-            FAIL(log,
-                 "context was not constructed correctly (duplicate devices)");
-          }
-        }
+        check_context_after_ctor(context, deviceList, log);
       }
 
       /** check (platform, async_handler) constructor
@@ -177,27 +143,10 @@ class TEST_NAME : public util::test_base {
         cts_selector selector;
         cts_async_handler asyncHandler;
         auto platform = util::get_cts_object::platform(selector);
+        auto deviceList = platform.get_devices();
         sycl::context context(platform, asyncHandler);
 
-        if (context.get_devices().size() != platform.get_devices().size()) {
-          FAIL(log, "context was not constructed correctly (get_devices size)");
-        }
-
-        for (auto &device : context.get_devices()) {
-          if (std::find(platform.get_devices().begin(),
-                        platform.get_devices().end(),
-                        device) == platform.get_devices().end()) {
-            FAIL(log,
-                 "context was not constructed correctly (device not in "
-                 "platform)");
-          }
-
-          if (std::count(context.get_devices().begin(),
-                         context.get_devices().end(), device) != 1) {
-            FAIL(log,
-                 "context was not constructed correctly (duplicate devices)");
-          }
-        }
+        check_context_after_ctor(context, deviceList, log);
       }
 
       /** check copy constructor

--- a/tests/context/context_constructors.cpp
+++ b/tests/context/context_constructors.cpp
@@ -60,8 +60,12 @@ class TEST_NAME : public util::test_base {
         auto device = util::get_cts_object::device(selector);
         sycl::context context(device);
 
-        if (context.is_host() != selector.is_host()) {
-          FAIL(log, "context was not constructed correctly (is_host)");
+        if (context.get_devices().size() != 1) {
+          FAIL(log, "context was not constructed correctly (get_devices size)");
+        }
+
+        if (context.get_devices()[0] != device) {
+          FAIL(log, "context was not constructed correctly (device equality)");
         }
       }
 
@@ -73,8 +77,12 @@ class TEST_NAME : public util::test_base {
         auto device = util::get_cts_object::device(selector);
         sycl::context context(device, asyncHandler);
 
-        if (context.is_host() != selector.is_host()) {
-          FAIL(log, "context was not constructed correctly (is_host)");
+        if (context.get_devices().size() != 1) {
+          FAIL(log, "context was not constructed correctly (get_devices size)");
+        }
+
+        if (context.get_devices()[0] != device) {
+          FAIL(log, "context was not constructed correctly (device equality)");
         }
       }
 
@@ -86,8 +94,23 @@ class TEST_NAME : public util::test_base {
         auto deviceList = platform.get_devices();
         sycl::context context(deviceList);
 
-        if (context.is_host() != selector.is_host()) {
-          FAIL(log, "context was not constructed correctly (is_host)");
+        if (context.get_devices().size() != deviceList.size()) {
+          FAIL(log, "context was not constructed correctly (get_devices size)");
+        }
+
+        for (auto &device : context.get_devices()) {
+          if (std::find(deviceList.begin(), deviceList.end(), device) ==
+              deviceList.end()) {
+            FAIL(log,
+                 "context was not constructed correctly (device not in passed "
+                 "device list)");
+          }
+
+          if (std::count(context.get_devices().begin(),
+                         context.get_devices().end(), device) != 1) {
+            FAIL(log,
+                 "context was not constructed correctly (duplicate devices)");
+          }
         }
       }
 
@@ -100,8 +123,23 @@ class TEST_NAME : public util::test_base {
         auto deviceList = platform.get_devices();
         sycl::context context(deviceList, asyncHandler);
 
-        if (context.is_host() != selector.is_host()) {
-          FAIL(log, "context was not constructed correctly (is_host)");
+        if (context.get_devices().size() != deviceList.size()) {
+          FAIL(log, "context was not constructed correctly (get_devices size)");
+        }
+
+        for (auto &device : context.get_devices()) {
+          if (std::find(deviceList.begin(), deviceList.end(), device) ==
+              deviceList.end()) {
+            FAIL(log,
+                 "context was not constructed correctly (device not in passed "
+                 "device list)");
+          }
+
+          if (std::count(context.get_devices().begin(),
+                         context.get_devices().end(), device) != 1) {
+            FAIL(log,
+                 "context was not constructed correctly (duplicate devices)");
+          }
         }
       }
 
@@ -112,8 +150,24 @@ class TEST_NAME : public util::test_base {
         auto platform = util::get_cts_object::platform(selector);
         sycl::context context(platform);
 
-        if (context.is_host() != selector.is_host()) {
-          FAIL(log, "context was not constructed correctly (is_host)");
+        if (context.get_devices().size() != platform.get_devices().size()) {
+          FAIL(log, "context was not constructed correctly (get_devices size)");
+        }
+
+        for (auto &device : context.get_devices()) {
+          if (std::find(platform.get_devices().begin(),
+                        platform.get_devices().end(),
+                        device) == platform.get_devices().end()) {
+            FAIL(log,
+                 "context was not constructed correctly (device not in "
+                 "platform)");
+          }
+
+          if (std::count(context.get_devices().begin(),
+                         context.get_devices().end(), device) != 1) {
+            FAIL(log,
+                 "context was not constructed correctly (duplicate devices)");
+          }
         }
       }
 
@@ -125,8 +179,24 @@ class TEST_NAME : public util::test_base {
         auto platform = util::get_cts_object::platform(selector);
         sycl::context context(platform, asyncHandler);
 
-        if (context.is_host() != selector.is_host()) {
-          FAIL(log, "context was not constructed correctly (is_host)");
+        if (context.get_devices().size() != platform.get_devices().size()) {
+          FAIL(log, "context was not constructed correctly (get_devices size)");
+        }
+
+        for (auto &device : context.get_devices()) {
+          if (std::find(platform.get_devices().begin(),
+                        platform.get_devices().end(),
+                        device) == platform.get_devices().end()) {
+            FAIL(log,
+                 "context was not constructed correctly (device not in "
+                 "platform)");
+          }
+
+          if (std::count(context.get_devices().begin(),
+                         context.get_devices().end(), device) != 1) {
+            FAIL(log,
+                 "context was not constructed correctly (duplicate devices)");
+          }
         }
       }
 
@@ -137,8 +207,8 @@ class TEST_NAME : public util::test_base {
         auto contextA = util::get_cts_object::context(selector);
         sycl::context contextB(contextA);
 
-        if (contextA.is_host() != contextB.is_host()) {
-          FAIL(log, "context was not copied correctly (is_host)");
+        if (contextA != contextB) {
+          FAIL(log, "context was not copied correctly (equality)");
         }
 
 #ifdef SYCL_BACKEND_OPENCL
@@ -159,8 +229,8 @@ class TEST_NAME : public util::test_base {
         auto contextA = util::get_cts_object::context(selector);
         sycl::context contextB = contextA;
 
-        if (contextA.is_host() != contextB.is_host()) {
-          FAIL(log, "context was not assigned correctly (is_host)");
+        if (contextA != contextB) {
+          FAIL(log, "context was not assigned correctly (equality)");
         }
 
 #ifdef SYCL_BACKEND_OPENCL
@@ -179,10 +249,11 @@ class TEST_NAME : public util::test_base {
       {
         cts_selector selector;
         auto contextA = util::get_cts_object::context(selector);
+        auto contextACopy = contextA;
         sycl::context contextB(std::move(contextA));
 
-        if (selector.is_host() != contextB.is_host()) {
-          FAIL(log, "context was not move constructed correctly (is_host)");
+        if (contextACopy != contextB) {
+          FAIL(log, "context was not move constructed correctly (equality)");
         }
       }
 
@@ -191,10 +262,11 @@ class TEST_NAME : public util::test_base {
       {
         cts_selector selector;
         auto contextA = util::get_cts_object::context(selector);
+        auto contextACopy = contextA;
         sycl::context contextB = std::move(contextA);
 
-        if (selector.is_host() != contextB.is_host()) {
-          FAIL(log, "context was not move assigned correctly (is_host)");
+        if (contextACopy != contextB) {
+          FAIL(log, "context was not move assigned correctly (equality)");
         }
       }
 

--- a/tests/device/device_api.cpp
+++ b/tests/device/device_api.cpp
@@ -86,15 +86,6 @@ class TEST_NAME : public util::test_base {
                                               "device::get_platform()");
       }
 
-      /** check is_host() member function
-       */
-      {
-        cts_selector selector;
-        auto dev = util::get_cts_object::device(selector);
-        auto isHost = dev.is_host();
-        check_return_type<bool>(log, isHost, "device::is_host()");
-      }
-
       /** check is_cpu() member function
        */
       {

--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -45,8 +45,8 @@ class TEST_NAME : public util::test_base {
       {
         sycl::device device;
 
-        if (!device.is_host()) {
-          FAIL(log, "device was not constructed correctly (is_host)");
+        if (device == sycl::device(sycl::default_selector_v)) {
+          FAIL(log, "device was not constructed correctly (equality)");
         }
       }
 
@@ -56,8 +56,8 @@ class TEST_NAME : public util::test_base {
         cts_selector selector;
         sycl::device device(selector);
 
-        if (device.is_host() != selector.is_host()) {
-          FAIL(log, "device was not constructed correctly (is_host)");
+        if (device != sycl::device(selector)) {
+          FAIL(log, "device was not constructed correctly (equality)");
         }
       }
 
@@ -68,8 +68,8 @@ class TEST_NAME : public util::test_base {
         sycl::device deviceA(selector);
         sycl::device deviceB(deviceA);
 
-        if (deviceA.is_host() != deviceB.is_host()) {
-          FAIL(log, "device was not copied correctly (is_host)");
+        if (deviceA != deviceB) {
+          FAIL(log, "device was not copied correctly (equality)");
         }
 
 #ifdef SYCL_BACKEND_OPENCL
@@ -90,8 +90,8 @@ class TEST_NAME : public util::test_base {
         sycl::device deviceA(selector);
         sycl::device deviceB = deviceA;
 
-        if (deviceA.is_host() != deviceB.is_host()) {
-          FAIL(log, "device was not assigned correctly (is_host)");
+        if (deviceA != deviceB) {
+          FAIL(log, "device was not assigned correctly (equality)");
         }
 #ifdef SYCL_BACKEND_OPENCL
         auto queue = util::get_cts_object::queue();
@@ -111,8 +111,8 @@ class TEST_NAME : public util::test_base {
         sycl::device deviceA(selector);
         sycl::device deviceB(std::move(deviceA));
 
-        if (selector.is_host() != deviceB.is_host()) {
-          FAIL(log, "device was not move constructed correctly (is_host)");
+        if (sycl::device(selector) != deviceB) {
+          FAIL(log, "device was not move constructed correctly (equality)");
         }
       }
 
@@ -123,8 +123,8 @@ class TEST_NAME : public util::test_base {
         sycl::device deviceA(selector);
         sycl::device deviceB = std::move(deviceA);
 
-        if (selector.is_host() != deviceB.is_host()) {
-          FAIL(log, "device was not move assigned correctly (is_host)");
+        if (sycl::device(selector) != deviceB) {
+          FAIL(log, "device was not move assigned correctly (equality)");
         }
       }
 

--- a/tests/device_selector/device_selector_custom.cpp
+++ b/tests/device_selector/device_selector_custom.cpp
@@ -108,7 +108,7 @@ class TEST_NAME : public util::test_base {
       */
       {
         auto devices = sycl::device::get_devices();
-        if(devices.size() > 1) {
+        if (devices.size() > 1) {
           auto excludedDevice = devices[0];
           negative_selector selector{excludedDevice};
           auto device = util::get_cts_object::device(selector);

--- a/tests/device_selector/device_selector_custom.cpp
+++ b/tests/device_selector/device_selector_custom.cpp
@@ -44,15 +44,14 @@ class call_selector : public sycl::device_selector {
  */
 class negative_selector : public sycl::device_selector {
  public:
-  negative_selector() {}
+  negative_selector(const sycl::device &excludeDevice)
+      : excludedDevice{excludeDevice} {}
 
   virtual int operator()(const sycl::device &device) const {
-    if (!device.is_host()) {
-      return -1;
-    } else {
-      return 1;
-    }
+    return device == excludedDevice ? -1 : 1;
   }
+private:
+  const sycl::device excludedDevice; 
 };
 
 /** check that we can use a custom device selector
@@ -108,12 +107,17 @@ class TEST_NAME : public util::test_base {
       /** check the ability to set negative scores
       */
       {
-        negative_selector selector;
-        auto device = util::get_cts_object::device(selector);
+        auto devices = sycl::device::get_devices();
+        if(devices.size() > 1) {
+          auto excludedDevice = devices[0];
+          negative_selector selector{excludedDevice};
+          auto device = util::get_cts_object::device(selector);
 
-        /* check our device selector was used */
-        if (!device.is_host()) {
-          FAIL(log, "custom selector selected a device with a negative score");
+          /* check our device selector was used */
+          if (device == excludedDevice) {
+            FAIL(log,
+                 "custom selector selected a device with a negative score");
+          }
         }
       }
     }

--- a/tests/device_selector/device_selector_custom.cpp
+++ b/tests/device_selector/device_selector_custom.cpp
@@ -50,8 +50,9 @@ class negative_selector : public sycl::device_selector {
   virtual int operator()(const sycl::device &device) const {
     return device == excludedDevice ? -1 : 1;
   }
-private:
-  const sycl::device excludedDevice; 
+
+ private:
+  const sycl::device excludedDevice;
 };
 
 /** check that we can use a custom device selector

--- a/tests/device_selector/device_selector_predefined.cpp
+++ b/tests/device_selector/device_selector_predefined.cpp
@@ -63,7 +63,8 @@ class TEST_NAME : public util::test_base {
         sycl::default_selector defaultSelector;
         try {
           auto defaultDevice = util::get_cts_object::device(defaultSelector);
-          if (!defaultDevice.is_host()) {
+          if (defaultDevice.get_info<sycl::info::device::device_type>() !=
+              sycl::info::device_type::host) {
             std::string errorMsg =
                 "a SYCL exception occured when default_selector tried to "
                 "select a device when no opencl devices available";
@@ -75,15 +76,6 @@ class TEST_NAME : public util::test_base {
                "default_selector failed to select a host device when no opencl "
                "devices available");
         }
-      }
-
-      /** check host_selector
-      */
-      sycl::host_selector hostSelector;
-      auto hostDevice = util::get_cts_object::device(hostSelector);
-
-      if (!hostDevice.is_host()) {
-        FAIL(log, "host_selector failed to select an appropriate device");
       }
 
       /** check cpu_selector

--- a/tests/kernel/kernel_api.cpp
+++ b/tests/kernel/kernel_api.cpp
@@ -45,7 +45,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     {
       auto ctsQueue = util::get_cts_object::queue();
-      const auto isHostCtx = ctsQueue.is_host();
       auto deviceList = ctsQueue.get_context().get_devices();
       auto ctx = ctsQueue.get_context();
 
@@ -57,9 +56,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
       ctsQueue.submit(
           [&](sycl::handler &h) { h.single_task(k_name{}); });
       ctsQueue.wait_and_throw();
-
-      // Check is_host()
-      bool isHost = kernel.is_host();
 
       // Check get_context()
       auto cxt = kernel.get_context();

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -78,10 +78,6 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
       /** check program info parameters
        */
-      if (!queue.is_host()) {
-        clUintRet =
-            kernel.get_info<sycl::info::kernel::reference_count>();
-      }
       stringRet = kernel.get_info<sycl::info::kernel::function_name>();
       clUintRet = kernel.get_info<sycl::info::kernel::num_args>();
       stringRet = kernel.get_info<sycl::info::kernel::attributes>();

--- a/tests/platform/platform_api.cpp
+++ b/tests/platform/platform_api.cpp
@@ -94,15 +94,6 @@ class TEST_NAME : public util::test_base {
                                                   "platform::get_info()");
       }
 
-      /** check is_host() member function
-      */
-      {
-        cts_selector selector;
-        auto plt = util::get_cts_object::platform(selector);
-        auto isHost = plt.is_host();
-        check_return_type<bool>(log, isHost, "platform::is_host()");
-      }
-
       /** check get_platforms() static method
       */
       {

--- a/tests/queue/queue_api.cpp
+++ b/tests/queue/queue_api.cpp
@@ -45,16 +45,6 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     {
-      /** check is_host() member function
-       */
-      {
-        cts_selector selector;
-        auto queue = util::get_cts_object::queue(selector);
-
-        auto isHost = queue.is_host();
-        check_return_type<bool>(log, isHost, "sycl::queue::is_host()");
-      }
-
       /** check get_context() member function
        */
       {

--- a/tests/queue/queue_constructors.cpp
+++ b/tests/queue/queue_constructors.cpp
@@ -88,10 +88,10 @@ class TEST_NAME : public util::test_base {
         cts_selector selector;
         sycl::queue queue(selector);
 
-        if (queue.is_host() != selector.is_host()) {
+        if (queue.get_device() != sycl::device(selector)) {
           FAIL(log,
                "queue with device_selector was not constructed correctly "
-               "(is_host)");
+               "(device equality)");
         }
       }
 
@@ -102,10 +102,10 @@ class TEST_NAME : public util::test_base {
         sycl::queue queue(selector,
                               {sycl::property::queue::enable_profiling()});
 
-        if (queue.is_host() != selector.is_host()) {
+        if (queue.get_device() != sycl::device(selector)) {
           FAIL(log,
                "queue with device_selector and property list was not "
-               "constructed correctly (is_host)");
+               "constructed correctly (device equality)");
         }
 
         if (!queue
@@ -123,10 +123,10 @@ class TEST_NAME : public util::test_base {
         cts_async_handler asyncHandler;
         sycl::queue queue(selector, asyncHandler);
 
-        if (queue.is_host() != selector.is_host()) {
+        if (queue.get_device() != sycl::device(selector)) {
           FAIL(log,
                "queue with device_selector and async_handler was not "
-               "constructed correctly (is_host)");
+               "constructed correctly (device equality)");
         }
       }
 
@@ -138,10 +138,10 @@ class TEST_NAME : public util::test_base {
         sycl::queue queue(selector, asyncHandler,
                               {sycl::property::queue::enable_profiling()});
 
-        if (queue.is_host() != selector.is_host()) {
+        if (queue.get_device() != sycl::device(selector)) {
           FAIL(log,
                "queue with device_selector, async_handler and "
-               "property_list was not constructed correctly (is_host)");
+               "property_list was not constructed correctly (device equality)");
         }
 
         if (!queue
@@ -158,10 +158,10 @@ class TEST_NAME : public util::test_base {
         sycl::device device = util::get_cts_object::device();
         sycl::queue queue(device);
 
-        if (queue.is_host() != device.is_host()) {
+        if (queue.get_device() != device) {
           FAIL(log,
                "queue with device was not constructed correctly "
-               "(is_host)");
+               "(device equality)");
         }
       }
 
@@ -172,10 +172,10 @@ class TEST_NAME : public util::test_base {
         sycl::queue queue(device,
                               {sycl::property::queue::enable_profiling()});
 
-        if (queue.is_host() != device.is_host()) {
+        if (queue.get_device() != device) {
           FAIL(log,
                "queue with device was not constructed correctly "
-               "(is_host)");
+               "(device equality)");
         }
 
         if (!queue
@@ -193,10 +193,10 @@ class TEST_NAME : public util::test_base {
         cts_async_handler asyncHandler;
         sycl::queue queue(device, asyncHandler);
 
-        if (queue.is_host() != device.is_host()) {
+        if (queue.get_device() != device) {
           FAIL(log,
                "queue with device and async_hander was not constructed "
-               "correctly (is_host)");
+               "correctly (device equality)");
         }
       }
 
@@ -208,10 +208,10 @@ class TEST_NAME : public util::test_base {
         sycl::queue queue(device, asyncHandler,
                               {sycl::property::queue::enable_profiling()});
 
-        if (queue.is_host() != device.is_host()) {
+        if (queue.get_device() != device) {
           FAIL(log,
                "queue with device and async_hander was not constructed "
-               "correctly (is_host)");
+               "correctly (device equality)");
         }
 
         if (!queue
@@ -229,10 +229,10 @@ class TEST_NAME : public util::test_base {
         auto context = util::get_cts_object::context(selector);
         sycl::queue queue(context, selector);
 
-        if (queue.is_host() != selector.is_host()) {
+        if (queue.get_device() != sycl::device(selector)) {
           FAIL(log,
                "queue with context and device_selector was not "
-               "constructed correctly (is_host)");
+               "constructed correctly (device equality)");
         }
       }
 
@@ -244,10 +244,10 @@ class TEST_NAME : public util::test_base {
         sycl::queue queue(context, selector,
                               {sycl::property::queue::enable_profiling()});
 
-        if (queue.is_host() != selector.is_host()) {
+        if (queue.get_device() != sycl::device(selector)) {
           FAIL(log,
                "queue with context and device_selector was not "
-               "constructed correctly (is_host)");
+               "constructed correctly (device equality)");
         }
 
         if (!queue
@@ -266,10 +266,10 @@ class TEST_NAME : public util::test_base {
         cts_async_handler asyncHandler;
         sycl::queue queue(context, selector, asyncHandler);
 
-        if (queue.is_host() != selector.is_host()) {
+        if (queue.get_device() != sycl::device(selector)) {
           FAIL(log,
                "queue with context, device_selector and async_handler was "
-               "not constructed correctly (is_host)");
+               "not constructed correctly (device equality)");
         }
       }
 
@@ -283,10 +283,10 @@ class TEST_NAME : public util::test_base {
         sycl::queue queue(context, selector, asyncHandler,
                               {sycl::property::queue::enable_profiling()});
 
-        if (queue.is_host() != selector.is_host()) {
+        if (queue.get_device() != sycl::device(selector)) {
           FAIL(log,
                "queue with context, device_selector, async_handler and "
-               "property_list was not constructed correctly (is_host)");
+               "property_list was not constructed correctly (device equality)");
         }
 
         if (!queue
@@ -304,14 +304,15 @@ class TEST_NAME : public util::test_base {
         auto queueA = util::get_cts_object::queue(selector);
         sycl::queue queueB(queueA);
 
-        if (queueA.is_host() != selector.is_host()) {
-          FAIL(log, "queue source after copy construction failed (is_host)");
+        if (queueA.get_device() != sycl::device(selector)) {
+          FAIL(log,
+               "queue source after copy construction failed (device equality)");
         }
 
-        if (queueA.is_host() != queueB.is_host()) {
+        if (queueA != queueB) {
           FAIL(log,
                "queue destination was not copy constructed correctly "
-               "(is_host)");
+               "(equality)");
         }
 
         if (!selector.is_host()) {
@@ -330,14 +331,16 @@ class TEST_NAME : public util::test_base {
         sycl::queue queueB;
         queueB = queueA;
 
-        if (queueA.is_host() != selector.is_host()) {
-          FAIL(log, "queue source after copy assignment (=) failed (is_host)");
+        if (queueA.get_device() != sycl::device(selector)) {
+          FAIL(log,
+               "queue source after copy assignment (=) failed (device "
+               "equality)");
         }
 
-        if (queueA.is_host() != queueB.is_host()) {
+        if (queueA != queueB) {
           FAIL(log,
                "queue destination was not copy assigned (=) correctly "
-               "(is_host)");
+               "(equality)");
         }
 
         if (!selector.is_host()) {
@@ -354,10 +357,12 @@ class TEST_NAME : public util::test_base {
       {
         cts_selector selector;
         auto queueA = util::get_cts_object::queue(selector);
+        auto queueACopy = queueA;
         sycl::queue queueB(std::move(queueA));
 
-        if (queueB.is_host() != selector.is_host()) {
-          FAIL(log, "queue was not move constructed correctly (is_host)");
+        if (queueB != queueACopy) {
+          FAIL(log,
+               "queue was not move constructed correctly (equality)");
         }
       }
 
@@ -366,12 +371,14 @@ class TEST_NAME : public util::test_base {
       {
         cts_selector selector;
         auto queueA = util::get_cts_object::queue(selector);
+        auto queueACopy = queueA;
 
         sycl::queue queueB;
         queueB = std::move(queueA);
 
-        if (queueB.is_host() != selector.is_host()) {
-          FAIL(log, "queue was not move assigned (=) correctly (is_host)");
+        if (queueB != queueACopy) {
+          FAIL(log,
+               "queue was not move assigned (=) correctly (equality)");
         }
       }
 

--- a/tests/queue/queue_constructors.cpp
+++ b/tests/queue/queue_constructors.cpp
@@ -361,8 +361,7 @@ class TEST_NAME : public util::test_base {
         sycl::queue queueB(std::move(queueA));
 
         if (queueB != queueACopy) {
-          FAIL(log,
-               "queue was not move constructed correctly (equality)");
+          FAIL(log, "queue was not move constructed correctly (equality)");
         }
       }
 
@@ -377,8 +376,7 @@ class TEST_NAME : public util::test_base {
         queueB = std::move(queueA);
 
         if (queueB != queueACopy) {
-          FAIL(log,
-               "queue was not move assigned (=) correctly (equality)");
+          FAIL(log, "queue was not move assigned (=) correctly (equality)");
         }
       }
 


### PR DESCRIPTION
SYCL 2020 removes the is_host member function from SYCL classes in tandem with removing the requirement that the host device must be available. This commit removes the uses of the is_host member function and fixes the expected behavior of the default device constructor to expect the resulting device to be the same as one constructed with default_selector_v.