### PR TITLE
Fix device_global tests

### DIFF
--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -175,37 +175,25 @@ inline constexpr auto get_init_value_helper<def_cnstr>(int x) {
 
 namespace get_cts_types {
 inline auto get_vector_types() {
-  static const auto pack =
-      named_type_pack<bool, char, signed char, unsigned char, short,
-                      unsigned short, int, unsigned int, long, unsigned long,
-                      long long, unsigned long long, float, sycl::cl_float,
-                      sycl::byte, sycl::cl_bool, sycl::cl_char, sycl::cl_uchar,
-                      sycl::cl_short, sycl::cl_ushort, sycl::cl_int,
-                      sycl::cl_uint, sycl::cl_long, sycl::cl_ulong>::generate(
-          "bool",
-          "char",
-          "signed char",
-          "unsigned char",
-          "short",
-          "unsigned short",
-          "int",
-          "unsigned int",
-          "long",
-          "unsigned long",
-          "long long",
-          "unsigned long long",
-          "float",
-          "sycl::cl_float",
-          "sycl::byte",
-          "sycl::cl_bool",
-          "sycl::cl_char",
-          "sycl::cl_uchar",
-          "sycl::cl_short",
-          "sycl::cl_ushort",
-          "sycl::cl_int",
-          "sycl::cl_uint",
-          "sycl::cl_long",
-          "sycl::cl_ulong");
+  static const auto pack = named_type_pack<
+      bool, char, signed char, unsigned char, short, unsigned short, int,
+      unsigned int, long, unsigned long, long long, unsigned long long, float,
+      sycl::cl_float, sycl::byte, sycl::cl_bool, sycl::cl_char, sycl::cl_uchar,
+      sycl::cl_short, sycl::cl_ushort, sycl::cl_int, sycl::cl_uint,
+      sycl::cl_long, sycl::cl_ulong>::generate("bool", "char", "signed char",
+                                               "unsigned char", "short",
+                                               "unsigned short", "int",
+                                               "unsigned int", "long",
+                                               "unsigned long", "long long",
+                                               "unsigned long long", "float",
+                                               "sycl::cl_float", "sycl::byte",
+                                               "sycl::cl_bool", "sycl::cl_char",
+                                               "sycl::cl_uchar",
+                                               "sycl::cl_short",
+                                               "sycl::cl_ushort",
+                                               "sycl::cl_int", "sycl::cl_uint",
+                                               "sycl::cl_long",
+                                               "sycl::cl_ulong");
   return pack;
 }
 }  // namespace get_cts_types

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -115,34 +115,35 @@ class no_def_cnstr {
   friend bool operator!=(const no_def_cnstr &lhs, const no_def_cnstr &rhs) {
     return !(lhs == rhs);
   }
-
-  // A user-defined struct with several scalar member variables, arrow operator
-  // overload, no constructor and
-  // destructor or member functions.
-  struct arrow_operator_overloaded {
-    float a;
-    int b;
-    char c;
-
-    void operator=(const int &v) {
-      this->a = v;
-      this->b = v;
-      this->c = v;
-    }
-
-    arrow_operator_overloaded *operator->() { return this; }
-    const arrow_operator_overloaded *operator->() const { return this; }
-
-    friend bool operator==(const arrow_operator_overloaded &lhs,
-                           const arrow_operator_overloaded &rhs) {
-      return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
-    }
-    friend bool operator!=(const arrow_operator_overloaded &lhs,
-                           const arrow_operator_overloaded &rhs) {
-      return !(lhs == rhs);
-    }
-  };
 };
+
+// A user-defined struct with several scalar member variables, arrow operator
+// overload, no constructor and
+// destructor or member functions.
+struct arrow_operator_overloaded {
+  float a;
+  int b;
+  char c;
+
+  void operator=(const int &v) {
+    this->a = v;
+    this->b = v;
+    this->c = v;
+  }
+
+  arrow_operator_overloaded *operator->() { return this; }
+  const arrow_operator_overloaded *operator->() const { return this; }
+
+  friend bool operator==(const arrow_operator_overloaded &lhs,
+                         const arrow_operator_overloaded &rhs) {
+    return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
+  }
+  friend bool operator!=(const arrow_operator_overloaded &lhs,
+                         const arrow_operator_overloaded &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
 // Returns instance of type T
 template <typename T>
 inline constexpr auto get_init_value_helper(int x) {

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -118,8 +118,7 @@ class no_def_cnstr {
 };
 
 // A user-defined struct with several scalar member variables, arrow operator
-// overload, no constructor and
-// destructor or member functions.
+// overload, no constructor and destructor or member functions.
 struct arrow_operator_overloaded {
   float a;
   int b;

--- a/tests/extension/oneapi_device_global/device_global_api_basic.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_basic.cpp
@@ -275,8 +275,8 @@ void run_test(util::logger& log, const std::string& type_name) {
   for (size_t i = integral(indx::same_type_const); i < integral(indx::size);
        ++i) {
     if (!result[i]) {
-      std::string fail_msg = get_case_description(
-          "Device global: get() method", error_strings[i], type_name);
+      std::string fail_msg = get_case_description("Device global: get() method",
+                                                  error_strings[i], type_name);
       FAIL(log, fail_msg);
     }
   }
@@ -339,8 +339,8 @@ template <typename T, typename prop_key, typename prop_value_t,
 void run_test(util::logger& log, const std::string& type_name) {
   // Check that instance has prop_key property
   if (dev_global<T, prop_value_t>.template has_property<prop_key>() != true) {
-    std::string fail_msg = get_case_description(
-        "Device global: has_property()", "Wrong value.", type_name);
+    std::string fail_msg = get_case_description("Device global: has_property()",
+                                                "Wrong value.", type_name);
     FAIL(log, fail_msg);
   }
   // Check that instance has no other_props

--- a/tests/extension/oneapi_device_global/device_global_api_basic.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_basic.cpp
@@ -25,10 +25,10 @@ using namespace sycl_cts;
 using namespace sycl_cts::util;
 using namespace device_global_common_functions;
 
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 
-using namespace sycl::ext::oneapi;
+using namespace sycl::ext::oneapi::experimental;
 
 template <typename T, test_names name,
           sycl::access::decorated Decorated = sycl::access::decorated::no>
@@ -86,6 +86,8 @@ void run_test(util::logger& log, const std::string& type_name) {
       auto result_acc =
           result_buf.template get_access<sycl::access_mode::read_write>(cgh);
 
+      T value_ref_zero_init{};
+      std::memset(&value_ref_zero_init, 0, sizeof(value_ref_zero_init));
       cgh.single_task<kernel>([=] {
         auto cmptr =
             const_dev_global<const T>.template get_multi_ptr<Decorated>();
@@ -97,30 +99,28 @@ void run_test(util::logger& log, const std::string& type_name) {
         result_acc[integral(indx::same_type_non_const)] =
             std::is_same<decltype(mptr), multi_ptr_t>::value;
 
-        // Check that multi_ptr references to default value
-        const T def_value{};
         // if *mptr and *cmptr equal to default value, then
         // test will be marked as passed, otherwise the test is failed
         result_acc[integral(indx::correct_def_val_const)] =
-            (*(cmptr.get()) == def_value);
+            (*(cmptr.get()) == value_ref_zero_init);
         result_acc[integral(indx::correct_def_val_non_const)] =
-            (*(mptr.get()) == def_value);
+            (*(mptr.get()) == value_ref_zero_init);
         // Change value, that multi_ptr points to
-        value_operations::assign<T>(*mptr, 42);
+        value_operations::assign(*mptr, 42);
         // Get current value from device_global, that should change in previous
         // step
         const T& current_value = dev_global<T>.get();
         result_acc[integral(indx::correct_changed_val)] =
-            value_operations::are_equal<T>(*mptr, current_value);
+            value_operations::are_equal(*mptr, current_value);
       });
     });
   }
   for (size_t i = integral(indx::same_type_const); i < integral(indx::size);
        ++i) {
     if (!result[i]) {
-      FAIL(log,
-           (get_case_description<T, Decorated>("Device global: get_multi_ptr()",
-                                               error_strings[i], type_name)));
+      std::string fail_msg = get_case_description<Decorated>(
+          "Device global: get_multi_ptr()", error_strings[i], type_name);
+      FAIL(log, fail_msg);
     }
   }
 }
@@ -167,36 +167,38 @@ void run_test(util::logger& log, const std::string& type_name) {
       auto result_acc =
           result_buf.template get_access<sycl::access_mode::read_write>(cgh);
 
+      T value_ref_zero_init{};
+      std::memset(&value_ref_zero_init, 0, sizeof(value_ref_zero_init));
       cgh.single_task<kernel>([=] {
         // Call copy constructor of T to access reference to the device_global
         // value
         const T& const_instance(const_dev_global<T>);
         T& instance(dev_global<T>);
 
-        T default_value{};
         // Check that resulted reference is to default value
         result_acc[integral(indx::is_def_value_const)] =
-            (default_value == instance);
+            (value_ref_zero_init == instance);
         result_acc[integral(indx::is_def_value_non_const)] =
-            (default_value == const_instance);
+            (value_ref_zero_init == const_instance);
 
-        // Changing non-const value
-        value_operations::assign<T>(dev_global<T>, 42);
+        // Changing value
+        value_operations::assign(dev_global<T>, 42);
         // Get current value from the device_global, which should change in
         // previous step
         T& current_value = dev_global<T>.get();
         // Check, that the device_global object contains new value
         result_acc[integral(indx::correct_changed_val)] =
-            value_operations::are_equal<T>(dev_global<T>, current_value);
+            value_operations::are_equal(dev_global<T>, current_value);
       });
     });
   }
   for (size_t i = integral(indx::is_def_value_const); i < integral(indx::size);
        ++i) {
     if (!result[i]) {
-      FAIL(log,
-           (get_case_description<T>("Device global: implicit conversation to T",
-                                    error_strings[i], type_name)));
+      std::string fail_msg =
+          get_case_description("Device global: implicit conversation to T",
+                               error_strings[i], type_name);
+      FAIL(log, fail_msg);
     }
   }
 }
@@ -246,6 +248,8 @@ void run_test(util::logger& log, const std::string& type_name) {
       auto result_acc =
           result_buf.template get_access<sycl::access_mode::read_write>(cgh);
 
+      T value_ref_zero_init{};
+      std::memset(&value_ref_zero_init, 0, sizeof(value_ref_zero_init));
       cgh.single_task<kernel>([=] {
         // Call get() to access reference
         const T& const_instance(const_dev_global<T>.get());
@@ -256,104 +260,123 @@ void run_test(util::logger& log, const std::string& type_name) {
         result_acc[integral(indx::same_type_non_const)] =
             std::is_same<decltype(instance), T&>::value;
         // Check that resulted reference is to default value
-        const T& def_value{};
         result_acc[integral(indx::correct_def_val_const)] =
-            (const_instance == def_value);
+            (const_instance == value_ref_zero_init);
         result_acc[integral(indx::correct_def_val_non_const)] =
-            (instance == def_value);
+            (instance == value_ref_zero_init);
         // Assign new value an check that device_global instance contains new
         // value
-        value_operations::assign<T>(instance, 42);
+        value_operations::assign(instance, 42);
         result_acc[integral(indx::correct_changed_val)] =
-            value_operations::are_equal<T>(dev_global<T>, instance);
+            value_operations::are_equal(dev_global<T>, instance);
       });
     });
   }
   for (size_t i = integral(indx::same_type_const); i < integral(indx::size);
        ++i) {
     if (!result[i]) {
-      FAIL(log, (get_case_description<T>("Device global: get() method",
-                                         error_strings[i], type_name)));
+      std::string fail_msg = get_case_description(
+          "Device global: get() method", error_strings[i], type_name);
+      FAIL(log, fail_msg);
     }
   }
 }
 }  // namespace get_method
 
 namespace has_property_method {
-using namespace sycl::ext::oneapi;
+using namespace sycl::ext::oneapi::experimental;
 // Creating instance with property prop_value_t with default
 // constructor
 template <typename T, typename prop_value_t>
-const device_global<T, property_list<prop_value_t>> dev_global;
+device_global<T, decltype(properties{prop_value_t{}})> dev_global;
 
 /** @brief The function tests that the device_global has only props, that was
- * given to property_list
+ * given to properties
  *  @tparam T Type of underlying device_global value
- *  @tparam prop_value_t Property contained by property_list
- *  @tparam other_props Properties, which should not be in property_list
+ *  @tparam prop_value_t Property contained by properties
+ *  @tparam other_props Properties, which should not be in properties
  */
 template <typename T, typename prop_value_t, typename other_prop>
 void has_no_other_props(util::logger& log, const std::string& type_name) {
   if (dev_global<T, prop_value_t>.template has_property<other_prop>() !=
       false) {
-    FAIL(log, get_case_description<T>("Device global: has_property()",
-                                      "Unexpected property returned true",
-                                      type_name));
+    std::string fail_msg =
+        get_case_description("Device global: has_property()",
+                             "Unexpected property returned true", type_name);
+    FAIL(log, fail_msg);
   }
 }
 
+// Helper for checking has_no_other_props for all properties in a type_pack.
+template <typename T, typename prop_value_t, typename other_props>
+struct check_has_no_other_props_helper;
+template <typename T, typename prop_value_t>
+struct check_has_no_other_props_helper<T, prop_value_t, type_pack<>> {
+  static void check(util::logger&, const std::string&) {}
+};
+template <typename T, typename prop_value_t, typename other_prop,
+          typename... other_props>
+struct check_has_no_other_props_helper<T, prop_value_t,
+                                       type_pack<other_prop, other_props...>> {
+  static void check(util::logger& log, const std::string& type_name) {
+    has_no_other_props<T, prop_value_t, other_prop>(log, type_name);
+    check_has_no_other_props_helper<
+        T, prop_value_t, type_pack<other_props...>>::check(log, type_name);
+  }
+};
+
 /** @brief The function tests that device_global method has_property() return
- * true on properties, that was given to property_list and false if property was
+ * true on properties, that was given to properties and false if property was
  * not provided
  *  @tparam T Type of underlying value
- *  @tparam prop_name Name of property that included in device_global property
+ *  @tparam prop_key Name of property that included in device_global property
  * list
- *  @tparam prop_value_t Property contained by property_list
- *  @tparam other_props Props, which should not be in property_list
+ *  @tparam prop_value_t Property contained by properties
+ *  @tparam other_props Props, which should not be in properties
  */
-template <typename T, typename prop_name, typename prop_value_t,
-          typename... other_props>
+template <typename T, typename prop_key, typename prop_value_t,
+          typename other_props>
 void run_test(util::logger& log, const std::string& type_name) {
-  // Check that instance has prop_name property
-  if (dev_global<T, prop_value_t>.template has_property<prop_name>() != true) {
-    FAIL(log, get_case_description<T>("Device global: has_property()",
-                                      "Wrong value.", type_name));
+  // Check that instance has prop_key property
+  if (dev_global<T, prop_value_t>.template has_property<prop_key>() != true) {
+    std::string fail_msg = get_case_description(
+        "Device global: has_property()", "Wrong value.", type_name);
+    FAIL(log, fail_msg);
   }
   // Check that instance has no other_props
-  (has_no_other_props<T, prop_value_t, other_props>(log, type_name), ...);
+  check_has_no_other_props_helper<T, prop_value_t, other_props>::check(
+      log, type_name);
 }
 }  // namespace has_property_method
 
 namespace get_property_method {
-using namespace sycl::ext::oneapi;
+using namespace sycl::ext::oneapi::experimental;
 // Creating instance with property prop_value_t with default
 // constructor
 template <typename T, typename prop_value_t>
-const device_global<T, property_list<prop_value_t>> dev_global;
+device_global<T, decltype(properties{prop_value_t{}})> dev_global;
 
 /** @brief The function tests that device_global get_property method returns
  * correct properties
  *  @tparam T Type of underlying device_global value
- *  @tparam prop_name Name of property that included in device_global property
+ *  @tparam prop_key Name of property that included in device_global property
  * list
  *  @tparam prop_value_t Integral_constant of property
- *  @tparam expected_prop_type Type of expecting property
  *  @param expected property that expecting from get_property()
  */
-template <typename T, typename prop_name, typename prop_value_t,
-          typename expected_prop_type = prop_name>
-void run_test(util::logger& log, const std::string& type_name,
-              expected_prop_type expected) {
+template <typename T, typename prop_key, typename prop_value_t>
+void run_test(util::logger& log, const std::string& type_name) {
   bool property_check{};
   // Check that get_property<prop_value_t> returns expected property of
   // expected_prop_type
   property_check =
-      (dev_global<T, prop_value_t>.template get_property<prop_name>() ==
-       expected);
+      (dev_global<T, prop_value_t>.template get_property<prop_key>() ==
+       prop_value_t{});
 
   if (!property_check) {
-    FAIL(log, get_case_description<T>("Device global: get_property",
-                                      "Wrong property returned.", type_name));
+    std::string fail_msg = get_case_description(
+        "Device global: get_property", "Wrong property returned.", type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace get_property_method
@@ -369,10 +392,10 @@ void run_test(util::logger& log, const std::string& type_name) {
   bool isSame = std::is_same<typename device_global<T>::element_type,
                              std::remove_extent_t<T>>::value;
   if (!isSame) {
-    FAIL(log,
-         get_case_description<T>(
-             "Device global: element_type",
-             "Wrong type. element_type != std::remove_extent_t<T>", type_name));
+    std::string fail_msg = get_case_description(
+        "Device global: element_type",
+        "Wrong type. element_type != std::remove_extent_t<T>", type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace element_type
@@ -390,60 +413,58 @@ void run_tests(sycl_cts::util::logger& log, const std::string& type_name) {
   // Run test of has_property method with different properties in device_global
   // property list
   {
-    using prop_name = host_access;
-    using prop_value = host_access::value_t<host_access::access::read>;
+    using prop_key = host_access_key;
+    using prop_value = host_access_key::value_t<host_access_enum::read>;
     using other_props =
-        type_pack<device_image_scope, init_mode, implement_in_csr>;
+        type_pack<device_image_scope_key, init_mode_key, implement_in_csr_key>;
 
-    has_property_method::run_test<T, prop_name, prop_value, other_props>(
+    has_property_method::run_test<T, prop_key, prop_value, other_props>(
         log, type_name);
   }
   {
-    using prop_name = device_image_scope;
-    using prop_value = device_image_scope::value_t;
-    using other_props = type_pack<host_access, init_mode, implement_in_csr>;
-
-    has_property_method::run_test<T, prop_name, prop_value, other_props>(
-        log, type_name);
-  }
-  {
-    using prop_name = init_mode;
-    using prop_value = init_mode::value_t<init_mode::trigger::reprogram>;
+    using prop_key = device_image_scope_key;
+    using prop_value = device_image_scope_key::value_t;
     using other_props =
-        type_pack<host_access, device_image_scope, implement_in_csr>;
+        type_pack<host_access_key, init_mode_key, implement_in_csr_key>;
 
-    has_property_method::run_test<T, prop_name, prop_value, other_props>(
+    has_property_method::run_test<T, prop_key, prop_value, other_props>(
         log, type_name);
   }
   {
-    using prop_name = implement_in_csr;
-    using prop_value = implement_in_csr::value_t<true>;
-    using other_props = type_pack<host_access, device_image_scope, init_mode>;
+    using prop_key = init_mode_key;
+    using prop_value = init_mode_key::value_t<init_mode_enum::reprogram>;
+    using other_props = type_pack<host_access_key, device_image_scope_key,
+                                  implement_in_csr_key>;
 
-    has_property_method::run_test<T, prop_name, prop_value, other_props>(
+    has_property_method::run_test<T, prop_key, prop_value, other_props>(
+        log, type_name);
+  }
+  {
+    using prop_key = implement_in_csr_key;
+    using prop_value = implement_in_csr_key::value_t<true>;
+    using other_props =
+        type_pack<host_access_key, device_image_scope_key, init_mode_key>;
+
+    has_property_method::run_test<T, prop_key, prop_value, other_props>(
         log, type_name);
   }
 
   // Run test of get_property method with different properties in
   // device_global property list
   {
-    using prop_name = host_access;
-    using prop_value = host_access::value_t<host_access::access::read>;
-    get_property_method::run_test<T, prop_name, prop_value>(
-        log, type_name, host_access::access::read);
+    using prop_key = host_access_key;
+    using prop_value = host_access_key::value_t<host_access_enum::read>;
+    get_property_method::run_test<T, prop_key, prop_value>(log, type_name);
   }
   {
-    using prop_name = init_mode::trigger;
-    using prop_value = init_mode::value_t<init_mode::trigger::reprogram>;
-    get_property_method::run_test<T, prop_name, prop_value>(
-        log, type_name, init_mode::trigger::reprogram);
+    using prop_key = init_mode_key;
+    using prop_value = init_mode_key::value_t<init_mode_enum::reprogram>;
+    get_property_method::run_test<T, prop_key, prop_value>(log, type_name);
   }
   {
-    using prop_name = implement_in_csr;
-    using prop_value = implement_in_csr::value_t<true>;
-    using expected_prop_type = bool;
-    get_property_method::run_test<T, prop_name, prop_value, expected_prop_type>(
-        log, type_name, true);
+    using prop_key = implement_in_csr_key;
+    using prop_value = implement_in_csr_key::value_t<true>;
+    get_property_method::run_test<T, prop_key, prop_value>(log, type_name);
   }
 
   element_type::run_test<T>(log, type_name);
@@ -472,8 +493,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else

--- a/tests/extension/oneapi_device_global/device_global_exceptions.cpp
+++ b/tests/extension/oneapi_device_global/device_global_exceptions.cpp
@@ -19,7 +19,7 @@ using namespace sycl_cts;
 using namespace sycl_cts::util;
 using namespace device_global_common_functions;
 
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 namespace oneapi = sycl::ext::oneapi;
 
@@ -31,13 +31,13 @@ namespace oneapi = sycl::ext::oneapi;
  * otherwise
  */
 inline bool is_errc_invalid(const sycl::exception& e) {
-  return e.code() != sycl::errc::invalid;
+  return e.code() == sycl::errc::invalid;
 }
 
 namespace handler_copy_exceptions {
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that .copy() member function overload throws an
  * exception with error code equal to errc::invalid if attempt to write beyond
@@ -76,18 +76,18 @@ void run_test(util::logger& log, const std::string& type_name) {
   queue.wait_and_throw();
 
   if (!is_exception_thrown) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::handler .copy() member function exception",
-             "Exception was not thrown after attempt to "
-             "write beyond the end of the destination variable",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::handler .copy() member function exception",
+        "Exception was not thrown after attempt to "
+        "write beyond the end of the destination variable",
+        type_name);
+    FAIL(log, fail_msg);
   } else if (!is_exception_correct) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::handler .copy() member function exception",
-             "Wrong errc inside the exception. Expected sycl::errc::invalid",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::handler .copy() member function exception",
+        "Wrong errc inside the exception. Expected sycl::errc::invalid",
+        type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace handler_copy_exceptions
@@ -95,7 +95,7 @@ void run_test(util::logger& log, const std::string& type_name) {
 namespace handler_memcpy_exceptions {
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that .memcpy() member function overload throws an
  * exception with error code equal to errc::invalid if attempt to write beyond
@@ -136,18 +136,18 @@ void run_test(util::logger& log, const std::string& type_name) {
   queue.wait_and_throw();
 
   if (!is_exception_thrown) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::handler .memcpy() member function exception",
-             "Exception was not thrown after attempt to "
-             "write beyond the end of the destination variable",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::handler .memcpy() member function exception",
+        "Exception was not thrown after attempt to "
+        "write beyond the end of the destination variable",
+        type_name);
+    FAIL(log, fail_msg);
   } else if (!is_exception_correct) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::handler .memcpy() member function exception",
-             "Wrong errc inside the exception. Expected sycl::errc::invalid",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::handler .memcpy() member function exception",
+        "Wrong errc inside the exception. Expected sycl::errc::invalid",
+        type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace handler_memcpy_exceptions
@@ -155,7 +155,7 @@ void run_test(util::logger& log, const std::string& type_name) {
 namespace queue_copy_exceptions {
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that .copy() member function overload throws an
  * exception with error code equal to errc::invalid if attempt to write beyond
@@ -189,18 +189,18 @@ void run_test(util::logger& log, const std::string& type_name) {
   }
 
   if (!is_exception_thrown) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::queue .copy() member function exception",
-             "Exception was not thrown after attempt to "
-             "write beyond the end of the destination variable",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::queue .copy() member function exception",
+        "Exception was not thrown after attempt to "
+        "write beyond the end of the destination variable",
+        type_name);
+    FAIL(log, fail_msg);
   } else if (!is_exception_correct) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::queue .copy() member function exception",
-             "Wrong errc inside the exception. Expected sycl::errc::invalid",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::queue .copy() member function exception",
+        "Wrong errc inside the exception. Expected sycl::errc::invalid",
+        type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace queue_copy_exceptions
@@ -208,7 +208,7 @@ void run_test(util::logger& log, const std::string& type_name) {
 namespace queue_memcpy_exceptions {
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that .memcpy() member function overload throws an
  * exception with error code equal to errc::invalid if attempt to write beyond
@@ -243,18 +243,18 @@ void run_test(util::logger& log, const std::string& type_name) {
   }
 
   if (!is_exception_thrown) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::queue .memcpy() member function exception",
-             "Exception was not thrown after attempt to "
-             "write beyond the end of the destination variable",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::queue .memcpy() member function exception",
+        "Exception was not thrown after attempt to "
+        "write beyond the end of the destination variable",
+        type_name);
+    FAIL(log, fail_msg);
   } else if (!is_exception_correct) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::queue .memcpy() member function exception",
-             "Wrong errc inside the exception. Expected sycl::errc::invalid",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::queue .memcpy() member function exception",
+        "Wrong errc inside the exception. Expected sycl::errc::invalid",
+        type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace queue_memcpy_exceptions
@@ -283,8 +283,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else

--- a/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
@@ -25,7 +25,7 @@ namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 using namespace device_global_common_functions;
 
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 namespace oneapi = sycl::ext::oneapi;
 
@@ -33,15 +33,15 @@ namespace define_various_ways {
 
 namespace {
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 }
 namespace dum_namespace {
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 }
 struct dum_struct {
   template <typename T>
-  static inline oneapi::device_global<T> dev_global;
+  static inline oneapi::experimental::device_global<T> dev_global;
 };
 
 template <typename T>
@@ -56,7 +56,7 @@ template <typename T>
 void run_test(util::logger& log, const std::string& type_name) {
   T def_value{};
   T new_val{};
-  value_operations<T>::assign(new_val, 1);
+  value_operations::assign(new_val, 1);
 
   auto queue = util::get_cts_object::queue();
   bool is_defined_correctly = false;
@@ -76,35 +76,36 @@ void run_test(util::logger& log, const std::string& type_name) {
         auto& dg3 = dum_struct::dev_global<T>.get();
 
         // Check that contains default values
-        is_default_acc[0] = value_operations::are_equal<T>(dg1, def_value);
-        is_default_acc[0] &= value_operations::are_equal<T>(dg2, def_value);
-        is_default_acc[0] &= value_operations::are_equal<T>(dg3, def_value);
+        is_default_acc[0] = value_operations::are_equal(dg1, def_value);
+        is_default_acc[0] &= value_operations::are_equal(dg2, def_value);
+        is_default_acc[0] &= value_operations::are_equal(dg3, def_value);
 
-        value_operations<T>::assign(dg1, new_val);
-        value_operations<T>::assign(dg2, new_val);
-        value_operations<T>::assign(dg3, new_val);
+        value_operations::assign(dg1, new_val);
+        value_operations::assign(dg2, new_val);
+        value_operations::assign(dg3, new_val);
 
         is_def_corr_acc[0] =
-            value_operations::are_equal<T>(dev_global<T>, new_val);
+            value_operations::are_equal(dev_global<T>, new_val);
         is_def_corr_acc[0] &=
-            value_operations::are_equal<T>(dum_namespace::dev_global<T>, new_val);
+            value_operations::are_equal(dum_namespace::dev_global<T>, new_val);
         is_def_corr_acc[0] &=
-            value_operations::are_equal<T>(dum_struct::dev_global<T>, new_val);
+            value_operations::are_equal(dum_struct::dev_global<T>, new_val);
       });
     });
     queue.wait_and_throw();
   }
   if (!is_default_values) {
-    FAIL(log, get_case_description(
-                  "device_global: Define various ways",
-                  "Instances were created with non-default values", type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: Define various ways",
+        "Instances were created with non-default values", type_name);
+    FAIL(log, fail_msg);
   }
   if (!is_defined_correctly) {
-    FAIL(log,
-         get_case_description(
-             "device_global: Define various ways",
-             "Wrong value after change when defined device_global various ways",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: Define various ways",
+        "Wrong value after change when defined device_global various ways",
+        type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace define_various_ways
@@ -132,8 +133,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else

--- a/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
@@ -47,7 +47,7 @@ class read_and_write_in_kernel {
    * new value in instance. Test will be failed if value from device_global
    * instance not equal to default value
    */
-  static inline void expect_def_val(sycl::queue &queue, util::logger& log,
+  static inline void expect_def_val(sycl::queue& queue, util::logger& log,
                                     const std::string& type_name) {
     run(queue, true,
         "Value read incorrectly from kernel on first invocation. Default "
@@ -60,7 +60,7 @@ class read_and_write_in_kernel {
    * new value in instance. Test will be failed if value from device_global
    * instance not equal to T{1}
    */
-  static inline void expect_new_val(sycl::queue &queue, util::logger& log,
+  static inline void expect_new_val(sycl::queue& queue, util::logger& log,
                                     const std::string& type_name) {
     run(queue, false,
         "Value read incorrectly from kernel on second invocation. "
@@ -75,7 +75,7 @@ class read_and_write_in_kernel {
    * @param is_def_val_expected The flag shows if default value expected
    * @param error_info String to display, when test fails
    */
-  static inline void run(sycl::queue &queue, const bool is_def_val_expected,
+  static inline void run(sycl::queue& queue, const bool is_def_val_expected,
                          const std::string& error_info, util::logger& log,
                          const std::string& type_name) {
     // is_read_correct will be set to true if device_global value is equal to

--- a/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_kernel_bundle.cpp
@@ -23,13 +23,13 @@ namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 using namespace device_global_common_functions;
 
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 namespace oneapi = sycl::ext::oneapi;
 
 namespace kernel_bundle_interaction {
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 template <typename T>
 struct kernel_read_then_write;
@@ -47,9 +47,9 @@ class read_and_write_in_kernel {
    * new value in instance. Test will be failed if value from device_global
    * instance not equal to default value
    */
-  static inline void expect_def_val(util::logger& log,
+  static inline void expect_def_val(sycl::queue &queue, util::logger& log,
                                     const std::string& type_name) {
-    run(true,
+    run(queue, true,
         "Value read incorrectly from kernel on first invocation. Default "
         "value expected",
         log, type_name);
@@ -60,9 +60,9 @@ class read_and_write_in_kernel {
    * new value in instance. Test will be failed if value from device_global
    * instance not equal to T{1}
    */
-  static inline void expect_new_val(util::logger& log,
+  static inline void expect_new_val(sycl::queue &queue, util::logger& log,
                                     const std::string& type_name) {
-    run(false,
+    run(queue, false,
         "Value read incorrectly from kernel on second invocation. "
         "Changed value expected",
         log, type_name);
@@ -75,7 +75,7 @@ class read_and_write_in_kernel {
    * @param is_def_val_expected The flag shows if default value expected
    * @param error_info String to display, when test fails
    */
-  static inline void run(const bool is_def_val_expected,
+  static inline void run(sycl::queue &queue, const bool is_def_val_expected,
                          const std::string& error_info, util::logger& log,
                          const std::string& type_name) {
     // is_read_correct will be set to true if device_global value is equal to
@@ -88,16 +88,15 @@ class read_and_write_in_kernel {
     T new_val{};
     // The function assign have default second parameter, so expect that all
     // values will change the same
-    value_operations::assign<T>(new_val, 42);
+    value_operations::assign(new_val, 42);
 
     {
       // Creating result buffer
       sycl::buffer<bool, 1> is_read_corr_buf(&is_read_correct,
                                              sycl::range<1>(1));
       // Setting kernel bundle
-      auto queue = util::get_cts_object::queue();
-      auto ctxt = queue.get_context();
       // Force online compilation
+      auto ctxt = queue.get_context();
       auto bundle =
           sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctxt);
 
@@ -114,20 +113,21 @@ class read_and_write_in_kernel {
         cgh.single_task<kernel>([=] {
           if (is_def_val_expected) {
             is_read_correct_acc[0] =
-                value_operations::are_equal<T>(dev_global<T>, def_val);
+                value_operations::are_equal(dev_global<T>, def_val);
           } else {
             is_read_correct_acc[0] =
-                value_operations::are_equal<T>(dev_global<T>, new_val);
+                value_operations::are_equal(dev_global<T>, new_val);
           }
-          value_operations::assign<T>(dev_global<T>, 42);
+          value_operations::assign(dev_global<T>, new_val);
         });
       });
       queue.wait_and_throw();
     }
     if (is_read_correct == false) {
-      FAIL(log, get_case_description(
-                    "device_global: Interaction with kernel bundles",
-                    error_info, type_name));
+      std::string fail_msg =
+          get_case_description("device_global: Interaction with kernel bundles",
+                               error_info, type_name);
+      FAIL(log, fail_msg);
     }
   }
 };
@@ -140,11 +140,13 @@ class read_and_write_in_kernel {
 template <typename T>
 void run_test(util::logger& log, const std::string& type_name) {
   using VerifierT = read_and_write_in_kernel<T>;
+  auto queue = util::get_cts_object::queue();
+
   // At the first run expect default value
-  VerifierT::expect_def_val(log, type_name);
+  VerifierT::expect_def_val(queue, log, type_name);
 
   // At the second run expect changed value
-  VerifierT::expect_new_val(log, type_name);
+  VerifierT::expect_new_val(queue, log, type_name);
 }
 }  // namespace kernel_bundle_interaction
 
@@ -171,8 +173,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else

--- a/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
@@ -43,7 +43,7 @@ class read_and_write_in_kernel {
    * new value in instance. Test will be failed if value from the device_global
    * instance not equal to default value
    */
-  static inline void expect_def_val(sycl::queue &queue, util::logger& log,
+  static inline void expect_def_val(sycl::queue& queue, util::logger& log,
                                     const std::string& type_name) {
     run(queue, true,
         "Value read incorrectly from kernel on first invocation. Default "
@@ -56,7 +56,7 @@ class read_and_write_in_kernel {
    * new value in instance. Test will be failed if value from device_global
    * instance not equal to T{1}
    */
-  static inline void expect_new_val(sycl::queue &queue, util::logger& log,
+  static inline void expect_new_val(sycl::queue& queue, util::logger& log,
                                     const std::string& type_name) {
     run(queue, false,
         "Value read incorrectly from kernel on second invocation. "
@@ -73,7 +73,7 @@ class read_and_write_in_kernel {
    * @param error_info String with additional info to display, when test fails
    * @param type_name Name of testing type for display if test fails
    */
-  static inline void run(sycl::queue &queue, const bool expect_def_value,
+  static inline void run(sycl::queue& queue, const bool expect_def_value,
                          const std::string& error_info, util::logger& log,
                          const std::string& type_name) {
     // Default value of type T in case if we expect to read default value
@@ -147,7 +147,7 @@ void run_tests_with_properties(sycl_cts::util::logger& log,
                                const std::string& type_name) {
   // Using a property_tag for kernel name
 
-    // Run without any properies
+  // Run without any properies
   run_test<T, decltype(oneapi::experimental::properties{}), property_tag::none>(
       log, type_name);
 

--- a/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
@@ -19,14 +19,14 @@
 
 namespace TEST_NAMESPACE {
 using namespace sycl_cts;
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 namespace oneapi = sycl::ext::oneapi;
 using namespace device_global_common_functions;
 
 namespace one_kernel_multiple_times {
-template <typename T, typename prop_value_t>
-oneapi::device_global<T, oneapi::property_list<prop_value_t>> dev_global;
+template <typename T, typename properties_t>
+oneapi::experimental::device_global<T, properties_t> dev_global;
 
 template <typename T, property_tag tag>
 struct kernel_read_then_write;
@@ -35,7 +35,7 @@ struct kernel_read_then_write;
  * @brief The class provide static functions to execute read and write
  * operations in the kernel
  */
-template <typename T, typename prop_value_t, property_tag tag>
+template <typename T, typename properties_t, property_tag tag>
 class read_and_write_in_kernel {
  public:
   /**
@@ -43,9 +43,9 @@ class read_and_write_in_kernel {
    * new value in instance. Test will be failed if value from the device_global
    * instance not equal to default value
    */
-  static inline void expect_def_val(util::logger& log,
+  static inline void expect_def_val(sycl::queue &queue, util::logger& log,
                                     const std::string& type_name) {
-    run(true,
+    run(queue, true,
         "Value read incorrectly from kernel on first invocation. Default "
         "value expected",
         log, type_name);
@@ -56,9 +56,9 @@ class read_and_write_in_kernel {
    * new value in instance. Test will be failed if value from device_global
    * instance not equal to T{1}
    */
-  static inline void expect_new_val(util::logger& log,
+  static inline void expect_new_val(sycl::queue &queue, util::logger& log,
                                     const std::string& type_name) {
-    run(false,
+    run(queue, false,
         "Value read incorrectly from kernel on second invocation. "
         "Changed value expected",
         log, type_name);
@@ -73,7 +73,7 @@ class read_and_write_in_kernel {
    * @param error_info String with additional info to display, when test fails
    * @param type_name Name of testing type for display if test fails
    */
-  static inline void run(const bool expect_def_value,
+  static inline void run(sycl::queue &queue, const bool expect_def_value,
                          const std::string& error_info, util::logger& log,
                          const std::string& type_name) {
     // Default value of type T in case if we expect to read default value
@@ -81,7 +81,7 @@ class read_and_write_in_kernel {
 
     // Changed value of type T in case if we expect to read modified value
     T new_val{};
-    value_operations::assign<T>(new_val, 42);
+    value_operations::assign(new_val, 42);
 
     // is_read_correct will be set to true if device_global value is equal to
     // the expected value inside kernel
@@ -90,7 +90,6 @@ class read_and_write_in_kernel {
       // Creating result buffer
       sycl::buffer<bool, 1> is_read_corr_buf(&is_read_correct,
                                              sycl::range<1>(1));
-      auto queue = util::get_cts_object::queue();
       queue.submit([&](sycl::handler& cgh) {
         using kernel = kernel_read_then_write<T, tag>;
         auto is_read_correct_acc =
@@ -100,21 +99,22 @@ class read_and_write_in_kernel {
         // then write new value
         cgh.single_task<kernel>([=] {
           if (expect_def_value) {
-            is_read_correct_acc[0] = value_operations::are_equal<T>(
-                dev_global<T, prop_value_t>, def_val);
+            is_read_correct_acc[0] = value_operations::are_equal(
+                dev_global<T, properties_t>, def_val);
           } else {
-            is_read_correct_acc[0] = value_operations::are_equal<T>(
-                dev_global<T, prop_value_t>, new_val);
+            is_read_correct_acc[0] = value_operations::are_equal(
+                dev_global<T, properties_t>, new_val);
           }
-          value_operations::assign<T>(dev_global<T, prop_value_t>, 42);
+          value_operations::assign(dev_global<T, properties_t>, 42);
         });
       });
       queue.wait_and_throw();
     }
     if (is_read_correct == false) {
-      FAIL(log, get_case_description(
-                    "device_global: Running one kernel multiple times",
-                    error_info, type_name));
+      std::string fail_msg = get_case_description(
+          "device_global: Running one kernel multiple times", error_info,
+          type_name);
+      FAIL(log, fail_msg);
     }
   }
 };
@@ -123,21 +123,23 @@ class read_and_write_in_kernel {
  * @brief The function tests that the device_global value is correctly read and
  * changed from a single kernel executed multiple times
  * @tparam T Type of underlying device_global value
- * @tparam prop_value_t Type of property_value that included in property_list
+ * @tparam prop_value_t Type of property_value that included in properties
  * @tparam tag For kernel naming
  */
 template <typename T, typename prop_value_t, property_tag tag>
 void run_test(util::logger& log, const std::string& type_name) {
   using VerifierT = read_and_write_in_kernel<T, prop_value_t, tag>;
+  auto queue = util::get_cts_object::queue();
+
   // At first run expecting default values
-  VerifierT::expect_def_val(log, type_name);
+  VerifierT::expect_def_val(queue, log, type_name);
 
   // At the second run expect changed value
-  VerifierT::expect_new_val(log, type_name);
+  VerifierT::expect_new_val(queue, log, type_name);
 }
 /**
  * @brief The function runs a test with properties that can include in
- * device_global property_list
+ * device_global properties
  * @tparam T Type of underlying value in device_global
  */
 template <typename T>
@@ -145,45 +147,62 @@ void run_tests_with_properties(sycl_cts::util::logger& log,
                                const std::string& type_name) {
   // Using a property_tag for kernel name
 
-  // Run without any properies
-  run_test<T, oneapi::property_value<>, property_tag::none>(log, type_name);
+    // Run without any properies
+  run_test<T, decltype(oneapi::experimental::properties{}), property_tag::none>(
+      log, type_name);
 
   {
-    using oneapi::device_image_scope;
+    using oneapi::experimental::device_image_scope;
     // Run with device_image_scope property
-    run_test<T, device_image_scope::value_t, property_tag::dev_image_scope>(
-        log, type_name);
+    run_test<T, decltype(oneapi::experimental::properties{device_image_scope}),
+             property_tag::dev_image_scope>(log, type_name);
   }
 
   {
-    using oneapi::host_access;
+    using oneapi::experimental::host_access;
+    using oneapi::experimental::host_access_enum;
     // Run with different host_access properies
-    run_test<T, host_access::value_t<host_access::access::read>,
+    run_test<T,
+             decltype(oneapi::experimental::properties{
+                 host_access<host_access_enum::read>}),
              property_tag::host_access_r>(log, type_name);
-    run_test<T, host_access::value_t<host_access::access::write>,
+    run_test<T,
+             decltype(oneapi::experimental::properties{
+                 host_access<host_access_enum::write>}),
              property_tag::host_access_w>(log, type_name);
-    run_test<T, host_access::value_t<host_access::access::read_write>,
+    run_test<T,
+             decltype(oneapi::experimental::properties{
+                 host_access<host_access_enum::read_write>}),
              property_tag::host_access_r_w>(log, type_name);
-    run_test<T, host_access::value_t<host_access::access::none>,
+    run_test<T,
+             decltype(oneapi::experimental::properties{
+                 host_access<host_access_enum::none>}),
              property_tag::host_access_none>(log, type_name);
   }
 
   {
-    using oneapi::init_mode;
+    using oneapi::experimental::init_mode;
+    using oneapi::experimental::init_mode_enum;
     // Run with different init_mode properies
-    run_test<T, init_mode::value_t<init_mode::trigger::reprogram>,
-             property_tag::init_mode_trig_reset>(log, type_name);
-    run_test<T, init_mode::value_t<init_mode::trigger::reset>,
+    run_test<T,
+             decltype(oneapi::experimental::properties{
+                 init_mode<init_mode_enum::reprogram>}),
              property_tag::init_mode_trig_reprogram>(log, type_name);
+    run_test<T,
+             decltype(oneapi::experimental::properties{
+                 init_mode<init_mode_enum::reset>}),
+             property_tag::init_mode_trig_reset>(log, type_name);
   }
 
   {
-    using oneapi::implement_in_csr;
+    using oneapi::experimental::implement_in_csr;
     // Run with different implement_in_csr properies
-    run_test<T, implement_in_csr::value_t<true>,
+    run_test<T,
+             decltype(oneapi::experimental::properties{implement_in_csr<true>}),
              property_tag::impl_in_csr_true>(log, type_name);
-    run_test<T, implement_in_csr::value_t<false>,
-             property_tag::impl_in_csr_false>(log, type_name);
+    run_test<
+        T, decltype(oneapi::experimental::properties{implement_in_csr<false>}),
+        property_tag::impl_in_csr_false>(log, type_name);
   }
 }
 
@@ -215,11 +234,12 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else
+    auto types = device_global_types::get_types();
     for_all_types<check_device_global_one_kernel_for_type>(types, log);
 #endif
   }

--- a/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_pass_pointer.cpp
@@ -87,8 +87,7 @@ void run_test(util::logger& log, const std::string& type_name) {
           is_read_corr_buf.template get_access<sycl::access_mode::write>(cgh);
 
       cgh.single_task<kernel>([=] {
-        is_read_correct_acc[0] =
-            (value_operations::are_equal(*(ptr), new_val));
+        is_read_correct_acc[0] = (value_operations::are_equal(*(ptr), new_val));
       });
     });
     queue.wait_and_throw();

--- a/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_spec_constants.cpp
@@ -48,7 +48,7 @@ class read_and_write_in_kernel {
    * new value from specialization constants in instance. Test will fail if
    * value from device_global instance not equal to default value
    */
-  static inline void expect_def_val(sycl::queue &queue, util::logger& log,
+  static inline void expect_def_val(sycl::queue& queue, util::logger& log,
                                     const std::string& type_name) {
     run(queue, true, "Expect to read default value", log, type_name);
   }
@@ -58,7 +58,7 @@ class read_and_write_in_kernel {
    * new value from specialization constants in instance. Test will be failed if
    * value from device_global instance not equal to T{1}
    */
-  static inline void expect_new_val(sycl::queue &queue, util::logger& log,
+  static inline void expect_new_val(sycl::queue& queue, util::logger& log,
                                     const std::string& type_name) {
     run(queue, false, "Expect to read modified value", log, type_name);
   }
@@ -70,14 +70,13 @@ class read_and_write_in_kernel {
    * @param is_def_val_expected The flag shows if default value expected
    * @param error_info String to display, when test fails
    */
-  static inline void run(sycl::queue &queue, const bool is_def_val_expected,
+  static inline void run(sycl::queue& queue, const bool is_def_val_expected,
                          const std::string& error_info, util::logger& log,
                          const std::string& type_name) {
-
     constexpr int initial_sc_val = 1;
     constexpr int changed_sc_val = 2;
     const int sc_val = is_def_val_expected ? initial_sc_val : changed_sc_val;
-    
+
     // Default value of type T in case if we expect to read default value
     T def_val{};
     // Changed value of type T in case if we expect to read modified value

--- a/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
@@ -20,7 +20,7 @@
 namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 using namespace device_global_common_functions;
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 namespace oneapi = sycl::ext::oneapi;
 
@@ -66,7 +66,7 @@ std::vector<sycl::device> try_to_get_sub_devices(const sycl::device& dev) {
 
 namespace unique_for_every_device {
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 template <typename T>
 struct write_kernel;
@@ -83,7 +83,7 @@ void call_write_kernel(sycl::queue& q) {
   using kernel = write_kernel<T>;
   q.submit([&](sycl::handler& cgh) {
     cgh.single_task<kernel>(
-        [=] { value_operations::assign<T>(dev_global<T>, 42); });
+        [=] { value_operations::assign(dev_global<T>, 42); });
   });
 }
 
@@ -96,7 +96,7 @@ void call_write_kernel(sycl::queue& q) {
 template <typename T>
 void call_read_kernel(sycl::queue& q, util::logger& log,
                       const std::string& type_name) {
-  using kernel = write_kernel<T>;
+  using kernel = read_kernel<T>;
   bool is_default_val{false};
   {
     sycl::buffer is_default_val_buf(&is_default_val, sycl::range<1>(1));
@@ -106,16 +106,19 @@ void call_read_kernel(sycl::queue& q, util::logger& log,
       cgh.single_task<kernel>([=] {
         T def_value{};
         is_default_val_acc[0] =
-            value_operations::are_equal<T>(dev_global<T>, def_value);
+            value_operations::are_equal(dev_global<T>, def_value);
       });
     });
   }
   // Test fails if non-default value read from the device_global instance
-  if (!is_default_val)
-    FAIL(log, get_case_description("device_global: Unique for every device",
-                                   "Value changed on another device. "
-                                   "Expect change only on one device",
-                                   type_name));
+  if (!is_default_val) {
+    std::string fail_msg =
+        get_case_description("device_global: Unique for every device",
+                             "Value changed on another device. "
+                             "Expect change only on one device",
+                             type_name);
+    FAIL(log, fail_msg);
+  }
 }
 /**
  * @brief The function tests that the device_global instance is unique for every
@@ -136,7 +139,8 @@ void run_test(util::logger& log, const std::string& type_name) {
       if (subdevices.size() > 1) {
         // Create sycl::queue instances for the subdevices and put it to the end
         // of queues vector
-        queues.insert(queues.end(), subdevices.begin(), subdevices.end());
+        for (const auto& subdevice : subdevices)
+          queues.emplace_back(subdevice);
       } else {
         // If device doesn't support partition then create sycl::queue
         // instance for the root device and put it to the end of queues vector
@@ -183,8 +187,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else

--- a/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
@@ -139,8 +139,7 @@ void run_test(util::logger& log, const std::string& type_name) {
       if (subdevices.size() > 1) {
         // Create sycl::queue instances for the subdevices and put it to the end
         // of queues vector
-        for (const auto& subdevice : subdevices)
-          queues.emplace_back(subdevice);
+        for (const auto& subdevice : subdevices) queues.emplace_back(subdevice);
       } else {
         // If device doesn't support partition then create sycl::queue
         // instance for the root device and put it to the end of queues vector

--- a/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
+++ b/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
@@ -391,15 +391,15 @@ void run_test(util::logger& log, const std::string& type_name) {
       });
       queue.wait_and_throw();
     }
-    }
+  }
 
-    if (!is_copy_correct) {
+  if (!is_copy_correct) {
     std::string fail_msg = get_case_description(
         "device_global: sycl::handler .memcpy() member function overload",
         "Wrong value after memcpy from the device_global instance", type_name);
     FAIL(log, fail_msg);
-    }
   }
+}
 }  // namespace memcpy_from_dg
 
 template <typename T>

--- a/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
+++ b/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
@@ -27,7 +27,7 @@ using namespace sycl_cts;
 using namespace sycl_cts::util;
 using namespace device_global_common_functions;
 
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 namespace oneapi = sycl::ext::oneapi;
 
@@ -38,7 +38,7 @@ template <typename T>
 struct kernel2;
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that .copy() member function overload correctly
  * copy data from the pointer to the device_global instance
@@ -60,7 +60,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T src_value;
-  value_operations<T>::assign(src_value, init_value);
+  value_operations::assign(src_value, init_value);
 
   element_ptr src = pointer_helper(src_value);
 
@@ -80,9 +80,9 @@ void run_test(util::logger& log, const std::string& type_name) {
           is_copy_correct_buf.template get_access<sycl::access_mode::write>(
               cgh);
       cgh.single_task<kernel1<T>>([=] {
-        // dev_global have to be equal to *src after copy
+        // dev_global have to be equal to src_value after copy
         is_copy_correct_acc[0] =
-            value_operations::are_equal<T>(dev_global<T>, *src);
+            value_operations::are_equal(dev_global<T>, src_value);
       });
     });
     queue.wait_and_throw();
@@ -94,7 +94,7 @@ void run_test(util::logger& log, const std::string& type_name) {
         // Changing value of the first element
         src[0] = changed_value;
         // Copy first element from the array
-        cgh.copy<T>(src, dev_global<T>, element_size, 0);
+        cgh.copy<T>(src, dev_global<T>, 1, 0);
       });
       queue.wait_and_throw();
 
@@ -103,9 +103,9 @@ void run_test(util::logger& log, const std::string& type_name) {
             is_copy_correct_buf.template get_access<sycl::access_mode::write>(
                 cgh);
         cgh.single_task<kernel2<T>>([=] {
-          // dev_global have to be equal to *src after copy
+          // dev_global have to be equal to src_value after copy
           is_copy_correct_acc[0] &=
-              value_operations::are_equal<T>(dev_global<T>, *src);
+              value_operations::are_equal(dev_global<T>, src_value);
         });
       });
       queue.wait_and_throw();
@@ -113,11 +113,10 @@ void run_test(util::logger& log, const std::string& type_name) {
   }
 
   if (!is_copy_correct) {
-    FAIL(
-        log,
-        get_case_description(
-            "device_global: sycl::handler .copy() member function overload",
-            "Wrong value after copy to the device_global instance", type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::handler .copy() member function overload",
+        "Wrong value after copy to the device_global instance", type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace copy_to_dg
@@ -131,7 +130,7 @@ template <typename T>
 struct kernel3;
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that .copy() member function overload correctly
  * copy data to the pointer from the device_global instance
@@ -151,7 +150,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T dest_value;
-  value_operations<T>::assign(dest_value, changed_value);
+  value_operations::assign(dest_value, changed_value);
 
   element_ptr dest = pointer_helper(dest_value);
 
@@ -172,9 +171,9 @@ void run_test(util::logger& log, const std::string& type_name) {
           is_copy_correct_buf.template get_access<sycl::access_mode::write>(
               cgh);
       cgh.single_task<kernel1<T>>([=] {
-        // dev_global have to be equal to *dest after copy
+        // dev_global have to be equal to dest_value after copy
         is_copy_correct_acc[0] =
-            value_operations::are_equal<T>(dev_global<T>, *dest);
+            value_operations::are_equal(dev_global<T>, dest_value);
       });
     });
     queue.wait_and_throw();
@@ -190,7 +189,7 @@ void run_test(util::logger& log, const std::string& type_name) {
 
       queue.submit([&](sycl::handler& cgh) {
         // Copy first element from the array
-        cgh.copy<T>(dev_global<T>, dest, element_size, 0);
+        cgh.copy<T>(dev_global<T>, dest, 1, 0);
       });
       queue.wait_and_throw();
 
@@ -201,7 +200,7 @@ void run_test(util::logger& log, const std::string& type_name) {
         cgh.single_task<kernel3<T>>([=] {
           // Compare again after copy
           is_copy_correct_acc[0] &=
-              value_operations::are_equal<T>(dev_global<T>, *dest);
+              value_operations::are_equal(dev_global<T>, dest_value);
         });
       });
       queue.wait_and_throw();
@@ -209,11 +208,10 @@ void run_test(util::logger& log, const std::string& type_name) {
   }
 
   if (!is_copy_correct) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::handler .copy() member function overload",
-             "Wrong value after copy from the device_global instance",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::handler .copy() member function overload",
+        "Wrong value after copy from the device_global instance", type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace copy_from_dg
@@ -225,7 +223,7 @@ template <typename T>
 struct kernel2;
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that .memcpy() member function overload correctly
  * copy memory from the pointer to the device_global instance
@@ -248,7 +246,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T src_value;
-  value_operations<T>::assign(src_value, init_value);
+  value_operations::assign(src_value, init_value);
   void_ptr src = static_cast<void_ptr>(pointer_helper(src_value));
 
   bool is_copy_correct{false};
@@ -268,9 +266,9 @@ void run_test(util::logger& log, const std::string& type_name) {
           is_copy_correct_buf.template get_access<sycl::access_mode::write>(
               cgh);
       cgh.single_task<kernel1<T>>([=] {
-        // dev_global have to be equal to *src after copy
-        is_copy_correct_acc[0] = value_operations::are_equal<T>(
-            dev_global<T>, *(static_cast<element_ptr>(src)));
+        // dev_global have to be equal to src_value after copy
+        is_copy_correct_acc[0] =
+            value_operations::are_equal(dev_global<T>, src_value);
       });
     });
     queue.wait_and_throw();
@@ -293,8 +291,8 @@ void run_test(util::logger& log, const std::string& type_name) {
                 cgh);
         cgh.single_task<kernel2<T>>([=] {
           // Compare again after copy
-          is_copy_correct_acc[0] &= value_operations::are_equal<T>(
-              dev_global<T>, *(static_cast<element_ptr>(src)));
+          is_copy_correct_acc[0] &=
+              value_operations::are_equal(dev_global<T>, src_value);
         });
       });
       queue.wait_and_throw();
@@ -302,11 +300,10 @@ void run_test(util::logger& log, const std::string& type_name) {
   }
 
   if (!is_copy_correct) {
-    FAIL(log,
-         get_case_description(
-             "device_global: sycl::handler .memcpy() member function overload",
-             "Wrong value after memcpy to the device_global instance",
-             type_name));
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::handler .memcpy() member function overload",
+        "Wrong value after memcpy to the device_global instance", type_name);
+    FAIL(log, fail_msg);
   }
 }
 }  // namespace memcpy_to_dg
@@ -320,7 +317,7 @@ template <typename T>
 struct kernel3;
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that .memcpy() member function overload correctly
  * copy memory to the pointer from the device_global instance
@@ -328,7 +325,6 @@ oneapi::device_global<T> dev_global;
 template <typename T>
 void run_test(util::logger& log, const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
-  using element_ptr = element_type*;
   using void_ptr = void*;
 
   // Count size of one element
@@ -340,7 +336,7 @@ void run_test(util::logger& log, const std::string& type_name) {
   changed_value = 2;
 
   T dest_value;
-  value_operations<T>::assign(dest_value, changed_value);
+  value_operations::assign(dest_value, changed_value);
 
   void_ptr dest = pointer_helper(dest_value);
 
@@ -362,8 +358,8 @@ void run_test(util::logger& log, const std::string& type_name) {
               cgh);
       cgh.single_task<kernel1<T>>([=] {
         // dev_global have to be equal to *dest after copy
-        is_copy_correct_acc[0] = value_operations::are_equal<T>(
-            dev_global<T>, *(static_cast<element_ptr>(dest)));
+        is_copy_correct_acc[0] =
+            value_operations::are_equal(dev_global<T>, dest_value);
       });
     });
     queue.wait_and_throw();
@@ -373,7 +369,7 @@ void run_test(util::logger& log, const std::string& type_name) {
     if constexpr (elements_count > 1) {
       queue.submit([&](sycl::handler& cgh) {
         // Changing value of the first element
-        cgh.singe_task<kernel2<T>>([=] { dev_global<T>[0] = changed_value; });
+        cgh.single_task<kernel2<T>>([=] { dev_global<T>[0] = changed_value; });
       });
       queue.wait_and_throw();
 
@@ -389,8 +385,8 @@ void run_test(util::logger& log, const std::string& type_name) {
                 cgh);
         cgh.single_task<kernel3<T>>([=] {
           // Compare again after copy
-          is_copy_correct_acc[0] = value_operations::are_equal<T>(
-              dev_global<T>, *(static_cast<element_type*>(dest)));
+          is_copy_correct_acc[0] =
+              value_operations::are_equal(dev_global<T>, dest_value);
         });
       });
       queue.wait_and_throw();
@@ -398,12 +394,11 @@ void run_test(util::logger& log, const std::string& type_name) {
     }
 
     if (!is_copy_correct) {
-      FAIL(
-          log,
-          get_case_description(
-              "device_global: sycl::handler .memcpy() member function overload",
-              "Wrong value after memcpy from the device_global instance",
-              type_name));
+      std::string fail_msg = get_case_description(
+          "device_global: sycl::handler .memcpy() member function overload",
+          "Wrong value after memcpy from the device_global instance",
+          type_name);
+      FAIL(log, fail_msg);
     }
   }
 }  // namespace memcpy_from_dg
@@ -436,8 +431,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else

--- a/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
+++ b/tests/extension/oneapi_device_global/device_global_handler_copy_memcpy_overloads.cpp
@@ -394,11 +394,10 @@ void run_test(util::logger& log, const std::string& type_name) {
     }
 
     if (!is_copy_correct) {
-      std::string fail_msg = get_case_description(
-          "device_global: sycl::handler .memcpy() member function overload",
-          "Wrong value after memcpy from the device_global instance",
-          type_name);
-      FAIL(log, fail_msg);
+    std::string fail_msg = get_case_description(
+        "device_global: sycl::handler .memcpy() member function overload",
+        "Wrong value after memcpy from the device_global instance", type_name);
+    FAIL(log, fail_msg);
     }
   }
 }  // namespace memcpy_from_dg

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -88,10 +88,8 @@ void run_test_copy_to_device_global(util::logger& log,
                                 sizeof(T) / sizeof(element_type), 0, depEvents);
   event3.wait();
   // Reverse order is used to increase probability of data race.
-  // Array in gens[0] is already copied after event2,
-  // so it's not copied here to not to rewrite result for previous case.
-  for (size_t i = numEvents - 1; i + 1 > 0; --i) {
-    gens[i].copy_arrays(queue);
+  for (size_t i = numEvents; i > 0; --i) {
+    gens[i - 1].copy_arrays(queue);
   }
 
   bool events_result = true;

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -188,10 +188,8 @@ void run_test_copy_from_device_global(util::logger& log,
                            sizeof(T) / sizeof(element_type), 0, depEvents);
   event3.wait();
   // Reverse order is used to increase probability of data race.
-  // Array in gens[0] is already copied after event2,
-  // so it's not copied here to not to rewrite result for previous case.
-  for (size_t i = numEvents - 1; i + 1 > 0; --i) {
-    gens[i].copy_arrays(queue);
+  for (size_t i = numEvents; i > 0; --i) {
+    gens[i - 1].copy_arrays(queue);
   }
 
   bool events_result = true;

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -18,7 +18,7 @@ namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 using namespace device_global_common_functions;
 
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 namespace oneapi = sycl::ext::oneapi;
 
@@ -30,13 +30,13 @@ struct change_dg_kernel;
 
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global1;
+oneapi::experimental::device_global<T> dev_global1;
 
 template <typename T>
-oneapi::device_global<T> dev_global2;
+oneapi::experimental::device_global<T> dev_global2;
 
 template <typename T>
-oneapi::device_global<T> dev_global3;
+oneapi::experimental::device_global<T> dev_global3;
 
 /** @brief The function tests that queue copy overloads correctly copy to
  * device_global
@@ -47,29 +47,22 @@ void run_test_copy_to_device_global(util::logger& log,
                                     const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T data{};
-  value_operations<T>::assign(data, 1);
+  value_operations::assign(data, 1);
   const auto src_data = pointer_helper(data);
+
+  auto queue = util::get_cts_object::queue();
 
   // to generate events with generator from usm_api.h
   // gens will generate events that will fill array arr_src
   // in single_task that will take a significant amount of time
   constexpr size_t numEvents = 5;
   constexpr size_t gen_buf_size = 1000;
-  std::array<usm_api::event_generator<element_type, gen_buf_size>, numEvents>
-      gens{};
+  usm_api::event_generator<element_type, gen_buf_size> gen{};
   element_type init_value{1};
-
-  auto queue = util::get_cts_object::queue();
+  sycl::event depEvent = gen.init(queue, init_value);
 
   auto event1 = queue.copy(src_data, dev_global1<T>);
   event1.wait();
-
-  // List of events that tested usm operation should wait
-  std::vector<sycl::event> depEvents(numEvents);
-  // Run time-consuming tasks to generate events
-  for (size_t i = 0; i < depEvents.size(); ++i) {
-    depEvents[i] = gens[i].init(queue, init_value);
-  }
 
   // Call overloads with events and check if they wait for events to pass.
   // Use fast copy arrays for future check. If overloads do not
@@ -77,11 +70,19 @@ void run_test_copy_to_device_global(util::logger& log,
   // initialized 'arr_src' will be copied to 'arr_dst' and the test
   // will fail with generator function check().
 
-  auto event2 =
-      queue.copy(src_data, dev_global2<T>,
-                      sizeof(T) / sizeof(element_type), 0, depEvents[0]);
+  auto event2 = queue.copy(src_data, dev_global2<T>,
+                           sizeof(T) / sizeof(element_type), 0, depEvent);
   event2.wait();
-  gens[0].copy_arrays(queue);
+  gen.copy_arrays(queue);
+
+  // List of events that tested usm operation should wait
+  std::array<usm_api::event_generator<element_type, gen_buf_size>, numEvents>
+      gens{};
+  std::vector<sycl::event> depEvents(numEvents);
+  // Run time-consuming tasks to generate events
+  for (size_t i = 0; i < depEvents.size(); ++i) {
+    depEvents[i] = gens[i].init(queue, init_value);
+  }
 
   auto event3 = queue.copy(src_data, dev_global3<T>,
                                 sizeof(T) / sizeof(element_type), 0, depEvents);
@@ -89,7 +90,7 @@ void run_test_copy_to_device_global(util::logger& log,
   // Reverse order is used to increase probability of data race.
   // Array in gens[0] is already copied after event2,
   // so it's not copied here to not to rewrite result for previous case.
-  for (size_t i = numEvents - 1; i > 1; --i) {
+  for (size_t i = numEvents - 1; i + 1 > 0; --i) {
     gens[i].copy_arrays(queue);
   }
 
@@ -111,24 +112,24 @@ void run_test_copy_to_device_global(util::logger& log,
       auto is_cop_corr_acc =
           is_cop_corr_buf.template get_access<sycl::access_mode::write>(cgh);
       cgh.single_task<check_copy_to_dg_kernel<T>>([=] {
-        is_cop_corr_acc[0] = value_operations::are_equal<T>(dev_global1<T>, data);
-        is_cop_corr_acc[0] &=
-            value_operations::are_equal<T>(dev_global2<T>, data);
-        is_cop_corr_acc[0] &=
-            value_operations::are_equal<T>(dev_global3<T>, data);
+        is_cop_corr_acc[0] =
+            value_operations::are_equal(dev_global1<T>, data) &&
+            value_operations::are_equal(dev_global2<T>, data) &&
+            value_operations::are_equal(dev_global3<T>, data);
       });
     });
     queue.wait_and_throw();
   }
   if (!is_copied_correctly) {
-    FAIL(log, get_case_description(
-                  "Overloads of sycl::queue::copy for device_global",
-                  "Didn't copy correct data to device_global", type_name));
+    std::string fail_msg = get_case_description(
+        "Overloads of sycl::queue::copy for device_global",
+        "Didn't copy correct data to device_global", type_name);
+    FAIL(log, fail_msg);
   }
 }
 
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that queue copy overloads correctly copy from
  * device_global
@@ -139,18 +140,17 @@ void run_test_copy_from_device_global(util::logger& log,
                                       const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T new_val{};
-  value_operations<T>::assign(new_val, 5);
+  value_operations::assign(new_val, 5);
   T data1{}, data2{}, data3{};
   auto dst_data1 = pointer_helper(data1);
   auto dst_data2 = pointer_helper(data2);
   auto dst_data3 = pointer_helper(data3);
 
-  sycl::queue queue;
   auto queue = util::get_cts_object::queue();
 
   queue.submit([&](sycl::handler& cgh) {
     cgh.single_task<change_dg_kernel<T>>(
-        [=] { value_operations<T>::assign(dev_global<T>, new_val); });
+        [=] { value_operations::assign(dev_global<T>, new_val); });
   });
   queue.wait_and_throw();
 
@@ -162,16 +162,9 @@ void run_test_copy_from_device_global(util::logger& log,
   // in single_task that will take a significant amount of time
   constexpr size_t numEvents = 5;
   constexpr size_t gen_buf_size = 1000;
-  std::array<usm_api::event_generator<element_type, gen_buf_size>, numEvents>
-      gens{};
+  usm_api::event_generator<element_type, gen_buf_size> gen{};
   element_type init_value{1};
-
-  // List of events that tested usm operation should wait
-  std::vector<sycl::event> depEvents(numEvents);
-  // Run time-consuming tasks to generate events
-  for (size_t i = 0; i < depEvents.size(); ++i) {
-    depEvents[i] = gens[i].init(queue, init_value);
-  }
+  sycl::event depEvent = gen.init(queue, init_value);
 
   // Call overloads with events and check if they wait for events to pass.
   // Use fast copy arrays for future check. If overloads do not
@@ -179,11 +172,19 @@ void run_test_copy_from_device_global(util::logger& log,
   // initialized 'arr_src' will be copied to 'arr_dst' and the test
   // will fail with generator function check().
 
-  auto event2 =
-      queue.copy(dev_global<T>, dst_data2,
-                      sizeof(T) / sizeof(element_type), 0, depEvents[0]);
+  auto event2 = queue.copy(dev_global<T>, dst_data2,
+                           sizeof(T) / sizeof(element_type), 0, depEvent);
   event2.wait();
-  gens[0].copy_arrays(queue);
+  gen.copy_arrays(queue);
+
+  // List of events that tested usm operation should wait
+  std::array<usm_api::event_generator<element_type, gen_buf_size>, numEvents>
+      gens{};
+  std::vector<sycl::event> depEvents(numEvents);
+  // Run time-consuming tasks to generate events
+  for (size_t i = 0; i < depEvents.size(); ++i) {
+    depEvents[i] = gens[i].init(queue, init_value);
+  }
 
   auto event3 = queue.copy(dev_global<T>, dst_data3,
                                 sizeof(T) / sizeof(element_type), 0, depEvents);
@@ -191,7 +192,7 @@ void run_test_copy_from_device_global(util::logger& log,
   // Reverse order is used to increase probability of data race.
   // Array in gens[0] is already copied after event2,
   // so it's not copied here to not to rewrite result for previous case.
-  for (size_t i = numEvents - 1; i > 1; --i) {
+  for (size_t i = numEvents - 1; i + 1 > 0; --i) {
     gens[i].copy_arrays(queue);
   }
 
@@ -205,12 +206,13 @@ void run_test_copy_from_device_global(util::logger& log,
          "Copy overloads from device_global didn't wait for depEvents to "
          "complete");
 
-  if (!value_operations::are_equal<T>(data1, new_val) ||
-      !value_operations::are_equal<T>(data2, new_val) ||
-      !value_operations::are_equal<T>(data3, new_val)) {
-    FAIL(log, get_case_description(
-                  "Overloads of sycl::queue::copy for device_global",
-                  "Didn't copy correct data from device_global", type_name));
+  if (!value_operations::are_equal(data1, new_val) ||
+      !value_operations::are_equal(data2, new_val) ||
+      !value_operations::are_equal(data3, new_val)) {
+    std::string fail_msg = get_case_description(
+        "Overloads of sycl::queue::copy for device_global",
+        "Didn't copy correct data from device_global", type_name);
+    FAIL(log, fail_msg);
   }
 }
 
@@ -241,8 +243,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else

--- a/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_copy.cpp
@@ -85,7 +85,7 @@ void run_test_copy_to_device_global(util::logger& log,
   }
 
   auto event3 = queue.copy(src_data, dev_global3<T>,
-                                sizeof(T) / sizeof(element_type), 0, depEvents);
+                           sizeof(T) / sizeof(element_type), 0, depEvents);
   event3.wait();
   // Reverse order is used to increase probability of data race.
   for (size_t i = numEvents; i > 0; --i) {
@@ -185,7 +185,7 @@ void run_test_copy_from_device_global(util::logger& log,
   }
 
   auto event3 = queue.copy(dev_global<T>, dst_data3,
-                                sizeof(T) / sizeof(element_type), 0, depEvents);
+                           sizeof(T) / sizeof(element_type), 0, depEvents);
   event3.wait();
   // Reverse order is used to increase probability of data race.
   // Array in gens[0] is already copied after event2,

--- a/tests/extension/oneapi_device_global/device_global_queue_memcpy.cpp
+++ b/tests/extension/oneapi_device_global/device_global_queue_memcpy.cpp
@@ -18,7 +18,7 @@ namespace TEST_NAMESPACE {
 using namespace sycl_cts;
 using namespace device_global_common_functions;
 
-#if defined(SYCL_EXT_ONEAPI_PROPERTY_LIST) && \
+#if defined(SYCL_EXT_ONEAPI_PROPERTIES) && \
     defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
 namespace oneapi = sycl::ext::oneapi;
 
@@ -30,13 +30,13 @@ struct memcpy_change_dg_kernel;
 
 // Creating instance with default constructor
 template <typename T>
-oneapi::device_global<T> dev_global1;
+oneapi::experimental::device_global<T> dev_global1;
 
 template <typename T>
-oneapi::device_global<T> dev_global2;
+oneapi::experimental::device_global<T> dev_global2;
 
 template <typename T>
-oneapi::device_global<T> dev_global3;
+oneapi::experimental::device_global<T> dev_global3;
 
 /** @brief The function tests that queue memcpy overloads correctly copy to
  *  device_global
@@ -47,7 +47,7 @@ void run_test_memcpy_to_device_global(util::logger& log,
                                       const std::string& type_name) {
   using element_type = std::remove_all_extents_t<T>;
   T data{};
-  value_operations<T>::assign(data, 1);
+  value_operations::assign(data, 1);
   const void* src_data = pointer_helper(data);
 
   // to generate events with generator from usm_api.h
@@ -110,24 +110,25 @@ void run_test_memcpy_to_device_global(util::logger& log,
           is_memcpy_corr_buf.template get_access<sycl::access_mode::write>(cgh);
       cgh.single_task<check_memcpy_to_dg_kernel<T>>([=] {
         is_memcpy_corr_acc[0] =
-            value_operations::are_equal<T>(dev_global1<T>, data);
+            value_operations::are_equal(dev_global1<T>, data);
         is_memcpy_corr_acc[0] &=
-            value_operations::are_equal<T>(dev_global2<T>, data);
+            value_operations::are_equal(dev_global2<T>, data);
         is_memcpy_corr_acc[0] &=
-            value_operations::are_equal<T>(dev_global3<T>, data);
+            value_operations::are_equal(dev_global3<T>, data);
       });
     });
     queue.wait_and_throw();
   }
   if (!is_copied_correctly) {
-    FAIL(log, get_case_description(
-                  "Overloads of sycl::queue::memcpy for device_global",
-                  "Didn't copy correct data to device_global", type_name));
+    std::string fail_msg = get_case_description(
+        "Overloads of sycl::queue::memcpy for device_global",
+        "Didn't copy correct data to device_global", type_name);
+    FAIL(log, fail_msg);
   }
 }
 
 template <typename T>
-oneapi::device_global<T> dev_global;
+oneapi::experimental::device_global<T> dev_global;
 
 /** @brief The function tests that queue memcpy overloads correctly copy from
  *  device_global
@@ -141,13 +142,13 @@ void run_test_memcpy_from_device_global(util::logger& log,
                                         bool val_default) {
   using element_type = std::remove_all_extents_t<T>;
   T new_val{};
-  value_operations<T>::assign(new_val, 5);
+  value_operations::assign(new_val, 5);
   T expected{};
   T data1{}, data2{}, data3{};
   if (val_default) {
-    value_operations<T>::assign(data1, new_val);
-    value_operations<T>::assign(data2, new_val);
-    value_operations<T>::assign(data3, new_val);
+    value_operations::assign(data1, new_val);
+    value_operations::assign(data2, new_val);
+    value_operations::assign(data3, new_val);
   }
   void* dst_data1 = pointer_helper(data1);
   void* dst_data2 = pointer_helper(data2);
@@ -156,10 +157,10 @@ void run_test_memcpy_from_device_global(util::logger& log,
   auto queue = util::get_cts_object::queue();
 
   if (!val_default) {
-    value_operations<T>::assign(expected, new_val);
+    value_operations::assign(expected, new_val);
     queue.submit([&](sycl::handler& cgh) {
       cgh.single_task<memcpy_change_dg_kernel<T>>(
-          [=] { value_operations<T>::assign(dev_global<T>, new_val); });
+          [=] { value_operations::assign(dev_global<T>, new_val); });
     });
     queue.wait_and_throw();
   }
@@ -213,12 +214,13 @@ void run_test_memcpy_from_device_global(util::logger& log,
          "Memcpy overloads from device_global didn't wait for depEvents to "
          "complete");
 
-  if (!value_operations::are_equal<T>(data1, expected) ||
-      !value_operations::are_equal<T>(data2, expected) ||
-      !value_operations::are_equal<T>(data3, expected)) {
-    FAIL(log, get_case_description(
-                  "Overloads of sycl::queue::memcpy for device_global",
-                  "Didn't copy correct data from device_global", type_name));
+  if (!value_operations::are_equal(data1, expected) ||
+      !value_operations::are_equal(data2, expected) ||
+      !value_operations::are_equal(data3, expected)) {
+    std::string fail_msg = get_case_description(
+        "Overloads of sycl::queue::memcpy for device_global",
+        "Didn't copy correct data from device_global", type_name);
+    FAIL(log, fail_msg);
   }
 }
 
@@ -251,8 +253,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
   /** execute the test
    */
   void run(util::logger& log) override {
-#if !defined(SYCL_EXT_ONEAPI_PROPERTY_LIST)
-    WARN("SYCL_EXT_ONEAPI_PROPERTY_LIST is not defined, test is skipped");
+#if !defined(SYCL_EXT_ONEAPI_PROPERTIES)
+    WARN("SYCL_EXT_ONEAPI_PROPERTIES is not defined, test is skipped");
 #elif !defined(SYCL_EXT_ONEAPI_DEVICE_GLOBAL)
     WARN("SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined, test is skipped");
 #else


### PR DESCRIPTION
This commit makes the following changes to device_global related tests:
* Moves arrow_operator_overloaded struct out of no_def_cnstr.
* Fix overloads of assign and are_equal for arrays and add device_global overload.
* Change SYCL_EXT_ONEAPI_PROPERTY_LIST to SYCL_EXT_ONEAPI_PROPERTIES after change to the corresponding extension.
* Add experimental to the namespace of properties and device_global.
* Fix failure reporting.
* Fix use of templates on `value_operations`.
* Prevent the use of different contexts expecting the same device_global.
* Fix uses of compile-time properties after changes to the extension.
* Additional small bugfixes.