### PR TITLE
Add tests for ranged accessors requirement for the entire buffer

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -124,6 +124,9 @@ inline std::string get_section_name(const std::string& type_name,
       .create();
 }
 
+// FIXME: re-enable when marrray is implemented in hipsycl and type_coverage is
+// enabled
+#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Factory function for getting type_pack with fp16 type
  */
@@ -232,6 +235,7 @@ inline auto add_vectors_to_type_pack(StrNameType type_name) {
                                   "vec<" + type_name + ", 8>",
                                   "vec<" + type_name + ", 16>");
 }
+#endif  // SYCL_CTS_COMPILING_WITH_HIPSYCL
 
 template <accessor_type AccType>
 struct tag_factory {
@@ -323,9 +327,11 @@ void check_def_constructor_post_conditions(TestingAccT testing_acc,
   res_acc[res_i++] = testing_acc.rbegin() == testing_acc.rend();
   res_acc[res_i++] = testing_acc.crbegin() == testing_acc.crend();
 }
-// FIXME: re-enable when handler.host_task and sycl::errc is implemented in hipsycl
+// FIXME: re-enable when handler.host_task and sycl::errc is implemented in
+// hipsycl and computcpp
 // FIXME: re-enable when target::host_task is implemented in dpcpp
-#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
+#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL && \
+    !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Common function that constructs accessor with default constructor
  *and checks post-conditions
@@ -372,7 +378,8 @@ void check_def_constructor(GetAccFunctorT get_accessor_functor) {
     CHECK(conditions_check[i]);
   }
 }
-#endif // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
+#endif  // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 namespace detail {
 /**
  * @brief Wraps callable to make possible chaining foo(boo(arg)) calls by fold
@@ -419,9 +426,11 @@ void read_write_zero_dim_acc(AccT testing_acc, ResultAccT res_acc) {
     value_operations::assign(acc_ref, changed_val);
   }
 }
-// FIXME: re-enable when handler.host_task and sycl::errc is implemented in hipsycl
+// FIXME: re-enable when handler.host_task and sycl::errc is implemented in
+// hipsycl and computecpp
 // FIXME: re-enable when target::host_task is implemented in dpcpp
-#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
+#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL && \
+    !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Function helps to check zero dimension constructor of accessor
  *
@@ -499,7 +508,8 @@ void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor,
     }
   }
 }
-#endif // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
+#endif  // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Function that tries to read or/and write depending on AccessMode
  * parameter. Results of compare will be stored in res_acc
@@ -525,9 +535,11 @@ void read_write_acc(AccT testing_acc, ResultAccT res_acc) {
     value_operations::assign(testing_acc[id], changed_val);
   }
 }
-// FIXME: re-enable when handler.host_task and sycl::errc is implemented in hipsycl
+// FIXME: re-enable when handler.host_task and sycl::errc is implemented in
+// hipsycl and computecpp
 // FIXME: re-enable when target::host_task is implemented in dpcpp
-#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
+#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL && \
+    !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Function helps to check common constructor of accessor
  *
@@ -658,7 +670,8 @@ void check_placeholder_accessor_exception(const sycl::range<Dimension>& r,
         sycl_cts::util::equals_exception(sycl::errc::kernel_argument));
   }
 }
-#endif // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
+#endif  // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Function mainly for testing no_init property. The function tries to
  * write to the accessor and only after that tries to read from the accessor.
@@ -681,8 +694,8 @@ void write_read_acc(AccT testing_acc, ResultAccT res_acc) {
   }
 }
 // FIXME: re-enable when handler.host_task and sycl::errc is implemented
-#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL
-// FIXME: re-enable when target::host_task and sycl::errc is implemented
+#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+// FIXME: re-enable when target::host_task is implemented
 #ifndef SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to check accessor constructor with no_init property
@@ -762,7 +775,8 @@ void check_no_init_prop_exception(GetAccFunctorT construct_acc,
     }
   }
 }
-#endif // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Function tests AccT::get_pointer() method
 
@@ -906,6 +920,9 @@ void check_get_property_member_func(GetAccFunctorT construct_acc,
   }
 }
 
+// FIXME: re-enable when handler.host_task and sycl::errc is implemented in
+// hipsycl and computecpp
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Function invokes \c get_property() member function without \c PropT
  * property and verifies that false returns
@@ -939,7 +956,8 @@ void check_get_property_member_without_no_init(GetAccFunctorT construct_acc,
                          sycl_cts::util::equals_exception(sycl::errc::invalid));
   }
 }
-
+#endif  // SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Function checks common buffer and local accessor member types
  */

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -12,8 +12,13 @@
 #include "../../util/sycl_exceptions.h"
 #include "../common/common.h"
 #include "../common/section_name_builder.h"
