### PR TITLE
Change string_view to int in util/named_requirement_verification

### DIFF
--- a/tests/accessor/accessor_iterator_requirement.cpp
+++ b/tests/accessor/accessor_iterator_requirement.cpp
@@ -23,12 +23,12 @@ namespace accessor_iterator_requirement {
  * @param errors Array with error messages
  */
 template <size_t N>
-inline void print_errors(
-    const std::array<named_requirement_verification::string_view, N>& errors) {
+inline void print_errors(const std::array<int, N>& errors) {
+  named_requirement_verification::error_messages error_messages;
   const bool false_to_fail_test = false;
   for (size_t i = 0; i < N; ++i) {
-    if (!errors[i].empty()) {
-      FAIL_CHECK(errors[i]);
+    if (errors[i] != 0) {
+      FAIL_CHECK(error_messages.error_message(errors[i]));
     }
   }
 }
@@ -45,13 +45,12 @@ inline auto fill_errors(std::tuple<ConstructAcc, GetIterator> ftuple) {
 
   constexpr size_t size_of_res_array =
       legacy_random_access_iterator_requirement::count_of_possible_errors;
-  std::array<named_requirement_verification::string_view, size_of_res_array>
-      errors;
+  std::array<int, size_of_res_array> errors;
+  errors.fill(0);
   constexpr size_t size_of_dummy = 1;
   int dummy[size_of_dummy] = {1};
   {
-    sycl::buffer<named_requirement_verification::string_view, 1> res_buf(
-        errors.data(), sycl::range(size_of_res_array));
+    sycl::buffer<int, 1> res_buf(errors.data(), sycl::range(size_of_res_array));
     sycl::buffer<int, 1> dummy_buf(dummy, sycl::range(size_of_dummy));
 
     auto action = [](auto& dummy_acc, auto& res_acc, auto& ftuple) {
@@ -61,7 +60,7 @@ inline auto fill_errors(std::tuple<ConstructAcc, GetIterator> ftuple) {
               dummy_acc_it);
       if (!verification_result.first) {
         for (int i = 0; i < size_of_res_array; ++i) {
-          if (!verification_result.second[i].empty()) {
+          if (verification_result.second[i] != 0) {
             // Copy errors to the host side
             res_acc[i] = verification_result.second[i];
           }

--- a/util/named_requirement_verification/common.h
+++ b/util/named_requirement_verification/common.h
@@ -12,45 +12,391 @@
 #include "../type_traits.h"
 
 #include <array>
+#include <map>
 #include <string_view>
 #include <utility>
 
 namespace named_requirement_verification {
 
+namespace common {
+static const int error_code_0 = -1;
+static const int error_code_1 = -2;
+}  // namespace common
+
+namespace equality_comparable {
+static const int error_code_0 = 1;
+static const int error_code_1 = 2;
+static const int error_code_2 = 3;
+static const int error_code_3 = 4;
+static const int error_code_4 = 5;
+}  // namespace equality_comparable
+
+namespace legacy_bidirectional_iterator {
+static const int error_code_0 = 6;
+static const int error_code_1 = 7;
+static const int error_code_2 = 8;
+static const int error_code_3 = 9;
+static const int error_code_4 = 10;
+static const int error_code_5 = 11;
+static const int error_code_6 = 12;
+static const int error_code_7 = 13;
+static const int error_code_8 = 14;
+}  // namespace legacy_bidirectional_iterator
+
+namespace legacy_forward_iterator {
+static const int error_code_0 = 15;
+static const int error_code_1 = 16;
+static const int error_code_2 = 17;
+static const int error_code_3 = 18;
+static const int error_code_4 = 19;
+static const int error_code_5 = 20;
+static const int error_code_6 = 21;
+static const int error_code_7 = 22;
+static const int error_code_8 = 23;
+static const int error_code_9 = 24;
+}  // namespace legacy_forward_iterator
+
+namespace legacy_input_iterator {
+static const int error_code_0 = 25;
+static const int error_code_1 = 26;
+static const int error_code_2 = 27;
+static const int error_code_3 = 28;
+static const int error_code_4 = 29;
+static const int error_code_5 = 30;
+static const int error_code_6 = 31;
+static const int error_code_7 = 32;
+static const int error_code_8 = 33;
+static const int error_code_9 = 34;
+static const int error_code_10 = 35;
+}  // namespace legacy_input_iterator
+
+namespace legacy_iterator {
+static const int error_code_0 = 36;
+static const int error_code_1 = 37;
+static const int error_code_2 = 38;
+static const int error_code_3 = 39;
+static const int error_code_4 = 40;
+static const int error_code_5 = 41;
+static const int error_code_6 = 42;
+static const int error_code_7 = 43;
+static const int error_code_8 = 44;
+static const int error_code_9 = 45;
+static const int error_code_10 = 46;
+static const int error_code_11 = 47;
+}  // namespace legacy_iterator
+
+namespace legacy_output_iterator {
+static const int error_code_0 = 48;
+static const int error_code_1 = 49;
+static const int error_code_2 = 50;
+static const int error_code_3 = 51;
+static const int error_code_4 = 52;
+static const int error_code_5 = 53;
+static const int error_code_6 = 54;
+static const int error_code_7 = 55;
+}  // namespace legacy_output_iterator
+
+namespace legacy_random_access_iterator {
+static const int error_code_0 = 56;
+static const int error_code_1 = 57;
+static const int error_code_2 = 58;
+static const int error_code_3 = 59;
+static const int error_code_4 = 60;
+static const int error_code_5 = 61;
+static const int error_code_6 = 62;
+static const int error_code_7 = 63;
+static const int error_code_8 = 64;
+static const int error_code_9 = 65;
+static const int error_code_10 = 66;
+static const int error_code_11 = 67;
+static const int error_code_12 = 68;
+static const int error_code_13 = 69;
+static const int error_code_14 = 70;
+static const int error_code_15 = 71;
+static const int error_code_16 = 72;
+static const int error_code_17 = 73;
+static const int error_code_18 = 74;
+static const int error_code_19 = 75;
+static const int error_code_20 = 76;
+static const int error_code_21 = 77;
+}  // namespace legacy_random_access_iterator
+
 using string_view = std::basic_string_view<char>;
 
+class error_messages {
+ public:
+  error_messages() { init(); }
+
+  const string_view& error_message(int error_code) const {
+    auto msg_it = m_error_map.find(error_code);
+    if (msg_it == m_error_map.end()) {
+      return m_error_map.at(common::error_code_1);
+    }
+    return msg_it->second;
+  }
+
+ private:
+  std::map<int, string_view> m_error_map;
+
+  void init() {
+    init_common();
+    init_equality_comparable();
+    init_legacy_bidirectional_iterator();
+    init_legacy_forward_iterator();
+    init_legacy_input_iterator();
+    init_legacy_iterator();
+    init_legacy_output_iterator();
+    init_legacy_random_access_iterator();
+  }
+
+  void init_common() {
+    m_error_map.insert(
+        {{common::error_code_0, "Size for error_codes_container setted wrong!"},
+         {common::error_code_1, "Wrong error code!"}});
+  }
+  void init_equality_comparable() {
+    m_error_map.insert({
+        {equality_comparable::error_code_0,
+         "Non-const copies of one object doesn't equal to each other equal "
+         "during comparing."},
+        {equality_comparable::error_code_1,
+         "Non-const copies of one object doesn't return convertible to bool "
+         "after comparing."},
+        {equality_comparable::error_code_2,
+         "Const copies of one object doesn't equal to each other equal "
+         "during comparing."},
+        {equality_comparable::error_code_3,
+         "Const copies of one object doesn't return convertible to bool "
+         "after comparing."},
+        {equality_comparable::error_code_4, "Iterator must have operator==()."},
+    });
+  }
+
+  void init_legacy_bidirectional_iterator() {
+    m_error_map.insert({
+        {legacy_bidirectional_iterator::error_code_0,
+         "Iterator expression --(++i) must return It& type."},
+        {legacy_bidirectional_iterator::error_code_1,
+         "Iterator doesn't have implemented operator--(int)"},
+        {legacy_bidirectional_iterator::error_code_2,
+         "Iterator expression --(++i) must be equal to i."},
+        {legacy_bidirectional_iterator::error_code_3,
+         "If --a == --b then a == b must be true."},
+        {legacy_bidirectional_iterator::error_code_4,
+         "--a must be equal to --b, if they are copy of same object."},
+        {legacy_bidirectional_iterator::error_code_5,
+         "Iterator expression --i must return It& data type."},
+        {legacy_bidirectional_iterator::error_code_6,
+         "Iterator must have operator--()."},
+        {legacy_bidirectional_iterator::error_code_7,
+         "Iterator expression (i++)-- must be convertible to const It&."},
+        {legacy_bidirectional_iterator::error_code_8,
+         "Iterator expression *i-- must return reference data type."},
+    });
+  }
+
+  void init_legacy_forward_iterator() {
+    m_error_map.insert({
+        {legacy_forward_iterator::error_code_0,
+         "Iterator must be default constructible."},
+        {legacy_forward_iterator::error_code_1,
+         "Provided iterator satisfy to LegacyOutputIterator requirement. "
+         "iterator_traits::reference must be T& or T&&."},
+        {legacy_forward_iterator::error_code_2,
+         "Provided iterator not satisfy to LegacyOutputIterator "
+         "requirement. iterator_traits::reference must be const T& or "
+         "const T&&."},
+        {legacy_forward_iterator::error_code_3,
+         "operator++(int) must return It."},
+        {legacy_forward_iterator::error_code_4,
+         "Iterator doesn't have implemented operator++(int)"},
+        {legacy_forward_iterator::error_code_5,
+         "Expression *i++ must be convertible to "
+         "iterator_traits::reference."},
+        {legacy_forward_iterator::error_code_6,
+         "If a and b compare equal (a == b) then *a and *b "
+         "are references bound to the same object."},
+        {legacy_forward_iterator::error_code_7,
+         "If *a and *b refer to the same object, then a == b equals "
+         "true."},
+        {legacy_forward_iterator::error_code_8,
+         "If a == b equals true then ++a == ++b also equals true."},
+        {legacy_forward_iterator::error_code_9,
+         "Incrementing copy of iterator instance must not affect "
+         "on the value read from original object."},
+    });
+  }
+
+  void init_legacy_input_iterator() {
+    m_error_map.insert({
+        {legacy_input_iterator::error_code_0,
+         "Iterator must have implemented operator==()."},
+        {legacy_input_iterator::error_code_1,
+         "Iterator must have implemented operator!=()."},
+        {legacy_input_iterator::error_code_2,
+         "Iterator must have implemented operator++(int)."},
+        {legacy_input_iterator::error_code_3,
+         "Two not equal iterators returns true with NOT EQUAL operator."},
+        {legacy_input_iterator::error_code_4,
+         "Two not equal iterators must return implicit convertible to "
+         "bool value with NOT EQUAL operator."},
+        {legacy_input_iterator::error_code_5,
+         "Iterator must return It& from operator++()."},
+        {legacy_input_iterator::error_code_6,
+         "Iterator expression *i++ must be convertible to "
+         "iterator_traits::value_type."},
+        {legacy_input_iterator::error_code_7,
+         "Iterator must return iterator_traits::reference from "
+         "operator*()."},
+        {legacy_input_iterator::error_code_8,
+         "operator*() result must be convertible to "
+         "iterator_traits::value_type."},
+        {legacy_input_iterator::error_code_9, ""},
+        {legacy_input_iterator::error_code_10, ""},
+    });
+  }
+
+  void init_legacy_iterator() {
+    m_error_map.insert({
+        {legacy_iterator::error_code_0, "Iterator must be copy constructable."},
+        {legacy_iterator::error_code_1, "Iterator must be copy assignable."},
+        {legacy_iterator::error_code_2, "Iterator must be destructible."},
+        {legacy_iterator::error_code_3, "Iterator must be swappable."},
+        {legacy_iterator::error_code_4,
+         "Iterator must have value_type member typedef."},
+        {legacy_iterator::error_code_5,
+         "Iterator must have difference_type member typedef."},
+        {legacy_iterator::error_code_6,
+         "Iterator must have reference member typedef."},
+        {legacy_iterator::error_code_7,
+         "Iterator must have pointer member typedef."},
+        {legacy_iterator::error_code_8,
+         "Iterator must have iterator_category member typedef."},
+        {legacy_iterator::error_code_9, "Iterator must have operator++()."},
+        {legacy_iterator::error_code_10,
+         "Iterator must return It& after usage of operator++()."},
+        {legacy_iterator::error_code_11, "Iterator must have operator*()."},
+    });
+  }
+
+  void init_legacy_output_iterator() {
+    m_error_map.insert({
+        {legacy_output_iterator::error_code_0,
+         "Iterator must return iterator_traits::value_type from "
+         "operator*()."},
+        {legacy_output_iterator::error_code_1,
+         "Iterator must return It& from operator++()."},
+        {legacy_output_iterator::error_code_2,
+         "Iterator must return convertible to const It from "
+         "operator++()."},
+        {legacy_output_iterator::error_code_3,
+         "Iterator must be assignable with iterator_traits::value_type "
+         "after usage of operator++() and operator*()."},
+        {legacy_output_iterator::error_code_4,
+         "Iterator must be assignable with iterator_traits::value_type "
+         "after usage of operator*()."},
+        {legacy_output_iterator::error_code_5, ""},
+        {legacy_output_iterator::error_code_6, ""},
+        {legacy_output_iterator::error_code_7, ""},
+    });
+  }
+
+  void init_legacy_random_access_iterator() {
+    m_error_map.insert({
+        {legacy_random_access_iterator::error_code_0,
+         "Iterator must have difference_type member typedef."},
+        {legacy_random_access_iterator::error_code_1,
+         "Iterator must have operator+=() between Iterator instance and "
+         "iterator_traits::difference_type."},
+        {legacy_random_access_iterator::error_code_2,
+         "Iterator must have operator-=() between Iterator instance and "
+         "iterator_traits::difference_type."},
+        {legacy_random_access_iterator::error_code_3,
+         "Iterator must have subtraction between iterators."},
+        {legacy_random_access_iterator::error_code_4,
+         "Iterator must have operator+() iterator_traits::difference_type "
+         "plus Iterator object with operator."},
+        {legacy_random_access_iterator::error_code_5,
+         "Iterator must have operator[]."},
+        {legacy_random_access_iterator::error_code_6,
+         "operator+=() and operator-=() must return It& for positive "
+         "and negative vales."},
+        {legacy_random_access_iterator::error_code_7,
+         "operator+() and operator-() must return It& for positive "
+         "and negative vales."},
+        {legacy_random_access_iterator::error_code_8,
+         "Iterator operator+=() must be commutative."},
+        {legacy_random_access_iterator::error_code_9,
+         "Iterator must have operator+() with "
+         "iterator_traits::difference_type operator."},
+        {legacy_random_access_iterator::error_code_10,
+         "Iterator object minus iterator_traits::difference_type must "
+         "return Iterator instance."},
+        {legacy_random_access_iterator::error_code_11,
+         "Iterator must have operator-() with "
+         "iterator_traits::difference_type operator."},
+        {legacy_random_access_iterator::error_code_12,
+         "operator-() of It instances must return "
+         "iterator_traits::difference_type."},
+        {legacy_random_access_iterator::error_code_13,
+         "operator[]() return value must be convertible to "
+         "iterator_traits::reference."},
+        {legacy_random_access_iterator::error_code_14,
+         "operator>() return value must be contextually convertible to "
+         "bool."},
+        {legacy_random_access_iterator::error_code_15,
+         "operator<() return value must be contextually convertible to "
+         "bool."},
+        {legacy_random_access_iterator::error_code_16,
+         "operator>=() return value must be contextually convertible to "
+         "bool."},
+        {legacy_random_access_iterator::error_code_17,
+         "Iterator must have operator>=()."},
+        {legacy_random_access_iterator::error_code_18,
+         "operator>=() return value must be contextually convertible to "
+         "bool."},
+        {legacy_random_access_iterator::error_code_19,
+         "Iterator must have operator>=()."},
+        {legacy_random_access_iterator::error_code_20,
+         "operator<=() return value must be contextually convertible to "
+         "bool."},
+        {legacy_random_access_iterator::error_code_21,
+         "Iterator must have operator<=()."},
+    });
+  }
+};
+
 /**
- * @brief Class for storing error messages during requirements verification.
+ * @brief Class for storing error codes during requirements verification.
  * Safe to use inside kernel with SYCL 2020.
  *
- * @tparam Size parameter used for allocation of std::array with
- * std::basic_string
+ * @tparam Size parameter used for allocation of std::array with int
  */
 template <size_t Size>
-class error_messages_container {
+class error_codes_container {
  private:
-  /* Array for storing error messages
+  /* Array for storing error codes
    * We can't use std::string since it's not supported in kernel
    *
-   * According to SYCL 2020 std::array and std::basic_string_view<char> are
+   * According to SYCL 2020 std::array and int are
    * supported on device side
    */
-  std::array<string_view, Size> m_error_msgs_container;
+  std::array<int, Size> m_error_codes_container;
   // Index for storing next error message
   size_t m_index = 0;
 
  public:
+  error_codes_container() { m_error_codes_container.fill(0); }
   /**
    * @brief Member function helps to add single error message
    */
-  void add_error(const string_view msg) {
+  void add_error(int error_code) {
     if (m_index < Size) {
-      m_error_msgs_container[m_index] = msg;
+      m_error_codes_container[m_index] = error_code;
       ++m_index;
     } else {
       // If Size of container doesn't fit
-      m_error_msgs_container[Size - 1] =
-          "Size for error_messages_container setted wrong!";
+      m_error_codes_container[Size - 1] = common::error_code_0;
     }
   }
 
@@ -58,19 +404,19 @@ class error_messages_container {
    * @brief Member function helps to add array with errors messages
    */
   template <size_t N>
-  void add_errors(const std::array<string_view, N> msgs) {
-    for (size_t i = 0; i < msgs.size(); ++i) {
+  void add_errors(const std::array<int, N> error_codes) {
+    for (size_t i = 0; i < error_codes.size(); ++i) {
       // Avoid copying of empty messages
-      if (!msgs[i].empty()) {
-        add_error(msgs[i]);
+      if (0 != error_codes[i]) {
+        add_error(error_codes[i]);
       }
     }
   }
 
   bool has_errors() const { return m_index != 0; }
 
-  const std::array<string_view, Size>& get_array() const {
-    return m_error_msgs_container;
+  const std::array<int, Size>& get_array() const {
+    return m_error_codes_container;
   }
 };
 }  // namespace named_requirement_verification

--- a/util/named_requirement_verification/equality_comparable.h
+++ b/util/named_requirement_verification/equality_comparable.h
@@ -21,13 +21,13 @@ namespace named_requirement_verification {
  */
 class equality_comparable_requirement {
  public:
-  // Will be used as size of container for error messages.
+  // Will be used as size of container for error codes.
   // Value should be equal to the number of add_error invocations.
   // Don't forget to update this value if there is any changes in class.
   static constexpr size_t count_of_possible_errors = 5;
 
  private:
-  error_messages_container<count_of_possible_errors> m_test_error_messages;
+  error_codes_container<count_of_possible_errors> m_test_error_codes;
 
  public:
   /**
@@ -35,12 +35,12 @@ class equality_comparable_requirement {
    * verification
    *
    * @tparam T Type for verification
-   * @return std::pair<bool,array<string_view>> First represents
-   * satisfaction of the requirement. Second contains error messages
+   * @return std::pair<bool,array<int>> First represents
+   * satisfaction of the requirement. Second contains error codes
    */
   template <typename T>
-  std::pair<bool, std::array<string_view, count_of_possible_errors>>
-  is_satisfied_for(T valid_iterator) {
+  std::pair<bool, std::array<int, count_of_possible_errors>> is_satisfied_for(
+      T valid_iterator) {
     // It will delete branch from code in compile time to not fail a compilation
     if constexpr (type_traits::has_comparison::is_equal_v<T>) {
       T a = valid_iterator;
@@ -51,43 +51,35 @@ class equality_comparable_requirement {
       const T const_c = valid_iterator;
 
       if (!(a == b) || !(b == a) || !(b == c) || !(a == c)) {
-        m_test_error_messages.add_error(
-            "Non-const copies of one object doesn't equal to each other equal "
-            "during comparing.");
+        m_test_error_codes.add_error(equality_comparable::error_code_0);
       }
 
       if ((!std::is_convertible_v<decltype((a == b)), bool>) ||
           (!std::is_convertible_v<decltype((b == a)), bool>) ||
           (!std::is_convertible_v<decltype((b == c)), bool>) ||
           (!std::is_convertible_v<decltype((a == c)), bool>)) {
-        m_test_error_messages.add_error(
-            "Non-const copies of one object doesn't return convertible to bool "
-            "after comparing.");
+        m_test_error_codes.add_error(equality_comparable::error_code_1);
       }
 
       if (!(const_a == const_b) || !(const_b == const_a) ||
           !(const_b == const_c) || !(const_a == const_c)) {
-        m_test_error_messages.add_error(
-            "Const copies of one object doesn't equal to each other equal "
-            "during comparing.");
+        m_test_error_codes.add_error(equality_comparable::error_code_2);
       }
 
       if ((!std::is_convertible_v<decltype((const_a == const_b)), bool>) ||
           (!std::is_convertible_v<decltype((const_b == const_c)), bool>) ||
           (!std::is_convertible_v<decltype((const_a == const_c)), bool>) ||
           (!std::is_convertible_v<decltype((const_b == const_a)), bool>)) {
-        m_test_error_messages.add_error(
-            "Const copies of one object doesn't return convertible to bool "
-            "after comparing.");
+        m_test_error_codes.add_error(equality_comparable::error_code_3);
       }
     } else {
-      m_test_error_messages.add_error("Iterator must have operator==().");
+      m_test_error_codes.add_error(equality_comparable::error_code_4);
     }
 
-    const bool is_satisfied = !m_test_error_messages.has_errors();
+    const bool is_satisfied = !m_test_error_codes.has_errors();
     // According to spec std::pair with device_copyable types(in this case:
-    // bool, string_view) can be used on device side
-    return std::make_pair(is_satisfied, m_test_error_messages.get_array());
+    // bool, int) can be used on device side
+    return std::make_pair(is_satisfied, m_test_error_codes.get_array());
   }
 };
 }  // namespace named_requirement_verification

--- a/util/named_requirement_verification/legacy_iterator.h
+++ b/util/named_requirement_verification/legacy_iterator.h
@@ -25,7 +25,7 @@ class legacy_iterator_requirement {
   static constexpr size_t count_of_possible_errors = 12;
 
  private:
-  error_messages_container<count_of_possible_errors> m_test_error_messages;
+  error_codes_container<count_of_possible_errors> m_test_error_codes;
 
  public:
   /**
@@ -33,72 +33,66 @@ class legacy_iterator_requirement {
    * verification
    *
    * @tparam It Type of iterator for verification
-   * @return std::pair<bool,array<string_view>> First represents
+   * @return std::pair<bool,array<int>> First represents
    * satisfaction of the requirement. Second contains error messages
    */
   template <typename It>
-  std::pair<bool, std::array<string_view, count_of_possible_errors>>
+  std::pair<bool, std::array<int, count_of_possible_errors>>
   is_satisfied_for() {
     if (!std::is_copy_constructible_v<It>) {
-      m_test_error_messages.add_error("Iterator must be copy constructable.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_0);
     }
 
     if (!std::is_copy_assignable_v<It>) {
-      m_test_error_messages.add_error("Iterator must be copy assignable.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_1);
     }
 
     if (!std::is_destructible_v<It>) {
-      m_test_error_messages.add_error("Iterator must be destructible.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_2);
     }
 
     if (!std::is_swappable_v<It>) {
-      m_test_error_messages.add_error("Iterator must be swappable.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_3);
     }
 
     if (!type_traits::has_field::value_type_v<It>) {
-      m_test_error_messages.add_error(
-          "Iterator must have value_type member typedef.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_4);
     }
 
     if (!type_traits::has_field::difference_type_v<It>) {
-      m_test_error_messages.add_error(
-          "Iterator must have difference_type member typedef.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_5);
     }
 
     if (!type_traits::has_field::reference_v<It>) {
-      m_test_error_messages.add_error(
-          "Iterator must have reference member typedef.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_6);
     }
 
     if (!type_traits::has_field::pointer_v<It>) {
-      m_test_error_messages.add_error(
-          "Iterator must have pointer member typedef.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_7);
     }
 
     if (!type_traits::has_field::iterator_category_v<It>) {
-      m_test_error_messages.add_error(
-          "Iterator must have iterator_category member typedef.");
+      m_test_error_codes.add_error(legacy_iterator::error_code_8);
     }
 
     if (!type_traits::has_arithmetic::pre_increment_v<It>) {
-      m_test_error_messages.add_error("Iterator must have operator++().");
+      m_test_error_codes.add_error(legacy_iterator::error_code_9);
     }
 
     if constexpr (type_traits::has_arithmetic::pre_increment_v<It>) {
       if (!std::is_same_v<decltype(++std::declval<It&>()), It&>) {
-        m_test_error_messages.add_error(
-            "Iterator must return It& after usage of operator++().");
+        m_test_error_codes.add_error(legacy_iterator::error_code_10);
       }
     }
 
     if (!is_dereferenceable_v<It>) {
-      m_test_error_messages.add_error("Iterator must have operator*().");
+      m_test_error_codes.add_error(legacy_iterator::error_code_11);
     }
 
-    const bool is_satisfied = !m_test_error_messages.has_errors();
+    const bool is_satisfied = !m_test_error_codes.has_errors();
     // According to spec std::pair with device_copyable types(in this case:
-    // bool, string_view) can be used on device side
-    return std::make_pair(is_satisfied, m_test_error_messages.get_array());
+    // bool, int) can be used on device side
+    return std::make_pair(is_satisfied, m_test_error_codes.get_array());
   }
 };
 }  // namespace named_requirement_verification

--- a/util/named_requirement_verification/legacy_random_access_iterator.h
+++ b/util/named_requirement_verification/legacy_random_access_iterator.h
@@ -31,7 +31,7 @@ class legacy_random_access_iterator_requirement {
       legacy_bidirectional_iterator_requirement::count_of_possible_errors + 21;
 
  private:
-  error_messages_container<count_of_possible_errors> m_test_error_messages;
+  error_codes_container<count_of_possible_errors> m_test_error_codes;
 
  public:
   /**
@@ -39,17 +39,17 @@ class legacy_random_access_iterator_requirement {
    * verification
    *
    * @tparam It Type of iterator for verification
-   * @return std::pair<bool,array<string_view>> First represents
+   * @return std::pair<bool,array<int>> First represents
    * satisfaction of the requirement. Second contains error messages
    */
   template <typename It>
-  std::pair<bool, std::array<string_view, count_of_possible_errors>>
-  is_satisfied_for(It valid_iterator) {
+  std::pair<bool, std::array<int, count_of_possible_errors>> is_satisfied_for(
+      It valid_iterator) {
     auto legacy_bidir_iterator_res =
         legacy_bidirectional_iterator_requirement{}.is_satisfied_for<It>(
             valid_iterator);
     if (!legacy_bidir_iterator_res.first) {
-      m_test_error_messages.add_errors(legacy_bidir_iterator_res.second);
+      m_test_error_codes.add_errors(legacy_bidir_iterator_res.second);
     }
 
     constexpr bool has_greater_than_operator =
@@ -68,8 +68,7 @@ class legacy_random_access_iterator_requirement {
         type_traits::has_field::difference_type_v<It>;
 
     if (!has_difference_type_member) {
-      m_test_error_messages.add_error(
-          "Iterator must have difference_type member typedef.");
+      m_test_error_codes.add_error(legacy_random_access_iterator::error_code_0);
     } else {
       using diff_t = typename std::iterator_traits<It>::difference_type;
 
@@ -88,30 +87,28 @@ class legacy_random_access_iterator_requirement {
           type_traits::has_arithmetic::subtraction_v<It, It>;
 
       if (!has_addition_compound_operator) {
-        m_test_error_messages.add_error(
-            "Iterator must have operator+=() between Iterator instance and "
-            "iterator_traits::difference_type.");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_1);
       }
 
       if (!has_subtraction_compound_operator) {
-        m_test_error_messages.add_error(
-            "Iterator must have operator-=() between Iterator instance and "
-            "iterator_traits::difference_type.");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_2);
       }
 
       if (!has_iterator_minus_iterator_operator) {
-        m_test_error_messages.add_error(
-            "Iterator must have subtraction between iterators.");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_3);
       }
 
       if (!has_diff_type_plus_iterator_operator) {
-        m_test_error_messages.add_error(
-            "Iterator must have operator+() iterator_traits::difference_type "
-            "plus Iterator object with operator.");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_4);
       }
 
       if (!has_subscript_operator) {
-        m_test_error_messages.add_error("Iterator must have operator[].");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_5);
       }
 
       if constexpr (has_addition_compound_operator &&
@@ -126,9 +123,8 @@ class legacy_random_access_iterator_requirement {
             decltype(std::declval<It&>() -= -std::declval<diff_t>()), It&>;
 
         if (!is_compund_ops_correct)
-          m_test_error_messages.add_error(
-              "operator+=() and operator-=() must return It& for positive "
-              "and negative vales.");
+          m_test_error_codes.add_error(
+              legacy_random_access_iterator::error_code_6);
       }
 
       if constexpr (has_diff_type_plus_iterator_operator &&
@@ -143,23 +139,21 @@ class legacy_random_access_iterator_requirement {
               // For negative n
               !std::is_same_v<decltype(a - n), It> ||
               !std::is_same_v<decltype(-n + a), It>) {
-            m_test_error_messages.add_error(
-                "operator+() and operator-() must return It& for positive "
-                "and negative vales.");
+            m_test_error_codes.add_error(
+                legacy_random_access_iterator::error_code_7);
           }
         }
 
         {
           It a = valid_iterator;
           if (!(a + n == n + a)) {
-            m_test_error_messages.add_error(
-                "Iterator operator+=() must be commutative.");
+            m_test_error_codes.add_error(
+                legacy_random_access_iterator::error_code_8);
           }
         }
       } else {
-        m_test_error_messages.add_error(
-            "Iterator must have operator+() with "
-            "iterator_traits::difference_type operator.");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_9);
       }
 
       if constexpr (has_iterator_minus_diff_type_operator) {
@@ -167,14 +161,12 @@ class legacy_random_access_iterator_requirement {
         diff_t n = 1;
 
         if (!std::is_same_v<decltype(a - n), It>) {
-          m_test_error_messages.add_error(
-              "Iterator object minus iterator_traits::difference_type must "
-              "return Iterator instance.");
+          m_test_error_codes.add_error(
+              legacy_random_access_iterator::error_code_10);
         }
       } else {
-        m_test_error_messages.add_error(
-            "Iterator must have operator-() with "
-            "iterator_traits::difference_type operator.");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_11);
       }
 
       It a{};
@@ -189,17 +181,15 @@ class legacy_random_access_iterator_requirement {
                       has_difference_type_member) {
           if (!std::is_same_v<decltype(b - a),
                               typename it_traits::difference_type>) {
-            m_test_error_messages.add_error(
-                "operator-() of It instances must return "
-                "iterator_traits::difference_type.");
+            m_test_error_codes.add_error(
+                legacy_random_access_iterator::error_code_12);
           }
         }
         if constexpr (has_subscript_operator && has_reference_member) {
           if (!std::is_convertible_v<decltype(a[0]),
                                      typename it_traits::reference>) {
-            m_test_error_messages.add_error(
-                "operator[]() return value must be convertible to "
-                "iterator_traits::reference.");
+            m_test_error_codes.add_error(
+                legacy_random_access_iterator::error_code_13);
           }
         }
       }
@@ -210,46 +200,46 @@ class legacy_random_access_iterator_requirement {
       It b{};
       if constexpr (has_greater_than_operator) {
         if (!std::is_convertible_v<decltype(a > b), bool>) {
-          m_test_error_messages.add_error(
-              "operator>() return value must be contextually convertible to "
-              "bool.");
+          m_test_error_codes.add_error(
+              legacy_random_access_iterator::error_code_14);
         }
       } else {
-        m_test_error_messages.add_error("Iterator must have operator>().");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_15);
       }
       if constexpr (has_less_than_operator) {
         if (!std::is_convertible_v<decltype(a < b), bool>) {
-          m_test_error_messages.add_error(
-              "operator<() return value must be contextually convertible to "
-              "bool.");
+          m_test_error_codes.add_error(
+              legacy_random_access_iterator::error_code_16);
         }
       } else {
-        m_test_error_messages.add_error("Iterator must have operator<().");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_17);
       }
       if constexpr (has_greater_or_equal_operator) {
         if (!std::is_convertible_v<decltype(a >= b), bool>) {
-          m_test_error_messages.add_error(
-              "operator>=() return value must be contextually convertible to "
-              "bool.");
+          m_test_error_codes.add_error(
+              legacy_random_access_iterator::error_code_18);
         }
       } else {
-        m_test_error_messages.add_error("Iterator must have operator>=().");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_19);
       }
       if constexpr (has_less_or_equal_operator) {
         if (!std::is_convertible_v<decltype(a <= b), bool>) {
-          m_test_error_messages.add_error(
-              "operator<=() return value must be contextually convertible to "
-              "bool.");
+          m_test_error_codes.add_error(
+              legacy_random_access_iterator::error_code_20);
         }
       } else {
-        m_test_error_messages.add_error("Iterator must have operator<=().");
+        m_test_error_codes.add_error(
+            legacy_random_access_iterator::error_code_21);
       }
     }
 
-    const bool is_satisfied = !m_test_error_messages.has_errors();
+    const bool is_satisfied = !m_test_error_codes.has_errors();
     // According to spec std::pair with device_copyable types(in this case:
-    // bool, string_view) can be used on device side
-    return std::make_pair(is_satisfied, m_test_error_messages.get_array());
+    // bool, int) can be used on device side
+    return std::make_pair(is_satisfied, m_test_error_codes.get_array());
   }
 };
 }  // namespace named_requirement_verification


### PR DESCRIPTION
According to [3.13.1. Device copyable](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable) - array<string_view> can only be used if the strings will be placed in USM, so change array<string_view> to array<int>