### PR TITLE
Add tests for sycl::atomic_ref constructors

### DIFF
--- a/tests/atomic_ref/CMakeLists.txt
+++ b/tests/atomic_ref/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB test_cases_list *.cpp)
+
+add_cts_test(${test_cases_list})

--- a/tests/atomic_ref/atomic_ref_common.h
+++ b/tests/atomic_ref/atomic_ref_common.h
@@ -1,0 +1,206 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Common functions for the atomic_ref tests.
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_ATOMIC_REF_COMMON_H
+#define SYCL_CTS_ATOMIC_REF_COMMON_H
+
+#include "../common/common.h"
+#include "../common/section_name_builder.h"
+#include "../common/type_coverage.h"
+
+#define SYCL_CTS_ATOMIC_REF_ON_HOST 0
+
+namespace atomic_ref_tests_common {
+using namespace sycl_cts;
+
+constexpr int expected_val = 42;
+constexpr int changed_val = 1;
+
+/**
+ * @brief Function helps to get string section name that will contain template
+ * parameters and function arguments
+ *
+ * @tparam Dimension Integer representing dimension
+ * @param type_name String with name of the testing type
+ * @param memory_order_name String with name of the testing memory_order
+ * @param memory_scope_name String with name of the testing memory_scope
+ * @param address_space String with name of the address_space
+ * @param section_description String with human-readable description of the test
+ * @return std::string String with name for section
+ */
+inline std::string get_section_name(const std::string& type_name,
+                                    const std::string& memory_order_name,
+                                    const std::string& memory_scope_name,
+                                    const std::string& address_space_name,
+                                    const std::string& section_description) {
+  return section_name(section_description)
+      .with("T", type_name)
+      .with("memory_order", memory_order_name)
+      .with("memory_scope", memory_scope_name)
+      .with("address_space", address_space_name)
+      .create();
+}
+
+/**
+ * @brief Function helps to get string section name that will contain template
+ * parameters and function arguments
+ *
+ * @tparam Dimension Integer representing dimension
+ * @param type_name String with name of the testing type
+ * @param memory_order_name String with name of the testing memory_order
+ * @param memory_scope_name String with name of the testing memory_scope
+ * @param address_space String with name of the address_space
+ * @param memory_order sycl::memory_order which will be used as parameter of
+ * atomic_ref method
+ * @param momory_scope sycl::memory_scope which will be used as parameter of
+ * atomic_ref method
+ * @param section_description String with human-readable description of the test
+ * @return std::string String with name for section
+ */
+inline std::string get_section_name(const std::string& type_name,
+                                    const std::string& memory_order_name,
+                                    const std::string& memory_scope_name,
+                                    const std::string& address_space_name,
+                                    const sycl::memory_order& memory_order,
+                                    const sycl::memory_scope& memory_scope,
+                                    const std::string& section_description) {
+  return section_name(section_description)
+      .with("T", type_name)
+      .with("memory_order", memory_order_name)
+      .with("memory_scope", memory_scope_name)
+      .with("address_space", address_space_name)
+      .with("memory_order arg", memory_order)
+      .with("memory_scope arg", memory_scope)
+      .create();
+}
+
+/**
+ * @brief Factory function for getting type_pack with fp64 type
+ */
+inline auto get_atomic64_types() {
+  static const auto types =
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
+      named_type_pack<long long, unsigned long long, double>::generate(
+          "long long", "unsigned long long", "double");
+#else
+      named_type_pack<long long, double>::generate("long long", "double");
+#endif
+  return types;
+}
+
+/**
+ * @brief Factory function for getting type_pack with all generic types
+ */
+inline auto get_full_conformance_type_pack() {
+  static const auto types =
+      named_type_pack<int, unsigned int, long int, unsigned long int,
+                      float>::generate("int", "unsigned int", "long int",
+                                       "unsigned long int", "float");
+  return types;
+}
+
+/**
+ * @brief Factory function for getting type_pack with generic types
+ */
+inline auto get_lightweight_type_pack() {
+  static const auto types =
+      named_type_pack<int, float>::generate("int", "float");
+  return types;
+}
+
+/**
+ * @brief Factory function for getting type_pack with types that depends on full
+ *        conformance mode enabling status
+ * @return lightweight or full named_type_pack
+ */
+inline auto get_conformance_type_pack() {
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  return get_full_conformance_type_pack();
+#else
+  return get_lightweight_type_pack();
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+}
+
+/**
+ * @brief Factory function for getting type_pack with memory_order values
+ */
+inline auto get_memory_orders() {
+  static const auto memory_orders =
+      value_pack<sycl::memory_order, sycl::memory_order::relaxed,
+                 sycl::memory_order::acq_rel,
+                 sycl::memory_order::seq_cst>::generate_named();
+  return memory_orders;
+}
+
+/**
+ * @brief Factory function for getting type_pack with memory_scope values
+ */
+inline auto get_memory_scopes() {
+  static const auto memory_scopes =
+      value_pack<sycl::memory_scope, sycl::memory_scope::work_item,
+                 sycl::memory_scope::sub_group, sycl::memory_scope::work_group,
+                 sycl::memory_scope::device,
+                 sycl::memory_scope::system>::generate_named();
+  return memory_scopes;
+}
+
+/**
+ * @brief Factory function for getting type_pack with address_space values
+ */
+inline auto get_address_spaces() {
+  static const auto address_spaces =
+      value_pack<sycl::access::address_space,
+                 sycl::access::address_space::global_space,
+                 sycl::access::address_space::local_space,
+                 sycl::access::address_space::generic_space>::generate_named();
+  return address_spaces;
+}
+
+inline bool memory_order_is_supported(sycl::queue& q,
+                                      sycl::memory_order order) {
+  std::vector<sycl::memory_order> memory_orders_supported =
+      q.get_device()
+          .get_info<sycl::info::device::atomic_memory_order_capabilities>();
+  auto it = std::find(memory_orders_supported.begin(),
+                      memory_orders_supported.end(), order);
+  return it != memory_orders_supported.end();
+}
+
+inline bool memory_scope_is_suppoted(sycl::queue& q, sycl::memory_scope scope) {
+  std::vector<sycl::memory_scope> memory_scopes_supported =
+      q.get_device()
+          .get_info<sycl::info::device::atomic_memory_scope_capabilities>();
+  auto it = std::find(memory_scopes_supported.begin(),
+                      memory_scopes_supported.end(), scope);
+  return it != memory_scopes_supported.end();
+}
+
+inline bool memory_order_and_scope_are_supported(sycl::queue& q,
+                                                 sycl::memory_order order,
+                                                 sycl::memory_scope scope) {
+  return memory_order_is_supported(q, order) &&
+         memory_scope_is_suppoted(q, scope);
+}
+
+inline bool memory_order_and_scope_are_not_supported(sycl::queue& q,
+                                                     sycl::memory_order order,
+                                                     sycl::memory_scope scope) {
+  return !memory_order_and_scope_are_supported(q, order, scope);
+}
+
+/**
+ * @brief Function to compare two floatinig point values
+ */
+template <typename T>
+bool compare_act_and_expd_with_epsilon(T actual, T expected, T eps) {
+  return ((expected - eps) <= actual) && (actual <= (expected - eps));
+}
+
+}  // namespace atomic_ref_tests_common
+
+#endif  // SYCL_CTS_ATOMIC_REF_COMMON_H