-#include "../common/type_coverage.h"
 #include "../common/value_operations.h"
+
+// FIXME: re-enable when marrray is implemented in hipsycl
+#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL
+#include "../common/type_coverage.h"
+#endif
+
 
 #include <catch2/matchers/catch_matchers.hpp>
 
@@ -201,6 +206,7 @@ inline auto get_all_dimensions() {
   static const auto dimensions = integer_pack<0, 1, 2, 3>::generate_unnamed();
   return dimensions;
 }
+// FIXME: re-enable when target::host_task is implemented
 #if !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Factory function for getting type_pack with target values
@@ -211,7 +217,7 @@ inline auto get_targets() {
                  sycl::target::host_task>::generate_named();
   return targets;
 }
-#endif
+#endif // !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to generate type_pack with sycl::vec of all supported
  * sizes
@@ -232,6 +238,7 @@ struct tag_factory {
   static_assert(AccType != AccType,
                 "There is no tag support for such accessor type");
 };
+// FIXME: re-enable when target::host_task is implemented
 #if !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to get TagT corresponding to AccessMode and Target
@@ -268,7 +275,7 @@ struct tag_factory<accessor_type::generic_accessor> {
     }
   }
 };
-#endif
+#endif // !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to get TagT corresponding to AccessMode parameter
  */
@@ -316,7 +323,9 @@ void check_def_constructor_post_conditions(TestingAccT testing_acc,
   res_acc[res_i++] = testing_acc.rbegin() == testing_acc.rend();
   res_acc[res_i++] = testing_acc.crbegin() == testing_acc.crend();
 }
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
+// FIXME: re-enable when handler.host_task and sycl::errc is implemented in hipsycl
+// FIXME: re-enable when target::host_task is implemented in dpcpp
+#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Common function that constructs accessor with default constructor
  *and checks post-conditions
@@ -363,7 +372,7 @@ void check_def_constructor(GetAccFunctorT get_accessor_functor) {
     CHECK(conditions_check[i]);
   }
 }
