### PR TITLE
Cover test gaps for has_property and get_property methods in sycl::accessor and sycl::host_accessor

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -838,9 +838,10 @@ void check_has_property_member_func(GetAccFunctorT construct_acc,
  *
  * @tparam GetAccFunctorT Type of functor that constructs testing accessor
  */
-template <accessor_type AccType, typename DataT, int Dimension, typename GetAccFunctorT>
+template <accessor_type AccType, typename DataT, int Dimension,
+          typename GetAccFunctorT>
 void check_has_property_member_without_no_init(GetAccFunctorT construct_acc,
-                                    const sycl::range<Dimension> r) {
+                                               const sycl::range<Dimension> r) {
   auto queue = util::get_cts_object::queue();
   bool compare_res = false;
   DataT some_data = value_operations::init<DataT>(expected_val);
@@ -860,10 +861,10 @@ void check_has_property_member_without_no_init(GetAccFunctorT construct_acc,
   CHECK(!compare_res);
 }
 
-/**                                    
+/**
  * @brief Function invokes \c get_property() member function with \c PropT
  * property and verifies that exception occures
- *  
+ *
  * @tparam GetAccFunctorT Type of functor that constructs testing accessor
  */
 template <accessor_type AccType, typename DataT, int Dimension, typename PropT,
@@ -898,7 +899,7 @@ void check_get_property_member_func(GetAccFunctorT construct_acc,
 template <accessor_type AccType, typename DataT, int Dimension,
           typename GetAccFunctorT>
 void check_get_property_member_without_no_init(GetAccFunctorT construct_acc,
-                                    const sycl::range<Dimension> r) {
+                                               const sycl::range<Dimension> r) {
   auto queue = util::get_cts_object::queue();
   DataT some_data = value_operations::init<DataT>(expected_val);
   sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
@@ -907,18 +908,19 @@ void check_get_property_member_without_no_init(GetAccFunctorT construct_acc,
     queue
         .submit([&](sycl::handler& cgh) {
           auto acc = construct_acc(data_buf, cgh);
-          auto action = [&] { acc.template get_property<sycl::property::no_init>(); };
+          auto action = [&] {
+            acc.template get_property<sycl::property::no_init>();
+          };
           CHECK_THROWS_MATCHES(
               action(), sycl::exception,
               sycl_cts::util::equals_exception(sycl::errc::invalid));
-              })
-              .wait_and_throw();
+        })
+        .wait_and_throw();
   } else {
     auto acc = construct_acc(data_buf);
     auto action = [&] { acc.template get_property<sycl::property::no_init>(); };
-    CHECK_THROWS_MATCHES(
-        action(), sycl::exception,
-        sycl_cts::util::equals_exception(sycl::errc::invalid));
+    CHECK_THROWS_MATCHES(action(), sycl::exception,
+                         sycl_cts::util::equals_exception(sycl::errc::invalid));
   }
 }
 

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -822,6 +822,36 @@ void check_has_property_member_func(GetAccFunctorT construct_acc,
 }
 
 /**
+ * @brief Function invokes \c has_property() member function without \c PropT
+ * property and verifies that false returns
+ *
+ * @tparam GetAccFunctorT Type of functor that constructs testing accessor
+ */
+template <accessor_type AccType, typename DataT, int Dimension,
+          sycl::access_mode AccessMode,
+          sycl::target Target = sycl::target::device, typename GetAccFunctorT>
+void check_has_property_member_without_no_init(
+    GetAccFunctorT get_accessor_functor, const sycl::range<Dimension> r) {
+  auto queue = util::get_cts_object::queue();
+  bool compare_res = false;
+  DataT some_data = value_operations::init<DataT>(expected_val);
+  sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
+
+  if constexpr (AccType != accessor_type::host_accessor) {
+    queue
+        .submit([&](sycl::handler& cgh) {
+          auto acc = get_accessor_functor(data_buf, cgh);
+          compare_res = acc.template has_property<sycl::property::no_init>();
+        })
+        .wait_and_throw();
+  } else {
+    auto acc = get_accessor_functor(data_buf);
+    compare_res = acc.template has_property<sycl::property::no_init>();
+  }
+  CHECK(false == compare_res);
+}
+
+/**
  * @brief Function invokes \c get_property() member function with \c PropT
  * property and verifies that returned object has same type as \c PropT
  *
@@ -838,6 +868,41 @@ void check_get_property_member_func(GetAccFunctorT construct_acc,
     auto acc_prop = accessor.template get_property<PropT>();
 
     CHECK(std::is_same_v<PropT, decltype(acc_prop)>);
+  }
+}
+
+/**
+ * @brief Function invokes \c get_property() member function without \c PropT
+ * property and verifies that false returns
+ *
+ * @tparam GetAccFunctorT Type of functor that constructs testing accessor
+ */
+template <accessor_type AccType, typename DataT, int Dimension,
+          sycl::access_mode AccessMode,
+          sycl::target Target = sycl::target::device, typename GetAccFunctorT>
+void check_get_property_member_without_no_init(
+    GetAccFunctorT get_accessor_functor, const sycl::range<Dimension> r) {
+  auto queue = util::get_cts_object::queue();
+  DataT some_data = value_operations::init<DataT>(expected_val);
+  sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
+
+  if constexpr (AccType != accessor_type::host_accessor) {
+    queue
+        .submit([&](sycl::handler& cgh) {
+          auto acc = get_accessor_functor(data_buf, cgh);
+          auto action = [&] {
+            acc.template get_property<sycl::property::no_init>();
+          };
+          CHECK_THROWS_MATCHES(
+              action(), sycl::exception,
+              sycl_cts::util::equals_exception(sycl::errc::invalid));
+        })
+        .wait_and_throw();
+  } else {
+    auto acc = get_accessor_functor(data_buf);
+    auto action = [&] { acc.template get_property<sycl::property::no_init>(); };
+    CHECK_THROWS_MATCHES(action(), sycl::exception,
+                         sycl_cts::util::equals_exception(sycl::errc::invalid));
   }
 }
 

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -809,29 +809,10 @@ void test_accessor_methods_common(const AccT& accessor,
  *
  * @tparam GetAccFunctorT Type of functor that constructs testing accessor
  */
-template <typename DataT, int Dimension, typename PropT,
+template <accessor_type AccType, typename DataT, int Dimension, typename PropT,
           typename GetAccFunctorT>
 void check_has_property_member_func(GetAccFunctorT construct_acc,
                                     const sycl::range<Dimension> r) {
-  DataT some_data = value_operations::init<DataT>(expected_val);
-  {
-    sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
-    auto accessor = construct_acc(data_buf);
-    CHECK(accessor.template has_property<PropT>());
-  }
-}
-
-/**
- * @brief Function invokes \c has_property() member function without \c PropT
- * property and verifies that false returns
- *
- * @tparam GetAccFunctorT Type of functor that constructs testing accessor
- */
-template <accessor_type AccType, typename DataT, int Dimension,
-          sycl::access_mode AccessMode,
-          sycl::target Target = sycl::target::device, typename GetAccFunctorT>
-void check_has_property_member_without_no_init(
-    GetAccFunctorT get_accessor_functor, const sycl::range<Dimension> r) {
   auto queue = util::get_cts_object::queue();
   bool compare_res = false;
   DataT some_data = value_operations::init<DataT>(expected_val);
@@ -840,33 +821,70 @@ void check_has_property_member_without_no_init(
   if constexpr (AccType != accessor_type::host_accessor) {
     queue
         .submit([&](sycl::handler& cgh) {
-          auto acc = get_accessor_functor(data_buf, cgh);
+          auto acc = construct_acc(data_buf, cgh);
           compare_res = acc.template has_property<sycl::property::no_init>();
         })
         .wait_and_throw();
   } else {
-    auto acc = get_accessor_functor(data_buf);
+    auto acc = construct_acc(data_buf);
     compare_res = acc.template has_property<sycl::property::no_init>();
   }
-  CHECK(false == compare_res);
+  CHECK(compare_res);
 }
 
 /**
- * @brief Function invokes \c get_property() member function with \c PropT
- * property and verifies that returned object has same type as \c PropT
+ * @brief Function invokes \c has_property() member function without \c PropT
+ * property and verifies that false returns
  *
  * @tparam GetAccFunctorT Type of functor that constructs testing accessor
  */
-template <typename DataT, int Dimension, typename PropT,
+template <accessor_type AccType, typename DataT, int Dimension, typename GetAccFunctorT>
+void check_has_property_member_without_no_init(GetAccFunctorT construct_acc,
+                                    const sycl::range<Dimension> r) {
+  auto queue = util::get_cts_object::queue();
+  bool compare_res = false;
+  DataT some_data = value_operations::init<DataT>(expected_val);
+  sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
+
+  if constexpr (AccType != accessor_type::host_accessor) {
+    queue
+        .submit([&](sycl::handler& cgh) {
+          auto acc = construct_acc(data_buf, cgh);
+          compare_res = acc.template has_property<sycl::property::no_init>();
+        })
+        .wait_and_throw();
+  } else {
+    auto acc = construct_acc(data_buf);
+    compare_res = acc.template has_property<sycl::property::no_init>();
+  }
+  CHECK(!compare_res);
+}
+
+/**                                    
+ * @brief Function invokes \c get_property() member function with \c PropT
+ * property and verifies that exception occures
+ *  
+ * @tparam GetAccFunctorT Type of functor that constructs testing accessor
+ */
+template <accessor_type AccType, typename DataT, int Dimension, typename PropT,
           typename GetAccFunctorT>
 void check_get_property_member_func(GetAccFunctorT construct_acc,
                                     const sycl::range<Dimension> r) {
+  auto queue = util::get_cts_object::queue();
   DataT some_data = value_operations::init<DataT>(expected_val);
-  {
-    sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
-    auto accessor = construct_acc(data_buf);
-    auto acc_prop = accessor.template get_property<PropT>();
+  sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
 
+  if constexpr (AccType != accessor_type::host_accessor) {
+    queue
+        .submit([&](sycl::handler& cgh) {
+          auto acc = construct_acc(data_buf, cgh);
+          auto acc_prop = acc.template get_property<PropT>();
+          CHECK(std::is_same_v<PropT, decltype(acc_prop)>);
+        })
+        .wait_and_throw();
+  } else {
+    auto acc = construct_acc(data_buf);
+    auto acc_prop = acc.template get_property<PropT>();
     CHECK(std::is_same_v<PropT, decltype(acc_prop)>);
   }
 }
@@ -878,10 +896,9 @@ void check_get_property_member_func(GetAccFunctorT construct_acc,
  * @tparam GetAccFunctorT Type of functor that constructs testing accessor
  */
 template <accessor_type AccType, typename DataT, int Dimension,
-          sycl::access_mode AccessMode,
-          sycl::target Target = sycl::target::device, typename GetAccFunctorT>
-void check_get_property_member_without_no_init(
-    GetAccFunctorT get_accessor_functor, const sycl::range<Dimension> r) {
+          typename GetAccFunctorT>
+void check_get_property_member_without_no_init(GetAccFunctorT construct_acc,
+                                    const sycl::range<Dimension> r) {
   auto queue = util::get_cts_object::queue();
   DataT some_data = value_operations::init<DataT>(expected_val);
   sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
@@ -889,20 +906,19 @@ void check_get_property_member_without_no_init(
   if constexpr (AccType != accessor_type::host_accessor) {
     queue
         .submit([&](sycl::handler& cgh) {
-          auto acc = get_accessor_functor(data_buf, cgh);
-          auto action = [&] {
-            acc.template get_property<sycl::property::no_init>();
-          };
+          auto acc = construct_acc(data_buf, cgh);
+          auto action = [&] { acc.template get_property<sycl::property::no_init>(); };
           CHECK_THROWS_MATCHES(
               action(), sycl::exception,
               sycl_cts::util::equals_exception(sycl::errc::invalid));
-        })
-        .wait_and_throw();
+              })
+              .wait_and_throw();
   } else {
-    auto acc = get_accessor_functor(data_buf);
+    auto acc = construct_acc(data_buf);
     auto action = [&] { acc.template get_property<sycl::property::no_init>(); };
-    CHECK_THROWS_MATCHES(action(), sycl::exception,
-                         sycl_cts::util::equals_exception(sycl::errc::invalid));
+    CHECK_THROWS_MATCHES(
+        action(), sycl::exception,
+        sycl_cts::util::equals_exception(sycl::errc::invalid));
   }
 }
 

--- a/tests/accessor/generic_accessor_properties.h
+++ b/tests/accessor/generic_accessor_properties.h
@@ -138,6 +138,105 @@ void test_exception(const std::string& type_name,
 
 template <typename DataT, int Dimension, sycl::access_mode AccessMode,
           sycl::target Target>
+void test_property_member_functions_without_no_init(
+    const std::string& type_name, const std::string& access_mode_name,
+    const std::string& target_name) {
+  const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
+  const auto offset = sycl::id<Dimension>();
+
+  {
+    auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf,
+                              sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf,
+                                                                  cgh);
+    };
+
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "Expecting false == accessor.has_property<property::no_init>() "
+        "for acc constructed with buffer constructor without no_init property");
+
+    SECTION(section_name) {
+      check_has_property_member_without_no_init<AccType, DataT, Dimension,
+                                                AccessMode, Target>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer constructor without no_init property");
+
+    SECTION(section_name) {
+      check_get_property_member_without_no_init<AccType, DataT, Dimension,
+                                                AccessMode, Target>(
+          get_acc_functor, r);
+    }
+  }
+  {
+    auto get_acc_functor = [r](sycl::buffer<DataT, Dimension>& data_buf,
+                               sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
+                                                                  r);
+    };
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "Expecting false == accessor.has_property<property::no_init>() "
+        "for acc constructed with buffer and range constructor without no_init "
+        "property");
+
+    SECTION(section_name) {
+      check_has_property_member_without_no_init<AccType, DataT, Dimension,
+                                                AccessMode, Target>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer and range constructor without no_init "
+        "property");
+
+    SECTION(section_name) {
+      check_get_property_member_without_no_init<AccType, DataT, Dimension,
+                                                AccessMode, Target>(
+          get_acc_functor, r);
+    }
+  }
+  {
+    auto get_acc_functor = [r, offset](sycl::buffer<DataT, Dimension>& data_buf,
+                                       sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
+                                                                  r, offset);
+    };
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "Expecting false == accessor.has_property<property::no_init>() "
+        "for acc constructed with buffer,range and offset constructor without "
+        "no_init property");
+
+    SECTION(section_name) {
+      check_has_property_member_without_no_init<AccType, DataT, Dimension,
+                                                AccessMode, Target>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer,range and offset constructor without "
+        "no_init property");
+
+    SECTION(section_name) {
+      check_get_property_member_without_no_init<AccType, DataT, Dimension,
+                                                AccessMode, Target>(
+          get_acc_functor, r);
+    }
+  }
+}
+
+template <typename DataT, int Dimension, sycl::access_mode AccessMode,
+          sycl::target Target>
 void test_property_member_functions(const std::string& type_name,
                                     const std::string& access_mode_name,
                                     const std::string& target_name) {
@@ -185,6 +284,9 @@ class run_tests_properties {
           type_name, access_mode_name, target_name);
 
       test_property_member_functions<T, Dimension, AccessMode, Target>(
+          type_name, access_mode_name, target_name);
+      test_property_member_functions_without_no_init<T, Dimension, AccessMode,
+                                                     Target>(
           type_name, access_mode_name, target_name);
     } else {
       test_exception<T, Dimension, Target>(type_name, target_name);

--- a/tests/accessor/generic_accessor_properties.h
+++ b/tests/accessor/generic_accessor_properties.h
@@ -145,6 +145,32 @@ void test_property_member_functions_without_no_init(
   const auto offset = sycl::id<Dimension>();
 
   {
+    auto get_acc_functor = [](
+                               sycl::buffer<DataT, Dimension>& data_buf,
+                               [[maybe_unused]]sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target, sycl::access::placeholder::true_t>(data_buf);
+    };
+
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "Expecting false == accessor.has_property<property::no_init>() "
+        "for acc constructed with buffer constructor without handler and no_init property");
+
+    SECTION(section_name) {
+      check_has_property_member_without_no_init<AccType, DataT, Dimension, AccessMode, Target>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer constructor without handler and no_init property");
+
+    SECTION(section_name) {
+      check_get_property_member_without_no_init<AccType, DataT, Dimension, AccessMode, Target>(
+          get_acc_functor, r);
+    }
+  }
+  {
     auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf,
                               sycl::handler& cgh) {
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf,

--- a/tests/accessor/generic_accessor_properties.h
+++ b/tests/accessor/generic_accessor_properties.h
@@ -145,28 +145,33 @@ void test_property_member_functions_without_no_init(
   const auto offset = sycl::id<Dimension>();
 
   {
-    auto get_acc_functor = [](
-                               sycl::buffer<DataT, Dimension>& data_buf,
-                               [[maybe_unused]]sycl::handler& cgh) {
-      return sycl::accessor<DataT, Dimension, AccessMode, Target, sycl::access::placeholder::true_t>(data_buf);
+    auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf,
+                              [[maybe_unused]] sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target,
+                            sycl::access::placeholder::true_t>(data_buf);
     };
 
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer constructor without handler and no_init property");
+        "for acc constructed with buffer constructor without handler and "
+        "no_init property");
 
     SECTION(section_name) {
-      check_has_property_member_without_no_init<AccType, DataT, Dimension, AccessMode, Target>(
+      check_has_property_member_without_no_init<AccType, DataT, Dimension,
+                                                AccessMode, Target>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer constructor without handler and no_init property");
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer constructor without handler and "
+        "no_init property");
 
     SECTION(section_name) {
-      check_get_property_member_without_no_init<AccType, DataT, Dimension, AccessMode, Target>(
+      check_get_property_member_without_no_init<AccType, DataT, Dimension,
+                                                AccessMode, Target>(
           get_acc_functor, r);
     }
   }

--- a/tests/accessor/generic_accessor_properties.h
+++ b/tests/accessor/generic_accessor_properties.h
@@ -138,67 +138,69 @@ void test_exception(const std::string& type_name,
 
 template <typename DataT, int Dimension, sycl::access_mode AccessMode,
           sycl::target Target>
-void test_property_member_functions_without_no_init(const std::string& type_name,
-                                    const std::string& access_mode_name,
-                                    const std::string& target_name) {
+void test_property_member_functions_without_no_init(
+    const std::string& type_name, const std::string& access_mode_name,
+    const std::string& target_name) {
   const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
   const auto offset = sycl::id<Dimension>();
 
   {
-    auto get_acc_functor = [](
-                               sycl::buffer<DataT, Dimension>& data_buf,
-                               [[maybe_unused]]sycl::handler& cgh) {
+    auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf,
+                              [[maybe_unused]] sycl::handler& cgh) {
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf);
     };
 
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer constructor without handler and no_init property");
- 
+        "for acc constructed with buffer constructor without handler and "
+        "no_init property");
+
     SECTION(section_name) {
       check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer constructor without handler and no_init property");
- 
-    SECTION(section_name) { 
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer constructor without handler and "
+        "no_init property");
+
+    SECTION(section_name) {
       check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
   {
-    auto get_acc_functor = [](
-                               sycl::buffer<DataT, Dimension>& data_buf,
-                               sycl::handler& cgh) {
-      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh);
+    auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf,
+                              sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf,
+                                                                  cgh);
     };
 
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
         "for acc constructed with buffer constructor without no_init property");
- 
+
     SECTION(section_name) {
       check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
         "for acc constructed with buffer constructor without no_init property");
- 
-    SECTION(section_name) { 
+
+    SECTION(section_name) {
       check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
   {
-    auto get_acc_functor = [r](
-                               sycl::buffer<DataT, Dimension>& data_buf,
+    auto get_acc_functor = [r](sycl::buffer<DataT, Dimension>& data_buf,
                                sycl::handler& cgh) {
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
                                                                   r);
@@ -206,43 +208,48 @@ void test_property_member_functions_without_no_init(const std::string& type_name
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer and range constructor without no_init property");
- 
+        "for acc constructed with buffer and range constructor without no_init "
+        "property");
+
     SECTION(section_name) {
       check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer and range constructor without no_init property");
- 
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer and range constructor without no_init "
+        "property");
+
     SECTION(section_name) {
       check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
   {
-    auto get_acc_functor = [r, offset](
-                               sycl::buffer<DataT, Dimension>& data_buf,
-                               sycl::handler& cgh) {
-      return sycl::accessor<DataT, Dimension, AccessMode, Target>(
-          data_buf, cgh, r, offset);
+    auto get_acc_functor = [r, offset](sycl::buffer<DataT, Dimension>& data_buf,
+                                       sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
+                                                                  r, offset);
     };
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer,range and offset constructor without no_init property");
- 
+        "for acc constructed with buffer,range and offset constructor without "
+        "no_init property");
+
     SECTION(section_name) {
       check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer,range and offset constructor without no_init property");
- 
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer,range and offset constructor without "
+        "no_init property");
+
     SECTION(section_name) {
       check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
@@ -262,49 +269,57 @@ void test_property_member_functions(const std::string& type_name,
   {
     auto get_acc_functor = [&prop_list](
                                sycl::buffer<DataT, Dimension>& data_buf,
-                               [[maybe_unused]]sycl::handler& cgh) {
-      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, prop_list);
+                               [[maybe_unused]] sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf,
+                                                                  prop_list);
     };
 
-    auto section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
-        "has_property member function invocation with buffer and without handler");
- 
+    auto section_name =
+        get_section_name<Dimension>(type_name, access_mode_name, target_name,
+                                    "has_property member function invocation "
+                                    "with buffer and without handler");
+
     SECTION(section_name) {
-      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_has_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
-    section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
-        "get_property member function invocation with buffer and without handler");
- 
-    SECTION(section_name) { 
-      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+    section_name =
+        get_section_name<Dimension>(type_name, access_mode_name, target_name,
+                                    "get_property member function invocation "
+                                    "with buffer and without handler");
+
+    SECTION(section_name) {
+      check_get_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
   }
   {
     auto get_acc_functor = [&prop_list](
                                sycl::buffer<DataT, Dimension>& data_buf,
                                sycl::handler& cgh) {
-      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh, prop_list);
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
+                                                                  prop_list);
     };
 
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "has_property member function invocation with buffer and handler");
- 
+
     SECTION(section_name) {
-      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_has_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "get_property member function invocation with buffer and handler");
- 
-    SECTION(section_name) { 
-      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+
+    SECTION(section_name) {
+      check_get_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
   }
   {
@@ -314,21 +329,25 @@ void test_property_member_functions(const std::string& type_name,
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
                                                                   r, prop_list);
     };
-    auto section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
-        "has_property member function invocation with buffer, handler and range");
- 
+    auto section_name =
+        get_section_name<Dimension>(type_name, access_mode_name, target_name,
+                                    "has_property member function invocation "
+                                    "with buffer, handler and range");
+
     SECTION(section_name) {
-      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_has_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
-    section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
-        "get_property member function invocation with buffer, handler and range");
- 
+    section_name =
+        get_section_name<Dimension>(type_name, access_mode_name, target_name,
+                                    "get_property member function invocation "
+                                    "with buffer, handler and range");
+
     SECTION(section_name) {
-      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_get_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
   }
   {
@@ -338,21 +357,25 @@ void test_property_member_functions(const std::string& type_name,
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(
           data_buf, cgh, r, offset, prop_list);
     };
-    auto section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
-        "has_property member function invocation with buffer, handler, range and offset");
- 
+    auto section_name =
+        get_section_name<Dimension>(type_name, access_mode_name, target_name,
+                                    "has_property member function invocation "
+                                    "with buffer, handler, range and offset");
+
     SECTION(section_name) {
-      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_has_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
-    section_name = get_section_name<Dimension>(
-        type_name, access_mode_name, target_name,
-        "get_property member function invocation with buffer, handler, range and offset");
- 
+    section_name =
+        get_section_name<Dimension>(type_name, access_mode_name, target_name,
+                                    "get_property member function invocation "
+                                    "with buffer, handler, range and offset");
+
     SECTION(section_name) {
-      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_get_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
   }
 }

--- a/tests/accessor/generic_accessor_properties.h
+++ b/tests/accessor/generic_accessor_properties.h
@@ -138,74 +138,67 @@ void test_exception(const std::string& type_name,
 
 template <typename DataT, int Dimension, sycl::access_mode AccessMode,
           sycl::target Target>
-void test_property_member_functions_without_no_init(
-    const std::string& type_name, const std::string& access_mode_name,
-    const std::string& target_name) {
+void test_property_member_functions_without_no_init(const std::string& type_name,
+                                    const std::string& access_mode_name,
+                                    const std::string& target_name) {
   const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
   const auto offset = sycl::id<Dimension>();
 
   {
-    auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf,
-                              [[maybe_unused]] sycl::handler& cgh) {
-      return sycl::accessor<DataT, Dimension, AccessMode, Target,
-                            sycl::access::placeholder::true_t>(data_buf);
+    auto get_acc_functor = [](
+                               sycl::buffer<DataT, Dimension>& data_buf,
+                               [[maybe_unused]]sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf);
     };
 
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer constructor without handler and "
-        "no_init property");
-
+        "for acc constructed with buffer constructor without handler and no_init property");
+ 
     SECTION(section_name) {
-      check_has_property_member_without_no_init<AccType, DataT, Dimension,
-                                                AccessMode, Target>(
+      check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call "
-        "accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer constructor without handler and "
-        "no_init property");
-
-    SECTION(section_name) {
-      check_get_property_member_without_no_init<AccType, DataT, Dimension,
-                                                AccessMode, Target>(
+        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer constructor without handler and no_init property");
+ 
+    SECTION(section_name) { 
+      check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
   {
-    auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf,
-                              sycl::handler& cgh) {
-      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf,
-                                                                  cgh);
+    auto get_acc_functor = [](
+                               sycl::buffer<DataT, Dimension>& data_buf,
+                               sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh);
     };
 
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
         "for acc constructed with buffer constructor without no_init property");
-
+ 
     SECTION(section_name) {
-      check_has_property_member_without_no_init<AccType, DataT, Dimension,
-                                                AccessMode, Target>(
+      check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call "
-        "accessor.get_property<property::no_init>() "
+        "Expecting exception for call accessor.get_property<property::no_init>() "
         "for acc constructed with buffer constructor without no_init property");
-
-    SECTION(section_name) {
-      check_get_property_member_without_no_init<AccType, DataT, Dimension,
-                                                AccessMode, Target>(
+ 
+    SECTION(section_name) { 
+      check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
   {
-    auto get_acc_functor = [r](sycl::buffer<DataT, Dimension>& data_buf,
+    auto get_acc_functor = [r](
+                               sycl::buffer<DataT, Dimension>& data_buf,
                                sycl::handler& cgh) {
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
                                                                   r);
@@ -213,54 +206,45 @@ void test_property_member_functions_without_no_init(
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer and range constructor without no_init "
-        "property");
-
+        "for acc constructed with buffer and range constructor without no_init property");
+ 
     SECTION(section_name) {
-      check_has_property_member_without_no_init<AccType, DataT, Dimension,
-                                                AccessMode, Target>(
+      check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call "
-        "accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer and range constructor without no_init "
-        "property");
-
+        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer and range constructor without no_init property");
+ 
     SECTION(section_name) {
-      check_get_property_member_without_no_init<AccType, DataT, Dimension,
-                                                AccessMode, Target>(
+      check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
   {
-    auto get_acc_functor = [r, offset](sycl::buffer<DataT, Dimension>& data_buf,
-                                       sycl::handler& cgh) {
-      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
-                                                                  r, offset);
+    auto get_acc_functor = [r, offset](
+                               sycl::buffer<DataT, Dimension>& data_buf,
+                               sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(
+          data_buf, cgh, r, offset);
     };
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer,range and offset constructor without "
-        "no_init property");
-
+        "for acc constructed with buffer,range and offset constructor without no_init property");
+ 
     SECTION(section_name) {
-      check_has_property_member_without_no_init<AccType, DataT, Dimension,
-                                                AccessMode, Target>(
+      check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name, target_name,
-        "Expecting exception for call "
-        "accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer,range and offset constructor without "
-        "no_init property");
-
+        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer,range and offset constructor without no_init property");
+ 
     SECTION(section_name) {
-      check_get_property_member_without_no_init<AccType, DataT, Dimension,
-                                                AccessMode, Target>(
+      check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
@@ -275,26 +259,101 @@ void test_property_member_functions(const std::string& type_name,
   const auto offset = sycl::id<Dimension>();
   const sycl::property_list prop_list(sycl::no_init);
 
-  const auto construct_acc =
-      [&prop_list](sycl::buffer<DataT, Dimension> data_buf) {
-        return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf,
-                                                                    prop_list);
-      };
+  {
+    auto get_acc_functor = [&prop_list](
+                               sycl::buffer<DataT, Dimension>& data_buf,
+                               [[maybe_unused]]sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, prop_list);
+    };
 
-  auto section_name =
-      get_section_name<Dimension>(type_name, access_mode_name, target_name,
-                                  "has_property member function invocation");
-  SECTION(section_name) {
-    check_has_property_member_func<DataT, Dimension, sycl::property::no_init>(
-        construct_acc, r);
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "has_property member function invocation with buffer and without handler");
+ 
+    SECTION(section_name) {
+      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "get_property member function invocation with buffer and without handler");
+ 
+    SECTION(section_name) { 
+      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
   }
+  {
+    auto get_acc_functor = [&prop_list](
+                               sycl::buffer<DataT, Dimension>& data_buf,
+                               sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh, prop_list);
+    };
 
-  section_name =
-      get_section_name<Dimension>(type_name, access_mode_name, target_name,
-                                  "get_property member function invocation");
-  SECTION(section_name) {
-    check_get_property_member_func<DataT, Dimension, sycl::property::no_init>(
-        construct_acc, r);
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "has_property member function invocation with buffer and handler");
+ 
+    SECTION(section_name) {
+      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "get_property member function invocation with buffer and handler");
+ 
+    SECTION(section_name) { 
+      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+  }
+  {
+    auto get_acc_functor = [&prop_list, r](
+                               sycl::buffer<DataT, Dimension>& data_buf,
+                               sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, cgh,
+                                                                  r, prop_list);
+    };
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "has_property member function invocation with buffer, handler and range");
+ 
+    SECTION(section_name) {
+      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "get_property member function invocation with buffer, handler and range");
+ 
+    SECTION(section_name) {
+      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+  }
+  {
+    auto get_acc_functor = [&prop_list, r, offset](
+                               sycl::buffer<DataT, Dimension>& data_buf,
+                               sycl::handler& cgh) {
+      return sycl::accessor<DataT, Dimension, AccessMode, Target>(
+          data_buf, cgh, r, offset, prop_list);
+    };
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "has_property member function invocation with buffer, handler, range and offset");
+ 
+    SECTION(section_name) {
+      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name, target_name,
+        "get_property member function invocation with buffer, handler, range and offset");
+ 
+    SECTION(section_name) {
+      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
   }
 }
 

--- a/tests/accessor/host_accessor_properties.h
+++ b/tests/accessor/host_accessor_properties.h
@@ -110,29 +110,160 @@ void test_exception(const std::string& type_name) {
 }
 
 template <typename DataT, int Dimension, sycl::access_mode AccessMode>
+void test_property_member_functions_without_no_init(const std::string& type_name,
+                                    const std::string& access_mode_name) {
+  const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
+  const auto offset = sycl::id<Dimension>();
+
+  {
+    auto get_acc_functor = [](
+                               sycl::buffer<DataT, Dimension>& data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf);
+    };
+
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "Expecting false == accessor.has_property<property::no_init>() "
+        "for acc constructed with buffer constructor without no_init property");
+ 
+    SECTION(section_name) {
+      check_has_property_member_without_no_init<AccType, DataT, Dimension>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer constructor without no_init property");
+ 
+    SECTION(section_name) { 
+      check_get_property_member_without_no_init<AccType, DataT, Dimension>(
+          get_acc_functor, r);
+    }
+  }
+  {
+    auto get_acc_functor = [r](
+                               sycl::buffer<DataT, Dimension>& data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r);
+    };
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "Expecting false == accessor.has_property<property::no_init>() "
+        "for acc constructed with buffer and range constructor without no_init property");
+ 
+    SECTION(section_name) {
+      check_has_property_member_without_no_init<AccType, DataT, Dimension>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer and range constructor without no_init property");
+ 
+    SECTION(section_name) {
+      check_get_property_member_without_no_init<AccType, DataT, Dimension>(
+          get_acc_functor, r);
+    }
+  }
+  {
+    auto get_acc_functor = [r, offset](
+                               sycl::buffer<DataT, Dimension>& data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(
+          data_buf, r, offset);
+    };
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "Expecting false == accessor.has_property<property::no_init>() "
+        "for acc constructed with buffer,range and offset constructor without no_init property");
+ 
+    SECTION(section_name) {
+      check_has_property_member_without_no_init<AccType, DataT, Dimension>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer,range and offset constructor without no_init property");
+ 
+    SECTION(section_name) {
+      check_get_property_member_without_no_init<AccType, DataT, Dimension>(
+          get_acc_functor, r);
+    }
+  }
+}
+
+template <typename DataT, int Dimension, sycl::access_mode AccessMode>
 void test_property_member_functions(const std::string& type_name,
                                     const std::string& access_mode_name) {
   const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
   const auto offset = sycl::id<Dimension>();
   const sycl::property_list prop_list(sycl::no_init);
+  {
+    auto get_acc_functor = [&prop_list](
+                               sycl::buffer<DataT, Dimension>& data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, prop_list);
+    };
 
-  const auto construct_acc =
-      [&prop_list](sycl::buffer<DataT, Dimension> data_buf) {
-        return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf,
-                                                                 prop_list);
-      };
-
-  auto section_name = get_section_name<Dimension>(
-      type_name, access_mode_name, "has_property member function invocation");
-  SECTION(section_name) {
-    check_has_property_member_func<DataT, Dimension, sycl::property::no_init>(
-        construct_acc, r);
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "has_property member function invocation with buffer");
+ 
+    SECTION(section_name) {
+      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "get_property member function invocation with buffer");
+ 
+    SECTION(section_name) { 
+      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
   }
-  section_name = get_section_name<Dimension>(
-      type_name, access_mode_name, "get_property member function invocation");
-  SECTION(section_name) {
-    check_get_property_member_func<DataT, Dimension, sycl::property::no_init>(
-        construct_acc, r);
+  {
+    auto get_acc_functor = [&prop_list, r](
+                               sycl::buffer<DataT, Dimension>& data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r, prop_list);
+    };
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "has_property member function invocation with buffer and range");
+ 
+    SECTION(section_name) {
+      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "get_property member function invocation with buffer and range");
+ 
+    SECTION(section_name) {
+      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+  }
+  {
+    auto get_acc_functor = [&prop_list, r, offset](
+                               sycl::buffer<DataT, Dimension>& data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(
+          data_buf, r, offset, prop_list);
+    };
+    auto section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "has_property member function invocation with buffer, range and offset");
+ 
+    SECTION(section_name) {
+      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
+    section_name = get_section_name<Dimension>(
+        type_name, access_mode_name,
+        "get_property member function invocation with buffer, range and offset");
+ 
+    SECTION(section_name) {
+      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
+          get_acc_functor, r);
+    }
   }
 }
 
@@ -150,6 +281,8 @@ class run_tests_properties {
                                                               access_mode_name);
 
       test_property_member_functions<T, Dimension, AccessMode>(
+          type_name, access_mode_name);
+      test_property_member_functions_without_no_init<T, Dimension, AccessMode>(
           type_name, access_mode_name);
     } else {
       test_exception<T, Dimension>(type_name);

--- a/tests/accessor/host_accessor_properties.h
+++ b/tests/accessor/host_accessor_properties.h
@@ -110,14 +110,13 @@ void test_exception(const std::string& type_name) {
 }
 
 template <typename DataT, int Dimension, sycl::access_mode AccessMode>
-void test_property_member_functions_without_no_init(const std::string& type_name,
-                                    const std::string& access_mode_name) {
+void test_property_member_functions_without_no_init(
+    const std::string& type_name, const std::string& access_mode_name) {
   const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
   const auto offset = sycl::id<Dimension>();
 
   {
-    auto get_acc_functor = [](
-                               sycl::buffer<DataT, Dimension>& data_buf) {
+    auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf) {
       return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf);
     };
 
@@ -125,65 +124,71 @@ void test_property_member_functions_without_no_init(const std::string& type_name
         type_name, access_mode_name,
         "Expecting false == accessor.has_property<property::no_init>() "
         "for acc constructed with buffer constructor without no_init property");
- 
+
     SECTION(section_name) {
       check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
-        "Expecting exception for call accessor.get_property<property::no_init>() "
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
         "for acc constructed with buffer constructor without no_init property");
- 
-    SECTION(section_name) { 
+
+    SECTION(section_name) {
       check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
   {
-    auto get_acc_functor = [r](
-                               sycl::buffer<DataT, Dimension>& data_buf) {
+    auto get_acc_functor = [r](sycl::buffer<DataT, Dimension>& data_buf) {
       return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r);
     };
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer and range constructor without no_init property");
- 
+        "for acc constructed with buffer and range constructor without no_init "
+        "property");
+
     SECTION(section_name) {
       check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
-        "Expecting exception for call accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer and range constructor without no_init property");
- 
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer and range constructor without no_init "
+        "property");
+
     SECTION(section_name) {
       check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
   }
   {
-    auto get_acc_functor = [r, offset](
-                               sycl::buffer<DataT, Dimension>& data_buf) {
-      return sycl::host_accessor<DataT, Dimension, AccessMode>(
-          data_buf, r, offset);
+    auto get_acc_functor = [r,
+                            offset](sycl::buffer<DataT, Dimension>& data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r,
+                                                               offset);
     };
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
         "Expecting false == accessor.has_property<property::no_init>() "
-        "for acc constructed with buffer,range and offset constructor without no_init property");
- 
+        "for acc constructed with buffer,range and offset constructor without "
+        "no_init property");
+
     SECTION(section_name) {
       check_has_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
-        "Expecting exception for call accessor.get_property<property::no_init>() "
-        "for acc constructed with buffer,range and offset constructor without no_init property");
- 
+        "Expecting exception for call "
+        "accessor.get_property<property::no_init>() "
+        "for acc constructed with buffer,range and offset constructor without "
+        "no_init property");
+
     SECTION(section_name) {
       check_get_property_member_without_no_init<AccType, DataT, Dimension>(
           get_acc_functor, r);
@@ -198,71 +203,81 @@ void test_property_member_functions(const std::string& type_name,
   const auto offset = sycl::id<Dimension>();
   const sycl::property_list prop_list(sycl::no_init);
   {
-    auto get_acc_functor = [&prop_list](
-                               sycl::buffer<DataT, Dimension>& data_buf) {
-      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, prop_list);
-    };
+    auto get_acc_functor =
+        [&prop_list](sycl::buffer<DataT, Dimension>& data_buf) {
+          return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf,
+                                                                   prop_list);
+        };
 
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
         "has_property member function invocation with buffer");
- 
+
     SECTION(section_name) {
-      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_has_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
         "get_property member function invocation with buffer");
- 
-    SECTION(section_name) { 
-      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+
+    SECTION(section_name) {
+      check_get_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
   }
   {
-    auto get_acc_functor = [&prop_list, r](
-                               sycl::buffer<DataT, Dimension>& data_buf) {
-      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r, prop_list);
+    auto get_acc_functor = [&prop_list,
+                            r](sycl::buffer<DataT, Dimension>& data_buf) {
+      return sycl::host_accessor<DataT, Dimension, AccessMode>(data_buf, r,
+                                                               prop_list);
     };
     auto section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
         "has_property member function invocation with buffer and range");
- 
+
     SECTION(section_name) {
-      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_has_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
     section_name = get_section_name<Dimension>(
         type_name, access_mode_name,
         "get_property member function invocation with buffer and range");
- 
+
     SECTION(section_name) {
-      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_get_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
   }
   {
-    auto get_acc_functor = [&prop_list, r, offset](
-                               sycl::buffer<DataT, Dimension>& data_buf) {
+    auto get_acc_functor = [&prop_list, r,
+                            offset](sycl::buffer<DataT, Dimension>& data_buf) {
       return sycl::host_accessor<DataT, Dimension, AccessMode>(
           data_buf, r, offset, prop_list);
     };
-    auto section_name = get_section_name<Dimension>(
-        type_name, access_mode_name,
-        "has_property member function invocation with buffer, range and offset");
- 
+    auto section_name =
+        get_section_name<Dimension>(type_name, access_mode_name,
+                                    "has_property member function invocation "
+                                    "with buffer, range and offset");
+
     SECTION(section_name) {
-      check_has_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_has_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
-    section_name = get_section_name<Dimension>(
-        type_name, access_mode_name,
-        "get_property member function invocation with buffer, range and offset");
- 
+    section_name =
+        get_section_name<Dimension>(type_name, access_mode_name,
+                                    "get_property member function invocation "
+                                    "with buffer, range and offset");
+
     SECTION(section_name) {
-      check_get_property_member_func<AccType, DataT, Dimension, sycl::property::no_init>(
-          get_acc_functor, r);
+      check_get_property_member_func<AccType, DataT, Dimension,
+                                     sycl::property::no_init>(get_acc_functor,
+                                                              r);
     }
   }
 }


### PR DESCRIPTION
Cover gaps for has_property and get_property methods with sycl::accessor and sycl::host_accessor initialized without no_init property