### PR TITLE
Fix out of bounds access in check_as_result

### DIFF
--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -37,7 +37,9 @@
 #include "../common/get_cts_object.h"
 #include "macros.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <type_traits>
 
@@ -442,7 +444,10 @@ asType check_as_result(sycl::vec<vecType, N> inputVec,
     tmp_ptr[i] = getElement(inputVec, i);
   }
   asType exp_ptr[asN];
-  memcpy(exp_ptr, tmp_ptr, sizeof(exp_ptr));
+  for (size_t i = 0; i < asN; ++i) {
+    exp_ptr[i] = getElement(asVec, i);
+  }
+  std::memcpy(exp_ptr, tmp_ptr, std::min(sizeof(exp_ptr), sizeof(tmp_ptr)));
   for (size_t i = 0; i < asN; ++i) {
     if (exp_ptr[i] != getElement(asVec, i)) {
       return false;


### PR DESCRIPTION
I previously fixed a strict aliasing violation in this function in #383, but that wasn't the only thing wrong with it. Apparently one of the instantiations run during testing has an input type of sycl::vec<sycl::byte, 3> and an output type of sycl::vec<char, 4>. Originally, this would have read an undefined fourth byte from the input array through a reinterpret_casted pointer; after my previous change, it reads the undefined fourth byte via memcpy. This isn't any more undefined, but it seems to more visibly expose the problem in some cases.

I don't know why this test was written to read values past the end of arrays, but it seems like it makes more sense to only test values that are in bounds. To do this, I'm initializing the exp_ptr array to the expected output values and only copying values that are in bounds in the input array to it.

Also, I've fully qualified the memcpy call and explicitly #included \<cstring> as suggested in the previous review to tidy things up.