### PR TITLE
Fix accessor_exeptions tests

### DIFF
--- a/tests/accessor/accessor_exceptions.h
+++ b/tests/accessor/accessor_exceptions.h
@@ -15,6 +15,7 @@
 #include <type_traits>
 
 namespace accessor_exceptions_test {
+using namespace accessor_tests_common;
 
 using generic_accessor = std::integral_constant<
     accessor_tests_common::accessor_type,
@@ -38,7 +39,7 @@ using host_accessor =
  *         accessor
  */
 template <accessor_tests_common::accessor_type AccType, typename DataT,
-          int Dimension, sycl::target Target = sycl::target::device,
+          int Dimension,
           typename GetAccFunctorT>
 void check_exception(GetAccFunctorT construct_acc) {
   auto queue = util::get_cts_object::queue();
@@ -98,6 +99,9 @@ class test_exception_for_local_acc {
         type_name + " data type.";
     SECTION(section_name) {
       auto construct_acc = [](sycl::queue& queue) {
+        constexpr size_t range_size = 2;
+      auto range = util::get_cts_object::range<Dimension>::get(
+          range_size, range_size, range_size);
         // Use a variable to avoid device code optimisation.
         auto is_empty =
             usm_helper::allocate_usm_memory<sycl::usm::alloc::shared, bool>(
@@ -105,7 +109,7 @@ class test_exception_for_local_acc {
         queue
             .submit([&](sycl::handler& cgh) {
               auto is_empty_ptr = is_empty.get();
-              sycl::local_accessor<DataT, Dimension> local_acc(cgh);
+              sycl::local_accessor<DataT, Dimension> local_acc(range, cgh);
               cgh.single_task([=](sycl::kernel_handler cgh) {
                 // Some interactions to avoid device code optimisation.
                 *is_empty_ptr = local_acc.empty();
@@ -113,7 +117,7 @@ class test_exception_for_local_acc {
             })
             .wait_and_throw();
       };
-      check_exception<AccTypeT::value, DataT, Dimension>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
   }
 };
@@ -126,29 +130,25 @@ class test_exception_for_local_acc {
  * @tparam DataT Current data type
  * @tparam AccessModeT Field of sycl::access_mode enumeration
  * @tparam DimensionT Dimension size
- * @tparam TargetT Current target
  * @param type_name Current data type string representation
  * @param access_mode_name Current access mode string representation
- * @param target_name Current target string representation
  */
 template <typename AccT, typename DataT, typename AccessModeT,
-          typename DimensionT, typename TargetT>
+          typename DimensionT>
 class test_exception_for_host_acc {
   static constexpr sycl::access_mode AccessMode = AccessModeT::value;
   static constexpr int Dimension = DimensionT::value;
-  static constexpr sycl::target Target = TargetT::value;
   static constexpr auto AccType = AccT::value;
 
  public:
   void operator()(const std::string& type_name,
-                  const std::string& access_mode_name,
-                  const std::string& target_name) {
+                  const std::string& access_mode_name) {
     auto great_range = util::get_cts_object::range<Dimension>::get(10, 10, 10);
     auto default_range = util::get_cts_object::range<Dimension>::get(1, 1, 1);
     auto id = util::get_cts_object::id<Dimension>::get(1, 1, 1);
 
     auto section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
+        type_name, access_mode_name,
         "Expecting exception when attempting to construct host_accessor from "
         "buffer and range. In case, the range exceeds the range of buffer "
         "in any dimension.");
@@ -158,11 +158,11 @@ class test_exception_for_host_acc {
             sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf,
                                                               great_range);
           };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
 
     section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
+        type_name, access_mode_name,
         "Expecting exception when attempting to construct host_accessor from "
         "buffer, range and tag. In case, the range exceeds the range of buffer "
         "in any dimension.");
@@ -172,11 +172,11 @@ class test_exception_for_host_acc {
             sycl::host_accessor<DataT, Dimension>(data_buf, great_range,
                                                   sycl::read_only);
           };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
 
     section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
+        type_name, access_mode_name,
         "Expecting exception when attempting to construct host_accessor from "
         "buffer, and range and id. In case, when the sum of range and offset "
         "exceeds the range of buffer in any dimension.");
@@ -186,11 +186,11 @@ class test_exception_for_host_acc {
         sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf,
                                                           default_range, id);
       };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
 
     section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
+        type_name, access_mode_name,
         "Expecting exception when attempting to construct host_accessor from "
         "buffer, and range, id and tag. In case, when the sum of range and "
         "offset exceeds the range of buffer in any dimension.");
@@ -200,7 +200,7 @@ class test_exception_for_host_acc {
         sycl::host_accessor<DataT, Dimension>(data_buf, default_range, id,
                                               sycl::read_only);
       };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
   }
 };
@@ -236,32 +236,17 @@ class test_exception_for_generic_acc {
 
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception when attempting to construct host_accessor from "
-        "buffer, and range that range and offset with no_init property and "
-        "access_mode::read");
-    SECTION(section_name) {
-      auto construct_acc = [&great_range](
-                               sycl::handler& cgh,
-                               sycl::buffer<DataT, Dimension> data_buf) {
-        sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf,
-                                                          great_range);
-      };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
-    }
-
-    section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
         "Expecting exception when attempting to construct accessor from "
         "buffer, tag and range. In case, the range exceeds the range of buffer "
         "in any dimension.");
     SECTION(section_name) {
+      constexpr auto tag = (Target == sycl::target::device) ? sycl::read_only : sycl::read_only_host_task;
       auto construct_acc = [&great_range](
                                sycl::handler& cgh,
                                sycl::buffer<DataT, Dimension> data_buf) {
-        sycl::accessor<DataT, Dimension>(data_buf, great_range,
-                                         sycl::read_only);
+        sycl::accessor<DataT, Dimension>(data_buf, great_range, tag);
       };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
 
     section_name =
@@ -278,7 +263,7 @@ class test_exception_for_generic_acc {
         sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf,
                                                              default_range, id);
       };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
 
     section_name = get_section_name<Dimension>(
@@ -288,13 +273,14 @@ class test_exception_for_generic_acc {
         "tag, range and id. In case, when the sum of range and offset exceeds "
         "the range of buffer in any dimension.");
     SECTION(section_name) {
+      constexpr auto tag = (Target == sycl::target::device) ? sycl::read_only : sycl::read_only_host_task;
       auto construct_acc = [&default_range, id](
                                sycl::handler& cgh,
                                sycl::buffer<DataT, Dimension> data_buf) {
         sycl::accessor<DataT, Dimension>(data_buf, default_range, id,
-                                         sycl::read_only);
+                                         tag);
       };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
 
     section_name = get_section_name<Dimension>(
@@ -309,7 +295,7 @@ class test_exception_for_generic_acc {
         sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
                                                              great_range);
       };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
 
     section_name = get_section_name<Dimension>(
@@ -319,13 +305,14 @@ class test_exception_for_generic_acc {
         "of "
         "buffer in any dimension.");
     SECTION(section_name) {
+      constexpr auto tag = (Target == sycl::target::device) ? sycl::read_only : sycl::read_only_host_task;
       auto construct_acc = [&great_range](
                                sycl::handler& cgh,
                                sycl::buffer<DataT, Dimension> data_buf) {
         sycl::accessor<DataT, Dimension>(data_buf, cgh, great_range,
-                                         sycl::read_only);
+                                         tag);
       };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
 
     section_name = get_section_name<Dimension>(
@@ -340,7 +327,7 @@ class test_exception_for_generic_acc {
         sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
                                                              default_range, id);
       };
-      check_exception<AccType, DataT, Dimension, Target>(construct_acc);
+      check_exception<AccType, DataT, Dimension>(construct_acc);
     }
   }
 };
