### PR TITLE
Add tests for queue shortcut functions

### DIFF
--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -58,6 +58,18 @@ struct no_cnstr {
   friend bool operator!=(const no_cnstr &lhs, const no_cnstr &rhs) {
     return !(lhs == rhs);
   }
+
+  no_cnstr &operator++() {
+    ++a;
+    ++b;
+    ++c;
+    return *this;
+  }
+
+  friend no_cnstr operator+(const no_cnstr &lhs, int i) {
+    return {lhs.a + static_cast<float>(i), lhs.b + i,
+            static_cast<char>(lhs.c + i)};
+  }
 };
 
 // A user-defined class with several scalar member variables, a user-defined

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -59,13 +59,6 @@ struct no_cnstr {
     return !(lhs == rhs);
   }
 
-  no_cnstr &operator++() {
-    ++a;
-    ++b;
-    ++c;
-    return *this;
-  }
-
   friend no_cnstr operator+(const no_cnstr &lhs, int i) {
     return {lhs.a + static_cast<float>(i), lhs.b + i,
             static_cast<char>(lhs.c + i)};

--- a/tests/queue/queue_shortcuts_common.h
+++ b/tests/queue/queue_shortcuts_common.h
@@ -26,7 +26,7 @@
 
 namespace queue_shortcuts_common {
 
-static auto get_types() {
+inline auto get_types() {
   static const auto types =
       named_type_pack<char, short, int, long long, std::size_t, bool, float,
                       user_def_types::no_cnstr>::generate("char", "short",
@@ -36,6 +36,15 @@ static auto get_types() {
                                                           "custom struct");
   static_assert(sycl::is_device_copyable_v<user_def_types::no_cnstr>);
   return types;
+}
+
+/** Performs std::iota with + 1 instead of ++ for compatibility with bool. */
+template <typename ForwardIt, typename T>
+constexpr void iota_comp(ForwardIt first, ForwardIt last, T value) {
+  while (first != last) {
+    *(first++) = value;
+    value = value + 1;
+  }
 }
 
 }  // namespace queue_shortcuts_common

--- a/tests/queue/queue_shortcuts_common.h
+++ b/tests/queue/queue_shortcuts_common.h
@@ -1,0 +1,43 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_COMMON_H
+#define SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_COMMON_H
+
+#include "../common/type_coverage.h"
+#include "../common/type_list.h"
+
+namespace queue_shortcuts_common {
+
+static auto get_types() {
+  static const auto types =
+      named_type_pack<char, short, int, long long, std::size_t, bool, float,
+                      user_def_types::no_cnstr>::generate("char", "short",
+                                                          "int", "long long",
+                                                          "std::size_t", "bool",
+                                                          "float",
+                                                          "custom struct");
+  static_assert(sycl::is_device_copyable_v<user_def_types::no_cnstr>);
+  return types;
+}
+
+}  // namespace queue_shortcuts_common
+
+#endif  // SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_COMMON_H

--- a/tests/queue/queue_shortcuts_explicit.h
+++ b/tests/queue/queue_shortcuts_explicit.h
@@ -25,8 +25,11 @@
 #include "../common/disabled_for_test_case.h"
 #include "../common/get_cts_object.h"
 #include "../common/value_operations.h"
+#include "queue_shortcuts_common.h"
 
 namespace queue_shortcuts_explict {
+
+using namespace queue_shortcuts_common;
 
 template <typename T>
 class simple_kernel0;
@@ -43,7 +46,7 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
   // copy (host raw pointer, accessor)
   {
     std::unique_ptr<T[]> src = std::make_unique<T[]>(element_count);
-    std::iota(src.get(), src.get() + element_count, t_test);
+    iota_comp(src.get(), src.get() + element_count, t_test);
 
     sycl::buffer<T, 1> buffer(range);
     sycl::accessor accessor(buffer, range, sycl::write_only);
@@ -52,13 +55,13 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
 
     sycl::host_accessor host_accessor(buffer, sycl::read_only);
     std::vector<T> expected(element_count);
-    std::iota(expected.begin(), expected.end(), t_test);
+    iota_comp(expected.begin(), expected.end(), t_test);
     CHECK(value_operations::are_equal(host_accessor, expected));
   }
   // copy (host shared pointer, accessor)
   {
     std::shared_ptr<T> src(new T[element_count]);
-    std::iota(src.get(), src.get() + element_count, t_test);
+    iota_comp(src.get(), src.get() + element_count, t_test);
 
     sycl::buffer<T, 1> buffer(range);
     sycl::accessor accessor(buffer, range, sycl::write_only);
@@ -67,7 +70,7 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
 
     sycl::host_accessor host_accessor(buffer, sycl::read_only);
     std::vector<T> expected(element_count);
-    std::iota(expected.begin(), expected.end(), t_test);
+    iota_comp(expected.begin(), expected.end(), t_test);
     CHECK(value_operations::are_equal(host_accessor, expected));
   }
   // ComputeCpp requested kernel name could not be found
@@ -91,7 +94,7 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
     sycl::buffer<T, 1> dest_buffer(dest.get(), range);
     sycl::host_accessor host_accessor(dest_buffer, sycl::read_only);
     std::vector<T> expected(element_count);
-    std::iota(expected.begin(), expected.end(), t_test);
+    iota_comp(expected.begin(), expected.end(), t_test);
     CHECK(value_operations::are_equal(host_accessor, expected));
   }
   // copy (accessor, host shared pointer)
@@ -113,7 +116,7 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
     sycl::buffer<T, 1> dest_buffer(dest, range);
     sycl::host_accessor host_accessor(dest_buffer, sycl::read_only);
     std::vector<T> expected(element_count);
-    std::iota(expected.begin(), expected.end(), t_test);
+    iota_comp(expected.begin(), expected.end(), t_test);
     CHECK(value_operations::are_equal(host_accessor, expected));
   }
   // copy (accessor, accessor)
@@ -134,9 +137,13 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
 
     sycl::host_accessor host_accessor(buffer_dest, sycl::read_only);
     std::vector<T> expected(element_count);
-    std::iota(expected.begin(), expected.end(), t_test);
+    iota_comp(expected.begin(), expected.end(), t_test);
     CHECK(value_operations::are_equal(host_accessor, expected));
   }
+#else
+  WARN(
+      "queue.copy() test does not compile for ComputeCPP"
+      "Skipping the test case.");
 #endif  // SYCL_CTS_COMPILING_WITH_COMPUTECPP
   // ComputeCpp gives an error next time the function is called
   // DPCPP no member named 'update_host' in 'sycl::queue'
@@ -150,6 +157,10 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
     sycl::event e = q.update_host(accessor);
     e.wait();
   }
