### PR TITLE
Fix SYCL 2020 multi_ptr tests

### DIFF
--- a/tests/multi_ptr/multi_ptr_access_members.h
+++ b/tests/multi_ptr/multi_ptr_access_members.h
@@ -130,6 +130,7 @@ class run_access_members_tests {
           sycl::local_accessor<T> acc_for_multi_ptr{sycl::range(1), cgh};
           cgh.parallel_for(sycl::nd_range(r, r), [=](sycl::nd_item<1> item) {
             value_operations::assign(acc_for_multi_ptr, value);
+            sycl::group_barrier(item.get_group());
             test_device_code(acc_for_multi_ptr);
           });
         } else if constexpr (space ==

--- a/tests/multi_ptr/multi_ptr_accessor_constructor.h
+++ b/tests/multi_ptr/multi_ptr_accessor_constructor.h
@@ -94,14 +94,16 @@ void run_tests(sycl_cts::util::logger& log, const std::string& type_name) {
     });
   }
   if (!same_type) {
-    FAIL(log, (get_case_description<dimension, Space, Mode,
-                                    sycl::access::target::device>(
-                  "Incorrect type", type_name)));
+    std::string fail_msg = get_case_description<dimension, Space, Mode,
+                                                sycl::access::target::device>(
+        "Incorrect type", type_name);
+    FAIL(log, fail_msg);
   }
   if (!same_value) {
-    FAIL(log, (get_case_description<dimension, Space, Mode,
-                                    sycl::access::target::device>(
-                  "Incorrect value", type_name)));
+    std::string fail_msg = get_case_description<dimension, Space, Mode,
+                                                sycl::access::target::device>(
+        "Incorrect value", type_name);
+    FAIL(log, fail_msg);
   }
 }
 