--- a/tests/atomic_ref/atomic_ref_constructors.h
+++ b/tests/atomic_ref/atomic_ref_constructors.h
@@ -1,0 +1,164 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides tests for SYCL atomic_ref constructors
+//
+*******************************************************************************/
+#ifndef SYCL_CTS_ATOMIC_REF_CONSTRUCTORS_H
+#define SYCL_CTS_ATOMIC_REF_CONSTRUCTORS_H
+
+#include "atomic_ref_common.h"
+#include <type_traits>
+
+namespace atomic_ref_constructors {
+using namespace atomic_ref_tests_common;
+
+template <typename T, typename MemoryOrderT, typename MemoryScopeT,
+          typename AddressSpaceT>
+class run_constructor_tests {
+  static constexpr sycl::memory_order MemoryOrder = MemoryOrderT::value;
+  static constexpr sycl::memory_scope MemoryScope = MemoryScopeT::value;
+  static constexpr sycl::access::address_space AddressSpace =
+      AddressSpaceT::value;
+  using AtomicRT = sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace>;
+  using ReferencedType = std::remove_pointer_t<T>;
+
+ public:
+  void operator()(const std::string &type_name,
+                  const std::string &memory_order_name,
+                  const std::string &memory_scope_name,
+                  const std::string &address_space_name) {
+    auto queue = util::get_cts_object::queue();
+    if (memory_order_and_scope_are_not_supported(queue, MemoryOrder,
+                                                 MemoryScope)) {
+      return;
+    }
+    ReferencedType data = value_operations::init<ReferencedType>(expected_val);
+    T value;
+    if constexpr (std::is_pointer_v<T>)
+      value = &data;
+    else
+      value = data;
+// FIXME: legal address spaces are not yet defined for atomic_ref used on the
+// host, it's possible that will be decided that atomic_ref isn't allowed in
+// host code at all. It can be tracked in this issue
+// https://gitlab.khronos.org/sycl/Specification/-/issues/637. When the decision
+// about atomic_ref usage have been done re-enable test running on host side or
+// remove it
+#if SYCL_CTS_ATOMIC_REF_ON_HOST == 1
+    if constexpr (AddressSpace != sycl::access::address_space::local_space) {
+      SECTION(get_section_name(type_name, memory_order_name, memory_scope_name,
+                               address_space_name,
+                               "Check constructors on host")) {
+        AtomicRT a_r(value);
+        auto result = a_r.load();
+        CHECK(result == value);
+        STATIC_CHECK(std::is_same_v<decltype(result), T>);
+
+        AtomicRT a_r_copy(a_r);
+        auto result_copy = a_r.load();
+        CHECK(result_copy == value);
+      }
+    }
+#endif
+    SECTION(get_section_name(type_name, memory_order_name, memory_scope_name,
+                             address_space_name,
+                             "Check constructors on device")) {
+      if constexpr (AddressSpace != sycl::access::address_space::global_space) {
+        std::array<bool, 2> res = {false, false};
+        {
+          sycl::buffer result_buf(res.data(), sycl::range(2));
+
+          queue
+              .submit([&](sycl::handler &cgh) {
+                auto result_accessor =
+                    result_buf.template get_access<sycl::access_mode::write>(
+                        cgh);
+                sycl::local_accessor<T, 1> loc_acc(sycl::range<1>(1), cgh);
+                cgh.parallel_for(sycl::nd_range<1>(1, 1),
+                                 [=](sycl::nd_item<1>) {
+                                   loc_acc[0] = value;
+                                   AtomicRT a_r(loc_acc[0]);
+
+                                   auto result = a_r.load();
+                                   result_accessor[0] = (result == value);
+
+                                   AtomicRT a_r_copy(a_r);
+                                   auto result_copy = a_r.load();
+                                   result_accessor[1] = (result_copy == value);
+                                 });
+              })
+              .wait_and_throw();
+        }
+        {
+          INFO("check atomic_ref(T&) (local space)");
+          CHECK(res[0]);
+        }
+        {
+          INFO("check copy-constructor (local space)");
+          CHECK(res[1]);
+        }
+      }
+      if constexpr (AddressSpace != sycl::access::address_space::local_space) {
+        std::array<bool, 2> res = {false, false};
+        {
+          sycl::buffer data_buf(&value, sycl::range(1));
+          sycl::buffer result_buf(res.data(), sycl::range(2));
+
+          queue
+              .submit([&](sycl::handler &cgh) {
+                auto data_accessor =
+                    data_buf.template get_access<sycl::access_mode::read_write>(
+                        cgh);
+                auto result_accessor =
+                    result_buf.template get_access<sycl::access_mode::write>(
+                        cgh);
+                cgh.single_task([=]() {
+                  AtomicRT a_r(data_accessor[0]);
+
+                  auto result = a_r.load();
+                  result_accessor[0] = (result == value);
+
+                  AtomicRT a_r_copy(a_r);
+                  auto result_copy = a_r.load();
+                  result_accessor[1] = (result_copy == value);
+                });
+              })
+              .wait_and_throw();
+        }
+        {
+          INFO("check atomic_ref(T&) (global space)");
+          CHECK(res[0]);
+        }
+        {
+          INFO("check copy-constructor (global space)");
+          CHECK(res[1]);
+        }
+      }
+    }
+  }
+};
+
+/**
+ * @brief Run tests for sycl::atomic_ref constructor
+ */
+template <typename T>
+struct run_test {
+  void operator()(const std::string &type_name) {
+    const auto memory_orders = get_memory_orders();
+    const auto memory_scopes = get_memory_scopes();
+    const auto address_spaces = get_address_spaces();
+
+    for_all_combinations<run_constructor_tests, T>(memory_orders, memory_scopes,
+                                                   address_spaces, type_name);
+
+    std::string type_name_for_pointer_types = type_name + "*";
+    for_all_combinations<run_constructor_tests, T *>(
+        memory_orders, memory_scopes, address_spaces,
+        type_name_for_pointer_types);
+  }
+};
+
+}  // namespace atomic_ref_constructors
+#endif  // SYCL_CTS_ATOMIC_REF_CONSTRUCTORS_H

