### PR TITLE
Add test plan for kernel_bundle

### DIFF
--- a/test_plans/kernel_bundle.asciidoc
+++ b/test_plans/kernel_bundle.asciidoc
@@ -22,30 +22,40 @@ is selected on the CTS command line if not stated otherwise.
 
 Check that result of function `is_compatible(const std::vector<kernel_id> &kernelIds, const device &dev)`:
 
-* `false` for zero kernels
-* `true` for built-in kernel id for the same device
-* `false` for built-in kernel id for the other device
-* for kernel with no kernel attributes:
+* `true` for zero kernels
+* `true` for built-in kernel id for the selected device
+* Construct a vector of the built-in kernel ids from every root device other than the selected device.
+Check that is_compatible returns false for this vector of kernel ids unless the vector is empty.
+* for kernels with no kernel attributes:
 
-** `true` for kernel with no optional features and any device
-** `true` for fp16/fp64/atomic64 kernel and device with appropriate aspect
-** `false` for fp16/fp64/atomic64 kernel and device without appropriate aspect
+** `true` for a kernel that uses `sycl::half` if and only if the selected device has `aspect::fp16`.
+** `true` for a kernel that uses `double` if and only if the selected device has `aspect::fp64`.
+** `true` for a kernel that uses 64-bit atomic operations if and only if the selected device has `aspect::atomic64`.
 
-* for kernel with `reqd_work_group_size`
+* Define kernels with the following values of the `[[sycl::reqd_work_group_size]]` attribute.
+Verify that `is_compatible` returns true if and only if the work group size is less than or equal to the value reported by `info::device::max_work_group_size` for the selected device.
 
-** `false` for kernel with no optional features and any device with `max_work_group_size` less than `reqd_work_group_size`
+** `[[sycl::reqd_work_group_size(8)]]`
+** `[[sycl::reqd_work_group_size(16)]]`
+** `[[sycl::reqd_work_group_size(4294967295)]]`
 
-* for kernel with `reqd_sub_group_size` (that is less than `max_work_group_size`)
+* Define kernels with the following values of the `[[sycl::reqd_sub_group_size]]` attribute.
+Verify that `is_compatible` returns true if and only if the sub group size is not one of the values reported by `info::device::sub_group_sizes` for the selected device.
 
-** `false` for kernel with no optional features and any device with `sub_group_sizes` not containing `reqd_sub_group_size`
+** `[[sycl::reqd_work_group_size(8)]]`
+** `[[sycl::reqd_work_group_size(16)]]`
+** `[[sycl::reqd_work_group_size(4099)]]`
 
-* for kernel with no optional features used and with sycl::requires() kernel attribute
+* for kernels with no optional features used and with `[[sycl::device_has()]]` kernel attribute
 
-** `true` for `has(fp16)`/`has(fp64)`/`has(atomic64)` and device with appropriate aspect
-** false for `has(fp16)`/`has(fp64)`/`has(atomic64)` and device without appropriate aspect
+** `true` for a kernel decorated with `[[sycl::device_has(aspect::fp16)]]` if and only if the selected device has that aspect.
+** `true` for a kernel decorated with `[[sycl::device_has(aspect::fp64)]]` if and only if the selected device has that aspect.
+** `true` for a kernel decorated with `[[sycl::device_has(aspect::atomic64)]]` if and only if the selected device has that aspect.
 
 * for multiple kernels result is equal to AND operation applied to the multiple calls - each one using single kernel id
-** Check with vector with kernel ids for same and other devices
+** Check with vector with built-in kernel ids and with the selected device - should return `true`
+** To previous vector add kernel id with large `[[sycl::reqd_work_group_size(4294967295)]]` attribute and with the selected device - should return `false` if value reported by `info::device::max_work_group_size` is less than 4294967295.
+
 
 ==== Tests for `template<typename KernelName> bool is_compatible(const device &dev)`
 