+#else
+  WARN(
+      "queue.update_host() test does not compile for ComputeCPP and DPCPP"
+      "Skipping the test case.");
 #endif
   // ComputeCpp function not defined
 #ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
@@ -163,6 +174,10 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
     sycl::host_accessor host_accessor(buffer, sycl::read_only);
     CHECK(value_operations::are_equal(host_accessor, t_test));
   }
+#else
+  WARN(
+      "queue.fill() test does not compile for ComputeCPP"
+      "Skipping the test case.");
 #endif  // SYCL_CTS_COMPILING_WITH_COMPUTECPP
 }
 

--- a/tests/queue/queue_shortcuts_explicit.h
+++ b/tests/queue/queue_shortcuts_explicit.h
@@ -1,0 +1,183 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_EXPLICIT_H
+#define SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_EXPLICIT_H
+
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "../common/get_cts_object.h"
+#include "../common/value_operations.h"
+
+namespace queue_shortcuts_explict {
+
+template <typename T>
+class simple_kernel0;
+template <typename T>
+class simple_kernel1;
+template <typename T>
+class simple_kernel2;
+
+template <typename T>
+void test_explicit_copy(sycl::queue q, unsigned int element_count) {
+  const T t_test{1};  // to initialize the sequence: t_test, ++t_test, etc.
+  const sycl::range<1> range = sycl::range<1>(element_count);
+
+  // copy (host raw pointer, accessor)
+  {
+    std::unique_ptr<T[]> src = std::make_unique<T[]>(element_count);
+    std::iota(src.get(), src.get() + element_count, t_test);
+
+    sycl::buffer<T, 1> buffer(range);
+    sycl::accessor accessor(buffer, range, sycl::write_only);
+    sycl::event e = q.copy(src.get(), accessor);
+    e.wait();
+
+    sycl::host_accessor host_accessor(buffer, sycl::read_only);
+    std::vector<T> expected(element_count);
+    std::iota(expected.begin(), expected.end(), t_test);
+    CHECK(value_operations::are_equal(host_accessor, expected));
+  }
+  // copy (host shared pointer, accessor)
+  {
+    std::shared_ptr<T> src(new T[element_count]);
+    std::iota(src.get(), src.get() + element_count, t_test);
+
+    sycl::buffer<T, 1> buffer(range);
+    sycl::accessor accessor(buffer, range, sycl::write_only);
+    sycl::event e = q.copy(src, accessor);
+    e.wait();
+
+    sycl::host_accessor host_accessor(buffer, sycl::read_only);
+    std::vector<T> expected(element_count);
+    std::iota(expected.begin(), expected.end(), t_test);
+    CHECK(value_operations::are_equal(host_accessor, expected));
+  }
+  // ComputeCpp requested kernel name could not be found
+#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+  //  copy (accessor, host raw pointer)
+  {
+    sycl::buffer<T, 1> buffer(range);
+    q.submit([&](sycl::handler& cgh) {
+      sycl::accessor accessor(buffer, cgh, sycl::write_only);
+      cgh.parallel_for<simple_kernel0<T>>(element_count, [=](sycl::id<1> idx) {
+        accessor[idx] = t_test + static_cast<int>(idx[0]);
+      });
+    });
+    q.wait();
+    sycl::accessor accessor(buffer);
+
+    std::unique_ptr<T[]> dest = std::make_unique<T[]>(element_count);
+    sycl::event e = q.copy(accessor, dest.get());
+    e.wait();
+
+    sycl::buffer<T, 1> dest_buffer(dest.get(), range);
+    sycl::host_accessor host_accessor(dest_buffer, sycl::read_only);
+    std::vector<T> expected(element_count);
+    std::iota(expected.begin(), expected.end(), t_test);
+    CHECK(value_operations::are_equal(host_accessor, expected));
+  }
+  // copy (accessor, host shared pointer)
+  {
+    sycl::buffer<T, 1> buffer(range);
+    q.submit([&](sycl::handler& cgh) {
+      sycl::accessor accessor(buffer, cgh, sycl::write_only);
+      cgh.parallel_for<simple_kernel1<T>>(element_count, [=](sycl::id<1> idx) {
+        accessor[idx] = t_test + static_cast<int>(idx[0]);
+      });
+    });
+    q.wait();
+    sycl::accessor accessor(buffer);
+
+    std::shared_ptr<T> dest(new T[element_count]);
+    sycl::event e = q.copy(accessor, dest);
+    e.wait();
+
+    sycl::buffer<T, 1> dest_buffer(dest, range);
+    sycl::host_accessor host_accessor(dest_buffer, sycl::read_only);
+    std::vector<T> expected(element_count);
+    std::iota(expected.begin(), expected.end(), t_test);
+    CHECK(value_operations::are_equal(host_accessor, expected));
+  }
+  // copy (accessor, accessor)
+  {
+    sycl::buffer<T, 1> buffer_src(range);
+    q.submit([&](sycl::handler& cgh) {
+      sycl::accessor accessor{buffer_src, cgh, sycl::write_only};
+      cgh.parallel_for<simple_kernel2<T>>(element_count, [=](sycl::id<1> idx) {
+        accessor[idx] = t_test + static_cast<int>(idx[0]);
+      });
+    });
+    q.wait();
+
+    sycl::buffer<T> buffer_dest(range);
+    sycl::event e =
+        q.copy(sycl::accessor(buffer_src), sycl::accessor(buffer_dest));
+    e.wait();
+
+    sycl::host_accessor host_accessor(buffer_dest, sycl::read_only);
+    std::vector<T> expected(element_count);
+    std::iota(expected.begin(), expected.end(), t_test);
+    CHECK(value_operations::are_equal(host_accessor, expected));
+  }
+#endif  // SYCL_CTS_COMPILING_WITH_COMPUTECPP
+  // ComputeCpp gives an error next time the function is called
+  // DPCPP no member named 'update_host' in 'sycl::queue'
+#if !(defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP) || \
+      defined(SYCL_CTS_COMPILING_WITH_DPCPP))
+  //  update_host
+  {
+    std::unique_ptr<T[]> src = std::make_unique<T[]>(element_count);
+    sycl::buffer<T, 1> buffer(src.get(), range);
+    sycl::accessor accessor(buffer, range, sycl::write_only);
+    sycl::event e = q.update_host(accessor);
+    e.wait();
+  }
+#endif
+  // ComputeCpp function not defined
+#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+  //  fill
+  {
+    sycl::buffer<T, 1> buffer(range);
+    sycl::accessor accessor(buffer, range, sycl::write_only);
+    sycl::event e = q.fill(accessor, t_test);
+    e.wait();
+
+    sycl::host_accessor host_accessor(buffer, sycl::read_only);
+    CHECK(value_operations::are_equal(host_accessor, t_test));
+  }
+#endif  // SYCL_CTS_COMPILING_WITH_COMPUTECPP
+}
+
+template <typename T>
+class check_queue_shortcuts_explicit_for_type {
+  static constexpr unsigned int element_count = 10;
+
+ public:
+  void operator()(sycl::queue queue, const std::string& type_name) {
+    INFO("for type \"" << type_name << "\": ");
+
+    test_explicit_copy<T>(queue, element_count);
+  }
+};
+
+}  // namespace queue_shortcuts_explict
+
+#endif  // SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_EXPLICIT_H