@@ -361,8 +348,7 @@ class run_tests_with_types {
     // Type packs instances have to be const, otherwise for_all_combination
     // will not compile
     const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    const auto dimensions = get_dimensions();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or for_all_device_copyable_std_containers.
@@ -373,12 +359,13 @@ class run_tests_with_types {
     constexpr accessor_tests_common::accessor_type acc_type = AccT::value;
     if constexpr (acc_type ==
                   accessor_tests_common::accessor_type::generic_accessor) {
+      const auto targets = get_targets();
       for_all_combinations<test_exception_for_generic_acc, AccT, T>(
           access_modes, dimensions, targets, actual_type_name);
     } else if constexpr (acc_type ==
                          accessor_tests_common::accessor_type::host_accessor) {
       for_all_combinations<test_exception_for_host_acc, AccT, T>(
-          access_modes, dimensions, targets, actual_type_name);
+          access_modes, dimensions, actual_type_name);
     } else if constexpr (acc_type ==
                          accessor_tests_common::accessor_type::local_accessor) {
       for_all_combinations<test_exception_for_local_acc, AccT, T>(

--- a/tests/accessor/accessor_exceptions.h
+++ b/tests/accessor/accessor_exceptions.h
@@ -39,8 +39,7 @@ using host_accessor =
  *         accessor
  */
 template <accessor_tests_common::accessor_type AccType, typename DataT,
-          int Dimension,
-          typename GetAccFunctorT>
+          int Dimension, typename GetAccFunctorT>
 void check_exception(GetAccFunctorT construct_acc) {
   auto queue = util::get_cts_object::queue();
   DataT some_data(expected_val);
@@ -100,8 +99,8 @@ class test_exception_for_local_acc {
     SECTION(section_name) {
       auto construct_acc = [](sycl::queue& queue) {
         constexpr size_t range_size = 2;
-      auto range = util::get_cts_object::range<Dimension>::get(
-          range_size, range_size, range_size);
+        auto range = util::get_cts_object::range<Dimension>::get(
+            range_size, range_size, range_size);
         // Use a variable to avoid device code optimisation.
         auto is_empty =
             usm_helper::allocate_usm_memory<sycl::usm::alloc::shared, bool>(
@@ -240,7 +239,9 @@ class test_exception_for_generic_acc {
         "buffer, tag and range. In case, the range exceeds the range of buffer "
         "in any dimension.");
     SECTION(section_name) {
-      constexpr auto tag = (Target == sycl::target::device) ? sycl::read_only : sycl::read_only_host_task;
+      constexpr auto tag = (Target == sycl::target::device)
+                               ? sycl::read_only
+                               : sycl::read_only_host_task;
       auto construct_acc = [&great_range](
                                sycl::handler& cgh,
                                sycl::buffer<DataT, Dimension> data_buf) {
@@ -273,12 +274,13 @@ class test_exception_for_generic_acc {
         "tag, range and id. In case, when the sum of range and offset exceeds "
         "the range of buffer in any dimension.");
     SECTION(section_name) {
-      constexpr auto tag = (Target == sycl::target::device) ? sycl::read_only : sycl::read_only_host_task;
+      constexpr auto tag = (Target == sycl::target::device)
+                               ? sycl::read_only
+                               : sycl::read_only_host_task;
       auto construct_acc = [&default_range, id](
                                sycl::handler& cgh,
                                sycl::buffer<DataT, Dimension> data_buf) {
-        sycl::accessor<DataT, Dimension>(data_buf, default_range, id,
-                                         tag);
+        sycl::accessor<DataT, Dimension>(data_buf, default_range, id, tag);
       };
       check_exception<AccType, DataT, Dimension>(construct_acc);
     }
@@ -305,12 +307,13 @@ class test_exception_for_generic_acc {
         "of "
         "buffer in any dimension.");
     SECTION(section_name) {
-      constexpr auto tag = (Target == sycl::target::device) ? sycl::read_only : sycl::read_only_host_task;
+      constexpr auto tag = (Target == sycl::target::device)
+                               ? sycl::read_only
+                               : sycl::read_only_host_task;
       auto construct_acc = [&great_range](
                                sycl::handler& cgh,
                                sycl::buffer<DataT, Dimension> data_buf) {
-        sycl::accessor<DataT, Dimension>(data_buf, cgh, great_range,
-                                         tag);
+        sycl::accessor<DataT, Dimension>(data_buf, cgh, great_range, tag);
       };
       check_exception<AccType, DataT, Dimension>(construct_acc);
     }


### PR DESCRIPTION
Fix accessor tests for exceptions and remove check for host_accessor that was erroneously added to sycl::accessor test