### PR TITLE
Fix SYCL 2020 accessor::value_type tests

### DIFF
--- a/tests/accessor_legacy/accessor_api_common_all.h
+++ b/tests/accessor_legacy/accessor_api_common_all.h
@@ -27,6 +27,8 @@
 #include "../common/common.h"
 #include "accessor_api_utility.h"
 
+#include <type_traits>
+
 ////////////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,8 +52,11 @@ void check_accessor_members(sycl_cts::util::logger &log,
 
   using acc_t = sycl::accessor<T, dims, mode, target, placeholder>;
 
+  using t_type = typename std::conditional<mode == sycl::access_mode::read, const T, T>::type;
+
   using value_type = typename acc_t::value_type;
-  static_assert(std::is_same<value_type, T>::value,
+
+  static_assert(std::is_same<value_type, t_type>::value,
                 "value_type is of wrong type");
 
   using reference = typename acc_t::reference;


### PR DESCRIPTION
The accessor class's value_type member was updated recently to change its "const"-ness when in read-only mode (https://github.com/intel/llvm/pull/7096) for SYCL 2020 compliance as defined in [Section 4.7.6.9.1](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_interface_for_buffer_command_accessors) The tests were not updated to reflect this change.

This patch specifically addresses the `accessor_api_buffer_core` test in the accessor_legacy directory and the error:

```
accessor_api_buffer_core - static assertion failed due to requirement 'std::is_same<const sycl::vec<int, 16>, sycl::vec<int, 16>>::value': value_type is of wrong type
```

In addition to the changes to accessor_api_common_all.h, it was necessary to resolve issues with accessor_api_image_common.h as there were tests in there for invalid targets. host_image, image, and image_array have been removed from the SYCL 2020 specification in favour of respectively specialised accessors. It was decided to simply remove these from the tests for that reason due to this being legacy testing.