### PR TITLE
Change event::wait_and_throw test case

### DIFF
--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -348,11 +348,14 @@ TEST_CASE(
 }
 
 // TODO SPEC: It is unclear what "any unconsumed error [...] will be passed to
-// the async handler associated with the context" means when two queues override
-// their (shared) context's async handler.
+// the async handler associated with the context" means when the context does
+// not have an async handler, but the queues do. This test assumes that the
+// asynch handler for the queues will be used as they are higher priority for
+// async errors.
+// See also: https://github.com/KhronosGroup/SYCL-Docs/issues/299
 TEST_CASE(
     "event::wait_and_throw reports asynchronous errors from related events on "
-    "other queues",
+    "corresponding queues",
     "[event][todo-spec][!mayfail]") {
   test_exception_handler teh1;
   test_exception_handler teh2;
@@ -366,13 +369,11 @@ TEST_CASE(
     sycl::event::wait_and_throw(std::vector{e2});
   }
 
-  CHECK(teh2.count() == 2);
-  CHECK(teh2.has("some-error"));
+  CHECK(teh2.count() == 1);
   CHECK(teh2.has("another-error"));
 
-  // This should be a no-op as the error already has been consumed
-  e1.wait_and_throw();
-  CHECK(teh1.count() == 0);
+  CHECK(teh1.count() == 1);
+  CHECK(teh1.has("some-error"));
 }
 
 TEST_CASE("event::wait_and_throw only reports unconsumed asynchronous errors",


### PR DESCRIPTION
One of the event::wait_and_throw test cases makes the assumption that queue async handlers are somehow propagated to contexts. However, according to [Section 4.13.1.3](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_priorities_of_async_handlers) there are priorities to which async handlers are to be used, where queue is the highest, assuming the runtime can make the association between events and queues. This commit changes the test to follow the aforementioned section, assuming the queues are associated with the events. See also https://github.com/KhronosGroup/SYCL-Docs/issues/299.