--- a/tests/atomic_ref/atomic_ref_constructors.h
+++ b/tests/atomic_ref/atomic_ref_constructors.h
@@ -35,7 +35,8 @@ class run_constructor_tests {
   static constexpr sycl::memory_scope MemoryScope = MemoryScopeT::value;
   static constexpr sycl::access::address_space AddressSpace =
       AddressSpaceT::value;
-  using atomic_ref_type = sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace>;
+  using atomic_ref_type =
+      sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace>;
   using referenced_type = std::remove_pointer_t<T>;
 
  public:
@@ -48,7 +49,8 @@ class run_constructor_tests {
                                                  MemoryScope)) {
       return;
     }
-    referenced_type data = value_operations::init<referenced_type>(expected_val);
+    referenced_type data =
+        value_operations::init<referenced_type>(expected_val);
     T value;
     if constexpr (std::is_pointer_v<T>)
       value = &data;

--- a/tests/atomic_ref/atomic_ref_constructors.h
+++ b/tests/atomic_ref/atomic_ref_constructors.h
@@ -2,7 +2,21 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Provides tests for SYCL atomic_ref constructors
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests for sycl::atomic_ref constructors.
 //
 *******************************************************************************/
 #ifndef SYCL_CTS_ATOMIC_REF_CONSTRUCTORS_H
