### PR TITLE
Fix invalid comparison in device_constructors

### DIFF
--- a/tests/device/device_constructors.cpp
+++ b/tests/device/device_constructors.cpp
@@ -45,7 +45,7 @@ class TEST_NAME : public util::test_base {
       {
         sycl::device device;
 
-        if (device == sycl::device(sycl::default_selector_v)) {
+        if (device != sycl::device(sycl::default_selector_v)) {
           FAIL(log, "device was not constructed correctly (equality)");
         }
       }


### PR DESCRIPTION
Currently the device constructor test inadverdently fails if the default-constructed device uses the one selected with the default device selector, while the reverse was the intention. This commit fixes this.