### PR TITLE
Fix and enable local_accessor iterator requirements test for DPCPP implementation

### DIFF
--- a/tests/accessor/accessor_iterator_requirement.cpp
+++ b/tests/accessor/accessor_iterator_requirement.cpp
@@ -8,6 +8,7 @@
 *******************************************************************************/
 #include "../../util/named_requirement_verification/legacy_random_access_iterator.h"
 #include "../common/disabled_for_test_case.h"
+#include "../common/get_cts_object.h"
 #include "catch2/catch_test_macros.hpp"
 
 // FIXME: re-enable when sycl::accessor is implemented
@@ -79,7 +80,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   print_errors(errors);
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("LegacyRandomAccessIterator requirement verification for sycl::local_accessor "
  "iterator",
  "[accessor]")({
@@ -90,12 +91,13 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
   constexpr size_t size_of_res_array =
       legacy_random_access_iterator_requirement::count_of_possible_errors;
-  named_requirement_verification::string_view errors[size_of_res_array];
+  std::array<named_requirement_verification::string_view, size_of_res_array>
+      errors;
 
   constexpr size_t alloc_size = 1;
   {
     sycl::buffer<named_requirement_verification::string_view, 1> res_buf(
-        errors, sycl::range(size_of_res_array));
+        errors.data(), sycl::range(size_of_res_array));
 
     q.submit([&](sycl::handler& cgh) {
       auto res_acc = res_buf.get_access<sycl::access_mode::write>(cgh);

--- a/tests/accessor/accessor_iterator_requirement.cpp
+++ b/tests/accessor/accessor_iterator_requirement.cpp
@@ -63,7 +63,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         auto dummy_acc_it = dummy_acc.begin();
         auto verification_result =
             legacy_random_access_iterator_requirement{}.is_satisfied_for(
-                dummy_acc_it, size_of_dummy);
+                dummy_acc_it);
         if (!verification_result.first) {
           for (int i = 0; i < size_of_res_array; ++i) {
             if (!verification_result.second[i].empty()) {
@@ -105,7 +105,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         auto dummy_acc_it = dummy_acc.begin();
         auto verification_result =
             legacy_random_access_iterator_requirement{}.is_satisfied_for(
-                dummy_acc_it, size_of_dummy);
+                dummy_acc_it);
         if (!verification_result.first) {
           for (int i = 0; i < size_of_res_array; ++i) {
             if (!verification_result.second[i].empty()) {
@@ -139,7 +139,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
     auto dummy_acc_it = dummy_acc.begin();
     auto verification_result =
         legacy_random_access_iterator_requirement{}.is_satisfied_for(
-            dummy_acc_it, size_of_dummy);
+            dummy_acc_it);
     if (!verification_result.first) {
       print_errors(verification_result.second);
     }

--- a/util/named_requirement_verification/legacy_bidirectional_iterator.h
+++ b/util/named_requirement_verification/legacy_bidirectional_iterator.h
@@ -13,8 +13,6 @@
 #include "common.h"
 #include "legacy_forward_iterator.h"
 
-#include "catch2/catch_test_macros.hpp"  // for WARN macro
-
 namespace named_requirement_verification {
 
 /**
@@ -46,10 +44,10 @@ class legacy_bidirectional_iterator_requirement {
    */
   template <typename It>
   std::pair<bool, std::array<string_view, count_of_possible_errors>>
-  is_satisfied_for(It valid_iterator, const size_t container_size) {
+  is_satisfied_for(It valid_iterator) {
     auto legacy_forward_iterator_res =
         legacy_forward_iterator_requirement{}.is_satisfied_for<It>(
-            valid_iterator, container_size);
+            valid_iterator);
 
     if (!legacy_forward_iterator_res.first) {
       m_test_error_messages.add_errors(legacy_forward_iterator_res.second);
@@ -83,37 +81,31 @@ class legacy_bidirectional_iterator_requirement {
           "Iterator doesn't have implemented operator--(int)");
     }
 
-    if (container_size == 0) {
-      WARN(
-          "Some of the test requires container size more than 0. These tests "
-          "have been skipped.");
-    } else {
-      if constexpr (can_pre_decrement && can_pre_increment &&
-                    is_dereferenceable) {
-        {
-          It a = valid_iterator;
-          It saved_a = a;
-          ++a;
-          --a;
-          if (a != saved_a) {
-            m_test_error_messages.add_error(
-                "Iterator expression --(++i) must be equal to i.");
-          }
+    if constexpr (can_pre_decrement && can_pre_increment &&
+                  is_dereferenceable) {
+      {
+        It a = valid_iterator;
+        It saved_a = a;
+        ++a;
+        --a;
+        if (a != saved_a) {
+          m_test_error_messages.add_error(
+              "Iterator expression --(++i) must be equal to i.");
         }
-        {
-          It a = valid_iterator;
-          It b = a;
-          ++a;
-          ++b;
-          if (--a == --b) {
-            if (a != b) {
-              m_test_error_messages.add_error(
-                  "If --a == --b then a == b must be true.");
-            }
-          } else {
+      }
+      {
+        It a = valid_iterator;
+        It b = a;
+        ++a;
+        ++b;
+        if (--a == --b) {
+          if (a != b) {
             m_test_error_messages.add_error(
-                "--a must be equal to --b, if they are copy of same object.");
+                "If --a == --b then a == b must be true.");
           }
+        } else {
+          m_test_error_messages.add_error(
+              "--a must be equal to --b, if they are copy of same object.");
         }
       }
     }

--- a/util/named_requirement_verification/legacy_forward_iterator.h
+++ b/util/named_requirement_verification/legacy_forward_iterator.h
@@ -14,8 +14,6 @@
 #include "legacy_input_iterator.h"
 #include "legacy_output_iterator.h"
 
-#include "catch2/catch_test_macros.hpp"  // for WARN macro
-
 namespace named_requirement_verification {
 
 /**
@@ -48,7 +46,7 @@ class legacy_forward_iterator_requirement {
    */
   template <typename It>
   std::pair<bool, std::array<string_view, count_of_possible_errors>>
-  is_satisfied_for(It valid_iterator, const size_t container_size) {
+  is_satisfied_for(It valid_iterator) {
     auto legacy_input_iterator_res =
         legacy_input_iterator_requirement{}.is_satisfied_for<It>(
             valid_iterator);
@@ -115,51 +113,45 @@ class legacy_forward_iterator_requirement {
       }
     }
 
-    if (container_size == 0) {
-      WARN(
-          "Some of the test requires container size more than 0. These tests "
-          "have been skipped.");
-    } else {
-      // Verify multipass guarantee
-      if constexpr (has_equal_operator && is_dereferenceable &&
-                    can_pre_increment) {
-        {
-          It a = valid_iterator;
-          It b = valid_iterator;
-          if (*a != *b) {
-            m_test_error_messages.add_error(
-                "If a and b compare equal (a == b) then *a and *b "
-                "are references bound to the same object.");
-          }
-
-          if (a != b) {
-            m_test_error_messages.add_error(
-                "If *a and *b refer to the same object, then a == b equals "
-                "true.");
-          }
-
-          if (++a != ++b) {
-            m_test_error_messages.add_error(
-                "If a == b equals true then ++a == ++b also equals true.");
-          }
+    // Verify multipass guarantee
+    if constexpr (has_equal_operator && is_dereferenceable &&
+                  can_pre_increment) {
+      {
+        It a = valid_iterator;
+        It b = valid_iterator;
+        if (*a != *b) {
+          m_test_error_messages.add_error(
+              "If a and b compare equal (a == b) then *a and *b "
+              "are references bound to the same object.");
         }
 
-        if constexpr (has_value_type_member) {
-          // Allows us to compare values without compilation error
-          constexpr bool is_value_type_comparable =
-              type_traits::has_comparison::is_equal_v<
-                  typename it_traits::value_type>;
+        if (a != b) {
+          m_test_error_messages.add_error(
+              "If *a and *b refer to the same object, then a == b equals "
+              "true.");
+        }
 
-          if constexpr (is_dereferenceable && can_pre_increment &&
-                        is_value_type_comparable) {
-            const auto zero_pos_value = *valid_iterator;
-            It zero_pos_it = valid_iterator;
-            ++zero_pos_it;
-            if (zero_pos_value != *valid_iterator) {
-              m_test_error_messages.add_error(
-                  "Incrementing copy of iterator instance must not affect "
-                  "on the value read from original object.");
-            }
+        if (++a != ++b) {
+          m_test_error_messages.add_error(
+              "If a == b equals true then ++a == ++b also equals true.");
+        }
+      }
+
+      if constexpr (has_value_type_member) {
+        // Allows us to compare values without compilation error
+        constexpr bool is_value_type_comparable =
+            type_traits::has_comparison::is_equal_v<
+                typename it_traits::value_type>;
+
+        if constexpr (is_dereferenceable && can_pre_increment &&
+                      is_value_type_comparable) {
+          const auto zero_pos_value = *valid_iterator;
+          It zero_pos_it = valid_iterator;
+          ++zero_pos_it;
+          if (zero_pos_value != *valid_iterator) {
+            m_test_error_messages.add_error(
+                "Incrementing copy of iterator instance must not affect "
+                "on the value read from original object.");
           }
         }
       }

--- a/util/named_requirement_verification/legacy_random_access_iterator.h
+++ b/util/named_requirement_verification/legacy_random_access_iterator.h
@@ -208,9 +208,6 @@ class legacy_random_access_iterator_requirement {
             }
           }
         }
-        m_test_error_messages.add_error(
-            "Iterator must have operator+() with "
-            "iterator_traits::difference_type operator.");
       }
     }
 

--- a/util/named_requirement_verification/legacy_random_access_iterator.h
+++ b/util/named_requirement_verification/legacy_random_access_iterator.h
@@ -44,10 +44,10 @@ class legacy_random_access_iterator_requirement {
    */
   template <typename It>
   std::pair<bool, std::array<string_view, count_of_possible_errors>>
-  is_satisfied_for(It valid_iterator, const size_t container_size) {
+  is_satisfied_for(It valid_iterator) {
     auto legacy_bidir_iterator_res =
         legacy_bidirectional_iterator_requirement{}.is_satisfied_for<It>(
-            valid_iterator, container_size);
+            valid_iterator);
     if (!legacy_bidir_iterator_res.first) {
       m_test_error_messages.add_errors(legacy_bidir_iterator_res.second);
     }
@@ -177,35 +177,29 @@ class legacy_random_access_iterator_requirement {
             "iterator_traits::difference_type operator.");
       }
 
-      if (container_size == 0) {
-        m_test_error_messages.add_error(
-            "Some of the test requires container size more than 0. These tests "
-            "have been skipped.");
-      } else {
-        It a{};
-        It b{};
-        diff_t n = 1;
-        // If current iterator has iterator plus difference_type make `b`
-        // iterator differ than `a` iterator
-        if constexpr (has_iterator_plus_diff_type_operator) {
-          b = b + n;
-          using it_traits = std::iterator_traits<It>;
-          if constexpr (has_iterator_minus_iterator_operator &&
-                        has_difference_type_member) {
-            if (!std::is_same_v<decltype(b - a),
-                                typename it_traits::difference_type>) {
-              m_test_error_messages.add_error(
-                  "operator-() of It instances must return "
-                  "iterator_traits::difference_type.");
-            }
+      It a{};
+      It b{};
+      diff_t n = 1;
+      // If current iterator has iterator plus difference_type make `b`
+      // iterator differ than `a` iterator
+      if constexpr (has_iterator_plus_diff_type_operator) {
+        b = b + n;
+        using it_traits = std::iterator_traits<It>;
+        if constexpr (has_iterator_minus_iterator_operator &&
+                      has_difference_type_member) {
+          if (!std::is_same_v<decltype(b - a),
+                              typename it_traits::difference_type>) {
+            m_test_error_messages.add_error(
+                "operator-() of It instances must return "
+                "iterator_traits::difference_type.");
           }
-          if constexpr (has_subscript_operator && has_reference_member) {
-            if (!std::is_convertible_v<decltype(a[0]),
-                                       typename it_traits::reference>) {
-              m_test_error_messages.add_error(
-                  "operator[]() return value must be convertible to "
-                  "iterator_traits::reference.");
-            }
+        }
+        if constexpr (has_subscript_operator && has_reference_member) {
+          if (!std::is_convertible_v<decltype(a[0]),
+                                     typename it_traits::reference>) {
+            m_test_error_messages.add_error(
+                "operator[]() return value must be convertible to "
+                "iterator_traits::reference.");
           }
         }
       }


### PR DESCRIPTION
Corresponding DPCPP implementation change: intel/llvm#6692.

This also resolves #388 