### PR TITLE
Buffers 2020 update

### DIFF
--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -290,7 +290,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
            "sycl::buffer::get_count() does not return "
            "the correct number of elements");
     }
-#endif
+#endif  // SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
 
     /* check the buffer returns the correct byte size */
     auto ret_size = buf.byte_size();

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -27,6 +27,9 @@
 namespace buffer_api_common {
 using namespace sycl_cts;
 
+template <int dims, typename alloc>
+struct write_id{};
+
 /** empty_kernel.
  * Empty kernel, required since command groups
  * are required to have a kernel.

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -278,7 +278,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
 
     /* check the buffer returns the correct element count
        with deprecated get_count */
-    // TODO: mark this check as testing deprecated functionality
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     auto count_depr = buf.get_count();
     check_return_type<size_t>(log, count_depr, "sycl::buffer::get_count()");
 
@@ -287,6 +287,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
            "sycl::buffer::get_count() does not return "
            "the correct number of elements");
     }
+#endif
 
     /* check the buffer returns the correct byte size */
     auto ret_size = buf.byte_size();
@@ -300,7 +301,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
 
     /* check the buffer returns the correct byte size
      with deprecated get_size*/
-    // TODO: mark this check as testing deprecated functionality
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     auto ret_size_depr = buf.get_size();
     check_return_type<size_t>(log, ret_size_depr, "sycl::buffer::get_size()");
 
@@ -309,6 +310,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
            "sycl::buffer::get_size() does not return "
            "the correct size of the buffer");
     }
+#endif
 
     auto q = util::get_cts_object::queue();
 
@@ -338,6 +340,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     });
 
     /* check the buffer returns the correct type of accessor */
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     {
       auto acc = buf.template get_access<sycl::access_mode::read_write>();
       check_return_type<
@@ -345,6 +348,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
                              sycl::target::host_buffer>>(
           log, acc, "sycl::buffer::get_access<read_write, host_buffer>()");
     }
+#endif
 
     /* check the buffer returns the correct type of accessor */
     q.submit([&](sycl::handler& cgh) {
@@ -360,6 +364,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     });
 
     /* check the buffer returns the correct type of accessor */
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     {
       auto acc = buf.template get_access<sycl::access_mode::read_write>(
           r, offset);
@@ -370,6 +375,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
           "sycl::buffer::get_access<read_write, host_buffer>(range<>, "
           "id<>)");
     }
