### PR TITLE
Add checks for iterator access functions for accessor

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -864,6 +864,105 @@ decltype(auto) get_subscript_overload(const AccT& accessor, size_t index) {
   if constexpr (dims == 3) return accessor[index][index][index];
 }
 
+template <typename AccT, typename T = int>
+void test_begin_end_host(AccT& accessor, T exp_first = T(), T exp_last = T(),
+                         bool empty = true) {
+  {
+    INFO("check begin() method");
+    auto it = accessor.begin();
+    STATIC_CHECK(std::is_same_v<decltype(it), typename AccT::iterator>);
+    if (!empty) CHECK(value_operations::are_equal(*it, exp_first));
+  }
+  {
+    INFO("check end() method");
+    auto it = accessor.end();
+    STATIC_CHECK(std::is_same_v<decltype(it), typename AccT::iterator>);
+    if (!empty) CHECK(value_operations::are_equal(*(--it), exp_last));
+  }
+  {
+    INFO("check cbegin() method");
+    auto it = accessor.cbegin();
+    STATIC_CHECK(std::is_same_v<decltype(it), typename AccT::const_iterator>);
+    if (!empty) CHECK(value_operations::are_equal(*it, exp_first));
+  }
+  {
+    INFO("check cend() method");
+    auto it = accessor.cend();
+    STATIC_CHECK(std::is_same_v<decltype(it), typename AccT::const_iterator>);
+    if (!empty) CHECK(value_operations::are_equal(*(--it), exp_last));
+  }
+  {
+    INFO("check rbegin() method");
+    auto it = accessor.rbegin();
+    STATIC_CHECK(std::is_same_v<decltype(it), typename AccT::reverse_iterator>);
+    if (!empty) CHECK(value_operations::are_equal(*it, exp_last));
+  }
+  {
+    INFO("check rend() method");
+    auto it = accessor.rend();
+    STATIC_CHECK(std::is_same_v<decltype(it), typename AccT::reverse_iterator>);
+    if (!empty) CHECK(value_operations::are_equal(*(--it), exp_first));
+  }
+  {
+    INFO("check crbegin() method");
+    auto it = accessor.crbegin();
+    STATIC_CHECK(
+        std::is_same_v<decltype(it), typename AccT::const_reverse_iterator>);
+    if (!empty) CHECK(value_operations::are_equal(*it, exp_last));
+  }
+  {
+    INFO("check crend() method");
+    auto it = accessor.crend();
+    STATIC_CHECK(
+        std::is_same_v<decltype(it), typename AccT::const_reverse_iterator>);
+    if (!empty) CHECK(value_operations::are_equal(*(--it), exp_first));
+  }
+}
+
+template <typename AccT, typename T = int>
+bool test_begin_end_device(AccT& accessor, T exp_first = T(), T exp_last = T(),
+                           bool empty = true) {
+  bool res = true;
+
+  auto it_begin = accessor.begin();
+  res &= std::is_same_v<decltype(it_begin), typename AccT::iterator>;
+  auto it_end = accessor.end();
+  res &= std::is_same_v<decltype(it_end), typename AccT::iterator>;
+
+  auto it_cbegin = accessor.cbegin();
+  res &= std::is_same_v<decltype(it_cbegin), typename AccT::const_iterator>;
+
+  auto it_cend = accessor.cend();
+  res &= std::is_same_v<decltype(it_cend), typename AccT::const_iterator>;
+
+  auto it_rbegin = accessor.rbegin();
+  res &= std::is_same_v<decltype(it_rbegin), typename AccT::reverse_iterator>;
+
+  auto it_rend = accessor.rend();
+  res &= std::is_same_v<decltype(it_rend), typename AccT::reverse_iterator>;
+
+  auto it_crbegin = accessor.crbegin();
+  res &= std::is_same_v<decltype(it_crbegin),
+                        typename AccT::const_reverse_iterator>;
+
+  auto it_crend = accessor.crend();
+  res &=
+      std::is_same_v<decltype(it_crend), typename AccT::const_reverse_iterator>;
+
+  if (!empty) {
+    res &= value_operations::are_equal(*it_begin, exp_first);
+    res &= value_operations::are_equal(*(--it_end), exp_first);
+    res &= value_operations::are_equal(*it_cbegin, exp_first);
+    res &= value_operations::are_equal(*(--it_cend), exp_first);
+    res &= value_operations::are_equal(*it_rbegin, exp_last);
+    res &= value_operations::are_equal(*(--it_rend), exp_first);
+    res &= value_operations::are_equal(*it_crbegin, exp_last);
+    res &= value_operations::are_equal(*(--it_crend), exp_first);
+  }
+
+  return res;
+}
+
 }  // namespace accessor_tests_common
 
 #endif  // SYCL_CTS_ACCESSOR_COMMON_H

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -951,9 +951,9 @@ bool test_begin_end_device(AccT& accessor, T exp_first = T(), T exp_last = T(),
 
   if (!empty) {
     res &= value_operations::are_equal(*it_begin, exp_first);
-    res &= value_operations::are_equal(*(--it_end), exp_first);
+    res &= value_operations::are_equal(*(--it_end), exp_last);
     res &= value_operations::are_equal(*it_cbegin, exp_first);
-    res &= value_operations::are_equal(*(--it_cend), exp_first);
+    res &= value_operations::are_equal(*(--it_cend), exp_last);
     res &= value_operations::are_equal(*it_rbegin, exp_last);
     res &= value_operations::are_equal(*(--it_rend), exp_first);
     res &= value_operations::are_equal(*it_crbegin, exp_last);

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -948,7 +948,7 @@ decltype(auto) get_subscript_overload(const AccT& accessor, size_t index) {
 }
 
 template <typename AccT, typename T = int>
-void test_begin_end_host(AccT& accessor, T exp_first = T(), T exp_last = T(),
+void test_begin_end_host(AccT& accessor, T exp_first = {}, T exp_last = {},
                          bool empty = true) {
   {
     INFO("check begin() method");
@@ -1003,12 +1003,10 @@ void test_begin_end_host(AccT& accessor, T exp_first = T(), T exp_last = T(),
 }
 
 template <typename AccT, typename T = int>
-bool test_begin_end_device(AccT& accessor, T exp_first = T(), T exp_last = T(),
+bool test_begin_end_device(AccT& accessor, T exp_first = {}, T exp_last = {},
                            bool empty = true) {
-  bool res = true;
-
   auto it_begin = accessor.begin();
-  res &= std::is_same_v<decltype(it_begin), typename AccT::iterator>;
+  bool res = std::is_same_v<decltype(it_begin), typename AccT::iterator>;
   auto it_end = accessor.end();
   res &= std::is_same_v<decltype(it_end), typename AccT::iterator>;
 

--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -273,9 +273,9 @@ class run_api_tests {
       auto offset_id =
           util::get_cts_object::id<dims>::get(offset, offset, offset);
       std::remove_const_t<T> data[buff_size];
-      for (size_t i = 0; i < buff_size; i++) {
-        data[i] = value_operations::init<T>(i);
-      }
+      std::generate(data, (data + buff_range.size()), [i = 0]() mutable {
+        return value_operations::init<T>(i++);
+      });
       bool res = false;
       {
         sycl::buffer<T, dims> data_buf(data, buff_range);

--- a/tests/accessor/host_accessor_api_common.h
+++ b/tests/accessor/host_accessor_api_common.h
@@ -53,6 +53,7 @@ class run_api_tests {
           acc, 0 /* expected_byte_size*/, 0 /*expected_size*/,
           util::get_cts_object::range<dims>::get(0, 0, 0) /*expected_range*/,
           sycl::id<dims>() /*&expected_offset)*/);
+      test_begin_end_host(acc);
     }
 
     SECTION(get_section_name<dims>(type_name, access_mode_name,
@@ -68,6 +69,7 @@ class run_api_tests {
             util::get_cts_object::range<dims>::get(1, 1, 1) /*expected_range*/,
             sycl::id<dims>() /*&expected_offset)*/);
         test_accessor_ptr(acc, expected_val);
+        test_begin_end_host(acc, expected_val, expected_val, false);
         auto &acc_ref = acc[sycl::id<dims>()];
         CHECK(value_operations::are_equal(acc_ref, expected_val));
         STATIC_CHECK(
@@ -113,6 +115,8 @@ class run_api_tests {
             offset_id /*&expected_offset)*/);
 
         test_accessor_ptr(acc, T());
+        test_begin_end_host(acc, value_operations::init<T>(0),
+                            value_operations::init<T>(buff_size - 1), false);
         auto &acc_ref = get_subscript_overload<T, AccT, dims>(acc, index);
         CHECK(value_operations::are_equal(acc_ref, linear_index));
         if constexpr (AccessMode != sycl::access_mode::read)

--- a/tests/accessor/local_accessor_api_common.h
+++ b/tests/accessor/local_accessor_api_common.h
@@ -16,6 +16,7 @@ using namespace accessor_tests_common;
 enum class check : size_t {
   subscript_id_type = 0U,
   subscript_size_t_type,
+  iterator_access,
   // only for non const
   subscript_id_result,
   subscript_size_t_result,
@@ -158,6 +159,10 @@ class run_api_tests {
                       value_operations::are_equal(ref_2, changed_val);
 
                   test_local_accessor_ptr(acc, expected_val, res_acc, item_id);
+                  res_acc[sycl::id<2>(to_integral(check::iterator_access),
+                                      item_id)] &=
+                      test_begin_end_device(acc, expected_val, changed_val,
+                                            false);
                 }
               });
             })
@@ -167,6 +172,8 @@ class run_api_tests {
       std::string info_strings[to_integral(check::nChecks)]{
           "return type for operator[](id<Dimensions> index)",
           "return type for operator[]](size_t index)",
+          "begin(), end(), cbegin(), cend(), rbegin(), rend(), crbegin(), "
+          "crend()",
           "result for operator[](id<Dimensions> index)",
           "result for operator[]](size_t index)",
           "return type for get_multi_ptr<sycl::access::decorated::no>()",


### PR DESCRIPTION
 Add checks for begin(), end(), cbegin(), cend(), rbegin(), rend(), crbegin(), crend() for sycl::accessor, sycl::host_accessor and sycl::local_accessor