### PR TITLE
CI: Summarize matrix build job results in final job

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -149,3 +149,19 @@ jobs:
         with:
           name: build-times-${{ matrix.sycl-impl }}
           path: ${{ env.container-workspace }}/build/build_times.log
+
+  # This job simply summarizes the results of the "compile-cts" matrix build job above.
+  # It can then be used in a branch protection rule instead of having to enumerate all
+  # entries of the matrix manually (and having to update it whenever the matrix changes).
+  cts-compiles-for-all-implementations:
+    needs: [compile-cts]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Summarize matrix build results
+        run: |
+          if [[ "${{ needs.compile-cts.result }}" == "success" ]]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION
This adds a new job to our CI pipeline that simply summarizes the results of the previous matrix job. This is useful because we can then use this job as a stand-in for the build step in GitHub's branch protection rules.

Currently, all entries in the build matrix need to be enumerated manually, and whenever the version of a SYCL implementation is updated, the rules need to be updated as well:

![image](https://user-images.githubusercontent.com/791348/189175317-6705f2c7-3c30-4550-be20-42fe978d15b1.png)

(Here, DPC++ was updated from caa696f to b3cbda5, so the former never runs and GitHub prevents the PR from being merged).