--- a/tests/queue/queue_shortcuts_explicit_core.cpp
+++ b/tests/queue/queue_shortcuts_explicit_core.cpp
@@ -28,12 +28,12 @@ namespace queue_shortcuts_explicit_core {
 using namespace queue_shortcuts_common;
 using namespace queue_shortcuts_explict;
 
-// hipSYCL, DPCPP not tested
-DISABLED_FOR_TEST_CASE(hipSYCL, DPCPP)
+// DPCPP does not define the explicit copy operations
+DISABLED_FOR_TEST_CASE(DPCPP)
 ("queue shortcuts explicit copy core", "[queue]")({
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
   const auto types = get_types();
   for_all_types<check_queue_shortcuts_explicit_for_type>(types, queue);
-});
+})
 
 }  // namespace queue_shortcuts_explicit_core

--- a/tests/queue/queue_shortcuts_explicit_core.cpp
+++ b/tests/queue/queue_shortcuts_explicit_core.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_common.h"
+#include "queue_shortcuts_explicit.h"
+
+namespace queue_shortcuts_explicit_core {
+
+using namespace queue_shortcuts_common;
+using namespace queue_shortcuts_explict;
+
+// hipSYCL, DPCPP not tested
+DISABLED_FOR_TEST_CASE(hipSYCL, DPCPP)
+("queue shortcuts explicit copy core", "[queue]")({
+  sycl::queue queue = sycl_cts::util::get_cts_object::queue();
+  const auto types = get_types();
+  for_all_types<check_queue_shortcuts_explicit_for_type>(types, queue);
+});
+
+}  // namespace queue_shortcuts_explicit_core

