### PR TITLE
Fix and enable local_accessor tests for access among work_items.

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -201,7 +201,7 @@ inline auto get_all_dimensions() {
   static const auto dimensions = integer_pack<0, 1, 2, 3>::generate_unnamed();
   return dimensions;
 }
-
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Factory function for getting type_pack with target values
  */
@@ -211,7 +211,7 @@ inline auto get_targets() {
                  sycl::target::host_task>::generate_named();
   return targets;
 }
-
+#endif
 /**
  * @brief Function helps to generate type_pack with sycl::vec of all supported
  * sizes
@@ -232,7 +232,7 @@ struct tag_factory {
   static_assert(AccType != AccType,
                 "There is no tag support for such accessor type");
 };
-
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to get TagT corresponding to AccessMode and Target
  * template parameters
@@ -268,7 +268,7 @@ struct tag_factory<accessor_type::generic_accessor> {
     }
   }
 };
-
+#endif
 /**
  * @brief Function helps to get TagT corresponding to AccessMode parameter
  */
@@ -316,7 +316,7 @@ void check_def_constructor_post_conditions(TestingAccT testing_acc,
   res_acc[res_i++] = testing_acc.rbegin() == testing_acc.rend();
   res_acc[res_i++] = testing_acc.crbegin() == testing_acc.crend();
 }
-
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Common function that constructs accessor with default constructor
  *and checks post-conditions
@@ -363,7 +363,7 @@ void check_def_constructor(GetAccFunctorT get_accessor_functor) {
     CHECK(conditions_check[i]);
   }
 }
-
+#endif
 namespace detail {
 /**
  * @brief Wraps callable to make possible chaining foo(boo(arg)) calls by fold
@@ -410,7 +410,7 @@ void read_write_zero_dim_acc(AccT testing_acc, ResultAccT res_acc) {
     value_operations::assign(acc_ref, changed_val);
   }
 }
-
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to check zero dimension constructor of accessor
  *
@@ -488,7 +488,7 @@ void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor,
     }
   }
 }
-
+#endif
 /**
  * @brief Function that tries to read or/and write depending on AccessMode
  * parameter. Results of compare will be stored in res_acc
@@ -514,7 +514,7 @@ void read_write_acc(AccT testing_acc, ResultAccT res_acc) {
     value_operations::assign(testing_acc[id], changed_val);
   }
 }
-
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to check common constructor of accessor
  *
@@ -645,7 +645,7 @@ void check_placeholder_accessor_exception(const sycl::range<Dimension>& r,
         sycl_cts::util::equals_exception(sycl::errc::kernel_argument));
   }
 }
-
+#endif
 /**
  * @brief Function mainly for testing no_init property. The function tries to
  * write to the accessor and only after that tries to read from the accessor.
@@ -667,7 +667,7 @@ void write_read_acc(AccT testing_acc, ResultAccT res_acc) {
     res_acc[0] = value_operations::are_equal(testing_acc[id], expected_data);
   }
 }
-
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to check accessor constructor with no_init property
  *
@@ -717,7 +717,7 @@ void check_no_init_prop(GetAccFunctorT get_accessor_functor,
     CHECK(compare_res);
   }
 }
-
+#endif
 /**
  * @brief Function helps to verify that constructor of accessor with no_init
  * property and access_mode::read triggers an exception

--- a/tests/accessor/local_accessor_access_among_work_items_core.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_core.cpp
@@ -13,8 +13,8 @@
 #include "../common/disabled_for_test_case.h"
 
 // FIXME: re-enable when sycl::accessor is implemented
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP && \
-    !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
 #include "local_accessor_access_among_work_items.h"
 
 using namespace local_accessor_access_among_work_items;
@@ -23,7 +23,7 @@ using namespace accessor_tests_common;
 
 namespace local_accessor_access_among_work_items_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sycl::local_accessor access among work items. core types", "[accessor]")({
   const auto types = get_conformance_type_pack();
 

--- a/tests/accessor/local_accessor_access_among_work_items_fp16.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_fp16.cpp
@@ -12,8 +12,7 @@
 #include "../common/disabled_for_test_case.h"
 
 // FIXME: re-enable when sycl::accessor is implemented
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP && \
-    !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 
 #include "local_accessor_access_among_work_items.h"
 
@@ -23,7 +22,7 @@ using namespace accessor_tests_common;
 
 namespace local_accessor_access_among_work_items_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sycl::local_accessor access among work items. fp16 type", "[accessor]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {

--- a/tests/accessor/local_accessor_access_among_work_items_fp64.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_fp64.cpp
@@ -12,8 +12,7 @@
 #include "../common/disabled_for_test_case.h"
 
 // FIXME: re-enable when sycl::accessor is implemented
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP && \
-    !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 
 #include "local_accessor_access_among_work_items.h"
 
@@ -23,7 +22,7 @@ using namespace accessor_tests_common;
 
 namespace local_accessor_access_among_work_items_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sycl::local_accessor access among work items. fp64 type", "[accessor]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {

--- a/tests/common/value_operations.h
+++ b/tests/common/value_operations.h
@@ -187,24 +187,34 @@ are_equal(const LeftNonArrT& left, const RightNonArrT& right) {
 }
 
 template <typename... Types, typename U>
-bool are_equal(std::tuple<Types...>& left, const U& right) {
+typename std::enable_if_t<!std::is_same_v<std::tuple<Types...>, U>, bool>
+are_equal(const std::tuple<Types...>& left, const U& right) {
   using tuple_t = std::remove_reference_t<decltype(left)>;
   using indexes = std::make_index_sequence<std::tuple_size<tuple_t>::value>;
   return detail::are_equal_by_index_sequence(left, right, indexes());
 }
 
 template <typename FirstT, typename SecondT = FirstT, typename U>
-bool are_equal(std::pair<FirstT, SecondT>& left, const U& right) {
+typename std::enable_if_t<!std::is_same_v<std::pair<FirstT, SecondT>, U>, bool>
+are_equal(const std::pair<FirstT, SecondT>& left, const U& right) {
   constexpr size_t pair_size = 2;
   using indexes = std::make_index_sequence<pair_size>;
   return detail::are_equal_by_index_sequence(left, right, indexes());
 }
 
 template <typename... Types, typename U>
-bool are_equal(std::variant<Types...>& left, const U& right) {
+typename std::enable_if_t<!std::is_same_v<std::variant<Types...>, U>, bool>
+are_equal(const std::variant<Types...>& left, const U& right) {
   return std::get<U>(left) == right;
 }
 //////////////////////////// Compare functions
+
+template <typename T>
+inline constexpr auto init(int val) {
+  std::remove_const_t<T> data;
+  assign(data, val);
+  return data;
+}
 
 }  // namespace value_operations
 #endif  //__SYCLCTS_TESTS_COMMON_VALUE_OPERATIONS_H


### PR DESCRIPTION
Fix local_accessor_access_among_work_items tests and enable tests.
Changes from https://github.com/KhronosGroup/SYCL-CTS/pull/401 are used.