### PR TITLE
Add tests for context class and device class

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -302,6 +302,14 @@ bool check_equal_values(const sycl::vec<T, numElements>& lhs,
   return result;
 }
 
+/**
+ * @brief Returns true if \p vec contains \p elem.
+ */
+template <typename T>
+bool check_contains(const std::vector<T>& vec, const T& elem) {
+  return std::find(vec.begin(), vec.end(), elem) != vec.end();
+}
+
 // ComputeCpp and hipSYCL do not yet support sycl::marray
 #if !SYCL_CTS_COMPILING_WITH_COMPUTECPP && !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**

--- a/tests/context/context_info.cpp
+++ b/tests/context/context_info.cpp
@@ -21,53 +21,59 @@
 
 #include "../common/common.h"
 
-#define TEST_NAME context_info
+TEST_CASE("context info", "[context]") {
+  auto ctx = sycl_cts::util::get_cts_object::context();
 
-namespace contect_info__ {
-using namespace sycl_cts;
-
-/** tests the info for sycl::context
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-  */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+  {  // check get_info for info::context::platform
+    check_get_info_param<sycl::info::context::platform, sycl::platform>(ctx);
   }
-
-  /** execute the test
-  */
-  void run(util::logger &log) override {
-    {
-      auto context = util::get_cts_object::context();
-
-      /** check get_info for info::context::platform
-       */
-      {
-        auto platform = context.get_info<sycl::info::context::platform>();
-        // FIXME: Reenable when struct information descriptors are implemented
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
-        check_get_info_param<sycl::info::context::platform, sycl::platform>(
-            log, context);
-#endif
-      }
-
-      /** check get_info for info::context::devices
-       */
-      {
-        auto devs = context.get_info<sycl::info::context::devices>();
-        // FIXME: Reenable when struct information descriptors are implemented
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
-        check_get_info_param<sycl::info::context::devices,
-                             std::vector<sycl::device>>(log, context);
-#endif
-      }
-    }
+  {  // check get_info for info::context::devices
+    check_get_info_param<sycl::info::context::devices,
+                         std::vector<sycl::device>>(ctx);
   }
-};
-
-// register this test with the test_collection
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace context_info__ */
+  {  // check get_info for info::context::atomic_memory_order_capabilities
+    check_get_info_param<sycl::info::context::atomic_memory_order_capabilities,
+                         std::vector<sycl::memory_order>>(ctx);
+    std::vector<sycl::memory_order> capabilities =
+        ctx.get_info<sycl::info::context::atomic_memory_order_capabilities>();
+    CHECK(check_contains(capabilities, sycl::memory_order::relaxed));
+  }
+#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
+  {  // check get_info for info::context::atomic_fence_order_capabilities
+    check_get_info_param<sycl::info::context::atomic_fence_order_capabilities,
+                         std::vector<sycl::memory_order>>(ctx);
+    std::vector<sycl::memory_order> capabilities =
+        ctx.get_info<sycl::info::context::atomic_fence_order_capabilities>();
+    CHECK(check_contains(capabilities, sycl::memory_order::relaxed));
+    CHECK(check_contains(capabilities, sycl::memory_order::acquire));
+    CHECK(check_contains(capabilities, sycl::memory_order::release));
+    CHECK(check_contains(capabilities, sycl::memory_order::acq_rel));
+  }
+#else
+  WARN(
+      "Implementation does not support "
+      "sycl::info::context::atomic_fence_order_capabilities "
+      "Skipping the test case.");
+#endif
+  {  // check get_info for info::context::atomic_memory_scope_capabilities
+    check_get_info_param<sycl::info::context::atomic_memory_scope_capabilities,
+                         std::vector<sycl::memory_scope>>(ctx);
+    std::vector<sycl::memory_scope> capabilities =
+        ctx.get_info<sycl::info::context::atomic_memory_scope_capabilities>();
+    CHECK(check_contains(capabilities, sycl::memory_scope::work_group));
+  }
+#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
+  {  // check get_info for info::context::atomic_fence_scope_capabilities
+    check_get_info_param<sycl::info::context::atomic_fence_scope_capabilities,
+                         std::vector<sycl::memory_scope>>(ctx);
+    std::vector<sycl::memory_scope> capabilities =
+        ctx.get_info<sycl::info::context::atomic_fence_scope_capabilities>();
+    CHECK(check_contains(capabilities, sycl::memory_scope::work_group));
+  }
+#else
+  WARN(
+      "Implementation does not support "
+      "sycl::info::context::atomic_fence_scope_capabilities "
+      "Skipping the test case.");
+#endif
+}

--- a/tests/device/device_info.cpp
+++ b/tests/device/device_info.cpp
@@ -21,265 +21,266 @@
 
 #include "../common/common.h"
 
-#define TEST_NAME device_info
-
-namespace device_info__ {
-
-using namespace sycl_cts;
-
-/** tests the info for sycl::device
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
+TEST_CASE("device info", "[device]") {
+  /** check info::device_type
    */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
+  check_enum_class_value(sycl::info::device_type::cpu);
+  check_enum_class_value(sycl::info::device_type::gpu);
+  check_enum_class_value(sycl::info::device_type::accelerator);
+  check_enum_class_value(sycl::info::device_type::custom);
+  check_enum_class_value(sycl::info::device_type::automatic);
+  check_enum_class_value(sycl::info::device_type::host);
+  check_enum_class_value(sycl::info::device_type::all);
 
-  /** execute the test
+  /** check info::partition_property
    */
-  void run(util::logger &log) override {
-    {
-      /** check info::device_type
-       */
-      check_enum_class_value(sycl::info::device_type::cpu);
-      check_enum_class_value(sycl::info::device_type::gpu);
-      check_enum_class_value(sycl::info::device_type::accelerator);
-      check_enum_class_value(sycl::info::device_type::custom);
-      check_enum_class_value(sycl::info::device_type::automatic);
-      check_enum_class_value(sycl::info::device_type::host);
-      check_enum_class_value(sycl::info::device_type::all);
+  check_enum_class_value(sycl::info::partition_property::no_partition);
+  check_enum_class_value(sycl::info::partition_property::partition_equally);
+  check_enum_class_value(sycl::info::partition_property::partition_by_counts);
+  check_enum_class_value(
+      sycl::info::partition_property::partition_by_affinity_domain);
 
-      /** check info::partion_property
-       */
-      check_enum_class_value(sycl::info::partition_property::no_partition);
-      check_enum_class_value(
-          sycl::info::partition_property::partition_equally);
-      check_enum_class_value(
-          sycl::info::partition_property::partition_by_counts);
-      check_enum_class_value(
-          sycl::info::partition_property::partition_by_affinity_domain);
+  /** check info::affinity_domain
+   */
+  check_enum_class_value(sycl::info::partition_affinity_domain::not_applicable);
+  check_enum_class_value(sycl::info::partition_affinity_domain::numa);
+  check_enum_class_value(sycl::info::partition_affinity_domain::L1_cache);
+  check_enum_class_value(sycl::info::partition_affinity_domain::L2_cache);
+  check_enum_class_value(sycl::info::partition_affinity_domain::L3_cache);
+  check_enum_class_value(sycl::info::partition_affinity_domain::L4_cache);
+  check_enum_class_value(
+      sycl::info::partition_affinity_domain::next_partitionable);
 
-      /** check info::affinity_domain
-       */
-      check_enum_class_value(
-          sycl::info::partition_affinity_domain::not_applicable);
-      check_enum_class_value(sycl::info::partition_affinity_domain::numa);
-      check_enum_class_value(
-          sycl::info::partition_affinity_domain::L1_cache);
-      check_enum_class_value(
-          sycl::info::partition_affinity_domain::L2_cache);
-      check_enum_class_value(
-          sycl::info::partition_affinity_domain::L3_cache);
-      check_enum_class_value(
-          sycl::info::partition_affinity_domain::L4_cache);
-      check_enum_class_value(
-          sycl::info::partition_affinity_domain::next_partitionable);
+  /** check info::local_mem_type
+   */
+  check_enum_class_value(sycl::info::local_mem_type::none);
+  check_enum_class_value(sycl::info::local_mem_type::local);
+  check_enum_class_value(sycl::info::local_mem_type::global);
 
-      /** check info::local_mem_type
-       */
-      check_enum_class_value(sycl::info::local_mem_type::none);
-      check_enum_class_value(sycl::info::local_mem_type::local);
-      check_enum_class_value(sycl::info::local_mem_type::global);
+  /** check info::fp_config
+   */
+  check_enum_class_value(sycl::info::fp_config::denorm);
+  check_enum_class_value(sycl::info::fp_config::inf_nan);
+  check_enum_class_value(sycl::info::fp_config::round_to_nearest);
+  check_enum_class_value(sycl::info::fp_config::round_to_zero);
+  check_enum_class_value(sycl::info::fp_config::round_to_inf);
+  check_enum_class_value(sycl::info::fp_config::fma);
+  check_enum_class_value(sycl::info::fp_config::correctly_rounded_divide_sqrt);
+  check_enum_class_value(sycl::info::fp_config::soft_float);
 
-      /** check info::fp_config
-       */
-      check_enum_class_value(sycl::info::fp_config::denorm);
-      check_enum_class_value(sycl::info::fp_config::inf_nan);
-      check_enum_class_value(sycl::info::fp_config::round_to_nearest);
-      check_enum_class_value(sycl::info::fp_config::round_to_zero);
-      check_enum_class_value(sycl::info::fp_config::round_to_inf);
-      check_enum_class_value(sycl::info::fp_config::fma);
-      check_enum_class_value(
-          sycl::info::fp_config::correctly_rounded_divide_sqrt);
-      check_enum_class_value(sycl::info::fp_config::soft_float);
+  /** check global_mem_cache_type
+   */
+  check_enum_class_value(sycl::info::global_mem_cache_type::none);
+  check_enum_class_value(sycl::info::global_mem_cache_type::read_only);
+  check_enum_class_value(sycl::info::global_mem_cache_type::read_write);
 
-      /** check global_mem_cache_type
-       */
-      check_enum_class_value(sycl::info::global_mem_cache_type::none);
-      check_enum_class_value(sycl::info::global_mem_cache_type::read_only);
-      check_enum_class_value(sycl::info::global_mem_cache_type::read_write);
+  /** check execution_capability
+   */
+  check_enum_class_value(sycl::info::execution_capability::exec_kernel);
+  check_enum_class_value(sycl::info::execution_capability::exec_native_kernel);
 
-      /** check execution_capability
-       */
-      check_enum_class_value(sycl::info::execution_capability::exec_kernel);
-      check_enum_class_value(
-          sycl::info::execution_capability::exec_native_kernel);
-
-      /** check get_info parameters
-       */
-      // FIXME: Reenable when struct information descriptors are implemented
+  /** check get_info parameters
+   */
+  // FIXME: Reenable when struct information descriptors are implemented
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
-      {
-        cts_selector selector;
-        auto dev = util::get_cts_object::device(selector);
-        check_get_info_param<sycl::info::device::device_type,
-                             sycl::info::device_type>(log, dev);
-        check_get_info_param<sycl::info::device::vendor_id, sycl::cl_uint>(log,
-                                                                           dev);
-        check_get_info_param<sycl::info::device::max_compute_units,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::max_work_item_dimensions,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::max_work_item_sizes<1>,
-                             sycl::id<1>>(log, dev);
-        check_get_info_param<sycl::info::device::max_work_item_sizes<2>,
-                             sycl::id<2>>(log, dev);
-        check_get_info_param<sycl::info::device::max_work_item_sizes<3>,
-                             sycl::id<3>>(log, dev);
-        check_get_info_param<sycl::info::device::max_work_group_size, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::preferred_vector_width_char,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::preferred_vector_width_short,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::preferred_vector_width_int,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::preferred_vector_width_long,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::preferred_vector_width_float,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::preferred_vector_width_double,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::preferred_vector_width_half,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::native_vector_width_char,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::native_vector_width_short,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::native_vector_width_int,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::native_vector_width_long,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::native_vector_width_float,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::native_vector_width_double,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::native_vector_width_half,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::max_clock_frequency,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::address_bits, sycl::cl_uint>(
-            log, dev);
-        check_get_info_param<sycl::info::device::max_mem_alloc_size,
-                             sycl::cl_ulong>(log, dev);
-        check_get_info_param<sycl::info::device::image_support, bool>(log, dev);
-        check_get_info_param<sycl::info::device::max_read_image_args,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::max_write_image_args,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::image2d_max_height, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::image2d_max_width, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::image3d_max_height, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::image3d_max_width, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::image3d_max_depth, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::image_max_buffer_size, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::image_max_array_size, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::max_samplers, sycl::cl_uint>(
-            log, dev);
-        check_get_info_param<sycl::info::device::max_parameter_size, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::mem_base_addr_align,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::half_fp_config,
-                             std::vector<sycl::info::fp_config>>(log, dev);
-        check_get_info_param<sycl::info::device::single_fp_config,
-                             std::vector<sycl::info::fp_config>>(log, dev);
-        check_get_info_param<sycl::info::device::double_fp_config,
-                             std::vector<sycl::info::fp_config>>(log, dev);
-        check_get_info_param<sycl::info::device::global_mem_cache_type,
-                             sycl::info::global_mem_cache_type>(log, dev);
-        check_get_info_param<sycl::info::device::global_mem_cache_line_size,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::global_mem_cache_size,
-                             sycl::cl_ulong>(log, dev);
-        check_get_info_param<sycl::info::device::global_mem_size,
-                             sycl::cl_ulong>(log, dev);
-        check_get_info_param<sycl::info::device::max_constant_buffer_size,
-                             sycl::cl_ulong>(log, dev);
-        check_get_info_param<sycl::info::device::max_constant_args,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::local_mem_type,
-                             sycl::info::local_mem_type>(log, dev);
-        check_get_info_param<sycl::info::device::local_mem_size,
-                             sycl::cl_ulong>(log, dev);
-        check_get_info_param<sycl::info::device::error_correction_support,
-                             bool>(log, dev);
-        check_get_info_param<sycl::info::device::host_unified_memory, bool>(
-            log, dev);
-        check_get_info_param<sycl::info::device::profiling_timer_resolution,
-                             size_t>(log, dev);
-        check_get_info_param<sycl::info::device::is_endian_little, bool>(log,
-                                                                         dev);
-        check_get_info_param<sycl::info::device::is_available, bool>(log, dev);
-        check_get_info_param<sycl::info::device::is_compiler_available, bool>(
-            log, dev);
-        check_get_info_param<sycl::info::device::is_linker_available, bool>(
-            log, dev);
-        check_get_info_param<sycl::info::device::execution_capabilities,
-                             std::vector<sycl::info::execution_capability>>(
-            log, dev);
-        check_get_info_param<sycl::info::device::queue_profiling, bool>(log,
-                                                                        dev);
-        check_get_info_param<sycl::info::device::built_in_kernels,
-                             std::vector<std::string>>(log, dev);
-        check_get_info_param<sycl::info::device::platform, sycl::platform>(log,
-                                                                           dev);
-        check_get_info_param<sycl::info::device::name, std::string>(log, dev);
-        check_get_info_param<sycl::info::device::vendor, std::string>(log, dev);
-        check_get_info_param<sycl::info::device::driver_version, std::string>(
-            log, dev);
-        check_get_info_param<sycl::info::device::profile, std::string>(log,
-                                                                       dev);
-        check_get_info_param<sycl::info::device::version, std::string>(log,
-                                                                       dev);
-        check_get_info_param<sycl::info::device::opencl_c_version, std::string>(
-            log, dev);
-        check_get_info_param<sycl::info::device::extensions,
-                             std::vector<std::string>>(log, dev);
-        check_get_info_param<sycl::info::device::printf_buffer_size, size_t>(
-            log, dev);
-        check_get_info_param<sycl::info::device::preferred_interop_user_sync,
-                             bool>(log, dev);
-        auto SupportedProperties =
-            dev.get_info<sycl::info::device::partition_properties>();
-        if (std::find(SupportedProperties.begin(), SupportedProperties.end(),
-                      sycl::info::partition_property::partition_equally) !=
-            SupportedProperties.end()) {
-
-          auto sub_device_partition_equal = dev.create_sub_devices<
-              sycl::info::partition_property::partition_equally>(1);
-
-          check_get_info_param<sycl::info::device::parent_device, sycl::device>(
-              log, sub_device_partition_equal[0]);
-        }
-        check_get_info_param<sycl::info::device::partition_max_sub_devices,
-                             sycl::cl_uint>(log, dev);
-        check_get_info_param<sycl::info::device::partition_properties,
-                             std::vector<sycl::info::partition_property>>(log,
-                                                                          dev);
-        check_get_info_param<
-            sycl::info::device::partition_affinity_domains,
-            std::vector<sycl::info::partition_affinity_domain>>(log, dev);
-        check_get_info_param<sycl::info::device::partition_type_property,
-                             sycl::info::partition_property>(log, dev);
-        check_get_info_param<sycl::info::device::partition_type_affinity_domain,
-                             sycl::info::partition_affinity_domain>(log, dev);
-      }
-#endif
+  {
+    cts_selector selector;
+    auto dev = sycl_cts::util::get_cts_object::device(selector);
+    check_get_info_param<sycl::info::device::device_type,
+                         sycl::info::device_type>(dev);
+    check_get_info_param<sycl::info::device::vendor_id, sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::max_compute_units, sycl::cl_uint>(
+        dev);
+    check_get_info_param<sycl::info::device::max_work_item_dimensions,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::max_work_item_sizes<1>,
+                         sycl::id<1>>(dev);
+    check_get_info_param<sycl::info::device::max_work_item_sizes<2>,
+                         sycl::id<2>>(dev);
+    check_get_info_param<sycl::info::device::max_work_item_sizes<3>,
+                         sycl::id<3>>(dev);
+    check_get_info_param<sycl::info::device::max_work_group_size, size_t>(dev);
+    check_get_info_param<sycl::info::device::max_num_sub_groups, uint32_t>(dev);
+    CHECK((dev.get_info<sycl::info::device::max_num_sub_groups>() != 0));
+    check_get_info_param<sycl::info::device::sub_group_sizes,
+                         std::vector<size_t>>(dev);
+    check_get_info_param<sycl::info::device::preferred_vector_width_char,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::preferred_vector_width_short,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::preferred_vector_width_int,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::preferred_vector_width_long,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::preferred_vector_width_float,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::preferred_vector_width_double,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::preferred_vector_width_half,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::native_vector_width_char,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::native_vector_width_short,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::native_vector_width_int,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::native_vector_width_long,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::native_vector_width_float,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::native_vector_width_double,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::native_vector_width_half,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::max_clock_frequency,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::address_bits, sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::max_mem_alloc_size,
+                         sycl::cl_ulong>(dev);
+    check_get_info_param<sycl::info::device::image_support, bool>(dev);
+    check_get_info_param<sycl::info::device::max_read_image_args,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::max_write_image_args,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::image2d_max_height, size_t>(dev);
+    check_get_info_param<sycl::info::device::image2d_max_width, size_t>(dev);
+    check_get_info_param<sycl::info::device::image3d_max_height, size_t>(dev);
+    check_get_info_param<sycl::info::device::image3d_max_width, size_t>(dev);
+    check_get_info_param<sycl::info::device::image3d_max_depth, size_t>(dev);
+    check_get_info_param<sycl::info::device::image_max_buffer_size, size_t>(
+        dev);
+    check_get_info_param<sycl::info::device::image_max_array_size, size_t>(dev);
+    check_get_info_param<sycl::info::device::max_samplers, sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::max_parameter_size, size_t>(dev);
+    check_get_info_param<sycl::info::device::mem_base_addr_align,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::half_fp_config,
+                         std::vector<sycl::info::fp_config>>(dev);
+    check_get_info_param<sycl::info::device::single_fp_config,
+                         std::vector<sycl::info::fp_config>>(dev);
+    check_get_info_param<sycl::info::device::double_fp_config,
+                         std::vector<sycl::info::fp_config>>(dev);
+    check_get_info_param<sycl::info::device::global_mem_cache_type,
+                         sycl::info::global_mem_cache_type>(dev);
+    check_get_info_param<sycl::info::device::global_mem_cache_line_size,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::global_mem_cache_size,
+                         sycl::cl_ulong>(dev);
+    check_get_info_param<sycl::info::device::global_mem_size, sycl::cl_ulong>(
+        dev);
+    check_get_info_param<sycl::info::device::max_constant_buffer_size,
+                         sycl::cl_ulong>(dev);
+    check_get_info_param<sycl::info::device::max_constant_args, sycl::cl_uint>(
+        dev);
+    check_get_info_param<sycl::info::device::local_mem_type,
+                         sycl::info::local_mem_type>(dev);
+    check_get_info_param<sycl::info::device::local_mem_size, sycl::cl_ulong>(
+        dev);
+    check_get_info_param<sycl::info::device::error_correction_support, bool>(
+        dev);
+    check_get_info_param<sycl::info::device::host_unified_memory, bool>(dev);
+    {
+      check_get_info_param<sycl::info::device::atomic_memory_order_capabilities,
+                           std::vector<sycl::memory_order>>(dev);
+      std::vector<sycl::memory_order> capabilities =
+          dev.get_info<sycl::info::device::atomic_memory_order_capabilities>();
+      CHECK(check_contains(capabilities, sycl::memory_order::relaxed));
     }
+#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
+    {
+      check_get_info_param<sycl::info::device::atomic_fence_order_capabilities,
+                           std::vector<sycl::memory_order>>(dev);
+      std::vector<sycl::memory_order> capabilities =
+          dev.get_info<sycl::info::device::atomic_fence_order_capabilities>();
+      CHECK(check_contains(capabilities, sycl::memory_order::relaxed));
+      CHECK(check_contains(capabilities, sycl::memory_order::acquire));
+      CHECK(check_contains(capabilities, sycl::memory_order::release));
+      CHECK(check_contains(capabilities, sycl::memory_order::acq_rel));
+    }
+#else
+    WARN(
+        "Implementation does not support "
+        "sycl::info::device::atomic_fence_order_capabilities "
+        "Skipping the test case.");
+#endif
+    {
+      check_get_info_param<sycl::info::device::atomic_memory_scope_capabilities,
+                           std::vector<sycl::memory_scope>>(dev);
+      std::vector<sycl::memory_scope> capabilities =
+          dev.get_info<sycl::info::device::atomic_memory_scope_capabilities>();
+      CHECK(check_contains(capabilities, sycl::memory_scope::work_group));
+    }
+#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
+    {
+      check_get_info_param<sycl::info::device::atomic_fence_scope_capabilities,
+                           std::vector<sycl::memory_scope>>(dev);
+      std::vector<sycl::memory_scope> capabilities =
+          dev.get_info<sycl::info::device::atomic_fence_scope_capabilities>();
+      CHECK(check_contains(capabilities, sycl::memory_scope::work_group));
+    }
+#else
+    WARN(
+        "Implementation does not support "
+        "sycl::info::device::atomic_fence_scope_capabilities "
+        "Skipping the test case.");
+#endif
+    check_get_info_param<sycl::info::device::profiling_timer_resolution,
+                         size_t>(dev);
+    check_get_info_param<sycl::info::device::is_endian_little, bool>(dev);
+    check_get_info_param<sycl::info::device::is_available, bool>(dev);
+    check_get_info_param<sycl::info::device::is_compiler_available, bool>(dev);
+    check_get_info_param<sycl::info::device::is_linker_available, bool>(dev);
+    check_get_info_param<sycl::info::device::execution_capabilities,
+                         std::vector<sycl::info::execution_capability>>(dev);
+    check_get_info_param<sycl::info::device::queue_profiling, bool>(dev);
+    check_get_info_param<sycl::info::device::built_in_kernel_ids,
+                         std::vector<sycl::kernel_id>>(dev);
+    check_get_info_param<sycl::info::device::built_in_kernels,
+                         std::vector<std::string>>(dev);
+    check_get_info_param<sycl::info::device::platform, sycl::platform>(dev);
+    check_get_info_param<sycl::info::device::name, std::string>(dev);
+    check_get_info_param<sycl::info::device::vendor, std::string>(dev);
+    check_get_info_param<sycl::info::device::driver_version, std::string>(dev);
+    check_get_info_param<sycl::info::device::profile, std::string>(dev);
+    check_get_info_param<sycl::info::device::version, std::string>(dev);
+    check_get_info_param<sycl::info::device::opencl_c_version, std::string>(
+        dev);
+    check_get_info_param<sycl::info::device::backend_version, std::string>(dev);
+#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
+    check_get_info_param<sycl::info::device::aspects,
+                         std::vector<sycl::aspect>>(dev);
+#else
+    WARN(
+        "Implementation does not support sycl::info::device::aspects "
+        "Skipping the test case.");
+#endif
+    check_get_info_param<sycl::info::device::extensions,
+                         std::vector<std::string>>(dev);
+    check_get_info_param<sycl::info::device::printf_buffer_size, size_t>(dev);
+    check_get_info_param<sycl::info::device::preferred_interop_user_sync, bool>(
+        dev);
+    auto SupportedProperties =
+        dev.get_info<sycl::info::device::partition_properties>();
+    if (std::find(SupportedProperties.begin(), SupportedProperties.end(),
+                  sycl::info::partition_property::partition_equally) !=
+        SupportedProperties.end()) {
+      auto sub_device_partition_equal = dev.create_sub_devices<
+          sycl::info::partition_property::partition_equally>(1);
+
+      check_get_info_param<sycl::info::device::parent_device, sycl::device>(
+          sub_device_partition_equal[0]);
+    }
+    check_get_info_param<sycl::info::device::partition_max_sub_devices,
+                         sycl::cl_uint>(dev);
+    check_get_info_param<sycl::info::device::partition_properties,
+                         std::vector<sycl::info::partition_property>>(dev);
+    check_get_info_param<sycl::info::device::partition_affinity_domains,
+                         std::vector<sycl::info::partition_affinity_domain>>(
+        dev);
+    check_get_info_param<sycl::info::device::partition_type_property,
+                         sycl::info::partition_property>(dev);
+    check_get_info_param<sycl::info::device::partition_type_affinity_domain,
+                         sycl::info::partition_affinity_domain>(dev);
   }
-};
-
-// construction of this proxy will register the above test
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace device_info__ */
+#endif
+}


### PR DESCRIPTION
Implements test plan #448. Note: edits are mostly due to moving the test to the new test framework, and the formatting changes that implies.