--- a/tests/queue/queue_shortcuts_explicit_fp16.cpp
+++ b/tests/queue/queue_shortcuts_explicit_fp16.cpp
@@ -28,14 +28,16 @@ namespace queue_shortcuts_explicit_fp16 {
 using namespace sycl_cts;
 using namespace queue_shortcuts_explict;
 
-// hipSYCL, DPCPP not tested
-DISABLED_FOR_TEST_CASE(hipSYCL, DPCPP)
+// DPCPP does not define the explicit copy operations
+DISABLED_FOR_TEST_CASE(DPCPP)
 ("queue shortcuts explicit copy fp16", "[queue]")({
   auto queue = util::get_cts_object::queue();
   using avaliability =
       util::extensions::availability<util::extensions::tag::fp16>;
   if (!avaliability::check(queue)) {
-    WARN("Device does not support half precision floating point operations");
+    WARN(
+        "Device does not support half precision floating point operations"
+        "Skipping the test case.");
     return;
   }
 

--- a/tests/queue/queue_shortcuts_explicit_fp16.cpp
+++ b/tests/queue/queue_shortcuts_explicit_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_explicit.h"
+
+namespace queue_shortcuts_explicit_fp16 {
+
+using namespace sycl_cts;
+using namespace queue_shortcuts_explict;
+
+// hipSYCL, DPCPP not tested
+DISABLED_FOR_TEST_CASE(hipSYCL, DPCPP)
+("queue shortcuts explicit copy fp16", "[queue]")({
+  auto queue = util::get_cts_object::queue();
+  using avaliability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!avaliability::check(queue)) {
+    WARN("Device does not support half precision floating point operations");
+    return;
+  }
+
+  check_queue_shortcuts_explicit_for_type<sycl::half>{}(queue, "sycl::half");
+})
+
+}  // namespace queue_shortcuts_explicit_fp16

--- a/tests/queue/queue_shortcuts_explicit_fp64.cpp
+++ b/tests/queue/queue_shortcuts_explicit_fp64.cpp
@@ -28,14 +28,16 @@ namespace queue_shortcuts_explicit_fp64 {
 using namespace sycl_cts;
 using namespace queue_shortcuts_explict;
 
-// hipSYCL, DPCPP not tested
-DISABLED_FOR_TEST_CASE(hipSYCL, DPCPP)
+// DPCPP does not define the explicit copy operations
+DISABLED_FOR_TEST_CASE(DPCPP)
 ("queue shortcuts explicit copy fp64", "[queue]")({
   auto queue = util::get_cts_object::queue();
   using avaliability =
       util::extensions::availability<util::extensions::tag::fp64>;
   if (!avaliability::check(queue)) {
-    WARN("Device does not support double precision floating point operations");
+    WARN(
+        "Device does not support double precision floating point operations"
+        "Skipping the test case.");
     return;
   }
 

--- a/tests/queue/queue_shortcuts_explicit_fp64.cpp
+++ b/tests/queue/queue_shortcuts_explicit_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_explicit.h"
+
+namespace queue_shortcuts_explicit_fp64 {
+
+using namespace sycl_cts;
+using namespace queue_shortcuts_explict;
+
+// hipSYCL, DPCPP not tested
+DISABLED_FOR_TEST_CASE(hipSYCL, DPCPP)
+("queue shortcuts explicit copy fp64", "[queue]")({
+  auto queue = util::get_cts_object::queue();
+  using avaliability =
+      util::extensions::availability<util::extensions::tag::fp64>;
+  if (!avaliability::check(queue)) {
+    WARN("Device does not support double precision floating point operations");
+    return;
+  }
+
+  check_queue_shortcuts_explicit_for_type<double>{}(queue, "double");
+})
+
+}  // namespace queue_shortcuts_explicit_fp64

--- a/tests/queue/queue_shortcuts_kernel.h
+++ b/tests/queue/queue_shortcuts_kernel.h
@@ -1,0 +1,276 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_KERNEL_H
+#define SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_KERNEL_H
+
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "../common/get_cts_object.h"
+
+namespace queue_shortcuts_kernel {
+
+constexpr int value_init = 0;
+constexpr int value_test = 1;
+static_assert(value_init != value_test);
+constexpr int range_dim = 3;
+
+struct simple_functor_single_task {
+  explicit simple_functor_single_task(int* p) : usm(p) {}
+
+  void operator()() const { *usm = value_test; }
+
+  int* const usm;
+};
+
+struct simple_functor_parallel_for_range {
+  explicit simple_functor_parallel_for_range(int* p) : usm(p) {}
+
+  void operator()(sycl::item<range_dim>) const { *usm = value_test; }
+
+  int* const usm;
+};
+
+struct simple_functor_parallel_for_nd_range {
+  explicit simple_functor_parallel_for_nd_range(int* p) : usm(p) {}
+
+  void operator()(sycl::nd_item<range_dim>) const { *usm = value_test; }
+
+  int* const usm;
+};
+
+template <typename T>
+class kernel_stnel;
+template <typename T>
+class kernel_stsel;
+template <typename T>
+class kernel_stmel;
+template <typename T>
+class kernel_stnef;
+template <typename T>
+class kernel_stsef;
+template <typename T>
+class kernel_stmef;
+template <typename T>
+class kernel_pfnel;
+template <typename T>
+class kernel_pfsel;
+template <typename T>
+class kernel_pfmel;
+template <typename T>
+class kernel_pfnef;
+template <typename T>
+class kernel_pfsef;
+template <typename T>
+class kernel_pfmef;
+template <typename T>
+class kernel_pfnrnel;
+template <typename T>
+class kernel_pfnrsel;
+template <typename T>
+class kernel_pfnrmel;
+template <typename T>
+class kernel_pfnrnef;
+template <typename T>
+class kernel_pfnrsef;
+template <typename T>
+class kernel_pfnrmef;
+
+template <typename kernel_helper>
+sycl::event run_test(sycl::queue queue, int* d_ptr, kernel_helper helper) {
+  // initialize the device-allocated usm buffer without using shortcuts
+  int init = value_init;
+  queue.submit(
+      [&](sycl::handler& cgh) { cgh.memcpy(d_ptr, &init, sizeof(int)); });
+  queue.wait();
+
+  // set the value using shortcuts
+  sycl::event event = helper();
+  event.wait();
+
+  // copy the value back to host without using shortcuts
+  int result;
+  queue.submit(
+      [&](sycl::handler& cgh) { cgh.memcpy(&result, d_ptr, sizeof(int)); });
+  queue.wait();
+
+  CHECK((result == value_test));
+  return event;
+}
+
+template <typename T>
+void test_kernel_function(sycl::queue q) {
+  if (!q.get_device().has(sycl::aspect::usm_device_allocations)) {
+    WARN(
+        "Device does not support USM device allocations. "
+        "Skipping the test case.");
+    return;
+  }
+
+  int* d_ptr = sycl::malloc_device<int>(1, q);
+
+  // single_task
+  {
+    const auto single_task_lambda = [=] { *d_ptr = value_test; };
+    const simple_functor_single_task single_task_functor(d_ptr);
+
+    {
+      sycl::event single_task_no_events_lambda = run_test(q, d_ptr, [&] {
+        return q.single_task<kernel_stnel<T>>(single_task_lambda);
+      });
+      sycl::event single_task_single_event_lambda = run_test(q, d_ptr, [&] {
+        return q.single_task<kernel_stsel<T>>(single_task_no_events_lambda,
+                                              single_task_lambda);
+      });
+      sycl::event single_task_multiple_events_lambda = run_test(q, d_ptr, [&] {
+        return q.single_task<kernel_stmel<T>>(
+            {single_task_no_events_lambda, single_task_single_event_lambda},
+            single_task_lambda);
+      });
+    }
+    {
+      sycl::event single_task_no_events_functor = run_test(q, d_ptr, [&] {
+        return q.single_task<kernel_stnef<T>>(single_task_functor);
+      });
+      sycl::event single_task_single_event_functor = run_test(q, d_ptr, [&] {
+        return q.single_task<kernel_stsef<T>>(single_task_no_events_functor,
+                                              single_task_functor);
+      });
+      sycl::event single_task_multiple_events_functor = run_test(q, d_ptr, [&] {
+        return q.single_task<kernel_stmef<T>>(
+            {single_task_no_events_functor, single_task_single_event_functor},
+            single_task_functor);
+      });
+    }
+  }
+  // parallel_for range
+  {
+    const sycl::range<range_dim> range(1, 1, 1);
+    const auto parallel_for_lambda = [=](sycl::item<range_dim>) {
+      *d_ptr = value_test;
+    };
+    const simple_functor_parallel_for_range parallel_for_functor(d_ptr);
+
+    {
+      sycl::event parallel_for_range_no_events_lambda = run_test(q, d_ptr, [&] {
+        return q.parallel_for<kernel_pfnel<T>>(range, parallel_for_lambda);
+      });
+      sycl::event parallel_for_range_single_event_lambda =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfsel<T>>(
+                range, parallel_for_range_no_events_lambda,
+                parallel_for_lambda);
+          });
+      sycl::event parallel_for_range_multiple_events_lambda =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfmel<T>>(
+                range,
+                {parallel_for_range_no_events_lambda,
+                 parallel_for_range_single_event_lambda},
+                parallel_for_lambda);
+          });
+    }
+    {
+      sycl::event parallel_for_range_no_events_functor =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfnef<T>>(range, parallel_for_functor);
+          });
+      sycl::event parallel_for_range_single_event_functor =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfsef<T>>(
+                range, parallel_for_range_no_events_functor,
+                parallel_for_functor);
+          });
+      sycl::event parallel_for_range_multiple_events_functor =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfmef<T>>(
+                range,
+                {parallel_for_range_no_events_functor,
+                 parallel_for_range_single_event_functor},
+                parallel_for_functor);
+          });
+    }
+  }
+  // parallel_for nd_range
+  {
+    const sycl::nd_range<range_dim> range({1, 1, 1}, {1, 1, 1});
+    const auto parallel_for_lambda = [=](sycl::nd_item<range_dim>) {
+      *d_ptr = value_test;
+    };
+    const simple_functor_parallel_for_nd_range parallel_for_functor(d_ptr);
+
+    {
+      sycl::event parallel_for_range_no_events_lambda = run_test(q, d_ptr, [&] {
+        return q.parallel_for<kernel_pfnrnel<T>>(range, parallel_for_lambda);
+      });
+      sycl::event parallel_for_range_single_event_lambda =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfnrsel<T>>(
+                range, parallel_for_range_no_events_lambda,
+                parallel_for_lambda);
+          });
+      sycl::event parallel_for_range_multiple_events_lambda =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfnrmel<T>>(
+                range,
+                {parallel_for_range_no_events_lambda,
+                 parallel_for_range_single_event_lambda},
+                parallel_for_lambda);
+          });
+    }
+    {
+      sycl::event parallel_for_range_no_events_functor =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfnrnef<T>>(range,
+                                                     parallel_for_functor);
+          });
+      sycl::event parallel_for_range_single_event_functor =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfnrsef<T>>(
+                range, parallel_for_range_no_events_functor,
+                parallel_for_functor);
+          });
+      sycl::event parallel_for_range_multiple_events_functor =
+          run_test(q, d_ptr, [&] {
+            return q.parallel_for<kernel_pfnrmef<T>>(
+                range,
+                {parallel_for_range_no_events_functor,
+                 parallel_for_range_single_event_functor},
+                parallel_for_functor);
+          });
+    }
+  }
+
+  sycl::free(d_ptr, q);
+}
+
+template <typename T>
+class check_queue_shortcuts_kernel_for_type {
+ public:
+  void operator()(sycl::queue queue, const std::string& type_name) {
+    INFO("for type \"" << type_name << "\": ");
+
+    test_kernel_function<T>(queue);
+  }
+};
+
+}  // namespace queue_shortcuts_kernel
+
+#endif  // SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_KERNEL_H

