### PR TITLE
Check if tests for `sycl::cl_`, `sycl::half` and `sycl::byte` should be disabled in scalars tests

### DIFF
--- a/tests/scalars/CMakeLists.txt
+++ b/tests/scalars/CMakeLists.txt
@@ -1,8 +1,8 @@
 
-if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS)
-  file(GLOB test_cases_list *.cpp)
-else()
-  file(GLOB test_cases_list scalars_sycl_types.cpp)
+file(GLOB test_cases_list *.cpp)
+
+if(NOT SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS)
+  list(FILTER test_cases_list EXCLUDE REGEX scalars_interopability_types.cpp)
 endif()
 
 add_cts_test(${test_cases_list})

--- a/tests/scalars/CMakeLists.txt
+++ b/tests/scalars/CMakeLists.txt
@@ -1,3 +1,8 @@
-file(GLOB test_cases_list *.cpp)
+
+if(SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS)
+  file(GLOB test_cases_list *.cpp)
+else()
+  file(GLOB test_cases_list scalars_sycl_types.cpp)
+endif()
 
 add_cts_test(${test_cases_list})

--- a/tests/scalars/scalars_sycl_types.cpp
+++ b/tests/scalars/scalars_sycl_types.cpp
@@ -72,8 +72,10 @@ class TEST_NAME : public util::test_base {
                                            "size_t");
 
       // SYCL Floating Point Data Types
+#if SYCL_CTS_ENABLE_HALF_TESTS
       check_type_min_size_sign_log<sycl::half>(log, 2, true,
                                                    "sycl::half");
+#endif
       check_type_min_size_sign_log<float>(log, 4, true, "float");
       check_type_min_size_sign_log<double>(log, 8, true, "double");
 
