### PR TITLE
Fix test_exception_handler in event tests

### DIFF
--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -274,8 +274,10 @@ class test_exception_handler {
   void clear() { captured_exceptions.clear(); }
 
  private:
-  sycl::queue queue;
   std::unordered_set<std::string> captured_exceptions;
+  // Queue has to be destroyed first since that can trigger the exception
+  // handler.
+  sycl::queue queue;
 
   void capture(sycl::exception_list el) {
     for (auto& e : el) {


### PR DESCRIPTION
Since the destruction of the queue can trigger the exception handler, it needs to happen before any of the other fields of test_exception_handler are destroyed.