-#endif
+#endif // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
 namespace detail {
 /**
  * @brief Wraps callable to make possible chaining foo(boo(arg)) calls by fold
@@ -410,7 +419,9 @@ void read_write_zero_dim_acc(AccT testing_acc, ResultAccT res_acc) {
     value_operations::assign(acc_ref, changed_val);
   }
 }
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
+// FIXME: re-enable when handler.host_task and sycl::errc is implemented in hipsycl
+// FIXME: re-enable when target::host_task is implemented in dpcpp
+#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Function helps to check zero dimension constructor of accessor
  *
@@ -488,7 +499,7 @@ void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor,
     }
   }
 }
-#endif
+#endif // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Function that tries to read or/and write depending on AccessMode
  * parameter. Results of compare will be stored in res_acc
@@ -514,7 +525,9 @@ void read_write_acc(AccT testing_acc, ResultAccT res_acc) {
     value_operations::assign(testing_acc[id], changed_val);
   }
 }
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
+// FIXME: re-enable when handler.host_task and sycl::errc is implemented in hipsycl
+// FIXME: re-enable when target::host_task is implemented in dpcpp
+#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Function helps to check common constructor of accessor
  *
@@ -645,7 +658,7 @@ void check_placeholder_accessor_exception(const sycl::range<Dimension>& r,
         sycl_cts::util::equals_exception(sycl::errc::kernel_argument));
   }
 }
-#endif
+#endif // !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Function mainly for testing no_init property. The function tries to
  * write to the accessor and only after that tries to read from the accessor.
@@ -667,7 +680,10 @@ void write_read_acc(AccT testing_acc, ResultAccT res_acc) {
     res_acc[0] = value_operations::are_equal(testing_acc[id], expected_data);
   }
 }
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
+// FIXME: re-enable when handler.host_task and sycl::errc is implemented
+#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL
+// FIXME: re-enable when target::host_task and sycl::errc is implemented
+#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to check accessor constructor with no_init property
  *
@@ -717,7 +733,7 @@ void check_no_init_prop(GetAccFunctorT get_accessor_functor,
     CHECK(compare_res);
   }
 }
-#endif
+#endif // !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to verify that constructor of accessor with no_init
  * property and access_mode::read triggers an exception
@@ -746,7 +762,7 @@ void check_no_init_prop_exception(GetAccFunctorT construct_acc,
     }
   }
 }
-
+#endif // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Function tests AccT::get_pointer() method
 

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -19,7 +19,6 @@
 #include "../common/type_coverage.h"
 #endif
 
-
 #include <catch2/matchers/catch_matchers.hpp>
 
 namespace accessor_tests_common {
@@ -220,7 +219,7 @@ inline auto get_targets() {
                  sycl::target::host_task>::generate_named();
   return targets;
 }
-#endif // !SYCL_CTS_COMPILING_WITH_DPCPP
+#endif  // !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to generate type_pack with sycl::vec of all supported
  * sizes
@@ -279,7 +278,7 @@ struct tag_factory<accessor_type::generic_accessor> {
     }
   }
 };
-#endif // !SYCL_CTS_COMPILING_WITH_DPCPP
+#endif  // !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to get TagT corresponding to AccessMode parameter
  */
@@ -390,7 +389,7 @@ class invoke_helper {
   const InvocableT& m_action;
 
  public:
-  invoke_helper(const InvocableT& action) : m_action(action){}
+  invoke_helper(const InvocableT& action) : m_action(action) {}
 
   template <typename... ArgsT>
   decltype(auto) operator=(ArgsT&&... args) {
@@ -694,7 +693,7 @@ void write_read_acc(AccT testing_acc, ResultAccT res_acc) {
   }
 }
 // FIXME: re-enable when handler.host_task and sycl::errc is implemented
-#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 // FIXME: re-enable when target::host_task is implemented
 #ifndef SYCL_CTS_COMPILING_WITH_DPCPP
 /**
@@ -746,7 +745,7 @@ void check_no_init_prop(GetAccFunctorT get_accessor_functor,
     CHECK(compare_res);
   }
 }
-#endif // !SYCL_CTS_COMPILING_WITH_DPCPP
+#endif  // !SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  * @brief Function helps to verify that constructor of accessor with no_init
  * property and access_mode::read triggers an exception

--- a/tests/accessor/accessor_requisite_entire_buffer.cpp
+++ b/tests/accessor/accessor_requisite_entire_buffer.cpp
@@ -1,0 +1,67 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provide checks that ranged accessor still creates a requisite for the entire
+//  underlying buffer
+//
+*******************************************************************************/
+
+#include "../common/disabled_for_test_case.h"
+#include "../common/get_cts_object.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "accessor_common.h"
+
+namespace accessor_requisite_entire_buffer {
+
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+("requisite for the entire underlying buffer for sycl::accessor ",
+ "[accessor]")({
+  auto q = sycl_cts::util::get_cts_object::queue();
+
+  constexpr size_t buffer_size = 10;
+  constexpr size_t offset_size = 7;
+  int data[buffer_size];
+  std::iota(data, (data + buffer_size), 0);
+  {
+    sycl::buffer<int, 1> data_buf(data, sycl::range(buffer_size));
+    // create two commands that uses ranaged accessors that access to
+    // non-overlapping regions of the same buffer since ranged accessor still
+    // creates a requisite for the entire underlying buffer second sommand
+    // should execute only after first finishes to check it both commands assign
+    // some data to usm check_data and it is expected that second command will
+    // do it only after first command even though first command will do it after
+    // delay via loop
+    int* check_data = sycl::malloc_shared<int>(1, q);
+
+    q.submit([&](sycl::handler& cgh) {
+      sycl::accessor<int, 1, sycl::access_mode::read_write,
+                     sycl::target::device>
+          acc(data_buf, cgh, sycl::range<1>(offset_size));
+
+      cgh.single_task([=] {
+        // to delay assigning expected_val to check_data use a loop that will
+        // take some time
+        for (int i = 0; i < 1000000; i++) {
+          int s = sycl::sqrt(float(i));
+          acc[s % offset_size] = accessor_tests_common::expected_val;
+        }
+        *check_data = accessor_tests_common::expected_val;
+      });
+    });
+
+    q.submit([&](sycl::handler& cgh) {
+      sycl::accessor<int, 1, sycl::access_mode::read, sycl::target::device> acc(
+          data_buf, cgh, sycl::range<1>(1), sycl::id<1>(offset_size));
+      cgh.single_task([=] {
+        *check_data = accessor_tests_common::changed_val;
+        auto v = acc[offset_size];
+      });
+    });
+    q.wait_and_throw();
+    CHECK(*check_data == accessor_tests_common::changed_val);
+  }
+});
+
+}  // namespace accessor_requisite_entire_buffer

--- a/tests/accessor/accessor_requisite_entire_buffer.cpp
+++ b/tests/accessor/accessor_requisite_entire_buffer.cpp
@@ -11,7 +11,10 @@
 #include "../common/get_cts_object.h"
 #include "catch2/catch_test_macros.hpp"
 
+// FIXME: re-enable when sycl::accessor is implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
+#endif
 
 namespace accessor_requisite_entire_buffer {
 

--- a/tests/accessor/accessor_requisite_entire_buffer.cpp
+++ b/tests/accessor/accessor_requisite_entire_buffer.cpp
@@ -11,16 +11,12 @@
 #include "../common/get_cts_object.h"
 #include "catch2/catch_test_macros.hpp"
 
-// FIXME: re-enable when sycl::accessor is implemented
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
-#endif
 
 namespace accessor_requisite_entire_buffer {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("requisite for the entire underlying buffer for sycl::accessor ",
- "[accessor]")({
+TEST_CASE("requisite for the entire underlying buffer for sycl::accessor ",
+ "[accessor]") {
   auto q = sycl_cts::util::get_cts_object::queue();
 
   constexpr size_t buffer_size = 10;
@@ -65,6 +61,6 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
     q.wait_and_throw();
     CHECK(*check_data == accessor_tests_common::changed_val);
   }
-});
+}
 
 }  // namespace accessor_requisite_entire_buffer

--- a/tests/accessor/accessor_requisite_entire_buffer.cpp
+++ b/tests/accessor/accessor_requisite_entire_buffer.cpp
@@ -14,9 +14,11 @@
 #include "accessor_common.h"
 
 namespace accessor_requisite_entire_buffer {
-
-TEST_CASE("requisite for the entire underlying buffer for sycl::accessor ",
- "[accessor]") {
+// FIXME: re-enable when possibility of a SYCL kernel with an unnamed type is
+// implemented in computecpp
+DISABLED_FOR_TEST_CASE(ComputeCpp)
+("requisite for the entire underlying buffer for sycl::accessor ",
+ "[accessor]")({
   auto q = sycl_cts::util::get_cts_object::queue();
 
   constexpr size_t buffer_size = 10;
@@ -61,6 +63,6 @@ TEST_CASE("requisite for the entire underlying buffer for sycl::accessor ",
     q.wait_and_throw();
     CHECK(*check_data == accessor_tests_common::changed_val);
   }
-}
+});
 
 }  // namespace accessor_requisite_entire_buffer

--- a/util/sycl_enums.h
+++ b/util/sycl_enums.h
@@ -13,7 +13,7 @@
 #include <sycl/sycl.hpp>
 
 // TODO: Remove when all implementations support the sycl::errc enum
-#if SYCL_CTS_COMPILING_WITH_HIPSYCL || SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#if SYCL_CTS_COMPILING_WITH_HIPSYCL
 #define SYCL_CTS_SUPPORT_HAS_ERRC_ENUM 0
 #else
 #define SYCL_CTS_SUPPORT_HAS_ERRC_ENUM 1

--- a/util/sycl_enums.h
+++ b/util/sycl_enums.h
@@ -13,7 +13,7 @@
 #include <sycl/sycl.hpp>
 
 // TODO: Remove when all implementations support the sycl::errc enum
-#if SYCL_CTS_COMPILING_WITH_HIPSYCL
+#if SYCL_CTS_COMPILING_WITH_HIPSYCL || SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #define SYCL_CTS_SUPPORT_HAS_ERRC_ENUM 0
 #else
 #define SYCL_CTS_SUPPORT_HAS_ERRC_ENUM 1


### PR DESCRIPTION
According to [4.7.6.8. Ranged accessors](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:accessors.ranged)
> A ranged accessor still creates a requisite for the entire underlying buffer, even for the portions not within the range. For example, if one command writes through a ranged accessor to one region of a buffer and a second command reads through a ranged accessor from a non-overlapping region of the same buffer, the second command must still be scheduled after the first because the requisites for the two commands are on the entire buffer, not on the sub-ranges of the ranged accessors.

This test check this requirement.