--- a/tests/queue/queue_shortcuts_kernel_core.cpp
+++ b/tests/queue/queue_shortcuts_kernel_core.cpp
@@ -19,7 +19,6 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/disabled_for_test_case.h"
 #include "queue_shortcuts_common.h"
 #include "queue_shortcuts_kernel.h"
 
@@ -28,12 +27,10 @@ namespace queue_shortcuts_kernel_core {
 using namespace queue_shortcuts_common;
 using namespace queue_shortcuts_kernel;
 
-// hipSYCL not tested
-DISABLED_FOR_TEST_CASE(hipSYCL)
-("queue shortcuts kernel function core", "[queue]")({
+TEST_CASE("queue shortcuts kernel function core", "[queue]") {
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
   const auto types = get_types();
   for_all_types<check_queue_shortcuts_kernel_for_type>(types, queue);
-});
+}
 
 }  // namespace queue_shortcuts_kernel_core

--- a/tests/queue/queue_shortcuts_kernel_core.cpp
+++ b/tests/queue/queue_shortcuts_kernel_core.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_common.h"
+#include "queue_shortcuts_kernel.h"
+
+namespace queue_shortcuts_kernel_core {
+
+using namespace queue_shortcuts_common;
+using namespace queue_shortcuts_kernel;
+
+// hipSYCL not tested
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("queue shortcuts kernel function core", "[queue]")({
+  sycl::queue queue = sycl_cts::util::get_cts_object::queue();
+  const auto types = get_types();
+  for_all_types<check_queue_shortcuts_kernel_for_type>(types, queue);
+});
+
+}  // namespace queue_shortcuts_kernel_core

--- a/tests/queue/queue_shortcuts_kernel_fp16.cpp
+++ b/tests/queue/queue_shortcuts_kernel_fp16.cpp
@@ -20,7 +20,6 @@
 
 #include "../../util/extensions.h"
 #include "../common/common.h"
-#include "../common/disabled_for_test_case.h"
 #include "queue_shortcuts_kernel.h"
 
 namespace queue_shortcuts_kernel_fp16 {
@@ -28,18 +27,18 @@ namespace queue_shortcuts_kernel_fp16 {
 using namespace sycl_cts;
 using namespace queue_shortcuts_kernel;
 
-// hipSYCL not tested
-DISABLED_FOR_TEST_CASE(hipSYCL)
-("queue shortcuts kernel function fp16", "[queue]")({
+TEST_CASE("queue shortcuts kernel function fp16", "[queue]") {
   auto queue = util::get_cts_object::queue();
   using avaliability =
       util::extensions::availability<util::extensions::tag::fp16>;
   if (!avaliability::check(queue)) {
-    WARN("Device does not support half precision floating point operations");
+    WARN(
+        "Device does not support half precision floating point operations"
+        "Skipping the test case.");
     return;
   }
 
   check_queue_shortcuts_kernel_for_type<sycl::half>{}(queue, "sycl::half");
-})
+}
 
 }  // namespace queue_shortcuts_kernel_fp16

--- a/tests/queue/queue_shortcuts_kernel_fp16.cpp
+++ b/tests/queue/queue_shortcuts_kernel_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_kernel.h"
+
+namespace queue_shortcuts_kernel_fp16 {
+
+using namespace sycl_cts;
+using namespace queue_shortcuts_kernel;
+
+// hipSYCL not tested
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("queue shortcuts kernel function fp16", "[queue]")({
+  auto queue = util::get_cts_object::queue();
+  using avaliability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!avaliability::check(queue)) {
+    WARN("Device does not support half precision floating point operations");
+    return;
+  }
+
+  check_queue_shortcuts_kernel_for_type<sycl::half>{}(queue, "sycl::half");
+})
+
+}  // namespace queue_shortcuts_kernel_fp16

