### PR TITLE
Fix strict aliasing violation in check_as_result

### DIFF
--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -441,7 +441,8 @@ asType check_as_result(sycl::vec<vecType, N> inputVec,
   for (size_t i = 0; i < N; ++i) {
     tmp_ptr[i] = getElement(inputVec, i);
   }
-  asType* exp_ptr = reinterpret_cast<asType*>(tmp_ptr);
+  asType exp_ptr[asN];
+  memcpy(exp_ptr, tmp_ptr, sizeof(exp_ptr));
   for (size_t i = 0; i < asN; ++i) {
     if (exp_ptr[i] != getElement(asVec, i)) {
       return false;


### PR DESCRIPTION
This function writes values into a temporary array using one type and then reads them back from the same array using a different type to compare against the expected result. This is undefined behavior in C and C++, so this has been causing a hang when running these tests. The fix is to do this properly by using separate arrays for the differently-typed values and a memcpy to copy the bits from the input type to the output type.