### PR TITLE
Add missing <optional> include in type_coverage

### DIFF
--- a/tests/common/type_coverage.h
+++ b/tests/common/type_coverage.h
@@ -9,6 +9,7 @@
 #ifndef __SYCLCTS_TESTS_COMMON_TYPE_COVERAGE_H
 #define __SYCLCTS_TESTS_COMMON_TYPE_COVERAGE_H
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>


### PR DESCRIPTION
This commit adds `#include <optional>` to type_coverage.h to fix the potentially unresolvable dependency.