+#endif
 
     /* check get_allocator() */
     {

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -28,7 +28,7 @@ namespace buffer_api_common {
 using namespace sycl_cts;
 
 template <int dims, typename alloc>
-struct write_id{};
+struct write_id {};
 
 /** empty_kernel.
  * Empty kernel, required since command groups

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -525,7 +525,7 @@ public:
 class check_buffer_linearization {
  public:
   void operator()(util::logger &log) {
-    const int size = 8;
+    constexpr int size = 8;
     // clang-format off
     sycl::nd_range<1> range1d(sycl::range<1>{size},
                               sycl::range<1>{size});

--- a/tests/buffer/buffer_api_core.cpp
+++ b/tests/buffer/buffer_api_core.cpp
@@ -30,6 +30,8 @@ public:
   /** execute the test
    */
   void run(util::logger &log) override {
+    buffer_api_common::check_buffer_linearization{}(log);
+
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types_and_vectors<buffer_api_common::check_buffer_api_for_type>(
         get_buffer_types::vector_types, log);

--- a/tests/buffer/buffer_api_core.cpp
+++ b/tests/buffer/buffer_api_core.cpp
@@ -32,7 +32,7 @@ public:
   void run(util::logger &log) override {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_all_types_and_vectors<buffer_api_common::check_buffer_api_for_type>(
-        get_cts_types::vector_types, log);
+        get_buffer_types::vector_types, log);
 #ifdef INT8_MAX
     for_type_and_vectors<buffer_api_common::check_buffer_api_for_type,
                          std::int8_t>(log, "std::int8_t");

--- a/tests/buffer/buffer_constructors_common.h
+++ b/tests/buffer/buffer_constructors_common.h
@@ -27,6 +27,33 @@
 namespace buffer_constructors_common {
 using namespace sycl_cts;
 
+inline std::stringstream alloc_log;
+
+template <typename T>
+class logging_alloc {
+ public:
+  typedef T value_type;
+  typedef T *pointer;
+  typedef size_t size_type;
+
+  T *allocate(size_t n) {
+    alloc_log << "Allocating " << n << " bytes of storage.\n";
+    T *mem = static_cast<T *>(malloc(sizeof(T) * n));
+    if (mem != nullptr)
+      return mem;
+    else {
+      alloc_log << "Failed!\n";
+      throw std::bad_alloc();
+    }
+  }
+
+  void deallocate(T *p, size_t n) {
+    alloc_log << "Deallocating " << n << " bytes of storage at " << p << "\n";
+    free(p);
+    return;
+  }
+};
+
 template <typename T, int size, int dims>
 class BufferInteropNoEvent;
 
@@ -106,6 +133,33 @@ class buffer_ctors {
           !check_buffer_constructor(buf1, r, data_verify)) {
         FAIL(log, "(const data pointer, range) constructor fail.");
       }
+    }
+
+    /* check (Container)*/
+    if (dims == 1) {
+      std::vector<T> cont(size);
+      sycl::buffer<T, dims> buf(cont, propList);
+      sycl::buffer<T, dims> buf1(cont);
+      constexpr bool data_verify = true;
+      if (!check_buffer_constructor(buf, r, data_verify) ||
+          !check_buffer_constructor(buf1, r, data_verify)) {
+        FAIL(log, "(Container) constructor fail.");
+      }
+    }
+
+    /* check (Container, allocator)*/
+    if (dims == 1) {
+      std::vector<T> cont(size);
+      buffer_constructors_common::logging_alloc<T> logging_alloc;
+      sycl::buffer<T, dims> buf(cont, logging_alloc, propList);
+      sycl::buffer<T, dims> buf1(cont, logging_alloc);
+      constexpr bool data_verify = true;
+      if (!check_buffer_constructor(buf, r, data_verify) ||
+          !check_buffer_constructor(buf1, r, data_verify) ||
+          alloc_log.str().empty()) {
+        FAIL(log, "(Container, allocator) constructor fail.");
+      }
+      alloc_log.clear();
     }
 
     /* check (shared pointer, range) constructor*/

--- a/tests/buffer/buffer_constructors_common.h
+++ b/tests/buffer/buffer_constructors_common.h
@@ -41,9 +41,9 @@ inline std::stringstream alloc_log;
 template <typename T>
 class logging_alloc {
  public:
-  typedef T value_type;
-  typedef T *pointer;
-  typedef size_t size_type;
+  using value_type = T;
+  using pointer = T *;
+  using size_type = size_t;
 
   T *allocate(size_t n) {
     alloc_log << "Allocating " << n << " bytes of storage.\n";

--- a/tests/buffer/buffer_constructors_common.h
+++ b/tests/buffer/buffer_constructors_common.h
@@ -48,18 +48,16 @@ class logging_alloc {
   T *allocate(size_t n) {
     alloc_log << "Allocating " << n << " bytes of storage.\n";
     T *mem = static_cast<T *>(malloc(sizeof(T) * n));
-    if (mem != nullptr)
-      return mem;
-    else {
+    if (!mem) {
       alloc_log << "Failed!\n";
       throw std::bad_alloc();
     }
+    return mem;
   }
 
   void deallocate(T *p, size_t n) {
     alloc_log << "Deallocating " << n << " bytes of storage at " << p << "\n";
     free(p);
-    return;
   }
 };
 

--- a/tests/buffer/buffer_constructors_core.cpp
+++ b/tests/buffer/buffer_constructors_core.cpp
@@ -34,7 +34,7 @@ public:
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types_and_vectors<
           buffer_constructors_common::check_buffer_ctors_for_type>(
-          get_cts_types::vector_types, log);
+          get_buffer_types::vector_types, log);
 #ifdef INT8_MAX
       for_type_and_vectors<
           buffer_constructors_common::check_buffer_ctors_for_type, std::int8_t>(

--- a/tests/buffer/buffer_storage_core.cpp
+++ b/tests/buffer/buffer_storage_core.cpp
@@ -35,7 +35,7 @@ public:
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
       for_all_types_and_vectors<
           buffer_storage_common::check_buffer_storage_for_type>(
-          get_cts_types::vector_types, log);
+          get_buffer_types::vector_types, log);
 #ifdef INT8_MAX
       for_type_and_vectors<buffer_storage_common::check_buffer_storage_for_type,
                            std::int8_t>(log, "std::int8_t");


### PR DESCRIPTION
This PR implements the [Buffers 2020 plan](https://github.com/KhronosGroup/SYCL-CTS/pull/410)

There is a mild overlap with [Add tests for correct liniarization for accessors](https://github.com/KhronosGroup/SYCL-CTS/pull/427). That test checks whether the iterator interface linearizes as expected, while this test checks whether `get_global_id()` and `get_global_id(int)` align and move data into a buffer according to [3.11.1](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:multi-dim-linearization). (Both tests involve buffers _and_ accessors so I can understand why both teams went and implemented something similar. The approaches to the tests slightly differ.)

We found that the buffer tests lack robust check on their contents. `check_buffer_constructor` checks whether a 0-initialized host container when dispatched via a buffer, kernels reading it really see zeroes. Any runtime that conservatively zero-inits device storage but doesn't dispatch anything will still pass these tests. In this spirit, the buffer tests themselves don't test the ordering of data being stored ever. If data is reversed, tests would still pass. The new `Container` CTORs were implemented in a spirit that checks ordering as well.