### PR TITLE
[CI] Update code review assignment rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owner(s)
-* @ProGTX @bader @illuhad @keryell
+* @KhronosGroup/sycl-cts-reviewers
 
 # Implementation specific cmake configuration file needs approval from
 # the corresponding owner only.
@@ -8,3 +8,5 @@
 /cmake/FindhipSYCL.cmake @illuhad
 # TODO: remove FindIntel_SYCL configuration file
 /cmake/FindIntel_SYCL.cmake @bader
+
+/test_plans @gmlueck @KhronosGroup/sycl-cts-reviewers


### PR DESCRIPTION
Replace individual accounts with dedicated team. This adds Tom to reviewers.

Add Greg to test plan reviewers.