@@ -59,71 +69,56 @@ Check that `std::is_default_constructible_v<sycl::kernel_bundle>` is `false`.
 
 ==== Test for `get_backend()`
 
-Call function `kernel::get_backend()` and check that return type is `sycl::backend`.
+Call function `kernel_bundle::get_backend()` and check that return type is `sycl::backend`.
 
 ==== Tests for `get_devices()`
 
-* Use some of available devices to create fill std::vector<device>.
-* Create kernel_bundle via `get_kernel_bundle(const context&, const std::vector<device>&)`.
+* Create a 1-element `std::vector<device>` containing the selected device.
+* Create kernel_bundle via `get_kernel_bundle<bundle_state::executable>(const context&, const std::vector<device>&)`.
+* Call `get_devices()`.
 * Check that return type is std::vector<device>.
-* Check that return vector contains all devices from input vector and only them.
+* Check that return vector contains only selected device.
 
 ==== `has_kernel(const kernel_id &kernelId, const device &dev)`
 
-Check that result of function is:
-
-* `true` if kernelId is within get_kernel_ids() and `is_compatible({kernelId}, const device&)` is `true`
-* `false` if kernelId is within get_kernel_ids() and `is_compatible({kernelId}, const device&)` is `false`
-* `false` if kernelId is not within get_kernel_ids() and `is_compatible({kernelId}, const device&)` is `true`
-* `false` if kernelId is not within get_kernel_ids() and `is_compatible({kernelId}, const device&)` is `false`
-
+* Create a kernel bundle in executable state which contains all the application's kernels by calling `get_kernel_bundle<bundle_state::executable>(const context &)`.
+* Iterate over all of the kernel ids returned by `get_kernel_ids()`.
+* Verify that `has_kernel(kernelId, dev)` returns `true` if and only if `is_compatible({kernelId}, const device&)` for selected device is `true`.
 
 ==== `std::vector<kernel_id> get_kernel_ids()`
 
 Define 4 kernels.
-Get kernel_bundle with built-in kernels.
-Check that result of get_kernel_ids:
+Get kernel_bundle that contains all of the kernels defined in the application via `get_kernel_bundle<bundle_state::executable>(const context &)`
+Check that result of `get_kernel_ids`:
 
 * has type `std::vector<kernel_id>`
-* has size 4
+* has size at least 4
 * has only different kernel ids
 
 ==== `get_kernel()`
 
-Define kernel KernelName.
-Get `kernel_bundle` with built-in kernels.
-
-* Use `get_kernel<KernelName>()` to get kernel and that return type is `sycl::kernel`
-* Try to use `get_kernel<OtherKernelName>()` and check that `errc::invalid` is thrown
+* Define kernel KernelName.
+* Get a kernel bundle in executable state that contains this kernel via `get_kernel_bundle<KernelName, bundle_state::executable>(const context &)`.
+* Use `get_kernel<KernelName>()` to get kernel and check that return type is `sycl::kernel`.
 
 === Tests for working with specialization constants
 
 Partially tested in https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/tests/specialization_constants/specialization_constants_via_kernel_bundle.h
 
-There are should be two spec constants defined - `SpecName` and `OtherSpecName`.
+There are should be defined spec constant `SpecName`.
 
 ==== Empty kernel bundle
 
-* Get an empty `kernel_bundle`.
+* Get an empty kernel bundle by calling get_kernel_bundle<bundle_state::executable>(const context &, const std::vector<device> &, Selector) where Selector is a function that always returns `false`.
 * Check that `contains_specialization_constants()` return `false`.
 * Check that `native_specialization_constant()` return `false`.
 * Check that `has_specialization_constant<SpecName>()` return `false`.
