### PR TITLE
Fix exception constructor tests

### DIFF
--- a/tests/exceptions/exceptions_constructors.cpp
+++ b/tests/exceptions/exceptions_constructors.cpp
@@ -46,7 +46,7 @@ inline void check_exception(sycl::exception e, const std::error_code errcode,
                             const std::string& what_arg) {
   CHECK(e.code() == errcode);
   CHECK(e.category() == errcat);
-  CHECK(e.what() == what_arg);
+  CHECK(std::string(e.what()).find(what_arg) != std::string::npos);
   CHECK(e.has_context() == false);
   CHECK_THROWS_MATCHES(e.get_context(), sycl::exception,
                        sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -87,7 +87,7 @@ inline void check_exception(sycl::exception e, const std::error_code errcode,
                             const sycl::context& ctx) {
   CHECK(e.code() == errcode);
   CHECK(e.category() == errcat);
-  CHECK(e.what() == what_arg);
+  CHECK(std::string(e.what()).find(what_arg) != std::string::npos);
   CHECK(e.has_context() == true);
   CHECK(e.get_context() == ctx);
 }


### PR DESCRIPTION
According to [4.13.2. Exception class interface](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:exception.class)

> The string returned by what() is guaranteed to contain what_arg as a substring

This patch changes test to check that what_arg is substring of what() instead of checking their equality.