--- a/tests/queue/queue_shortcuts_kernel_fp64.cpp
+++ b/tests/queue/queue_shortcuts_kernel_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_kernel.h"
+
+namespace queue_shortcuts_kernel_fp64 {
+
+using namespace sycl_cts;
+using namespace queue_shortcuts_kernel;
+
+// hipSYCL not tested
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("queue shortcuts kernel function fp64", "[queue]")({
+  auto queue = util::get_cts_object::queue();
+  using avaliability =
+      util::extensions::availability<util::extensions::tag::fp64>;
+  if (!avaliability::check(queue)) {
+    WARN("Device does not support double precision floating point operations");
+    return;
+  }
+
+  check_queue_shortcuts_kernel_for_type<double>{}(queue, "double");
+})
+
+}  // namespace queue_shortcuts_kernel_fp64

--- a/tests/queue/queue_shortcuts_kernel_fp64.cpp
+++ b/tests/queue/queue_shortcuts_kernel_fp64.cpp
@@ -20,7 +20,6 @@
 
 #include "../../util/extensions.h"
 #include "../common/common.h"
-#include "../common/disabled_for_test_case.h"
 #include "queue_shortcuts_kernel.h"
 
 namespace queue_shortcuts_kernel_fp64 {
@@ -28,18 +27,18 @@ namespace queue_shortcuts_kernel_fp64 {
 using namespace sycl_cts;
 using namespace queue_shortcuts_kernel;
 
-// hipSYCL not tested
-DISABLED_FOR_TEST_CASE(hipSYCL)
-("queue shortcuts kernel function fp64", "[queue]")({
+TEST_CASE("queue shortcuts kernel function fp64", "[queue]") {
   auto queue = util::get_cts_object::queue();
   using avaliability =
       util::extensions::availability<util::extensions::tag::fp64>;
   if (!avaliability::check(queue)) {
-    WARN("Device does not support double precision floating point operations");
+    WARN(
+        "Device does not support double precision floating point operations"
+        "Skipping the test case.");
     return;
   }
 
   check_queue_shortcuts_kernel_for_type<double>{}(queue, "double");
-})
+}
 
 }  // namespace queue_shortcuts_kernel_fp64

--- a/tests/queue/queue_shortcuts_usm.h
+++ b/tests/queue/queue_shortcuts_usm.h
@@ -1,0 +1,291 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_USM_H
+#define SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_USM_H
+
+#include <utility>
+
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "../common/get_cts_object.h"
+
+namespace queue_shortcuts_usm {
+
+template <typename T>
+struct runner_memcpy {
+  runner_memcpy(sycl::queue q, unsigned int count)
+      : queue(q), element_count(count) {}
+
+  template <typename kernel_helper>
+  sycl::event run_memcpy_copy(kernel_helper helper) {
+    // set up initial values on host
+    const T t_init{0};
+    const T t_test{1};  // to initialize the sequence: t_test, ++t_test, etc.
+    std::unique_ptr<T[]> h_src = std::make_unique<T[]>(element_count);
+    std::iota(h_src.get(), h_src.get() + element_count, t_test);
+    std::unique_ptr<T[]> h_dest = std::make_unique<T[]>(element_count);
+    std::fill(h_dest.get(), h_dest.get() + element_count, t_init);
+
+    // set initial values of device-allocated usm buffer without using shortcuts
+    T* d_src = sycl::malloc_device<T>(element_count, queue);
+    T* d_dest = sycl::malloc_device<T>(element_count, queue);
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.memcpy(d_src, h_src.get(), element_count * sizeof(T));
+      cgh.memcpy(d_dest, h_dest.get(), element_count * sizeof(T));
+    });
+    queue.wait();
+
+    // perform the copy from d_src to d_dest using shortcuts
+    sycl::event event = helper(d_dest, d_src);
+    event.wait();
+
+    // copy destination buffer back to host without shortcut functions
+    std::unique_ptr<T[]> h_actual = std::make_unique<T[]>(element_count);
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.memcpy(h_actual.get(), d_dest, element_count * sizeof(T));
+    });
+    queue.wait();
+
+    // check the result
+    for (unsigned int i = 0; i < element_count; i++) {
+      CHECK(((t_test + i) == h_actual[i]));
+    }
+
+    sycl::free(d_dest, queue);
+    sycl::free(d_src, queue);
+
+    return event;
+  }
+
+  template <typename kernel_helper>
+  sycl::event run_memset(kernel_helper helper) {
+    constexpr char init = 0;
+    constexpr char test = 1;
+
+    // set up initial values on host
+    std::unique_ptr<T[]> h_ptr = std::make_unique<T[]>(element_count);
+    std::memset(reinterpret_cast<void*>(h_ptr.get()), init,
+                element_count * sizeof(T));
+
+    // set initial values of device-allocated usm buffer without using shortcuts
+    T* d_ptr = sycl::malloc_device<T>(element_count, queue);
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.memcpy(d_ptr, h_ptr.get(), element_count * sizeof(T));
+    });
+    queue.wait();
+
+    // perform the memset from d_src to d_dest using shortcuts
+    sycl::event event = helper(d_ptr, test);
+    event.wait();
+
+    // copy destination buffer back to host without shortcut functions
+    std::unique_ptr<T[]> h_actual = std::make_unique<T[]>(element_count);
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.memcpy(h_actual.get(), d_ptr, element_count * sizeof(T));
+    });
+    queue.wait();
+
+    // check the result
+    char* actual_char = reinterpret_cast<char*>(h_actual.get());
+    for (unsigned int i = 0; i < element_count * sizeof(T); i++) {
+      CHECK((test == actual_char[i]));
+    }
+
+    sycl::free(d_ptr, queue);
+
+    return event;
+  }
+
+  template <typename kernel_helper>
+  sycl::event run_fill(kernel_helper helper) {
+    // set up initial values on host
+    const T t_init{0};
+    const T t_test{1};
+    std::unique_ptr<T[]> h_ptr = std::make_unique<T[]>(element_count);
+    std::fill(h_ptr.get(), h_ptr.get() + element_count, t_init);
+
+    // set initial values of device-allocated usm buffer without using shortcuts
+    T* d_ptr = sycl::malloc_device<T>(element_count, queue);
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.memcpy(d_ptr, h_ptr.get(), element_count * sizeof(T));
+    });
+    queue.wait();
+
+    // perform the memset from d_src to d_dest using shortcuts
+    sycl::event event = helper(d_ptr, t_test);
+    event.wait();
+
+    // copy destination buffer back to host without shortcut functions
+    std::unique_ptr<T[]> h_actual = std::make_unique<T[]>(element_count);
+    queue.submit([&](sycl::handler& cgh) {
+      cgh.memcpy(h_actual.get(), d_ptr, element_count * sizeof(T));
+    });
+    queue.wait();
+
+    // check the result
+    for (unsigned int i = 0; i < element_count; i++) {
+      CHECK((t_test == h_actual[i]));
+    }
+
+    sycl::free(d_ptr, queue);
+
+    return event;
+  }
+
+  sycl::queue queue;
+  const unsigned int element_count;
+};
+
+template <typename T>
+void test_unified_shared_memory(sycl::queue q, unsigned int element_count) {
+  const bool has_usm_device_allocations =
+      q.get_device().has(sycl::aspect::usm_device_allocations);
+  const bool has_usm_shared_allocations =
+      q.get_device().has(sycl::aspect::usm_shared_allocations);
+
+  runner_memcpy<T> runner(q, element_count);
+
+  // memcpy and copy
+  if (has_usm_device_allocations) {
+    sycl::event memcpy_no_events =
+        runner.template run_memcpy_copy<>([&](T* dest, T* src) {
+          return q.memcpy(dest, src, element_count * sizeof(T));
+        });
+    sycl::event memcpy_single_event =
+        runner.template run_memcpy_copy<>([&](T* dest, T* src) {
+          return q.memcpy(dest, src, element_count * sizeof(T),
+                          memcpy_no_events);
+        });
+    sycl::event memcpy_multiple_events =
+        runner.template run_memcpy_copy<>([&](T* dest, T* src) {
+          return q.memcpy(dest, src, element_count * sizeof(T),
+                          {memcpy_no_events, memcpy_single_event});
+        });
+
+    sycl::event copy_no_events = runner.template run_memcpy_copy<>(
+        [&](T* dest, T* src) { return q.copy(src, dest, element_count); });
+    sycl::event copy_single_event =
+        runner.template run_memcpy_copy<>([&](T* dest, T* src) {
+          return q.copy(src, dest, element_count, copy_no_events);
+        });
+    sycl::event copy_multiple_events =
+        runner.template run_memcpy_copy<>([&](T* dest, T* src) {
+          return q.copy(src, dest, element_count,
+                        {copy_no_events, copy_single_event});
+        });
+  } else {
+    WARN(
+        "Device does not support USM device allocations. "
+        "Skipping the test case.");
+  }
+
+  // memset and fill
+  if (has_usm_device_allocations) {
+    sycl::event memset_no_events =
+        runner.template run_memset<>([&](T* ptr, char pattern) {
+          return q.memset(ptr, pattern, element_count * sizeof(T));
+        });
+    sycl::event memset_single_event =
+        runner.template run_memset<>([&](T* ptr, char pattern) {
+          return q.memset(ptr, pattern, element_count * sizeof(T),
+                          memset_no_events);
+        });
+    sycl::event memset_multiple_events =
+        runner.template run_memset<>([&](T* ptr, char pattern) {
+          return q.memset(ptr, pattern, element_count * sizeof(T),
+                          {memset_no_events, memset_single_event});
+        });
+
+    sycl::event fill_no_events = runner.template run_fill<>(
+        [&](T* ptr, T pattern) { return q.fill(ptr, pattern, element_count); });
+    sycl::event fill_single_event =
+        runner.template run_fill<>([&](T* ptr, T pattern) {
+          return q.fill(ptr, pattern, element_count, fill_no_events);
+        });
+    sycl::event fill_multiple_events =
+        runner.template run_fill<>([&](T* ptr, T pattern) {
+          return q.fill(ptr, pattern, element_count,
+                        {fill_no_events, fill_single_event});
+        });
+  } else {
+    WARN(
+        "Device does not support USM device allocations. "
+        "Skipping the test case.");
+  }
+
+  // prefetch
+  if (has_usm_shared_allocations) {
+    T* ptr = sycl::malloc_shared<T>(element_count, q);
+    sycl::event prefetch_no_events = q.prefetch(ptr, element_count * sizeof(T));
+#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+    sycl::event prefetch_single_event =
+        q.prefetch(ptr, element_count * sizeof(T), prefetch_no_events);
+    sycl::event prefetch_multiple_events =
+        q.prefetch(ptr, element_count * sizeof(T),
+                   {prefetch_no_events, prefetch_single_event});
+    prefetch_multiple_events.wait();
+#endif  // SYCL_CTS_COMPILING_WITH_COMPUTECPP
+    prefetch_no_events.wait();
+    sycl::free(ptr, q);
+  } else {
+    WARN(
+        "Device does not support USM shared allocations. "
+        "Skipping the test case.");
+  }
+
+  // advise
+  if (has_usm_device_allocations) {
+    T* ptr = sycl::malloc_device<T>(element_count, q);
+    constexpr int advice = 0;
+    sycl::event advise_no_events =
+        q.mem_advise(ptr, element_count * sizeof(int), advice);
+#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+    sycl::event advise_single_event = q.mem_advise(
+        ptr, element_count * sizeof(int), advice, advise_no_events);
+    sycl::event advise_multiple_events =
+        q.mem_advise(ptr, element_count * sizeof(int), advice,
+                     {advise_no_events, advise_single_event});
+    advise_multiple_events.wait();
+#endif  // SYCL_CTS_COMPILING_WITH_COMPUTECPP
+    advise_no_events.wait();
+    sycl::free(ptr, q);
+  } else {
+    WARN(
+        "Device does not support USM device allocations. "
+        "Skipping the test case.");
+  }
+}
+
+template <typename T>
+class check_queue_shortcuts_usm_for_type {
+  static constexpr unsigned int element_count = 10;
+
+ public:
+  void operator()(sycl::queue queue, const std::string& type_name) {
+    INFO("for type \"" << type_name << "\": ");
+
+    test_unified_shared_memory<T>(queue, element_count);
+  }
+};
+
+};  // namespace queue_shortcuts_usm
+
+#endif  // SYCL_CTS_QUEUE_QUEUE_SHORTCUTS_USM_H

