### PR TITLE
Fix reference capture lifetime bug in event tests; update spec comment

### DIFF
--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -288,9 +288,8 @@ class test_exception_handler {
   }
 };
 
-// TODO SPEC: It is unclear whether uncaught exceptions inside
-//            host tasks get reported as asynchronous errors.
-// See also: https://github.com/KhronosGroup/SYCL-Docs/issues/214
+// According to section 4.10.1 "Any uncaught exception thrown during the
+// execution of a host task will be turned into an async error [...]".
 static sycl::event make_throwing_host_event(
     sycl::queue& queue, std::string name,
     const std::vector<sycl::event>& dependencies = {}) {

--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -294,11 +294,11 @@ class test_exception_handler {
 static sycl::event make_throwing_host_event(
     sycl::queue& queue, std::string name,
     const std::vector<sycl::event>& dependencies = {}) {
-  return queue.submit([&name, &dependencies](sycl::handler& cgh) {
+  return queue.submit([name, &dependencies](sycl::handler& cgh) {
     for (auto& dep : dependencies) {
       cgh.depends_on(dep);
     }
-    cgh.host_task([&name](auto) { throw test_exception{std::move(name)}; });
+    cgh.host_task([name](auto) { throw test_exception{name}; });
   });
 }
 


### PR DESCRIPTION
Not sure what I originally intended to do here, but reference capturing an lvalue parameter of the surrounding function into a host task lambda is a bad idea. Also update the comment on uncaught exceptions in host tasks since that has been clarified in KhronosGroup/SYCL-Docs#246.