@@ -11,8 +25,8 @@
 #include "atomic_ref_common.h"
 #include <type_traits>
 
-namespace atomic_ref_constructors {
-using namespace atomic_ref_tests_common;
+namespace atomic_ref::constructors {
+using namespace atomic_ref::tests::common;
 
 template <typename T, typename MemoryOrderT, typename MemoryScopeT,
           typename AddressSpaceT>
@@ -21,8 +35,8 @@ class run_constructor_tests {
   static constexpr sycl::memory_scope MemoryScope = MemoryScopeT::value;
   static constexpr sycl::access::address_space AddressSpace =
       AddressSpaceT::value;
-  using AtomicRT = sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace>;
-  using ReferencedType = std::remove_pointer_t<T>;
+  using atomic_ref_type = sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace>;
+  using referenced_type = std::remove_pointer_t<T>;
 
  public:
   void operator()(const std::string &type_name,
@@ -34,7 +48,7 @@ class run_constructor_tests {
                                                  MemoryScope)) {
       return;
     }
-    ReferencedType data = value_operations::init<ReferencedType>(expected_val);
+    referenced_type data = value_operations::init<referenced_type>(expected_val);
     T value;
     if constexpr (std::is_pointer_v<T>)
       value = &data;
@@ -51,12 +65,12 @@ class run_constructor_tests {
       SECTION(get_section_name(type_name, memory_order_name, memory_scope_name,
                                address_space_name,
                                "Check constructors on host")) {
-        AtomicRT a_r(value);
+        atomic_ref_type a_r(value);
         auto result = a_r.load();
         CHECK(result == value);
         STATIC_CHECK(std::is_same_v<decltype(result), T>);
 
-        AtomicRT a_r_copy(a_r);
+        atomic_ref_type a_r_copy(a_r);
         auto result_copy = a_r.load();
         CHECK(result_copy == value);
       }
@@ -79,12 +93,12 @@ class run_constructor_tests {
                 cgh.parallel_for(sycl::nd_range<1>(1, 1),
                                  [=](sycl::nd_item<1>) {
                                    loc_acc[0] = value;
-                                   AtomicRT a_r(loc_acc[0]);
+                                   atomic_ref_type a_r(loc_acc[0]);
 
                                    auto result = a_r.load();
                                    result_accessor[0] = (result == value);
 
-                                   AtomicRT a_r_copy(a_r);
+                                   atomic_ref_type a_r_copy(a_r);
                                    auto result_copy = a_r.load();
                                    result_accessor[1] = (result_copy == value);
                                  });
@@ -114,13 +128,13 @@ class run_constructor_tests {
                 auto result_accessor =
                     result_buf.template get_access<sycl::access_mode::write>(
                         cgh);
-                cgh.single_task([=]() {
-                  AtomicRT a_r(data_accessor[0]);
+                cgh.single_task([=] {
+                  atomic_ref_type a_r(data_accessor[0]);
 
                   auto result = a_r.load();
                   result_accessor[0] = (result == value);
 
-                  AtomicRT a_r_copy(a_r);
+                  atomic_ref_type a_r_copy(a_r);
                   auto result_copy = a_r.load();
                   result_accessor[1] = (result_copy == value);
                 });
@@ -160,5 +174,5 @@ struct run_test {
   }
 };
 
-}  // namespace atomic_ref_constructors
+}  // namespace atomic_ref::constructors
 #endif  // SYCL_CTS_ATOMIC_REF_CONSTRUCTORS_H

--- a/tests/atomic_ref/atomic_ref_constructors_core.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_core.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides sycl::atomic_ref constructors test for generic types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "atomic_ref_constructors.h"
+
+namespace atomic_ref_constructors_core {
+
+TEST_CASE("sycl::atomic_ref constructors. core types", "[atomic_ref]") {
+  const auto types = atomic_ref_tests_common::get_conformance_type_pack();
+  for_all_types<atomic_ref_constructors::run_test>(types);
+}
+
+}  // namespace atomic_ref_constructors_core

--- a/tests/atomic_ref/atomic_ref_constructors_core.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_core.cpp
@@ -2,7 +2,21 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Provides sycl::atomic_ref constructors test for generic types
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref constructors test for generic types.
 //
 *******************************************************************************/
 #include "../common/disabled_for_test_case.h"
@@ -20,12 +34,12 @@
 
 #endif
 
-namespace atomic_ref_constructors_core {
+namespace atomic_ref::constructors::core {
 
 DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("sycl::atomic_ref constructors. core types", "[atomic_ref]")({
-  const auto types = atomic_ref_tests_common::get_conformance_type_pack();
-  for_all_types<atomic_ref_constructors::run_test>(types);
+  const auto types = atomic_ref::tests::common::get_conformance_type_pack();
+  for_all_types<atomic_ref::constructors::run_test>(types);
 });
 
-}  // namespace atomic_ref_constructors_core
+}  // namespace atomic_ref::constructors::core

--- a/tests/atomic_ref/atomic_ref_constructors_core.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_core.cpp
@@ -8,13 +8,24 @@
 #include "../common/disabled_for_test_case.h"
 #include "catch2/catch_test_macros.hpp"
 
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
 #include "atomic_ref_constructors.h"
+
+#endif
 
 namespace atomic_ref_constructors_core {
 
-TEST_CASE("sycl::atomic_ref constructors. core types", "[atomic_ref]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref constructors. core types", "[atomic_ref]")({
   const auto types = atomic_ref_tests_common::get_conformance_type_pack();
   for_all_types<atomic_ref_constructors::run_test>(types);
-}
+});
 
 }  // namespace atomic_ref_constructors_core

--- a/tests/atomic_ref/atomic_ref_constructors_core_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_core_atomic64.cpp
@@ -8,11 +8,22 @@
 #include "../common/disabled_for_test_case.h"
 #include "catch2/catch_test_macros.hpp"
 
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
 #include "atomic_ref_constructors.h"
+
+#endif
 
 namespace atomic_ref_constructors_core_atomic64 {
 
-TEST_CASE("sycl::atomic_ref constructors. atomic64 types", "[atomic_ref]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref constructors. atomic64 types", "[atomic_ref]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::atomic64)) {
     WARN(
@@ -22,6 +33,6 @@ TEST_CASE("sycl::atomic_ref constructors. atomic64 types", "[atomic_ref]") {
   }
   const auto type_pack = atomic_ref_tests_common::get_atomic64_types();
   for_all_types<atomic_ref_constructors::run_test>(type_pack);
-}
+});
 
 }  // namespace atomic_ref_constructors_core_atomic64

--- a/tests/atomic_ref/atomic_ref_constructors_core_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_core_atomic64.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provides sycl::atomic_ref constructors test for atomic64 types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "atomic_ref_constructors.h"
+
+namespace atomic_ref_constructors_core_atomic64 {
+
+TEST_CASE("sycl::atomic_ref constructors. atomic64 types", "[atomic_ref]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64)) {
+    WARN(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+    return;
+  }
+  const auto type_pack = atomic_ref_tests_common::get_atomic64_types();
+  for_all_types<atomic_ref_constructors::run_test>(type_pack);
+}
+
+}  // namespace atomic_ref_constructors_core_atomic64

--- a/tests/atomic_ref/atomic_ref_constructors_core_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_core_atomic64.cpp
@@ -2,7 +2,21 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Provides sycl::atomic_ref constructors test for atomic64 types
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref constructors test for atomic64 types.
 //
 *******************************************************************************/
 #include "../common/disabled_for_test_case.h"
@@ -20,7 +34,7 @@
 
 #endif
 
-namespace atomic_ref_constructors_core_atomic64 {
+namespace atomic_ref::constructors::core::atomic64 {
 
 DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("sycl::atomic_ref constructors. atomic64 types", "[atomic_ref]")({
@@ -31,8 +45,8 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
         "Skipping the test case.");
     return;
   }
-  const auto type_pack = atomic_ref_tests_common::get_atomic64_types();
-  for_all_types<atomic_ref_constructors::run_test>(type_pack);
+  const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
+  for_all_types<atomic_ref::constructors::run_test>(type_pack);
 });
 
-}  // namespace atomic_ref_constructors_core_atomic64
+}  // namespace atomic_ref::constructors::core::atomic64


### PR DESCRIPTION
Create tests according to 3.1.3. Common constructors section of test plan https://github.com/KhronosGroup/SYCL-CTS/pull/450