### PR TITLE
Add test plan for stream class

### DIFF
--- a/test_plans/stream_class.asciidoc
+++ b/test_plans/stream_class.asciidoc
@@ -1,0 +1,33 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for stream class interface
+
+This is a test plan for the interface of the stream class as described in Section 4.16.1 of the SYCL 2020 specification. The existing tests are updated from SYCL 1.2.1 to SYCL 2020. The estimated development time is half a day.
+
+== Testing scope
+No negative test are included. Specifically, the statement
+
+[source]
+----
+Regardless of this implementation defined behavior of output exceeding the limits, no undefined or erroneous behavior is permitted of an implementation when the limits are exceeded.
+----
+is not included in the test plan.
+
+=== Backend coverage
+
+All the tests described below are not backend-specific and are performed for any SYCL backend.
+
+=== Device coverage
+
+All tests construct a test device for which conformance is assessed. All the tests described below are performed once for that test device.
+
+== Tests
+=== Constructor
+- The existing constructor test is extended to also check construction when an empty property list is passed. Note: no properties are defined for `sycl::stream`.
+
+=== Member function
+- Duplicate `get_size()` test, and rename function to `size()`. Check for `noexcept`.
+- Mark `get_size()` test as deprecated.
+- Duplicate `get_max_statement_size()` test, and rename function to `get_work_item_buffer_size()`.
+- Mark `get_max_statement_size()` test as deprecated.

--- a/test_plans/stream_class.asciidoc
+++ b/test_plans/stream_class.asciidoc
@@ -23,6 +23,22 @@ All the tests described below are not backend-specific and are performed for any
 All tests construct a test device for which conformance is assessed. All the tests described below are performed once for that test device.
 
 == Tests
+=== Types
+The existing test for the stream class tests the stream operator using a multitude of types. The following types are not supported in SYCL 2020 and are removed from the test:
+
+- `cl_char`
+- `cl_uchar`
+- `cl_int`
+- `cl_uint`
+- `cl_short`
+- `cl_ushort`
+- `cl_long`
+- `cl_ulong`
+- `sycl::byte`
+- `cl_float`
+- `cl_double`
+- `cl_half`
+
 === Constructor
 - The existing constructor test is extended to also check construction when an empty property list is passed. Note: no properties are defined for `sycl::stream`.
 


### PR DESCRIPTION
Adds a test plan for the stream class as described in Section 4.16.1. of the SYCL 2020 specification.