### PR TITLE
CI: Check that changes are formatted according to clang-format

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -85,6 +85,27 @@ jobs:
           build-args: |
             IMPL_VERSION=${{ matrix.version }}
 
+  check-clang-format:
+    if: github.event_name == 'pull_request'
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Need to check out base branch as well
+      - name: Run clang-format on changed files
+        run: |
+          set -o errexit -o pipefail -o noclobber -o nounset
+          DIFF=$( git diff -U0 --no-color ${{ github.event.pull_request.base.sha }} | clang-format-diff-14 -p1 )
+          if [ ! -z "$DIFF" ]; then
+            echo 'The following changes are not formatted according to `clang-format`:' >> $GITHUB_STEP_SUMMARY
+            echo '```diff' >> $GITHUB_STEP_SUMMARY
+            echo "$DIFF" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "Not all files are formatted according to clang-format. See workflow summary for details."
+            exit 1 # Fail CI run
+          fi
+
   compile-cts:
     needs: build-image-for-sycl-impl
     # Wait for Docker image builds, but run even if they're skipped


### PR DESCRIPTION
This adds a new step to our CI pipeline that checks whether all changes made in a PR are formatted according to `clang-format`.

I hand-rolled this functionality since there doesn't seem to be a GitHub action on the marketplace that only checks against a diff (instead always checking all files).

The changes that aren't formatted will be reported on the workflow summary page. You can see an example of what this looks like [here](https://github.com/psalz/SYCL-CTS/actions/runs/3016109194).