--- a/tests/queue/queue_shortcuts_usm_core.cpp
+++ b/tests/queue/queue_shortcuts_usm_core.cpp
@@ -19,7 +19,6 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/disabled_for_test_case.h"
 #include "queue_shortcuts_common.h"
 #include "queue_shortcuts_usm.h"
 
@@ -28,12 +27,10 @@ namespace queue_shortcuts_usm_core {
 using namespace queue_shortcuts_common;
 using namespace queue_shortcuts_usm;
 
-// hipSYCL not tested
-DISABLED_FOR_TEST_CASE(hipSYCL)
-("queue shortcuts unified shared memory core", "[queue]")({
+TEST_CASE("queue shortcuts unified shared memory core", "[queue]") {
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
   const auto types = get_types();
   for_all_types<check_queue_shortcuts_usm_for_type>(types, queue);
-});
+}
 
 }  // namespace queue_shortcuts_usm_core

--- a/tests/queue/queue_shortcuts_usm_core.cpp
+++ b/tests/queue/queue_shortcuts_usm_core.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_common.h"
+#include "queue_shortcuts_usm.h"
+
+namespace queue_shortcuts_usm_core {
+
+using namespace queue_shortcuts_common;
+using namespace queue_shortcuts_usm;
+
+// hipSYCL not tested
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("queue shortcuts unified shared memory core", "[queue]")({
+  sycl::queue queue = sycl_cts::util::get_cts_object::queue();
+  const auto types = get_types();
+  for_all_types<check_queue_shortcuts_usm_for_type>(types, queue);
+});
+
+}  // namespace queue_shortcuts_usm_core

