### PR TITLE
Cover gaps for subscript operator for accessors

### DIFF
--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -206,24 +206,40 @@ class run_api_tests {
               if constexpr (Target == sycl::target::host_task) {
                 cgh.host_task([=] {
                   test_accessor_ptr_host(acc, expected_val);
-                  auto &acc_ref = acc[sycl::id<dims>()];
-                  CHECK(value_operations::are_equal(acc_ref, expected_val));
-                  STATIC_CHECK(std::is_same_v<decltype(acc_ref),
+                  auto &acc_ref1 = acc[sycl::id<dims>()];
+                  auto &acc_ref2 =
+                      get_subscript_overload<T, AccT, dims>(acc, 0);
+                  CHECK(value_operations::are_equal(acc_ref1, expected_val));
+                  CHECK(value_operations::are_equal(acc_ref2, expected_val));
+                  STATIC_CHECK(std::is_same_v<decltype(acc_ref1),
                                               typename AccT::reference>);
-                  if constexpr (AccessMode != sycl::access_mode::read)
-                    value_operations::assign(acc_ref, changed_val);
+                  STATIC_CHECK(std::is_same_v<decltype(acc_ref2),
+                                              typename AccT::reference>);
+                  if constexpr (AccessMode != sycl::access_mode::read) {
+                    value_operations::assign(acc_ref1, changed_val);
+                    CHECK(value_operations::are_equal(acc_ref2, changed_val));
+                  }
                 });
               } else {
                 sycl::accessor res_acc(res_buf, cgh);
                 cgh.single_task([acc, res_acc]() {
                   test_accessor_ptr_device(acc, expected_val, res_acc);
-                  auto &acc_ref = acc[sycl::id<dims>()];
+                  auto &acc_ref1 = acc[sycl::id<dims>()];
+                  auto &acc_ref2 =
+                      get_subscript_overload<T, AccT, dims>(acc, 0);
                   res_acc[0] &=
-                      value_operations::are_equal(acc_ref, expected_val);
-                  res_acc[0] &= std::is_same_v<decltype(acc_ref),
+                      value_operations::are_equal(acc_ref1, expected_val);
+                  res_acc[0] &=
+                      value_operations::are_equal(acc_ref2, expected_val);
+                  res_acc[0] &= std::is_same_v<decltype(acc_ref1),
                                                typename AccT::reference>;
-                  if constexpr (AccessMode != sycl::access_mode::read)
-                    value_operations::assign(acc_ref, changed_val);
+                  res_acc[0] &= std::is_same_v<decltype(acc_ref2),
+                                               typename AccT::reference>;
+                  if constexpr (AccessMode != sycl::access_mode::read) {
+                    value_operations::assign(acc_ref1, changed_val);
+                    res_acc[0] &=
+                        alue_operations::are_equal(acc_ref2, changed_val);
+                  }
                 });
               }
             })
@@ -272,30 +288,40 @@ class run_api_tests {
               if constexpr (Target == sycl::target::host_task) {
                 cgh.host_task([=] {
                   test_accessor_ptr_host(acc, T());
-                  auto &acc_ref =
+                  auto &acc_ref1 =
                       get_subscript_overload<T, AccT, dims>(acc, index);
-                  CHECK(value_operations::are_equal(acc_ref, linear_index));
-                  if constexpr (AccessMode != sycl::access_mode::read)
-                    value_operations::assign(acc_ref, changed_val);
+                  auto &acc_ref2 = acc[sycl::id<dims>()];
+                  CHECK(value_operations::are_equal(acc_ref1, linear_index));
+                  CHECK(value_operations::are_equal(acc_ref2, 0));
+                  if constexpr (AccessMode != sycl::access_mode::read) {
+                    value_operations::assign(acc_ref1, changed_val);
+                    value_operations::assign(acc_ref2, expected_val);
+                  }
                 });
               } else {
                 sycl::accessor res_acc(res_buf, cgh);
                 cgh.single_task([=]() {
                   test_accessor_ptr_device(acc, T(), res_acc);
-                  auto &acc_ref =
+                  auto &acc_ref1 =
                       get_subscript_overload<T, AccT, dims>(acc, index);
+                  auto &acc_ref2 = acc[sycl::id<dims>()];
                   res_acc[0] &=
-                      value_operations::are_equal(acc_ref, linear_index);
-                  if constexpr (AccessMode != sycl::access_mode::read)
-                    value_operations::assign(acc_ref, changed_val);
+                      value_operations::are_equal(acc_ref1, linear_index);
+                  res_acc[0] &= value_operations::are_equal(acc_ref2, 0);
+                  if constexpr (AccessMode != sycl::access_mode::read) {
+                    value_operations::assign(acc_ref1, changed_val);
+                    value_operations::assign(acc_ref2, expected_val);
+                  }
                 });
               }
             })
             .wait_and_throw();
       }
       if constexpr (Target == sycl::target::device) CHECK(res);
