### PR TITLE
Fix tests for swap for sycl::accessor and sycl::host_accessor

### DIFF
--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -298,7 +298,7 @@ class run_api_tests {
         CHECK(value_operations::are_equal(data[linear_index], changed_val));
     }
     SECTION(get_section_name<dims>(type_name, access_mode_name, target_name,
-                                    "Check swap for accessor")) {
+                                   "Check swap for accessor")) {
       T data1 = value_operations::init<T>(expected_val);
       T data2 = value_operations::init<T>(changed_val);
       bool res = false;
@@ -327,8 +327,10 @@ class run_api_tests {
                 cgh.single_task([=]() {
                   auto &acc_ref1 = acc1[sycl::id<dims>()];
                   auto &acc_ref2 = acc2[sycl::id<dims>()];
-                  res_acc[0] = value_operations::are_equal(acc_ref1, changed_val);
-                  res_acc[0] &= value_operations::are_equal(acc_ref2, expected_val);
+                  res_acc[0] =
+                      value_operations::are_equal(acc_ref1, changed_val);
+                  res_acc[0] &=
+                      value_operations::are_equal(acc_ref2, expected_val);
                   if constexpr (AccessMode != sycl::access_mode::read) {
                     value_operations::assign(acc_ref1, expected_val);
                     value_operations::assign(acc_ref2, changed_val);
@@ -342,8 +344,7 @@ class run_api_tests {
       if constexpr (AccessMode != sycl::access_mode::read) {
         CHECK(value_operations::are_equal(data1, changed_val));
         CHECK(value_operations::are_equal(data2, expected_val));
-      }
-      else {
+      } else {
         CHECK(value_operations::are_equal(data1, expected_val));
         CHECK(value_operations::are_equal(data2, changed_val));
       }

--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -297,28 +297,55 @@ class run_api_tests {
       if constexpr (AccessMode != sycl::access_mode::read)
         CHECK(value_operations::are_equal(data[linear_index], changed_val));
     }
-    if constexpr (AccessMode != sycl::access_mode::read) {
-      SECTION(get_section_name<dims>(type_name, access_mode_name, target_name,
-                                     "Check swap for accessor")) {
-        T data1(expected_val);
-        T data2(changed_val);
-        {
-          sycl::buffer<T, dims> data_buf1(&data1, r);
-          sycl::buffer<T, dims> data_buf2(&data2, r);
-          queue
-              .submit([&](sycl::handler &cgh) {
-                AccT acc1(data_buf1);
-                AccT acc2(data_buf2);
-                if constexpr (Target == sycl::target::host_task) {
-                  cgh.host_task([=] { acc1.swap(acc2); });
-                } else {
-                  cgh.single_task([=]() { acc1.swap(acc2); });
-                }
-              })
-              .wait_and_throw();
-        }
+    SECTION(get_section_name<dims>(type_name, access_mode_name, target_name,
+                                    "Check swap for accessor")) {
+      T data1 = value_operations::init<T>(expected_val);
+      T data2 = value_operations::init<T>(changed_val);
+      bool res = false;
+      {
+        sycl::buffer res_buf(&res, sycl::range(1));
+        sycl::buffer<T, dims> data_buf1(&data1, r);
+        sycl::buffer<T, dims> data_buf2(&data2, r);
+        queue
+            .submit([&](sycl::handler &cgh) {
+              AccT acc1(data_buf1, cgh);
+              AccT acc2(data_buf2, cgh);
+              acc1.swap(acc2);
+              if constexpr (Target == sycl::target::host_task) {
+                cgh.host_task([=] {
+                  auto &acc_ref1 = acc1[sycl::id<dims>()];
+                  auto &acc_ref2 = acc2[sycl::id<dims>()];
+                  CHECK(value_operations::are_equal(acc_ref1, changed_val));
+                  CHECK(value_operations::are_equal(acc_ref2, expected_val));
+                  if constexpr (AccessMode != sycl::access_mode::read) {
+                    value_operations::assign(acc_ref1, expected_val);
+                    value_operations::assign(acc_ref2, changed_val);
+                  }
+                });
+              } else {
+                sycl::accessor res_acc(res_buf, cgh);
+                cgh.single_task([=]() {
+                  auto &acc_ref1 = acc1[sycl::id<dims>()];
+                  auto &acc_ref2 = acc2[sycl::id<dims>()];
+                  res_acc[0] = value_operations::are_equal(acc_ref1, changed_val);
+                  res_acc[0] &= value_operations::are_equal(acc_ref2, expected_val);
+                  if constexpr (AccessMode != sycl::access_mode::read) {
+                    value_operations::assign(acc_ref1, expected_val);
+                    value_operations::assign(acc_ref2, changed_val);
+                  }
+                });
+              }
+            })
+            .wait_and_throw();
+      }
+      if constexpr (Target == sycl::target::device) CHECK(res);
+      if constexpr (AccessMode != sycl::access_mode::read) {
         CHECK(value_operations::are_equal(data1, changed_val));
         CHECK(value_operations::are_equal(data2, expected_val));
+      }
+      else {
+        CHECK(value_operations::are_equal(data1, expected_val));
+        CHECK(value_operations::are_equal(data2, changed_val));
       }
     }
   }

--- a/tests/accessor/host_accessor_api_common.h
+++ b/tests/accessor/host_accessor_api_common.h
@@ -131,7 +131,7 @@ class run_api_tests {
         CHECK(value_operations::are_equal(data[linear_index], changed_val));
     }
     SECTION(get_section_name<dims>(type_name, access_mode_name,
-                                    "Check swap for host_accessor")) {
+                                   "Check swap for host_accessor")) {
       T data1 = value_operations::init<T>(expected_val);
       T data2 = value_operations::init<T>(changed_val);
       {
@@ -152,8 +152,7 @@ class run_api_tests {
       if constexpr (AccessMode != sycl::access_mode::read) {
         CHECK(value_operations::are_equal(data1, changed_val));
         CHECK(value_operations::are_equal(data2, expected_val));
-      }
-      else {
+      } else {
         CHECK(value_operations::are_equal(data1, expected_val));
         CHECK(value_operations::are_equal(data2, changed_val));
       }

--- a/tests/common/value_operations.h
+++ b/tests/common/value_operations.h
@@ -187,24 +187,34 @@ are_equal(const LeftNonArrT& left, const RightNonArrT& right) {
 }
 
 template <typename... Types, typename U>
-bool are_equal(std::tuple<Types...>& left, const U& right) {
+typename std::enable_if_t<!std::is_same_v<std::tuple<Types...>, U>, bool>
+are_equal(const std::tuple<Types...>& left, const U& right) {
   using tuple_t = std::remove_reference_t<decltype(left)>;
   using indexes = std::make_index_sequence<std::tuple_size<tuple_t>::value>;
   return detail::are_equal_by_index_sequence(left, right, indexes());
 }
 
 template <typename FirstT, typename SecondT = FirstT, typename U>
-bool are_equal(std::pair<FirstT, SecondT>& left, const U& right) {
+typename std::enable_if_t<!std::is_same_v<std::pair<FirstT, SecondT>, U>, bool>
+are_equal(const std::pair<FirstT, SecondT>& left, const U& right) {
   constexpr size_t pair_size = 2;
   using indexes = std::make_index_sequence<pair_size>;
   return detail::are_equal_by_index_sequence(left, right, indexes());
 }
 
 template <typename... Types, typename U>
-bool are_equal(std::variant<Types...>& left, const U& right) {
+typename std::enable_if_t<!std::is_same_v<std::variant<Types...>, U>, bool>
+are_equal(const std::variant<Types...>& left, const U& right) {
   return std::get<U>(left) == right;
 }
 //////////////////////////// Compare functions
+
+template <typename T>
+inline constexpr auto init(int val) {
+  std::remove_const_t<T> data;
+  assign(data, val);
+  return data;
+}
 
 }  // namespace value_operations
 #endif  //__SYCLCTS_TESTS_COMMON_VALUE_OPERATIONS_H


### PR DESCRIPTION
Change test for swap to correct call and correct checks. 
Changes from #401 are used.