### PR TITLE
Update vector alias tests to use SYCL 2020 aliases

### DIFF
--- a/tests/common/common_python_vec.py
+++ b/tests/common/common_python_vec.py
@@ -74,17 +74,14 @@ class Data:
     }
 
     alias_dict = {
-        'char': 'sycl::char',
-        'signed char': 'sycl::schar',
-        'unsigned char': 'sycl::uchar',
-        'short': 'sycl::short',
-        'unsigned short': 'sycl::ushort',
-        'int': 'sycl::int',
-        'unsigned int': 'sycl::uint',
-        'long': 'sycl::long',
-        'unsigned long': 'sycl::ulong',
-        'long long': 'sycl::longlong',
-        'unsigned long long': 'sycl::ulonglong',
+        'std::int8_t': 'sycl::char',
+        'std::uint8_t': 'sycl::uchar',
+        'std::int16_t': 'sycl::short',
+        'std::uint16_t': 'sycl::ushort',
+        'std::int32_t': 'sycl::int',
+        'std::uint32_t': 'sycl::uint',
+        'std::int64_t': 'sycl::long',
+        'std::uint64_t': 'sycl::ulong',
         'float': 'sycl::float',
         'double': 'sycl::double',
         'sycl::half': 'sycl::half'

--- a/tests/vector_alias/CMakeLists.txt
+++ b/tests/vector_alias/CMakeLists.txt
@@ -1,9 +1,23 @@
 set(TEST_CASES_LIST "")
 
-set(TYPE_LIST "")
-get_std_type(TYPE_LIST)
+set(VEC_TYPE_LIST "")
+list(APPEND VEC_TYPE_LIST
+  "std::int8_t"
+  "std::uint8_t"
+  "std::int16_t"
+  "std::uint16_t"
+  "std::int32_t"
+  "std::uint32_t"
+  "std::int64_t"
+  "std::uint64_t"
+  "float"
+  "double"
+  "sycl::half"
+)
 
-foreach(TY IN LISTS TYPE_LIST)
+half_double_filter(VEC_TYPE_LIST)
+
+foreach(TY IN LISTS VEC_TYPE_LIST)
   set(OUT_FILE "vector_alias_${TY}.cpp")
   STRING(REGEX REPLACE ":" "_" OUT_FILE ${OUT_FILE})
   STRING(REGEX REPLACE " " "_" OUT_FILE ${OUT_FILE})

--- a/tests/vector_alias/generate_vector_alias.py
+++ b/tests/vector_alias/generate_vector_alias.py
@@ -57,13 +57,10 @@ def make_tests(type_str, input_file, output_file):
 
 def get_types():
     types = list()
-    types.append('char')
-    for base_type in Data.standard_types:
+    for base_type in Data.fixed_width_types:
         for sign in Data.signs:
-            if (base_type == 'float' or base_type == 'double'
-                or base_type == 'sycl::half') and sign is False:
-                continue
-            types.append(Data.standard_type_dict[(sign, base_type)])
+            types.append(Data.fixed_width_type_dict[(sign, base_type)])
+    types += ["float", "double", "sycl::half"]
     return types
 
 def main():


### PR DESCRIPTION
This PR updates the vector alias tests to use the aliases listed in Section 4.14.2.2 of the SYCL 2020 specification. 

Further, `half` and `double` tests are removed from the list of types to test with if the respective CMake variables are set (this is done using the already implemented `half_double_filter` CMake macro).