### PR TITLE
Split fp64 case from usm_atomic_access and usm_atomic_access_atomic64

### DIFF
--- a/tests/usm/usm_atomic_access.h
+++ b/tests/usm/usm_atomic_access.h
@@ -20,7 +20,7 @@
 
 namespace usm_atomic_access {
 
-static auto get_scalar_types() {
+inline auto get_nondouble_scalar_types() {
   static const auto scalar_types =
       named_type_pack<int, unsigned int, long,
                       unsigned long, float, double, long long,
@@ -28,6 +28,11 @@ static auto get_scalar_types() {
                                            "unsigned long", "float", "double",
                                            "long long", "unsigned long long");
   return scalar_types;
+}
+
+inline auto get_fp64_type() {
+  static const auto types = named_type_pack<double>::generate("double");
+  return types;
 }
 
 /** @brief Return atomic aspect depending on the type of allocated memory

--- a/tests/usm/usm_atomic_access_atomic64.cpp
+++ b/tests/usm/usm_atomic_access_atomic64.cpp
@@ -31,7 +31,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
       auto queue{util::get_cts_object::queue()};
 
       for_all_types<usm_atomic_access::run_all_tests>(
-          usm_atomic_access::get_scalar_types(), queue, log,
+          usm_atomic_access::get_nondouble_scalar_types(), queue, log,
           usm_atomic_access::with_atomic64);
     }
   }

--- a/tests/usm/usm_atomic_access_atomic64_fp64.cpp
+++ b/tests/usm/usm_atomic_access_atomic64_fp64.cpp
@@ -3,13 +3,13 @@
 //  SYCL 2020 Conformance Test Suite
 //
 //  Provide verification to atomic access for USM allocations that underlying
-//  type size lower than 64 byte.
+//  type size equal than 64 byte.
 //
 *******************************************************************************/
 
 #include "usm_atomic_access.h"
 
-#define TEST_NAME usm_atomic_access_core
+#define TEST_NAME usm_atomic_access_atomic64_fp64
 
 namespace TEST_NAMESPACE {
 using namespace sycl_cts;
@@ -29,10 +29,15 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     {
       auto queue{util::get_cts_object::queue()};
-
+      if (!queue.get_device().has(sycl::aspect::fp64)) {
+        log.note(
+            "Device does not support double precision floating point "
+            "operations");
+        return;
+      }
       for_all_types<usm_atomic_access::run_all_tests>(
-          usm_atomic_access::get_nondouble_scalar_types(), queue, log,
-          usm_atomic_access::without_atomic64);
+          usm_atomic_access::get_fp64_type(), queue, log,
+          usm_atomic_access::with_atomic64);
     }
   }
 };


### PR DESCRIPTION
The use of double in usm_atomic_access and usm_atomic_access_atomic64 is not guarded by a check for fp64. This commit splits these checks for double into a new test usm_atomic_access_atomic64_fp64. Note that we do not need usm_atomic_access_fp64 as testing for double atomics require both fp64 and atomic64.