-      if constexpr (AccessMode != sycl::access_mode::read)
+      if constexpr (AccessMode != sycl::access_mode::read) {
         CHECK(value_operations::are_equal(data[linear_index], changed_val));
+        CHECK(value_operations::are_equal(data[0], expected_val));
+      }
     }
     SECTION(get_section_name<dims>(type_name, access_mode_name, target_name,
                                    "Check swap for accessor")) {

--- a/tests/accessor/host_accessor_api_common.h
+++ b/tests/accessor/host_accessor_api_common.h
@@ -68,12 +68,17 @@ class run_api_tests {
             util::get_cts_object::range<dims>::get(1, 1, 1) /*expected_range*/,
             sycl::id<dims>() /*&expected_offset)*/);
         test_accessor_ptr(acc, expected_val);
-        auto &acc_ref = acc[sycl::id<dims>()];
-        CHECK(value_operations::are_equal(acc_ref, expected_val));
+        auto &acc_ref1 = acc[sycl::id<dims>()];
+        auto &acc_ref2 = get_subscript_overload<T, AccT, dims>(acc, 0);
+        CHECK(value_operations::are_equal(acc_ref1, expected_val));
+        CHECK(value_operations::are_equal(acc_ref2, expected_val));
         STATIC_CHECK(
-            std::is_same_v<decltype(acc_ref), typename AccT::reference>);
+            std::is_same_v<decltype(acc_ref1), typename AccT::reference>);
+        STATIC_CHECK(
+            std::is_same_v<decltype(acc_ref2), typename AccT::reference>);
         if constexpr (AccessMode != sycl::access_mode::read)
-          value_operations::assign(acc_ref, changed_val);
+          value_operations::assign(acc_ref1, changed_val);
+        CHECK(value_operations::are_equal(acc_ref2, changed_val));
       }
       if constexpr (AccessMode != sycl::access_mode::read)
         CHECK(value_operations::are_equal(data, changed_val));
@@ -113,13 +118,19 @@ class run_api_tests {
             offset_id /*&expected_offset)*/);
 
         test_accessor_ptr(acc, T());
-        auto &acc_ref = get_subscript_overload<T, AccT, dims>(acc, index);
-        CHECK(value_operations::are_equal(acc_ref, linear_index));
-        if constexpr (AccessMode != sycl::access_mode::read)
-          value_operations::assign(acc_ref, changed_val);
+        auto &acc_ref1 = get_subscript_overload<T, AccT, dims>(acc, index);
+        auto &acc_ref2 = acc[sycl::id<dims>()];
+        CHECK(value_operations::are_equal(acc_ref1, linear_index));
+        CHECK(value_operations::are_equal(acc_ref2, 0));
+        if constexpr (AccessMode != sycl::access_mode::read) {
+          value_operations::assign(acc_ref1, changed_val);
+          value_operations::assign(acc_ref2, expected_val);
+        }
       }
-      if constexpr (AccessMode != sycl::access_mode::read)
+      if constexpr (AccessMode != sycl::access_mode::read) {
         CHECK(value_operations::are_equal(data[linear_index], changed_val));
+        CHECK(value_operations::are_equal(data[0], expected_val));
+      }
     }
     SECTION(get_section_name<dims>(type_name, access_mode_name,
                                    "Check swap for host_accessor")) {


### PR DESCRIPTION
Add check for unspecified operator[](size_t index) const for non ranged sycl::accessor and sycl::host_accessor
Add check for reference operator[](id<Dimensions> index) const for ranged sycl::accessor and sycl::host_accessor