--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -51,12 +51,10 @@ class run_multi_ptr_arithmetic_op_test {
   static constexpr sycl::access::decorated decorated = IsDecoratedT::value;
   using multi_ptr_t = sycl::multi_ptr<T, space, decorated>;
 
-  constexpr size_t m_array_size = 10;
+  static constexpr size_t m_array_size = 10;
   // Array that will be used in multi_ptr
   T m_arr[m_array_size];
-  size_t m_middle_elem_index = m_array_size / 2;
-
-  sycl::range m_r(1);
+  static constexpr size_t m_middle_elem_index = m_array_size / 2;
 
   template <typename TestActionT>
   void run_test(sycl::queue &queue, TestActionT test_action,
@@ -66,23 +64,41 @@ class run_multi_ptr_arithmetic_op_test {
     detail::test_results<T> test_results;
 
     {
+      sycl::range m_r(1);
       sycl::buffer<detail::test_results<T>> test_result_buffer(&test_results,
                                                                m_r);
 
-      sycl::buffer<T> buffer_for_mptr(m_arr, sycl::range(m_array_size));
+      sycl::buffer<T> arr_buffer(m_arr, sycl::range(m_array_size));
       queue.submit([&](sycl::handler &cgh) {
         auto test_result_acc =
             test_result_buffer.template get_access<sycl::access_mode::write>(
                 cgh);
-        auto acc_for_mptr =
-            buffer_for_mptr.template get_access<sycl::access_mode::read>(cgh);
+        auto arr_acc =
+            arr_buffer.template get_access<sycl::access_mode::read>(cgh);
 
-        if constexpr (space == sycl::access::address_space::global_space) {
-          cgh.single_task([=] { test_action(acc_for_mptr, test_result_acc); });
-        } else {
-          cgh.parallel_for(sycl::nd_range(m_r, m_r), [=](sycl::nd_item item) {
-            test_action(acc_for_mptr, test_result_acc);
+        if constexpr (space == sycl::access::address_space::local_space) {
+          sycl::local_accessor<T, 1> acc_for_mptr{sycl::range(m_array_size),
+                                                  cgh};
+          cgh.parallel_for(sycl::nd_range(m_r, m_r),
+                           [=](sycl::nd_item<1> item) {
+                             for (size_t i = 0; i < m_array_size; ++i)
+                               acc_for_mptr[i] = arr_acc[i];
+                             test_action(acc_for_mptr, test_result_acc);
+                           });
+        } else if constexpr (space ==
+                             sycl::access::address_space::private_space) {
+          cgh.single_task([=] {
+            T priv_arr[m_array_size];
+            for (size_t i = 0; i < m_array_size; ++i) priv_arr[i] = arr_acc[i];
+            sycl::multi_ptr<T, sycl::access::address_space::private_space,
+                            decorated>
+                priv_arr_mptr = sycl::address_space_cast<
+                    sycl::access::address_space::private_space, decorated>(
+                    priv_arr);
+            test_action(priv_arr_mptr, test_result_acc);
           });
+        } else {
+          cgh.single_task([=] { test_action(arr_acc, test_result_acc); });
         }
       });
     }
@@ -116,7 +132,7 @@ class run_multi_ptr_arithmetic_op_test {
       m_arr[i] = i;
     }
 
-    SECTION(section_name("Check multi_ptr operator++(multi_ptr& mp)")
+    SECTION(sycl_cts::section_name("Check multi_ptr operator++(multi_ptr& mp)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
@@ -141,11 +157,12 @@ class run_multi_ptr_arithmetic_op_test {
       };
       run_test(queue, run_test_action, verification_points);
     }
-    SECTION(section_name("Check multi_ptr operator++(multi_ptr&, int)")
-                .with("T", type_name)
-                .with("address_space", address_space_name)
-                .with("decorated", is_decorated_name)
-                .create()) {
+    SECTION(
+        sycl_cts::section_name("Check multi_ptr operator++(multi_ptr&, int)")
+            .with("T", type_name)
+            .with("address_space", address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::test_results<T> verification_points;
@@ -165,7 +182,7 @@ class run_multi_ptr_arithmetic_op_test {
       };
       run_test(queue, run_test_action, verification_points);
     }
-    SECTION(section_name("Check multi_ptr operator--(multi_ptr&)")
+    SECTION(sycl_cts::section_name("Check multi_ptr operator--(multi_ptr&)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
@@ -194,11 +211,12 @@ class run_multi_ptr_arithmetic_op_test {
       };
       run_test(queue, run_test_action, verification_points);
     }
-    SECTION(section_name("Check multi_ptr operator--(multi_ptr&, int)")
-                .with("T", type_name)
-                .with("address_space", address_space_name)
-                .with("decorated", is_decorated_name)
-                .create()) {
+    SECTION(
+        sycl_cts::section_name("Check multi_ptr operator--(multi_ptr&, int)")
+            .with("T", type_name)
+            .with("address_space", address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::test_results<T> verification_points;
@@ -224,9 +242,10 @@ class run_multi_ptr_arithmetic_op_test {
       run_test(queue, run_test_action, verification_points);
     }
 
-    using diff_t = multi_ptr_t::difference_type;
+    using diff_t = typename multi_ptr_t::difference_type;
     diff_t shift = m_array_size / 3;
-    SECTION(section_name("Check multi_ptr operator+=(multi_ptr&, diff_type)")
+    SECTION(sycl_cts::section_name(
+                "Check multi_ptr operator+=(multi_ptr&, diff_type)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
@@ -248,7 +267,8 @@ class run_multi_ptr_arithmetic_op_test {
       };
       run_test(queue, run_test_action, verification_points);
     }
-    SECTION(section_name("Check multi_ptr operator-=(multi_ptr&, diff_type)")
+    SECTION(sycl_cts::section_name(
+                "Check multi_ptr operator-=(multi_ptr&, diff_type)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
@@ -274,12 +294,12 @@ class run_multi_ptr_arithmetic_op_test {
       };
       run_test(queue, run_test_action, verification_points);
     }
-    SECTION(
-        section_name("Check multi_ptr operator+(const multi_ptr&, diff_type)")
-            .with("T", type_name)
-            .with("address_space", address_space_name)
-            .with("decorated", is_decorated_name)
-            .create()) {
+    SECTION(sycl_cts::section_name(
+                "Check multi_ptr operator+(const multi_ptr&, diff_type)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::test_results<T> verification_points;
@@ -297,12 +317,12 @@ class run_multi_ptr_arithmetic_op_test {
       };
       run_test(queue, run_test_action, verification_points);
     }
-    SECTION(
-        section_name("Check multi_ptr operator-(const multi_ptr&, diff_type)")
-            .with("T", type_name)
-            .with("address_space", address_space_name)
-            .with("decorated", is_decorated_name)
-            .create()) {
+    SECTION(sycl_cts::section_name(
+                "Check multi_ptr operator-(const multi_ptr&, diff_type)")
+                .with("T", type_name)
+                .with("address_space", address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::test_results<T> verification_points;
@@ -325,11 +345,12 @@ class run_multi_ptr_arithmetic_op_test {
       };
       run_test(queue, run_test_action, verification_points);
     }
-    SECTION(section_name("Check multi_ptr operator*(const multi_ptr&)")
-                .with("T", type_name)
-                .with("address_space", address_space_name)
-                .with("decorated", is_decorated_name)
-                .create()) {
+    SECTION(
+        sycl_cts::section_name("Check multi_ptr operator*(const multi_ptr&)")
+            .with("T", type_name)
+            .with("address_space", address_space_name)
+            .with("decorated", is_decorated_name)
+            .create()) {
       // Variable that contains all variables that will be used to verify test
       // result
       detail::test_results<T> verification_points;

--- a/tests/multi_ptr/multi_ptr_arithmetic_op_core.cpp
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op_core.cpp
@@ -14,8 +14,8 @@ namespace multi_ptr_arithmetic_op_core {
 
 TEST_CASE("Arithmetic operators. Core types.", "[multi_ptr]") {
   using namespace multi_ptr_arithmetic_op;
-  auto types = multi_ptr_convert::get_types();
-  auto composite_types = multi_ptr_convert::get_composite_types();
+  auto types = multi_ptr_common::get_types();
+  auto composite_types = multi_ptr_common::get_composite_types();
 
   for_all_types<check_multi_ptr_arithmetic_op_for_type>(types);
   for_all_types<check_multi_ptr_arithmetic_op_for_type>(composite_types);

--- a/tests/multi_ptr/multi_ptr_common_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_common_assignment_ops.h
@@ -67,7 +67,7 @@ class run_common_assign_tests {
           sycl::local_accessor<T> local_acc(r, cgh);
           cgh.parallel_for(sycl::nd_range<1>(r, r), [=](sycl::nd_item<1> item) {
             if constexpr (space == sycl::access::address_space::local_space) {
-              auto ref = local_acc[0];
+              auto &ref = local_acc[0];
               value_operations::assign(ref, expected_val);
               const multi_ptr_t const_mptr_in(local_acc);
               multi_ptr_t mptr_in(local_acc);
@@ -88,7 +88,7 @@ class run_common_assign_tests {
         }
       });
     }
-    SECTION(section_name("Check &operator=(const multi_ptr&)")
+    SECTION(sycl_cts::section_name("Check &operator=(const multi_ptr&)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
@@ -96,7 +96,7 @@ class run_common_assign_tests {
       CHECK(res[0]);
     }
 
-    SECTION(section_name("Check &operator=(multi_ptr&&)")
+    SECTION(sycl_cts::section_name("Check &operator=(multi_ptr&&)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)
@@ -104,7 +104,7 @@ class run_common_assign_tests {
       CHECK(res[1]);
     }
 
-    SECTION(section_name("Check &operator=(std::nullptr_t)")
+    SECTION(sycl_cts::section_name("Check &operator=(std::nullptr_t)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("decorated", is_decorated_name)

--- a/tests/multi_ptr/multi_ptr_common_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_common_assignment_ops.h
@@ -69,6 +69,8 @@ class run_common_assign_tests {
             if constexpr (space == sycl::access::address_space::local_space) {
               auto &ref = local_acc[0];
               value_operations::assign(ref, expected_val);
+              sycl::group_barrier(item.get_group());
+
               const multi_ptr_t const_mptr_in(local_acc);
               multi_ptr_t mptr_in(local_acc);
 

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -152,18 +152,19 @@ class run_multi_ptr_comparison_op_test {
         if constexpr (space == sycl::access::address_space::local_space) {
           sycl::local_accessor<T, 1> acc_for_mptr{
               sycl::range(m_values_arr_size), cgh};
-          cgh.parallel_for(sycl::nd_range(m_r, m_r),
-                           [=](sycl::nd_item<1> item) {
-                             for (size_t i = 0; i < m_values_arr_size; ++i)
-                               acc_for_mptr[i] = array_acc[i];
-                             test_action(acc_for_mptr, test_result_acc);
-                           });
+          cgh.parallel_for(
+              sycl::nd_range(m_r, m_r), [=](sycl::nd_item<1> item) {
+                for (size_t i = 0; i < m_values_arr_size; ++i)
+                  value_operations::assign(acc_for_mptr[i], array_acc[i]);
+                sycl::group_barrier(item.get_group());
+                test_action(acc_for_mptr, test_result_acc);
+              });
         } else if constexpr (space ==
                              sycl::access::address_space::private_space) {
           cgh.single_task([=] {
             T priv_arr[m_values_arr_size];
             for (size_t i = 0; i < m_values_arr_size; ++i)
-              priv_arr[i] = array_acc[i];
+              value_operations::assign(priv_arr[i], array_acc[i]);
             sycl::multi_ptr<T, sycl::access::address_space::private_space,
                             decorated>
                 priv_arr_mptr = sycl::address_space_cast<

--- a/tests/multi_ptr/multi_ptr_comparison_op_core.cpp
+++ b/tests/multi_ptr/multi_ptr_comparison_op_core.cpp
@@ -14,8 +14,8 @@ namespace multi_ptr_comparison_op_core {
 
 TEST_CASE("multi_ptr comparison operators. Core types", "[multi_ptr]") {
   using namespace multi_ptr_comparison_op;
-  auto types = multi_ptr_convert::get_types();
-  auto composite_types = multi_ptr_convert::get_composite_types();
+  auto types = multi_ptr_common::get_types();
+  auto composite_types = multi_ptr_common::get_composite_types();
 
   for_all_types<check_multi_ptr_comparison_op_for_type>(types);
   for_all_types<check_multi_ptr_comparison_op_for_type>(composite_types);

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
@@ -79,6 +79,7 @@ class run_convert_assignment_operators_tests {
                                 sycl::access::address_space::local_space) {
                     auto &ref = local_acc[0];
                     value_operations::assign(ref, expected_val);
+                    sycl::group_barrier(item.get_group());
 
                     const src_multi_ptr_t mptr_in(local_acc);
                     dst_multi_ptr_t mptr_out;
@@ -147,6 +148,7 @@ class run_convert_assignment_operators_tests {
                                 sycl::access::address_space::local_space) {
                     auto &ref = local_acc[0];
                     value_operations::assign(ref, expected_val);
+                    sycl::group_barrier(item.get_group());
 
                     const src_multi_ptr_t mptr_in(local_acc);
                     dst_multi_ptr_t mptr_out;

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops_core.cpp
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops_core.cpp
@@ -14,8 +14,8 @@ namespace multi_ptr_convert_assignment_ops_core {
 
 TEST_CASE("Convert assignment operators. core types", "[multi_ptr]") {
   using namespace multi_ptr_convert_assignment_ops;
-  auto types = multi_ptr_convert::get_types();
-  auto composite_types = multi_ptr_convert::get_composite_types();
+  auto types = multi_ptr_common::get_types();
+  auto composite_types = multi_ptr_common::get_composite_types();
   for_all_types<check_multi_ptr_convert_assign_for_type>(types);
   for_all_types<check_multi_ptr_convert_assign_for_type>(composite_types);
 }

--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -74,6 +74,8 @@ class run_explicit_convert_tests {
                           sycl::access::address_space::local_space) {
               auto &ref = local_acc[0];
               value_operations::assign(ref, expected_val);
+              sycl::group_barrier(item.get_group());
+
               input_multi_ptr_t<T> mptr_in(local_acc);
 
               auto mptr_out =

--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -46,7 +46,7 @@ class run_explicit_convert_tests {
    * @param r sycl::range that will be used in parallel_for
    */
   template <typename T1>
-  void run_test(sycl::queue &queue, sycl::range &r) {
+  void run_test(sycl::queue &queue, sycl::range<1> &r) {
     bool res = false;
     T value = user_def_types::get_init_value_helper<T>(expected_val);
     {
@@ -60,9 +60,9 @@ class run_explicit_convert_tests {
           auto val_acc =
               val_buffer.template get_access<sycl::access_mode::read>(cgh);
           cgh.single_task([=] {
-            input_multi_ptr_t<T1> mptr_in(val_acc);
+            input_multi_ptr_t<T> mptr_in(val_acc);
             auto mptr_out =
-                sycl::multi_ptr<T, target_space, decorated>(mptr_in);
+                sycl::multi_ptr<T1, target_space, decorated>(mptr_in);
 
             // Check that second mptr has the same value as first mptr
             res_acc[0] = *(mptr_out.get_raw()) == val_acc[0];
@@ -72,23 +72,23 @@ class run_explicit_convert_tests {
           cgh.parallel_for(sycl::nd_range<1>(r, r), [=](sycl::nd_item<1> item) {
             if constexpr (target_space ==
                           sycl::access::address_space::local_space) {
-              auto ref = local_acc[0];
+              auto &ref = local_acc[0];
               value_operations::assign(ref, expected_val);
-              input_multi_ptr_t<T1> mptr_in(local_acc);
+              input_multi_ptr_t<T> mptr_in(local_acc);
 
               auto mptr_out =
-                  sycl::multi_ptr<T, target_space, decorated>(mptr_in);
+                  sycl::multi_ptr<T1, target_space, decorated>(mptr_in);
               res_acc[0] = (*(mptr_out.get()) == ref);
             } else {
               T private_val =
                   user_def_types::get_init_value_helper<T>(expected_val);
 
-              input_multi_ptr_t<T1> mptr_in = sycl::address_space_cast<
+              input_multi_ptr_t<T> mptr_in = sycl::address_space_cast<
                   sycl::access::address_space::generic_space, decorated, T>(
                   &private_val);
 
               auto mptr_out =
-                  sycl::multi_ptr<T, target_space, decorated>(mptr_in);
+                  sycl::multi_ptr<T1, target_space, decorated>(mptr_in);
               res_acc[0] = *(mptr_out.get_raw()) == private_val;
             }
           });
@@ -113,17 +113,17 @@ class run_explicit_convert_tests {
     auto queue = sycl_cts::util::get_cts_object::queue();
     auto r = sycl::range(1);
 
-    SECTION(
-        section_name("Check multi_ptr<T, target_address_space, IsDecorated>()")
-            .with("T", type_name)
-            .with("target address_space", target_address_space_name)
-            .with("decorated", is_decorated_name)
-            .create()) {
+    SECTION(sycl_cts::section_name(
+                "Check multi_ptr<T, target_address_space, IsDecorated>()")
+                .with("T", type_name)
+                .with("target address_space", target_address_space_name)
+                .with("decorated", is_decorated_name)
+                .create()) {
       run_test<T>(queue, r);
     }
 
-    SECTION(section_name("Check multi_ptr<const T, target_address_space, "
-                         "IsDecorated>() const")
+    SECTION(sycl_cts::section_name("Check multi_ptr<const T, "
+                                   "target_address_space, IsDecorated>() const")
                 .with("T", type_name)
                 .with("target address_space", target_address_space_name)
                 .with("decorated", is_decorated_name)
@@ -134,8 +134,8 @@ class run_explicit_convert_tests {
 };
 
 template <typename T>
-bool check_pointer_aliases(const std::string &type_name) {
-  SECTION(section_name("Check explicit pointer aliases")
+void check_pointer_aliases(const std::string &type_name) {
+  SECTION(sycl_cts::section_name("Check explicit pointer aliases")
               .with("T", type_name)
               .create()) {
     {

--- a/tests/multi_ptr/multi_ptr_implicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_implicit_conversions.h
@@ -117,6 +117,7 @@ class run_implicit_convert_tests {
           sycl::local_accessor<T> expected_val_acc{sycl::range(1), cgh};
           cgh.parallel_for(sycl::nd_range(r, r), [=](sycl::nd_item<1> item) {
             value_operations::assign(expected_val_acc, value);
+            sycl::group_barrier(item.get_group());
             test_device_code(expected_val_acc);
           });
         } else if constexpr (address_space ==

--- a/tests/multi_ptr/multi_ptr_local_accessor_constructor.h
+++ b/tests/multi_ptr/multi_ptr_local_accessor_constructor.h
@@ -27,7 +27,7 @@ class run_local_accessor_cnstr_tests {
                   const std::string &address_space_name) {
     auto queue = sycl_cts::util::get_cts_object::queue();
     auto r = sycl_cts::util::get_cts_object::range<dims>::get(1, 1, 1);
-    SECTION(section_name("Check multi_ptr(local_accessor<T, dims>)")
+    SECTION(sycl_cts::section_name("Check multi_ptr(local_accessor<T, dims>)")
                 .with("T", type_name)
                 .with("address_space", address_space_name)
                 .with("dimension", dims)
@@ -41,7 +41,7 @@ class run_local_accessor_cnstr_tests {
           sycl::local_accessor<T, dims> acc(r, cgh);
           cgh.parallel_for(sycl::nd_range<dims>(r, r),
                            [=](sycl::nd_item<dims> item) {
-                             auto ref = acc[sycl::id<dims>()];
+                             auto &ref = acc[sycl::id<dims>()];
                              value_operations::assign(ref, expected_val);
                              // Creating multi_ptr object with local_accessor
                              // constructor

--- a/tests/multi_ptr/multi_ptr_members.h
+++ b/tests/multi_ptr/multi_ptr_members.h
@@ -99,17 +99,17 @@ struct run_test_with_chosen_data_type {
   void operator()(sycl_cts::util::logger &log, const std::string &type_name) {
     verify_members<VariableT, sycl::access::address_space::global_space,
                    sycl::access::decorated::yes>(log, type_name);
-    verify_members<VariableT, sycl::access::address_space::local_space,
-                   sycl::access::decorated::no>(log, type_name);
-    verify_members<VariableT, sycl::access::address_space::private_space,
-                   sycl::access::decorated::yes>(log, type_name);
-    verify_members<VariableT, sycl::access::address_space::generic_space,
-                   sycl::access::decorated::no>(log, type_name);
     verify_members<VariableT, sycl::access::address_space::global_space,
+                   sycl::access::decorated::no>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::local_space,
                    sycl::access::decorated::yes>(log, type_name);
     verify_members<VariableT, sycl::access::address_space::local_space,
                    sycl::access::decorated::no>(log, type_name);
     verify_members<VariableT, sycl::access::address_space::private_space,
+                   sycl::access::decorated::yes>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::private_space,
+                   sycl::access::decorated::no>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::generic_space,
                    sycl::access::decorated::yes>(log, type_name);
     verify_members<VariableT, sycl::access::address_space::generic_space,
                    sycl::access::decorated::no>(log, type_name);

--- a/tests/multi_ptr/multi_ptr_members.h
+++ b/tests/multi_ptr/multi_ptr_members.h
@@ -14,46 +14,6 @@
 
 namespace multi_ptr_members {
 
-/** @brief Dummy struct with overloaded call operator that will be called in
- *         "for_all_types" function
- *  @tparam VariableT Variable type for type coverage
- */
-template <typename VariableT>
-struct run_test_with_chosen_data_type {
-  /** @brief Run verification's function with provided variable type and
-   *         sycl::access::address_space and sycl::access::decorated
-   *         enumerations fields
-   *  @param log sycl_cts::util::logger class object
-   *  @param type_name a string representing the currently tested type
-   */
-  void operator()(sycl_cts::util::logger &log, const std::string &type_name) {
-    verify_members<VariableT,
-                   sycl::access::address_space::global_space,
-                   sycl::access::decorated::yes>(log, type_name);
-    verify_members<VariableT,
-                   sycl::access::address_space::local_space,
-                   sycl::access::decorated::no>(log, type_name);
-    verify_members<VariableT,
-                   sycl::access::address_space::private_space,
-                   sycl::access::decorated::yes>(log, type_name);
-    verify_members<VariableT,
-                   sycl::access::address_space::generic_space,
-                   sycl::access::decorated::no>(log, type_name);
-    verify_members<VariableT,
-                   sycl::access::address_space::global_space,
-                   sycl::access::decorated::yes>(log, type_name);
-    verify_members<VariableT,
-                   sycl::access::address_space::local_space,
-                   sycl::access::decorated::no>(log, type_name);
-    verify_members<VariableT,
-                   sycl::access::address_space::private_space,
-                   sycl::access::decorated::yes>(log, type_name);
-    verify_members<VariableT,
-                   sycl::access::address_space::generic_space,
-                   sycl::access::decorated::no>(log, type_name);
-  }
-};
-
 /** @brief Verify that sycl::multi_ptr members are equal to:
  *          1) sycl::multi_ptr::value_type is same as provided element type
  *          2) sycl::multi_ptr::iterator_category is same as
@@ -87,17 +47,18 @@ static void verify_members(sycl_cts::util::logger &log,
   std::string log_suffix{" with address type: " + address_type_str +
                          ", with decorated type: " + decorated_str +
                          ", with tested type: " + type_name};
-  if (!std::is_same_v<decltype(multi_ptr)::value_type, VariableT>) {
+  if (!std::is_same_v<typename decltype(multi_ptr)::value_type, VariableT>) {
     FAIL(log,
          "sycl::multi_ptr::value_type doesn't equal to provided value type" +
              log_suffix);
   }
-  if (!std::is_same_v<decltype(multi_ptr)::difference_type, std::ptrdiff_t>) {
+  if (!std::is_same_v<typename decltype(multi_ptr)::difference_type,
+                      std::ptrdiff_t>) {
     FAIL(log,
          "sycl::multi_ptr::difference_type doesn't equal to std::ptrdiff_t" +
              log_suffix);
   }
-  if (!std::is_same_v<decltype(multi_ptr)::iterator_category,
+  if (!std::is_same_v<typename decltype(multi_ptr)::iterator_category,
                       std::random_access_iterator_tag>) {
     FAIL(log,
          "sycl::multi_ptr::iterator_category doesn't equal to "
@@ -106,14 +67,14 @@ static void verify_members(sycl_cts::util::logger &log,
   }
 
   if constexpr (Decorated == sycl::access::decorated::no) {
-    if (!std::is_same_v<decltype(multi_ptr)::pointer,
+    if (!std::is_same_v<typename decltype(multi_ptr)::pointer,
                         std::add_pointer_t<VariableT>>) {
       FAIL(log,
            "sycl::multi_ptr::pointer doesen't equal to "
            "std::add_pointer_t<value_type>" +
                log_suffix);
     }
-    if (!std::is_same_v<decltype(multi_ptr)::reference,
+    if (!std::is_same_v<typename decltype(multi_ptr)::reference,
                         std::add_lvalue_reference_t<VariableT>>) {
       FAIL(log,
            "sycl::multi_ptr::reference doesn't equal to "
@@ -122,6 +83,38 @@ static void verify_members(sycl_cts::util::logger &log,
     }
   }
 }
+
+/** @brief Dummy struct with overloaded call operator that will be called in
+ *         "for_all_types" function
+ *  @tparam VariableT Variable type for type coverage
+ */
+template <typename VariableT>
+struct run_test_with_chosen_data_type {
+  /** @brief Run verification's function with provided variable type and
+   *         sycl::access::address_space and sycl::access::decorated
+   *         enumerations fields
+   *  @param log sycl_cts::util::logger class object
+   *  @param type_name a string representing the currently tested type
+   */
+  void operator()(sycl_cts::util::logger &log, const std::string &type_name) {
+    verify_members<VariableT, sycl::access::address_space::global_space,
+                   sycl::access::decorated::yes>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::local_space,
+                   sycl::access::decorated::no>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::private_space,
+                   sycl::access::decorated::yes>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::generic_space,
+                   sycl::access::decorated::no>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::global_space,
+                   sycl::access::decorated::yes>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::local_space,
+                   sycl::access::decorated::no>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::private_space,
+                   sycl::access::decorated::yes>(log, type_name);
+    verify_members<VariableT, sycl::access::address_space::generic_space,
+                   sycl::access::decorated::no>(log, type_name);
+  }
+};
 
 }  // namespace multi_ptr_members
 

--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -45,7 +45,7 @@ class run_prefetch_test {
 
     auto queue = sycl_cts::util::get_cts_object::queue();
     T value = user_def_types::get_init_value_helper<T>(expected_val);
-    SECTION(section_name("Check multi_ptr::prefetch()")
+    SECTION(sycl_cts::section_name("Check multi_ptr::prefetch()")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")
                 .with("decorated", is_decorated_name)

--- a/tests/multi_ptr/multi_ptr_prefetch_member_core.cpp
+++ b/tests/multi_ptr/multi_ptr_prefetch_member_core.cpp
@@ -14,8 +14,8 @@ namespace multi_ptr_prefetch_member_core {
 
 TEST_CASE("Prefetch member. core types", "[multi_ptr]") {
   using namespace multi_ptr_prefetch_member;
-  auto types = multi_ptr_convert::get_types();
-  auto composite_types = multi_ptr_convert::get_composite_types();
+  auto types = multi_ptr_common::get_types();
+  auto composite_types = multi_ptr_common::get_composite_types();
   for_all_types<check_multi_ptr_prefetch_for_type>(types);
   for_all_types<check_multi_ptr_prefetch_for_type>(composite_types);
 }


### PR DESCRIPTION
This commit fixes the tests for SYCL 2020 multi_ptr. The following changes are being made:
* Add missing sycl_cts namespaces.
* Add missing typename specifiers.
* Fix uses of constexpr member variables.
* Fix uses of the FAIL macro by getting case description prior to the use of the macro.
* Correctly initialize parameterized result values.
* Remove constant_space from non-legacy multi_ptr tests.
* Fix misspellings of the multi_ptr_common namespace.
* Fix auto reference declarations.
* Move run_test_with_chosen_data_type to after verify_members.
* Fix the handling of constructing multi_ptr with access::address_space::private_space by passing a preconstructed multi_ptr rather than an accessor to the corresponding tests.
* Minor fixes.