### PR TITLE
Configure OpenCL proxy before configuring SYCL executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-include(AddSYCLExecutable)
 include(AddCTSOption)
 
 add_cts_option(SYCL_CTS_ENABLE_FULL_CONFORMANCE
@@ -66,25 +65,8 @@ add_cts_option(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
 add_cts_option(SYCL_CTS_ENABLE_CUDA_INTEROP_TESTS
     "Enable CUDA interoperability tests", OFF)
 
-# ------------------
-# Define OpenCL proxy library which is linked against by other CTS targets.
-# The proxy library transitively links to either a fully fleged OpenCL
-# library or the bundled OpenCL headers submodule (see below).
-add_library(OpenCL_Proxy INTERFACE)
-target_compile_definitions(OpenCL_Proxy INTERFACE "CL_TARGET_OPENCL_VERSION=120")
-add_library(CTS::OpenCL_Proxy ALIAS OpenCL_Proxy)
-
-# We use the OpenCL headers from the bundled submodule unless OpenCL
-# interop testing is enabled, or we are compiling with ComputeCpp,
-# which has a dependency on OpenCL (see FindComputeCpp.cmake module).
-if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS OR SYCL_IMPLEMENTATION STREQUAL "ComputeCpp")
-    find_package(OpenCL 1.2 REQUIRED)
-    target_link_libraries(OpenCL_Proxy INTERFACE OpenCL::OpenCL)
-else()
-    add_submodule_directory(vendor/OpenCL-Headers)
-    target_link_libraries(OpenCL_Proxy INTERFACE OpenCL::Headers)
-endif()
-# ------------------
+include(AddOpenCLProxy)
+include(AddSYCLExecutable)
 
 # ------------------
 # Enable CUDA language and add library, for CUDA interop tests

--- a/cmake/AddOpenCLProxy.cmake
+++ b/cmake/AddOpenCLProxy.cmake
@@ -15,7 +15,3 @@ else()
     add_submodule_directory(vendor/OpenCL-Headers)
     target_link_libraries(OpenCL_Proxy INTERFACE OpenCL::Headers)
 endif()
-
-# Signal that the OpenCL proxy has been configured to allow for ordering checks
-# in subsequent configurations.
-set(SYCL_CTS_OPENCL_PROXY_CONFIGURED 1)

--- a/cmake/AddOpenCLProxy.cmake
+++ b/cmake/AddOpenCLProxy.cmake
@@ -15,3 +15,7 @@ else()
     add_submodule_directory(vendor/OpenCL-Headers)
     target_link_libraries(OpenCL_Proxy INTERFACE OpenCL::Headers)
 endif()
+
+# Signal that the OpenCL proxy has been configured to allow for ordering checks
+# in subsequent configurations.
+set(SYCL_CTS_OPENCL_PROXY_CONFIGURED 1)

--- a/cmake/AddOpenCLProxy.cmake
+++ b/cmake/AddOpenCLProxy.cmake
@@ -1,0 +1,17 @@
+# Define OpenCL proxy library which is linked against by other CTS targets.
+# The proxy library transitively links to either a fully fleged OpenCL
+# library or the bundled OpenCL headers submodule (see below).
+add_library(OpenCL_Proxy INTERFACE)
+target_compile_definitions(OpenCL_Proxy INTERFACE "CL_TARGET_OPENCL_VERSION=120")
+add_library(CTS::OpenCL_Proxy ALIAS OpenCL_Proxy)
+
+# We use the OpenCL headers from the bundled submodule unless OpenCL
+# interop testing is enabled, or we are compiling with ComputeCpp,
+# which has a dependency on OpenCL (see FindComputeCpp.cmake module).
+if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS OR SYCL_IMPLEMENTATION STREQUAL "ComputeCpp")
+    find_package(OpenCL 1.2 REQUIRED)
+    target_link_libraries(OpenCL_Proxy INTERFACE OpenCL::OpenCL)
+else()
+    add_submodule_directory(vendor/OpenCL-Headers)
+    target_link_libraries(OpenCL_Proxy INTERFACE OpenCL::Headers)
+endif()

--- a/cmake/AddSYCLExecutable.cmake
+++ b/cmake/AddSYCLExecutable.cmake
@@ -5,6 +5,14 @@ if (NOT ${SYCL_IMPLEMENTATION} IN_LIST KNOWN_SYCL_IMPLEMENTATIONS)
         "-DSYCL_IMPLEMENTATION=[Intel_SYCL,DPCPP;ComputeCpp,hipSYCL]")
 endif()
 
+if(NOT DEFINED SYCL_CTS_OPENCL_PROXY_CONFIGURED)
+    message(FATAL_ERROR
+        "The SYCL CTS requires the OpenCL proxy to be configured prior to "
+        "detection of SYCL compiler to avoid incompatible compilers from being "
+        "used when configuring the OpenCL proxy."
+    )
+endif()
+
 if(${SYCL_IMPLEMENTATION} STREQUAL "Intel_SYCL")
     set(CANONICAL_SYCL_IMPLEMENTATION "DPCPP")
 else()

--- a/cmake/AddSYCLExecutable.cmake
+++ b/cmake/AddSYCLExecutable.cmake
@@ -5,7 +5,7 @@ if (NOT ${SYCL_IMPLEMENTATION} IN_LIST KNOWN_SYCL_IMPLEMENTATIONS)
         "-DSYCL_IMPLEMENTATION=[Intel_SYCL,DPCPP;ComputeCpp,hipSYCL]")
 endif()
 
-if(NOT DEFINED SYCL_CTS_OPENCL_PROXY_CONFIGURED)
+if(NOT TARGET OpenCL_Proxy)
     message(FATAL_ERROR
         "The SYCL CTS requires the OpenCL proxy to be configured prior to "
         "detection of SYCL compiler to avoid incompatible compilers from being "


### PR DESCRIPTION
This commit moves the OpenCL proxy configuration into a separate cmake file (cmake/AddOpenCLProxy.cmake) and includes it before including AddSYCLExecutable. This is motivated by CMake on Windows failing to configure for DPC++ due to the OpenCL proxy picking Clang as a C compiler due to FindDPCPP overwriting the compilers.

Additionally, since the OpenCL proxy needs options to be correctly configured the CTS options are declared before including both the OpenCL proxy and the SYCL executable.