@@ -107,8 +109,12 @@ class TEST_NAME : public util::test_base {
             accSignResult[8] = check_type_sign<unsigned long long int>(false);
             accSignResult[9] = check_type_sign<long long int>(true);
             accSignResult[10] = check_type_sign<size_t>(false);
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS // sycl::byte is deprecated
             accSignResult[11] = check_type_sign<sycl::byte>(false);
+#endif
+#if SYCL_CTS_ENABLE_HALF_TESTS
             accSignResult[12] = check_type_sign<sycl::half>(true);
+#endif
             accSignResult[13] = check_type_sign<float>(true);
             accSignResult[14] = check_type_sign<double>(true);
 
@@ -125,8 +131,12 @@ class TEST_NAME : public util::test_base {
             accSizeResult[9] = check_type_min_size<unsigned long long int>(8);
             accSizeResult[10] = check_type_min_size<long long int>(8);
             accSizeResult[11] = check_type_min_size<size_t>(host_size_t_size);
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS // sycl::byte is deprecated
             accSizeResult[12] = check_type_min_size<sycl::byte>(1);
+#endif
+#if SYCL_CTS_ENABLE_HALF_TESTS
             accSizeResult[13] = check_type_min_size<sycl::half>(2);
+#endif
             accSizeResult[14] = check_type_min_size<float>(4);
             accSizeResult[15] = check_type_min_size<double>(8);
 
@@ -168,12 +178,16 @@ class TEST_NAME : public util::test_base {
       if (!signResults[10]) {
         FAIL(log, errorStr + "sign: size_t");
       }
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS // sycl::byte is deprecated
       if (!signResults[11]) {
         FAIL(log, errorStr + "sign: sycl::byte");
       }
+#endif
+#if SYCL_CTS_ENABLE_HALF_TESTS
       if (!signResults[12]) {
         FAIL(log, errorStr + "sign: sycl::half");
       }
+#endif
       if (!signResults[13]) {
         FAIL(log, errorStr + "sign: float");
       }
@@ -218,12 +232,16 @@ class TEST_NAME : public util::test_base {
       if (!sizeResults[11]) {
         FAIL(log, errorStr + "size: size_t");
       }
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS // sycl::byte is deprecated
       if (!sizeResults[12]) {
         FAIL(log, errorStr + "size: sycl::byte");
       }
+#endif
+#if SYCL_CTS_ENABLE_HALF_TESTS
       if (!sizeResults[13]) {
         FAIL(log, errorStr + "size: sycl::half");
       }
+#endif
       if (!sizeResults[14]) {
         FAIL(log, errorStr + "size: float");
       }

--- a/tests/scalars/scalars_sycl_types.cpp
+++ b/tests/scalars/scalars_sycl_types.cpp
@@ -39,8 +39,8 @@ class TEST_NAME : public util::test_base {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
-  std::string errorStr = std::string(
-      "The following device type does not have the correct ");
+  std::string errorStr =
+      std::string("The following device type does not have the correct ");
 
   /** execute the test
    */
@@ -73,8 +73,7 @@ class TEST_NAME : public util::test_base {
 
       // SYCL Floating Point Data Types
 #if SYCL_CTS_ENABLE_HALF_TESTS
-      check_type_min_size_sign_log<sycl::half>(log, 2, true,
-                                                   "sycl::half");
+      check_type_min_size_sign_log<sycl::half>(log, 2, true, "sycl::half");
 #endif
       check_type_min_size_sign_log<float>(log, 4, true, "float");
       check_type_min_size_sign_log<double>(log, 8, true, "double");
@@ -84,10 +83,10 @@ class TEST_NAME : public util::test_base {
       std::array<bool, 15> signResults;
       std::array<bool, 16> sizeResults;
       {
-        sycl::buffer<bool, 1> bufSignResult(
-            signResults.data(), sycl::range<1>(signResults.size()));
-        sycl::buffer<bool, 1> bufSizeResult(
-            sizeResults.data(), sycl::range<1>(sizeResults.size()));
+        sycl::buffer<bool, 1> bufSignResult(signResults.data(),
+                                            sycl::range<1>(signResults.size()));
+        sycl::buffer<bool, 1> bufSizeResult(sizeResults.data(),
+                                            sycl::range<1>(sizeResults.size()));
 
         myQueue.submit([&](sycl::handler &cgh) {
           auto accSignResult =
@@ -109,7 +108,7 @@ class TEST_NAME : public util::test_base {
             accSignResult[8] = check_type_sign<unsigned long long int>(false);
             accSignResult[9] = check_type_sign<long long int>(true);
             accSignResult[10] = check_type_sign<size_t>(false);
-#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS // sycl::byte is deprecated
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS  // sycl::byte is deprecated
             accSignResult[11] = check_type_sign<sycl::byte>(false);
 #endif
 #if SYCL_CTS_ENABLE_HALF_TESTS
@@ -131,7 +130,7 @@ class TEST_NAME : public util::test_base {
             accSizeResult[9] = check_type_min_size<unsigned long long int>(8);
             accSizeResult[10] = check_type_min_size<long long int>(8);
             accSizeResult[11] = check_type_min_size<size_t>(host_size_t_size);
-#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS // sycl::byte is deprecated
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS  // sycl::byte is deprecated
             accSizeResult[12] = check_type_min_size<sycl::byte>(1);
 #endif
 #if SYCL_CTS_ENABLE_HALF_TESTS
@@ -139,7 +138,6 @@ class TEST_NAME : public util::test_base {
 #endif
             accSizeResult[14] = check_type_min_size<float>(4);
             accSizeResult[15] = check_type_min_size<double>(8);
-
           });
         });
       }
@@ -178,7 +176,7 @@ class TEST_NAME : public util::test_base {
       if (!signResults[10]) {
         FAIL(log, errorStr + "sign: size_t");
       }
-#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS // sycl::byte is deprecated
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS  // sycl::byte is deprecated
       if (!signResults[11]) {
         FAIL(log, errorStr + "sign: sycl::byte");
       }
@@ -232,7 +230,7 @@ class TEST_NAME : public util::test_base {
       if (!sizeResults[11]) {
         FAIL(log, errorStr + "size: size_t");
       }
-#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS // sycl::byte is deprecated
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS  // sycl::byte is deprecated
       if (!sizeResults[12]) {
         FAIL(log, errorStr + "size: sycl::byte");
       }


### PR DESCRIPTION
The tests in `tests/scalars` did not take the CMake variables `SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS`, `SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS`, and `SYCL_CTS_ENABLE_HALF_TESTS` into account. Now
- the tests for the `sycl::cl_` types are only compiled if `SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS` is defined,
- the tests using `sycl::byte` are only compiled if `SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS` is defined (since `sycl::byte` is deprecated according to [section 4.14.1 of the SYCL 2020 spec](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_scalar_data_types)), and
- the tests using `sycl::half` are only compiled if `SYCL_CTS_ENABLE_HALF_TESTS` is defined.