### PR TITLE
Make local_accessor test names unique

### DIFF
--- a/tests/accessor/local_accessor_access_among_work_items_core.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_core.cpp
@@ -24,7 +24,7 @@ using namespace accessor_tests_common;
 namespace local_accessor_access_among_work_items_core {
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
-("sycl::host_accessor properties. core types", "[accessor]")({
+("sycl::local_accessor access among work items. core types", "[accessor]")({
   const auto types = get_conformance_type_pack();
 
   for_all_types_vectors_marray<

--- a/tests/accessor/local_accessor_access_among_work_items_fp16.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_fp16.cpp
@@ -24,7 +24,7 @@ using namespace accessor_tests_common;
 namespace local_accessor_access_among_work_items_fp16 {
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
-("Generic sycl::accessor constructor exceptions. fp16 type", "[accessor]")({
+("sycl::local_accessor access among work items. fp16 type", "[accessor]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(

--- a/tests/accessor/local_accessor_access_among_work_items_fp64.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_fp64.cpp
@@ -24,7 +24,7 @@ using namespace accessor_tests_common;
 namespace local_accessor_access_among_work_items_fp64 {
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
-("Generic sycl::accessor constructor exceptions. fp64 type", "[accessor]")({
+("sycl::local_accessor access among work items. fp64 type", "[accessor]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(


### PR DESCRIPTION
Otherwise no tests can be launched due to errors like:
```
$ ./bin/test_accessor
===============================================================================
No tests ran

error: test case "sycl::host_accessor properties. core types", with tags "[accessor]" already defined.
        First seen at KhronosGroup/SYCL-CTS/tests/accessor/host_accessor_properties_core.cpp:24
        Redefined at KhronosGroup/SYCL-CTS/tests/accessor/local_accessor_access_among_work_items_core.cpp:27
```