-
-==== Kernel bundle without `kernel_handler::get_specialization_constant()` call
-
-* Get an input `kernel_bundle` with kernel without `kernel_handler::get_specialization_constant()` call.
-* Check that `contains_specialization_constants()` return `false`.
-* Check that `native_specialization_constant()` return `false`.
-* Check that `has_specialization_constant<SpecName>()` return `false`.
-* Check that `get_specialization_constant<SpecName>()` return default value.
-* Call `compile()` to build the `kernel_bundle` into `object` state.
-* Check the same.
-* Call `link()` to build the `kernel_bundle` into `executable` state.
-* Check the same.
 
 ==== Kernel bundle with `kernel_handler::get_specialization_constant()` call
 
-* Get an input `kernel_bundle` with kernel with `kernel_handler::get_specialization_constant<SpecName>()` call.
+* Define a kernel named `KernelName` that calls `kernel_handler::get_specialization_constant<SpecName>()`.
+* Attempt to get a kernel bundle in input state that contains this kernel by calling `get_kernel_bundle<KernelName, bundle_state::input>(const context &, const std::vector<device>& )` with 1-element `std::vector<device>` containing the selected device.
+* Test if the kernel bundle contains that kernel by calling `kernel_bundle::has_kernel<KernelName()`. If this returns `false`, the test is skipped.
 * Set each spec constant to a different value via `kernel_bundle::set_specialization_constant()`.
 * Check that `contains_specialization_constants()` return `true`.
 * Check that called `native_specialization_constant()` without exception.

--- a/test_plans/kernel_bundle.asciidoc
+++ b/test_plans/kernel_bundle.asciidoc
@@ -57,6 +57,10 @@ Same tests as previous section except no zero, built-in and multiple kernels cas
 
 Check that `std::is_default_constructible_v<sycl::kernel_bundle>` is `false`.
 
+==== Test for `get_backend()`
+
+Call function `kernel::get_backend()` and check that return type is `sycl::backend`.
+
 ==== Tests for `get_devices()`
 
 * Use some of available devices to create fill std::vector<device>.

--- a/test_plans/kernel_bundle.asciidoc
+++ b/test_plans/kernel_bundle.asciidoc
@@ -25,22 +25,23 @@ Check that result of function `is_compatible(const std::vector<kernel_id> &kerne
 * `true` for zero kernels
 * `true` for built-in kernel id for the selected device
 * Construct a vector of the built-in kernel ids from every root device other than the selected device.
-Check that is_compatible returns false for this vector of kernel ids unless the vector is empty.
+Check that is_compatible returns `false` for this vector of kernel ids unless the vector is empty.
 * for kernels with no kernel attributes:
 
+** `true` for kernel with no optional features and the selected device
 ** `true` for a kernel that uses `sycl::half` if and only if the selected device has `aspect::fp16`.
 ** `true` for a kernel that uses `double` if and only if the selected device has `aspect::fp64`.
 ** `true` for a kernel that uses 64-bit atomic operations if and only if the selected device has `aspect::atomic64`.
 
-* Define kernels with the following values of the `[[sycl::reqd_work_group_size]]` attribute.
+* Define kernels with the following values of the `[[sycl::reqd_work_group_size()]]` attribute.
 Verify that `is_compatible` returns true if and only if the work group size is less than or equal to the value reported by `info::device::max_work_group_size` for the selected device.
 
 ** `[[sycl::reqd_work_group_size(8)]]`
 ** `[[sycl::reqd_work_group_size(16)]]`
 ** `[[sycl::reqd_work_group_size(4294967295)]]`
 
-* Define kernels with the following values of the `[[sycl::reqd_sub_group_size]]` attribute.
-Verify that `is_compatible` returns true if and only if the sub group size is not one of the values reported by `info::device::sub_group_sizes` for the selected device.
+* Define kernels with the following values of the `[[sycl::reqd_sub_group_size()]]` attribute.
+Verify that `is_compatible` returns true if and only if the sub group size is one of the values reported by `info::device::sub_group_sizes` for the selected device.
 
 ** `[[sycl::reqd_work_group_size(8)]]`
 ** `[[sycl::reqd_work_group_size(16)]]`
@@ -88,7 +89,7 @@ Call function `kernel_bundle::get_backend()` and check that return type is `sycl
 ==== `std::vector<kernel_id> get_kernel_ids()`
 
 Define 4 kernels.