--- a/tests/queue/queue_shortcuts_usm_fp16.cpp
+++ b/tests/queue/queue_shortcuts_usm_fp16.cpp
@@ -20,7 +20,6 @@
 
 #include "../../util/extensions.h"
 #include "../common/common.h"
-#include "../common/disabled_for_test_case.h"
 #include "queue_shortcuts_usm.h"
 
 namespace queue_shortcuts_usm_fp16 {
@@ -28,18 +27,18 @@ namespace queue_shortcuts_usm_fp16 {
 using namespace sycl_cts;
 using namespace queue_shortcuts_usm;
 
-// hipSYCL not tested
-DISABLED_FOR_TEST_CASE(hipSYCL)
-("queue shortcuts unified shared memory fp16", "[queue]")({
+TEST_CASE("queue shortcuts unified shared memory fp16", "[queue]") {
   auto queue = util::get_cts_object::queue();
   using avaliability =
       util::extensions::availability<util::extensions::tag::fp16>;
   if (!avaliability::check(queue)) {
-    WARN("Device does not support half precision floating point operations");
+    WARN(
+        "Device does not support half precision floating point operations"
+        "Skipping the test case.");
     return;
   }
 
   check_queue_shortcuts_usm_for_type<sycl::half>{}(queue, "sycl::half");
-})
+}
 
 }  // namespace queue_shortcuts_usm_fp16

--- a/tests/queue/queue_shortcuts_usm_fp16.cpp
+++ b/tests/queue/queue_shortcuts_usm_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_usm.h"
+
+namespace queue_shortcuts_usm_fp16 {
+
+using namespace sycl_cts;
+using namespace queue_shortcuts_usm;
+
+// hipSYCL not tested
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("queue shortcuts unified shared memory fp16", "[queue]")({
+  auto queue = util::get_cts_object::queue();
+  using avaliability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!avaliability::check(queue)) {
+    WARN("Device does not support half precision floating point operations");
+    return;
+  }
+
+  check_queue_shortcuts_usm_for_type<sycl::half>{}(queue, "sycl::half");
+})
+
+}  // namespace queue_shortcuts_usm_fp16

--- a/tests/queue/queue_shortcuts_usm_fp64.cpp
+++ b/tests/queue/queue_shortcuts_usm_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2022 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
+#include "queue_shortcuts_usm.h"
+
+namespace queue_shortcuts_usm_fp64 {
+
+using namespace sycl_cts;
+using namespace queue_shortcuts_usm;
+
+// hipSYCL not tested
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("queue shortcuts unified shared memory fp64", "[queue]")({
+  auto queue = util::get_cts_object::queue();
+  using avaliability =
+      util::extensions::availability<util::extensions::tag::fp64>;
+  if (!avaliability::check(queue)) {
+    WARN("Device does not support double precision floating point operations");
+    return;
+  }
+
+  check_queue_shortcuts_usm_for_type<double>{}(queue, "double");
+})
+
+}  // namespace queue_shortcuts_usm_fp64

--- a/tests/queue/queue_shortcuts_usm_fp64.cpp
+++ b/tests/queue/queue_shortcuts_usm_fp64.cpp
@@ -20,7 +20,6 @@
 
 #include "../../util/extensions.h"
 #include "../common/common.h"
-#include "../common/disabled_for_test_case.h"
 #include "queue_shortcuts_usm.h"
 
 namespace queue_shortcuts_usm_fp64 {
@@ -28,18 +27,18 @@ namespace queue_shortcuts_usm_fp64 {
 using namespace sycl_cts;
 using namespace queue_shortcuts_usm;
 
-// hipSYCL not tested
-DISABLED_FOR_TEST_CASE(hipSYCL)
-("queue shortcuts unified shared memory fp64", "[queue]")({
+TEST_CASE("queue shortcuts unified shared memory fp64", "[queue]") {
   auto queue = util::get_cts_object::queue();
   using avaliability =
       util::extensions::availability<util::extensions::tag::fp64>;
   if (!avaliability::check(queue)) {
-    WARN("Device does not support double precision floating point operations");
+    WARN(
+        "Device does not support double precision floating point operations"
+        "Skipping the test case.");
     return;
   }
 
   check_queue_shortcuts_usm_for_type<double>{}(queue, "double");
-})
+}
 
 }  // namespace queue_shortcuts_usm_fp64


### PR DESCRIPTION
Adds tests for queue shortcut functions according to test plan #407.

Several parts of the tests are compile-time disabled for ComputeC++ and DPCPP to ensure that the tests build successfully.