-Get kernel_bundle that contains all of the kernels defined in the application via `get_kernel_bundle<bundle_state::executable>(const context &)`
+Get kernel_bundle via `get_kernel_bundle<bundle_state::executable>(const context &)`
 Check that result of `get_kernel_ids`:
 
 * has type `std::vector<kernel_id>`
@@ -105,7 +106,8 @@ Check that result of `get_kernel_ids`:
 
 Partially tested in https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/tests/specialization_constants/specialization_constants_via_kernel_bundle.h
 
-There are should be defined spec constant `SpecName`.
+There are two spec constant defined: `SpecName` and `OtherSpecName`.
+kernel_handler::get_specialization_constant<OtherSpecName>() shouldn't be used in any kernel in the application.
 
 ==== Empty kernel bundle
 

--- a/test_plans/kernel_bundle.asciidoc
+++ b/test_plans/kernel_bundle.asciidoc
@@ -82,7 +82,7 @@ Call function `kernel_bundle::get_backend()` and check that return type is `sycl
 
 ==== `has_kernel(const kernel_id &kernelId, const device &dev)`
 
-* Create a kernel bundle in executable state which contains all the application's kernels by calling `get_kernel_bundle<bundle_state::executable>(const context &)`.
+* Create a kernel bundle by calling `get_kernel_bundle<bundle_state::executable>(const context &)`.
 * Iterate over all of the kernel ids returned by `get_kernel_ids()`.
 * Verify that `has_kernel(kernelId, dev)` returns `true` if and only if `is_compatible({kernelId}, const device&)` for selected device is `true`.
 

--- a/test_plans/kernel_bundle.asciidoc
+++ b/test_plans/kernel_bundle.asciidoc
@@ -1,0 +1,140 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for kernel_bundle (cover gaps)
+
+This is a test plan cover kernel_bundle functionality that is not covered by current tests.
+
+== Testing scope
+
+Tests intend to cover functions from 4.11. Kernel bundles that are not covered in https://github.com/KhronosGroup/SYCL-CTS/tree/SYCL-2020/tests/kernel_bundle
+
+=== Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line if not stated otherwise.
+
+== Tests
+
+=== Finctions `is_compatible`
+
+==== Tests for `is_compatible(const std::vector<kernel_id> &kernelIds, const device &dev)`
+
+Check that result of function `is_compatible(const std::vector<kernel_id> &kernelIds, const device &dev)`:
+
+* `false` for zero kernels
+* `true` for built-in kernel id for the same device
+* `false` for built-in kernel id for the other device
+* for kernel with no kernel attributes:
+
+** `true` for kernel with no optional features and any device
+** `true` for fp16/fp64/atomic64 kernel and device with appropriate aspect
+** `false` for fp16/fp64/atomic64 kernel and device without appropriate aspect
+
+* for kernel with `reqd_work_group_size`
+
+** `false` for kernel with no optional features and any device with `max_work_group_size` less than `reqd_work_group_size`
+
+* for kernel with `reqd_sub_group_size` (that is less than `max_work_group_size`)
+
+** `false` for kernel with no optional features and any device with `sub_group_sizes` not containing `reqd_sub_group_size`
+
+* for kernel with no optional features used and with sycl::requires() kernel attribute
+
+** `true` for `has(fp16)`/`has(fp64)`/`has(atomic64)` and device with appropriate aspect
+** false for `has(fp16)`/`has(fp64)`/`has(atomic64)` and device without appropriate aspect
+
+* for multiple kernels result is equal to AND operation applied to the multiple calls - each one using single kernel id
+** Check with vector with kernel ids for same and other devices
+
+==== Tests for `template<typename KernelName> bool is_compatible(const device &dev)`
+
+Same tests as previous section except no zero, built-in and multiple kernels cases.
+
+=== `sycl::kernel_bundle` API
+
+==== Deleted default constructor
+
+Check that `std::is_default_constructible_v<sycl::kernel_bundle>` is `false`.
+
+==== Tests for `get_devices()`
+
+* Use some of available devices to create fill std::vector<device>.
+* Create kernel_bundle via `get_kernel_bundle(const context&, const std::vector<device>&)`.
+* Check that return type is std::vector<device>.
+* Check that return vector contains all devices from input vector and only them.
+
+==== `has_kernel(const kernel_id &kernelId, const device &dev)`
+
+Check that result of function is:
+
+* `true` if kernelId is within get_kernel_ids() and `is_compatible({kernelId}, const device&)` is `true`
+* `false` if kernelId is within get_kernel_ids() and `is_compatible({kernelId}, const device&)` is `false`
+* `false` if kernelId is not within get_kernel_ids() and `is_compatible({kernelId}, const device&)` is `true`
+* `false` if kernelId is not within get_kernel_ids() and `is_compatible({kernelId}, const device&)` is `false`
+
+
+==== `std::vector<kernel_id> get_kernel_ids()`
+
+Define 4 kernels.
+Get kernel_bundle with built-in kernels.
+Check that result of get_kernel_ids:
+
+* has type `std::vector<kernel_id>`
+* has size 4
+* has only different kernel ids
+
+==== `get_kernel()`
+
+Define kernel KernelName.
+Get `kernel_bundle` with built-in kernels.
+
+* Use `get_kernel<KernelName>()` to get kernel and that return type is `sycl::kernel`
+* Try to use `get_kernel<OtherKernelName>()` and check that `errc::invalid` is thrown
+
+=== Tests for working with specialization constants
+
+Partially tested in https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/tests/specialization_constants/specialization_constants_via_kernel_bundle.h
+
+There are should be two spec constants defined - `SpecName` and `OtherSpecName`.
+
+==== Empty kernel bundle
+
+* Get an empty `kernel_bundle`.
+* Check that `contains_specialization_constants()` return `false`.
+* Check that `native_specialization_constant()` return `false`.
+* Check that `has_specialization_constant<SpecName>()` return `false`.
+
+==== Kernel bundle without `kernel_handler::get_specialization_constant()` call
+
+* Get an input `kernel_bundle` with kernel without `kernel_handler::get_specialization_constant()` call.
+* Check that `contains_specialization_constants()` return `false`.
+* Check that `native_specialization_constant()` return `false`.
+* Check that `has_specialization_constant<SpecName>()` return `false`.
+* Check that `get_specialization_constant<SpecName>()` return default value.
+* Call `compile()` to build the `kernel_bundle` into `object` state.
+* Check the same.
+* Call `link()` to build the `kernel_bundle` into `executable` state.
+* Check the same.
+
+==== Kernel bundle with `kernel_handler::get_specialization_constant()` call
+
+* Get an input `kernel_bundle` with kernel with `kernel_handler::get_specialization_constant<SpecName>()` call.
+* Set each spec constant to a different value via `kernel_bundle::set_specialization_constant()`.
+* Check that `contains_specialization_constants()` return `true`.
+* Check that called `native_specialization_constant()` without exception.
+* Check that `has_specialization_constant<SpecName>()` return `true`.
+* Check that `has_specialization_constant<OtherSpecName>()` return `false`.
+* Check that `get_specialization_constant<SpecName>()` return new value.
+* Call `compile()` to build the `kernel_bundle` into `object` state.
+* Check the same.
+* Call `link()` to build the `kernel_bundle` into `executable` state.
+* Check the same.
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Most of kernel_bundle functionality covered by tests https://github.com/KhronosGroup/SYCL-CTS/tree/SYCL-2020/tests/kernel_bundle.
This is test plan for remaining gaps.