### PR TITLE
Group functions test implementation

### DIFF
--- a/ci/hipsycl.filter
+++ b/ci/hipsycl.filter
@@ -17,6 +17,7 @@ item
 kernel
 kernel_args
 kernel_bundle
+marray
 math_builtin_api
 marray
 multi_ptr

--- a/test_plans/group_functions.asciidoc
+++ b/test_plans/group_functions.asciidoc
@@ -59,10 +59,10 @@ In addition, if the device has aspect::fp16:
 
 If function accepts another types, the following list of types is added:
 
-* `vec<2, int>`
-* `vec<16, unsigned long long>`
-* `marray<5, float>`
-* `marray<7, short>`
+* `vec<int, 2>`
+* `vec<unsigned long long, 16>`
+* `marray<float, 5>`
+* `marray<short, 7>`
 * `struct { int a; bool b; }`
 
 Pointers are taken from the same list of types.
@@ -83,7 +83,8 @@ Data for the functions are sequences of 1, 2, 3, etc. corresponding to increasin
 Functions will be executed by a group using `sycl::parallel_for` with `nd_range<Dims>`
 corresponding to one group of maximal group size available on device with `Dims = 1,2,3`
 (by querying `info::device::max_work_item_sizes<Dims>` and `info::device::max_work_group_size`).
-Sub-group variants will execute functions on the first subgroup of this large group only.
+Sub-group variants will execute functions on all the subgroups or, if this is not possible,
+on the first subgroup of this large group only.
 
 === Traits
 

--- a/tests/group_functions/CMakeLists.txt
+++ b/tests/group_functions/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB test_cases_list *.cpp)
+
+add_cts_test(${test_cases_list})

--- a/tests/group_functions/group_barrier.cpp
+++ b/tests/group_functions/group_barrier.cpp
@@ -1,0 +1,234 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "group_functions_common.h"
+
+template <int D>
+class test_fence;
+
+TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
+                       2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // FIXME: hipSYCL and DPCPP have no implemented
+  //  atomic_fence_scope_capabilities query
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // mock for not available info
+  std::vector<sycl::memory_scope> supported_barriers{
+      sycl::memory_scope::sub_group, sycl::memory_scope::work_group,
+      sycl::memory_scope::device, sycl::memory_scope::system};
+  WARN(
+      "hipSYCL and DPCPP have no implementation of "
+      "atomic_fence_scope_capabilities query, suppose all barrier types as "
+      "valid.");
+#else
+  std::vector<sycl::memory_scope> supported_barriers =
+      queue.get_context()
+          .get_info<sycl::info::context::atomic_fence_scope_capabilities>();
+#endif
+
+  using sms = std::tuple<sycl::memory_scope, bool, bool>;
+  enum s { scope = 0, support = 1, test = 2 };
+
+  std::array<sms, 4> group_barriers{
+      sms{sycl::memory_scope::work_group, true, true},
+      sms{sycl::memory_scope::work_group, true, true},
+      sms{sycl::memory_scope::device, true, true},
+      sms{sycl::memory_scope::system, true, true}};
+  std::array<std::string, 4> group_barriers_names{
+      "default", "sycl::memory_scope::work_group", "sycl::memory_scope::device",
+      "sycl::memory_scope::system"};
+  for (auto& barrier : group_barriers) {
+    auto& sb = supported_barriers;
+    if (std::find(sb.begin(), sb.end(), std::get<s::scope>(barrier)) ==
+        sb.end()) {
+      std::get<s::support>(barrier) = false;
+    }
+  }
+
+  std::array<sms, 5> sub_group_barriers{
+      sms{sycl::memory_scope::sub_group, true, true},
+      sms{sycl::memory_scope::sub_group, true, true},
+      sms{sycl::memory_scope::work_group, true, true},
+      sms{sycl::memory_scope::device, true, true},
+      sms{sycl::memory_scope::system, true, true}};
+  std::array<std::string, 5> sub_group_barriers_names{
+      "default", "sycl::memory_scope::sub_group",
+      "sycl::memory_scope::work_group", "sycl::memory_scope::device",
+      "sycl::memory_scope::system"};
+  for (auto& barrier : sub_group_barriers) {
+    auto& sb = supported_barriers;
+    if (std::find(sb.begin(), sb.end(), std::get<s::scope>(barrier)) ==
+        sb.end()) {
+      std::get<s::support>(barrier) = false;
+    }
+  }
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  std::vector<int32_t> v(work_group_size, 0);
+  sycl::buffer<int32_t, 1> global_mem(v.data(),
+                                      sycl::range<1>(work_group_size));
+
+  sycl::buffer<sms, 1> group_barriers_buf(group_barriers.data(),
+                                          sycl::range<1>(4));
+  sycl::buffer<sms, 1> sub_group_barriers_buf(sub_group_barriers.data(),
+                                              sycl::range<1>(5));
+
+  queue.submit([&](sycl::handler& cgh) {
+    sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+    auto group_barriers_acc =
+        group_barriers_buf.get_access<sycl::access::mode::read_write>(cgh);
+    auto sub_group_barriers_acc =
+        sub_group_barriers_buf.get_access<sycl::access::mode::read_write>(cgh);
+
+    sycl::local_accessor<int32_t, 1> local_acc(sycl::range<1>(work_group_size),
+                                               cgh);
+    sycl::accessor<int32_t, 1> global_acc =
+        global_mem.get_access<sycl::access::mode::read_write>(cgh);
+
+    cgh.parallel_for<test_fence<D>>(executionRange, [=](sycl::nd_item<D> item) {
+      sycl::group<D> group = item.get_group();
+      size_t llid = group.get_local_linear_id();
+      size_t max_id = group.get_local_linear_range() - 1;
+
+      ASSERT_RETURN_TYPE(void, sycl::group_barrier(group),
+                         "Return type of group_barrier(group g) is wrong\n");
+      ASSERT_RETURN_TYPE(void, sycl::group_barrier(group, group.fence_scope),
+                         "Return type of group_barrier(group g, memory_scope "
+                         "fence_scope) is wrong\n");
+
+      // test of default barrier
+      local_acc[llid] = 0;
+      sycl::group_barrier(group);
+
+      local_acc[llid] = 1;
+      sycl::group_barrier(group);
+
+      if (local_acc[max_id - llid] != 1)
+        std::get<s::test>(group_barriers_acc[0]) = false;
+
+      for (int i = 1; i < 4; ++i) {
+        auto& barrier = group_barriers_acc[i];
+
+        if (std::get<s::support>(barrier)) {
+          local_acc[llid] = 0;
+          global_acc[llid] = 0;
+
+          sycl::group_barrier(group);
+
+          // fallthrough is intentional
+          switch (std::get<s::scope>(barrier)) {
+            case sycl::memory_scope::work_group:
+              local_acc[llid] = 1;
+              sycl::group_barrier(group, std::get<s::scope>(barrier));
+
+              if (local_acc[max_id - llid] != 1)
+                std::get<s::test>(barrier) = false;
+
+            default:
+              global_acc[llid] = 1;
+              sycl::group_barrier(group, std::get<s::scope>(barrier));
+
+              if (global_acc[max_id - llid] != 1)
+                std::get<s::test>(barrier) = false;
+          }
+        }
+      }
+
+      sycl::sub_group sub_group = item.get_sub_group();
+      llid = sub_group.get_local_linear_id();
+      max_id = sub_group.get_local_linear_range() - 1;
+
+      ASSERT_RETURN_TYPE(
+          void, sycl::group_barrier(sub_group),
+          "Return type of group_barrier(sub_group g) is wrong\n");
+      ASSERT_RETURN_TYPE(void,
+                         sycl::group_barrier(group, sub_group.fence_scope),
+                         "Return type of group_barrier(sub_group g, "
+                         "memory_scope fence_scope) is wrong\n");
+
+      // test of default barrier
+      local_acc[llid] = 0;
+      sycl::group_barrier(sub_group);
+
+      local_acc[llid] = 1;
+      sycl::group_barrier(sub_group);
+
+      if (local_acc[max_id - llid] != 1)
+        std::get<s::test>(sub_group_barriers_acc[0]) = false;
+
+      for (int i = 1; i < 5; ++i) {
+        auto& barrier = sub_group_barriers_acc[i];
+
+        if ((sub_group.get_group_linear_id() == 0) &&
+            std::get<s::support>(barrier)) {
+          local_acc[llid] = 0;
+          global_acc[llid] = 0;
+
+          sycl::group_barrier(sub_group);
+
+          // fallthrough is intentional
+          switch (std::get<s::scope>(barrier)) {
+            case sycl::memory_scope::sub_group:
+            case sycl::memory_scope::work_group:
+              local_acc[llid] = 1;
+              sycl::group_barrier(sub_group, std::get<s::scope>(barrier));
+
+              if (local_acc[max_id - llid] != 1)
+                std::get<s::test>(barrier) = false;
+
+            default:
+              global_acc[llid] = 1;
+              sycl::group_barrier(sub_group, std::get<s::scope>(barrier));
+
+              if (global_acc[max_id - llid] != 1)
+                std::get<s::test>(barrier) = false;
+          }
+        }
+      }
+    });
+  });
+
+  for (int i = 0; i < 4; ++i) {
+    bool result = std::get<s::test>(group_barriers[i]);
+    std::string work_group = util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Result of group_barrier invocation for group and "
+         << group_barriers_names[i] << " memory scope is "
+         << (result ? "right" : "wrong"));
+    CHECK(result);
+  }
+  for (int i = 0; i < 5; ++i) {
+    bool result = std::get<s::test>(sub_group_barriers[i]);
+    std::string work_group = util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Result of group_barrier invocation for sub-group and "
+         << sub_group_barriers_names[i] << " memory scope is "
+         << (result ? "right" : "wrong"));
+    CHECK(result);
+  }
+}

--- a/tests/group_functions/group_barrier.cpp
+++ b/tests/group_functions/group_barrier.cpp
@@ -33,7 +33,7 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
   // FIXME: hipSYCL and DPCPP have no implemented
   //  atomic_fence_scope_capabilities query
 #if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP))
+      defined(SYCL_CTS_COMPILING_WITH_DPCPP))
   std::vector<sycl::memory_scope> supported_barriers =
       queue.get_context()
           .get_info<sycl::info::context::atomic_fence_scope_capabilities>();
@@ -54,10 +54,10 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
 
   constexpr int group_barrier_variants = 4;
   std::array<sms, group_barrier_variants> group_barriers{
-      sms{sycl::memory_scope::work_group, true, true},
-      sms{sycl::memory_scope::work_group, true, true},
-      sms{sycl::memory_scope::device, true, true},
-      sms{sycl::memory_scope::system, true, true}};
+      {{sycl::memory_scope::work_group, true, true},
+       {sycl::memory_scope::work_group, true, true},
+       {sycl::memory_scope::device, true, true},
+       {sycl::memory_scope::system, true, true}}};
   std::array<std::string, group_barrier_variants> group_barriers_names{
       "default", "sycl::memory_scope::work_group", "sycl::memory_scope::device",
       "sycl::memory_scope::system"};
@@ -71,11 +71,11 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
 
   constexpr int sub_group_barrier_variants = 5;
   std::array<sms, sub_group_barrier_variants> sub_group_barriers{
-      sms{sycl::memory_scope::sub_group, true, true},
-      sms{sycl::memory_scope::sub_group, true, true},
-      sms{sycl::memory_scope::work_group, true, true},
-      sms{sycl::memory_scope::device, true, true},
-      sms{sycl::memory_scope::system, true, true}};
+      {{sycl::memory_scope::sub_group, true, true},
+       {sycl::memory_scope::sub_group, true, true},
+       {sycl::memory_scope::work_group, true, true},
+       {sycl::memory_scope::device, true, true},
+       {sycl::memory_scope::system, true, true}}};
   std::array<std::string, sub_group_barrier_variants> sub_group_barriers_names{
       "default", "sycl::memory_scope::sub_group",
       "sycl::memory_scope::work_group", "sycl::memory_scope::device",

--- a/tests/group_functions/group_broadcast.cpp
+++ b/tests/group_functions/group_broadcast.cpp
@@ -62,9 +62,10 @@ TEMPLATE_LIST_TEST_CASE("Group broadcast", "[group_func][type_list][dim]",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -94,9 +95,10 @@ TEMPLATE_LIST_TEST_CASE("Sub-group broadcast and select",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else

--- a/tests/group_functions/group_broadcast.cpp
+++ b/tests/group_functions/group_broadcast.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_broadcast.h"
+
+// FIXME: DPCPP does not implement group_broadcast for sycl::vec
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+using BroadcastTypes =
+    concatenation<FundamentalTypes, std::tuple<bool, sycl::marray<float, 5>,
+                                               sycl::marray<short int, 7>,
+                                               util::custom_type>>::type;
+// FIXME: ComputeCpp does not implement group_broadcast for sycl::vec,
+//        sycl::marray, unsigned long long int, and long long int
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+using BroadcastTypes =
+    std::tuple<size_t, float, char, signed char, unsigned char, short int,
+               unsigned short int, int, unsigned int, long int,
+               unsigned long int, bool, util::custom_type>;
+#else
+using BroadcastTypes = std::tuple<float, char, int, bool, util::custom_type>;
+#endif
+#else
+using BroadcastTypes = CustomTypes;
+#endif
+
+TEMPLATE_LIST_TEST_CASE("Group broadcast", "[group_func][type_list][dim]",
+                        BroadcastTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check type to only print warning once
+  if constexpr (std::is_same_v<TestType, char>) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement group_broadcast for vec types. "
+        "Skipping those test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement group_broadcast for vec, marray, "
+        "unsigned long long int, and long long int types. Skipping those test "
+        "cases.");
+#endif
+  }
+
+  // check all work group dimensions
+  broadcast_group<1, TestType>(queue);
+  broadcast_group<2, TestType>(queue);
+  broadcast_group<3, TestType>(queue);
+}
+
+TEMPLATE_LIST_TEST_CASE("Sub-group broadcast and select",
+                        "[group_func][type_list][dim]", BroadcastTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check type to only print warning once
+  if constexpr (std::is_same_v<TestType, char>) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement group_broadcast for vec types. "
+        "Skipping those test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement group_broadcast for vec, marray, "
+        "unsigned long long int, and long long int types. Skipping those test "
+        "cases.");
+#endif
+  }
+
+  // check all work group dimensions
+  broadcast_sub_group<1, TestType>(queue);
+  broadcast_sub_group<2, TestType>(queue);
+  broadcast_sub_group<3, TestType>(queue);
+}

--- a/tests/group_functions/group_broadcast.cpp
+++ b/tests/group_functions/group_broadcast.cpp
@@ -41,10 +41,10 @@ using BroadcastTypes = std::tuple<float, char, int, bool, util::custom_type>;
 using BroadcastTypes = CustomTypes;
 #endif
 
+static auto queue = sycl_cts::util::get_cts_object::queue();
+
 TEMPLATE_LIST_TEST_CASE("Group broadcast", "[group_func][type_list][dim]",
                         BroadcastTypes) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
-
   // check type to only print warning once
   if constexpr (std::is_same_v<TestType, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
@@ -56,19 +56,27 @@ TEMPLATE_LIST_TEST_CASE("Group broadcast", "[group_func][type_list][dim]",
         "ComputeCpp does not implement group_broadcast for vec, marray, "
         "unsigned long long int, and long long int types. Skipping those test "
         "cases.");
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
 #endif
   }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   // check all work group dimensions
   broadcast_group<1, TestType>(queue);
   broadcast_group<2, TestType>(queue);
   broadcast_group<3, TestType>(queue);
+#endif
 }
 
 TEMPLATE_LIST_TEST_CASE("Sub-group broadcast and select",
                         "[group_func][type_list][dim]", BroadcastTypes) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
-
   // check type to only print warning once
   if constexpr (std::is_same_v<TestType, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
@@ -80,11 +88,21 @@ TEMPLATE_LIST_TEST_CASE("Sub-group broadcast and select",
         "ComputeCpp does not implement group_broadcast for vec, marray, "
         "unsigned long long int, and long long int types. Skipping those test "
         "cases.");
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
 #endif
   }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   // check all work group dimensions
   broadcast_sub_group<1, TestType>(queue);
   broadcast_sub_group<2, TestType>(queue);
   broadcast_sub_group<3, TestType>(queue);
+#endif
 }

--- a/tests/group_functions/group_broadcast.h
+++ b/tests/group_functions/group_broadcast.h
@@ -1,0 +1,213 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_functions_common.h"
+
+template <int D, typename T>
+class broadcast_group_kernel;
+
+/**
+ * @brief Provides test for broadcast values inside the group
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type for broadcasted value
+ */
+template <int D, typename T>
+void broadcast_group(sycl::queue& queue) {
+  // 3 functions
+  constexpr int test_matrix = 3;
+  const std::string test_names[test_matrix] = {
+      "T group_broadcast(group g, T x)",
+      "T group_broadcast(group g, T x, group::linear_id_type local_linear_id)",
+      "T group_broadcast(group g, T x, group::id_type local_id)"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results
+  T res[test_matrix] = {init_helper<T>(0)};
+  {
+    sycl::buffer<T, 1> res_sycl(res, sycl::range<1>(test_matrix));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc =
+          res_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<broadcast_group_kernel<D, T>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            sycl::group<D> group = item.get_group();
+
+            // find local id of last group item
+            sycl::id<D> last_item = group.get_local_range();
+            for (int i = 0; i < D; ++i) {
+              --last_item[i];
+            }
+
+            T local_var = init_helper<T>(item.get_local_linear_id() + 1);
+
+            // broadcast from the first workitem
+            ASSERT_RETURN_TYPE(
+                T, sycl::group_broadcast(group, local_var),
+                "Return type of group_broadcast(group g, T x) is wrong\n");
+
+            local_var = sycl::group_broadcast(group, local_var);
+            if (item.get_local_linear_id() ==
+                group.get_local_linear_range() - 1)
+              res_acc[0] = local_var;
+
+            local_var = init_helper<T>(item.get_local_linear_id() + 1);
+
+            // broadcast from the last workitem 1
+            ASSERT_RETURN_TYPE(
+                T,
+                sycl::group_broadcast(group, local_var,
+                                      group.get_local_linear_range() - 1),
+                "Return type of group_broadcast(group g, T x, "
+                "group::linear_id_type local_linear_id) is wrong\n");
+
+            local_var = sycl::group_broadcast(
+                group, local_var, group.get_local_linear_range() - 1);
+            if (item.get_local_linear_id() == 0) res_acc[1] = local_var;
+
+            local_var = init_helper<T>(item.get_local_linear_id() + 1);
+
+            // broadcast from the last workitem 2
+            ASSERT_RETURN_TYPE(
+                T, sycl::group_broadcast(group, local_var, last_item),
+                "Return type of group_broadcast(group g, T x, group::id_type "
+                "local_id) is wrong\n");
+
+            local_var = sycl::group_broadcast(group, local_var, last_item);
+            if (item.get_local_linear_id() == 0) res_acc[2] = local_var;
+          });
+    });
+  }
+
+  T expected[test_matrix] = {init_helper<T>(1), init_helper<T>(work_group_size),
+                             init_helper<T>(work_group_size)};
+
+  for (int i = 0; i < test_matrix; ++i) {
+    std::string work_group = util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Return value of "
+         << test_names[i] << " with T = " << type_name<T>() << " is "
+         << (equal(res[i], expected[i]) ? "right" : "wrong"));
+    CHECK(equal(res[i], expected[i]));
+  }
+}
+
+template <int D, typename T>
+class broadcast_sub_group_kernel;
+
+template <int D, typename T>
+void broadcast_sub_group(sycl::queue& queue) {
+  // 4 functions
+  constexpr int test_matrix = 4;
+  const std::string test_names[test_matrix] = {
+      "T group_broadcast(sub_group g, T x)",
+      "T group_broadcast(sub_group g, T x, sub_group::linear_id_type "
+      "local_linear_id)",
+      "T group_broadcast(sub_group g, T x, sub_group::id_type local_id)",
+      "T select_from_group(sub_group g, T x, sub_group::id_type local_id)"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+
+  // array to return results
+  T res[test_matrix + 1] = {init_helper<T>(0)};
+  {
+    sycl::buffer<T, 1> res_sycl(res, sycl::range<1>(test_matrix + 1));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc =
+          res_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<broadcast_sub_group_kernel<
+          D, T>>(executionRange, [=](sycl::nd_item<D> item) {
+        sycl::sub_group sub_group = item.get_sub_group();
+
+        T local_var(init_helper<T>(0));
+
+        if (sub_group.get_group_id()[0] == 0) {
+          // find local id of last group item
+          sycl::id<1> last_item = sub_group.get_local_range();
+          --last_item[0];
+
+          // broadcast from the first workitem
+          local_var = init_helper<T>(item.get_global_linear_id() + 1);
+          ASSERT_RETURN_TYPE(
+              T, sycl::group_broadcast(sub_group, local_var),
+              "Return type of group_broadcast(sub_group g, T x) is wrong\n");
+
+          local_var = sycl::group_broadcast(sub_group, local_var);
+          if (sub_group.get_local_linear_id() ==
+              sub_group.get_local_linear_range() - 1)
+            res_acc[0] = local_var;
+
+          // broadcast from the last workitem 1
+          local_var = init_helper<T>(item.get_global_linear_id() + 1);
+          ASSERT_RETURN_TYPE(
+              T, sycl::group_broadcast(sub_group, local_var, last_item),
+              "Return type of group_broadcast(sub_group g, T x, "
+              "sub_group::linear_id_type local_linear_id) is wrong\n");
+
+          local_var = sycl::group_broadcast(
+              sub_group, local_var, sub_group.get_local_linear_range() - 1);
+          if (sub_group.get_local_linear_id() == 0) res_acc[1] = local_var;
+
+          // broadcast from the last workitem 2
+          local_var = init_helper<T>(item.get_global_linear_id() + 1);
+          ASSERT_RETURN_TYPE(
+              T, sycl::group_broadcast(sub_group, local_var, last_item),
+              "Return type of group_broadcast(sub_group g, T x, "
+              "sub_group::id_type local_id) is wrong\n");
+
+          local_var = sycl::group_broadcast(sub_group, local_var, last_item);
+          if (sub_group.get_local_linear_id() == 0) res_acc[2] = local_var;
+
+          // select from the last workitem
+          local_var = init_helper<T>(item.get_global_linear_id() + 1);
+          ASSERT_RETURN_TYPE(
+              T, sycl::select_from_group(sub_group, local_var, last_item),
+              "Return type of select_from_group(sub_group g, T x, "
+              "sub_group::id_type local_id) is wrong\n");
+
+          local_var = sycl::select_from_group(sub_group, local_var, last_item);
+          if (sub_group.get_local_linear_id() == 0) res_acc[3] = local_var;
+
+          // return the sub-group size
+          if (sub_group.get_local_linear_id() == 0)
+            res_acc[4] = sub_group.get_local_linear_range();
+        }
+      });
+    });
+  }
+  T expected[test_matrix] = {init_helper<T>(1), res[4], res[4], res[4]};
+  for (int i = 0; i < test_matrix; ++i) {
+    std::string work_group = util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Return value of "
+         << test_names[i] << " with T = " << type_name<T>() << " is "
+         << (equal(res[i], expected[i]) ? "right" : "wrong"));
+    CHECK(equal(res[i], expected[i]));
+  }
+}

--- a/tests/group_functions/group_broadcast.h
+++ b/tests/group_functions/group_broadcast.h
@@ -41,7 +41,7 @@ void broadcast_group(sycl::queue& queue) {
   size_t work_group_size = work_group_range.size();
 
   // array to return results
-  T res[test_matrix] = {init_helper<T>(0)};
+  T res[test_matrix] = {splat_init<T>(0)};
   {
     sycl::buffer<T, 1> res_sycl(res, sycl::range<1>(test_matrix));
 
@@ -61,7 +61,7 @@ void broadcast_group(sycl::queue& queue) {
               --last_item[i];
             }
 
-            T local_var = init_helper<T>(item.get_local_linear_id() + 1);
+            T local_var = splat_init<T>(item.get_local_linear_id() + 1);
 
             // broadcast from the first workitem
             ASSERT_RETURN_TYPE(
@@ -73,7 +73,7 @@ void broadcast_group(sycl::queue& queue) {
                 group.get_local_linear_range() - 1)
               res_acc[0] = local_var;
 
-            local_var = init_helper<T>(item.get_local_linear_id() + 1);
+            local_var = splat_init<T>(item.get_local_linear_id() + 1);
 
             // broadcast from the last workitem 1
             ASSERT_RETURN_TYPE(
@@ -87,7 +87,7 @@ void broadcast_group(sycl::queue& queue) {
                 group, local_var, group.get_local_linear_range() - 1);
             if (item.get_local_linear_id() == 0) res_acc[1] = local_var;
 
-            local_var = init_helper<T>(item.get_local_linear_id() + 1);
+            local_var = splat_init<T>(item.get_local_linear_id() + 1);
 
             // broadcast from the last workitem 2
             ASSERT_RETURN_TYPE(
@@ -101,8 +101,8 @@ void broadcast_group(sycl::queue& queue) {
     });
   }
 
-  T expected[test_matrix] = {init_helper<T>(1), init_helper<T>(work_group_size),
-                             init_helper<T>(work_group_size)};
+  T expected[test_matrix] = {splat_init<T>(1), splat_init<T>(work_group_size),
+                             splat_init<T>(work_group_size)};
 
   for (int i = 0; i < test_matrix; ++i) {
     std::string work_group = util::work_group_print(work_group_range);
@@ -131,7 +131,7 @@ void broadcast_sub_group(sycl::queue& queue) {
   sycl::range<D> work_group_range = util::work_group_range<D>(queue);
 
   // array to return results
-  T res[test_matrix + 1] = {init_helper<T>(0)};
+  T res[test_matrix + 1] = {splat_init<T>(0)};
   {
     sycl::buffer<T, 1> res_sycl(res, sycl::range<1>(test_matrix + 1));
 
@@ -145,7 +145,7 @@ void broadcast_sub_group(sycl::queue& queue) {
           D, T>>(executionRange, [=](sycl::nd_item<D> item) {
         sycl::sub_group sub_group = item.get_sub_group();
 
-        T local_var(init_helper<T>(0));
+        T local_var(splat_init<T>(0));
 
         if (sub_group.get_group_id()[0] == 0) {
           // find local id of last group item
@@ -153,7 +153,7 @@ void broadcast_sub_group(sycl::queue& queue) {
           --last_item[0];
 
           // broadcast from the first workitem
-          local_var = init_helper<T>(item.get_global_linear_id() + 1);
+          local_var = splat_init<T>(item.get_global_linear_id() + 1);
           ASSERT_RETURN_TYPE(
               T, sycl::group_broadcast(sub_group, local_var),
               "Return type of group_broadcast(sub_group g, T x) is wrong\n");
@@ -164,7 +164,7 @@ void broadcast_sub_group(sycl::queue& queue) {
             res_acc[0] = local_var;
 
           // broadcast from the last workitem 1
-          local_var = init_helper<T>(item.get_global_linear_id() + 1);
+          local_var = splat_init<T>(item.get_global_linear_id() + 1);
           ASSERT_RETURN_TYPE(
               T, sycl::group_broadcast(sub_group, local_var, last_item),
               "Return type of group_broadcast(sub_group g, T x, "
@@ -175,7 +175,7 @@ void broadcast_sub_group(sycl::queue& queue) {
           if (sub_group.get_local_linear_id() == 0) res_acc[1] = local_var;
 
           // broadcast from the last workitem 2
-          local_var = init_helper<T>(item.get_global_linear_id() + 1);
+          local_var = splat_init<T>(item.get_global_linear_id() + 1);
           ASSERT_RETURN_TYPE(
               T, sycl::group_broadcast(sub_group, local_var, last_item),
               "Return type of group_broadcast(sub_group g, T x, "
@@ -185,7 +185,7 @@ void broadcast_sub_group(sycl::queue& queue) {
           if (sub_group.get_local_linear_id() == 0) res_acc[2] = local_var;
 
           // select from the last workitem
-          local_var = init_helper<T>(item.get_global_linear_id() + 1);
+          local_var = splat_init<T>(item.get_global_linear_id() + 1);
           ASSERT_RETURN_TYPE(
               T, sycl::select_from_group(sub_group, local_var, last_item),
               "Return type of select_from_group(sub_group g, T x, "
@@ -201,7 +201,7 @@ void broadcast_sub_group(sycl::queue& queue) {
       });
     });
   }
-  T expected[test_matrix] = {init_helper<T>(1), res[4], res[4], res[4]};
+  T expected[test_matrix] = {splat_init<T>(1), res[4], res[4], res[4]};
   for (int i = 0; i < test_matrix; ++i) {
     std::string work_group = util::work_group_print(work_group_range);
     CAPTURE(D, work_group);

--- a/tests/group_functions/group_broadcast_fp16.cpp
+++ b/tests/group_functions/group_broadcast_fp16.cpp
@@ -33,9 +33,10 @@ TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp16][dim]",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -58,9 +59,10 @@ TEMPLATE_TEST_CASE_SIG("Sub-group broadcast and select",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else

--- a/tests/group_functions/group_broadcast_fp16.cpp
+++ b/tests/group_functions/group_broadcast_fp16.cpp
@@ -20,24 +20,54 @@
 
 #include "group_broadcast.h"
 
+static auto queue = sycl_cts::util::get_cts_object::queue();
+
 TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp16][dim]",
                        ((int D), D), 1, 2, 3) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
+  // check dimension to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
+#endif
+  }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   if (queue.get_device().has(sycl::aspect::fp16)) {
     broadcast_group<D, sycl::half>(queue);
   } else {
     WARN("Device does not support half precision floating point operations.");
   }
+#endif
 }
 
 TEMPLATE_TEST_CASE_SIG("Sub-group broadcast and select",
                        "[group_func][fp16][dim]", ((int D), D), 1, 2, 3) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
+  // check dimension to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
+#endif
+  }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   if (queue.get_device().has(sycl::aspect::fp16)) {
     broadcast_sub_group<D, sycl::half>(queue);
   } else {
     WARN("Device does not support half precision floating point operations.");
   }
+#endif
 }

--- a/tests/group_functions/group_broadcast_fp16.cpp
+++ b/tests/group_functions/group_broadcast_fp16.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_broadcast.h"
+
+TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp16][dim]",
+                       ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    broadcast_group<D, sycl::half>(queue);
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG("Sub-group broadcast and select",
+                       "[group_func][fp16][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    broadcast_sub_group<D, sycl::half>(queue);
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+}

--- a/tests/group_functions/group_broadcast_fp64.cpp
+++ b/tests/group_functions/group_broadcast_fp64.cpp
@@ -33,9 +33,10 @@ TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp64][dim]",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -58,9 +59,10 @@ TEMPLATE_TEST_CASE_SIG("Sub-group broadcast and select",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else

--- a/tests/group_functions/group_broadcast_fp64.cpp
+++ b/tests/group_functions/group_broadcast_fp64.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_broadcast.h"
+
+TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp64][dim]",
+                       ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    broadcast_group<D, double>(queue);
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG("Sub-group broadcast and select",
+                       "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    broadcast_sub_group<D, double>(queue);
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+}

--- a/tests/group_functions/group_broadcast_fp64.cpp
+++ b/tests/group_functions/group_broadcast_fp64.cpp
@@ -20,24 +20,54 @@
 
 #include "group_broadcast.h"
 
+static auto queue = sycl_cts::util::get_cts_object::queue();
+
 TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp64][dim]",
                        ((int D), D), 1, 2, 3) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
+  // check dimension to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
+#endif
+  }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   if (queue.get_device().has(sycl::aspect::fp64)) {
     broadcast_group<D, double>(queue);
   } else {
     WARN("Device does not support double precision floating point operations.");
   }
+#endif
 }
 
 TEMPLATE_TEST_CASE_SIG("Sub-group broadcast and select",
                        "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
+  // check dimension to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
+#endif
+  }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   if (queue.get_device().has(sycl::aspect::fp64)) {
     broadcast_sub_group<D, double>(queue);
   } else {
     WARN("Device does not support double precision floating point operations.");
   }
+#endif
 }

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -63,7 +63,7 @@ bool equal(const T& a, const U& b) {
  * As a result the helper below is needed
  */
 template <typename T, typename U>
-T init_helper(const U init) {
+T splat_init(const U init) {
   T res;
   value_operations::assign(res, init);
   return res;

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -192,14 +192,14 @@ struct custom_type {
  *
  */
 template <typename T>
-static constexpr uint64_t exact_max = std::numeric_limits<T>::max();
+inline constexpr uint64_t exact_max = std::numeric_limits<T>::max();
 
 template <>
-static constexpr uint64_t exact_max<sycl::half> = 1ull << 11;
+inline constexpr uint64_t exact_max<sycl::half> = 1ull << 11;
 template <>
-static constexpr uint64_t exact_max<float> = 1ull << 24;
+inline constexpr uint64_t exact_max<float> = 1ull << 24;
 template <>
-static constexpr uint64_t exact_max<double> = 1ull << 53;
+inline constexpr uint64_t exact_max<double> = 1ull << 53;
 
 }  // namespace util
 

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -1,0 +1,305 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "type_coverage.h"
+
+#include <catch2/catch_template_test_macros.hpp>
+
+/*
+ * FIXME: hipSYCL does not implement size member function of sycl::vec
+ * As a result the following implementation is not working
+ * Workaround is presented below
+
+template<typename T, typename U>
+bool equal(const T& a, const U& b)
+{
+  return value_operations::are_equal(a, b);
+}
+*/
+template <typename T, typename U>
+bool equal_impl(const T& a, const U& b) {
+  return a == b;
+}
+
+template <typename T, int N>
+bool equal_impl(const sycl::vec<T, N>& a, const sycl::vec<T, N>& b) {
+  bool res = true;
+  for (int i = 0; i < N; ++i) res &= (a[i] == b[i]);
+  return res;
+}
+
+template <typename T, int N, typename U>
+bool equal_impl(const sycl::vec<T, N>& a, const U& b) {
+  bool res = true;
+  for (int i = 0; i < N; ++i) res &= (a[i] == b);
+  return res;
+}
+
+template <typename T, typename U>
+bool equal(const T& a, const U& b) {
+  return equal_impl(a, b);
+}
+
+/*
+ * FIXME: hipSYCL cannot construct vector from 1 value
+ * As a result the helper below is needed
+ */
+template <typename T, typename U>
+T init_helper(const U init) {
+  T res;
+  value_operations::assign(res, init);
+  return res;
+}
+
+namespace util {
+/**
+ * Since \p sycl::range by standard provides no default constructor,
+ * this function returns a \p sycl::range with 1 for each dimension. */
+template <int Dimensions>
+sycl::range<Dimensions> get_default_range();
+
+template <>
+inline sycl::range<1> get_default_range() {
+  return sycl::range<1>{1};
+}
+
+template <>
+inline sycl::range<2> get_default_range() {
+  return sycl::range<2>{1, 1};
+}
+
+template <>
+inline sycl::range<3> get_default_range() {
+  return sycl::range<3>{1, 1, 1};
+}
+
+/**
+ * @brief Provides range for maximal size work-group
+ *        supported by device of a given queue.
+ *        Multidimentional work-group range is made
+ *        as hyper-cybic as possible
+ * @tparam Dimensions Dimension to use for group instance
+ */
+template <int Dimensions>
+sycl::range<Dimensions> work_group_range(sycl::queue queue) {
+  // query device for work-group sizes
+  size_t max_work_item_sizes[Dimensions];
+  {
+    // FIXME: hipSYCL and ComputeCPP do not implement
+    //        sycl::info::device::max_work_item_sizes<3> property
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    sycl::id<3> sizes =
+        queue.get_device().get_info<sycl::info::device::max_work_item_sizes>();
+#else
+    sycl::id<3> sizes =
+        queue.get_device()
+            .get_info<sycl::info::device::max_work_item_sizes<3>>();
+#endif
+    for (int i = 0; i < Dimensions; ++i) {
+      max_work_item_sizes[i] = sizes.get(i);
+    }
+  }
+  size_t max_work_group_size =
+      queue.get_device().get_info<sycl::info::device::max_work_group_size>();
+
+  // make work-group size as much square/cubic as possible
+  size_t work_group_sizes[Dimensions] = {
+      std::min(max_work_item_sizes[0], max_work_group_size)};
+  if constexpr (Dimensions > 1) {
+    size_t rest_work_group_size = max_work_group_size;
+    for (int cur_D = Dimensions; cur_D > 1; --cur_D) {
+      size_t pref_size = pow(rest_work_group_size, 1. / cur_D) + 1;
+      pref_size = std::min(pref_size, max_work_item_sizes[cur_D - 1]);
+      // in the worst case of prime rest_work_group_size pref_size comes to 1
+      while (rest_work_group_size % pref_size != 0) {
+        --pref_size;
+      }
+      work_group_sizes[cur_D - 1] = pref_size;
+      rest_work_group_size /= pref_size;
+    }
+    work_group_sizes[0] =
+        std::min(max_work_item_sizes[0], rest_work_group_size);
+  }
+
+  sycl::range<Dimensions> work_group_range = get_default_range<Dimensions>();
+  for (int i = 0; i < Dimensions; ++i)
+    work_group_range[i] = work_group_sizes[i];
+
+  return work_group_range;
+}
+
+/**
+ * @brief Provides group size pretty printing
+ * @tparam D Dimension of group instance
+ */
+template <int D>
+std::string work_group_print(const sycl::range<D>& work_group_range) {
+  std::string res("{ " + std::to_string(work_group_range[0]));
+  for (int i = 1; i < D; ++i) res += ", " + std::to_string(work_group_range[i]);
+  res += " }";
+  return res;
+}
+
+/** @brief A user-defined class with several scalar member variables, default
+ *         constructor and some overloaded operators.
+ */
+struct custom_type {
+  int m_int_field{};
+  bool m_bool_field{};
+
+  custom_type() = default;
+
+  custom_type(int value) {
+    m_int_field = value;
+    m_bool_field = value;
+  }
+
+  friend bool operator==(const custom_type& c_t_l, const custom_type& c_t_r) {
+    return c_t_l.m_int_field == c_t_r.m_int_field &&
+           c_t_l.m_bool_field == c_t_r.m_bool_field;
+  }
+
+  operator int() const { return m_int_field; }
+
+  void operator=(int value) {
+    m_int_field = value;
+    m_bool_field = value;
+  }
+};
+
+/**
+ * @brief Provides limit for exact integer number representation by different
+ * types
+ *
+ */
+template <typename T>
+static constexpr uint64_t exact_max = std::numeric_limits<T>::max();
+
+template <>
+static constexpr uint64_t exact_max<sycl::half> = 1ull << 11;
+template <>
+static constexpr uint64_t exact_max<float> = 1ull << 24;
+template <>
+static constexpr uint64_t exact_max<double> = 1ull << 53;
+
+}  // namespace util
+
+// Cartesian product of type lists
+// adapted from Patrick Fromberg, https://stackoverflow.com/a/19611856
+template <typename... T>
+struct concatenation;
+
+template <template <typename...> class R, typename... As, typename... Bs>
+struct concatenation<R<As...>, R<Bs...>> {
+  using type = R<As..., Bs...>;
+};
+
+template <template <typename...> class R, typename... As, typename... Bs>
+struct concatenation<R<As...>, Bs...> {
+  using type = R<As..., Bs...>;
+};
+
+template <typename... Ts>
+struct product_helper;
+
+template <template <typename...> class R, typename... Ts>
+struct product_helper<R<Ts...>> {  // stop condition
+  using type = R<Ts...>;
+};
+
+template <template <typename...> class R, typename... Ts>
+struct product_helper<R<R<>>, Ts...> {  // catches first empty tuple
+  using type = R<>;
+};
+
+template <template <typename...> class R, typename... Ts, typename... Rests>
+struct product_helper<R<Ts...>, R<>,
+                      Rests...> {  // catches any empty tuple except first
+  using type = R<>;
+};
+
+template <template <typename...> class R, typename... X, typename H,
+          typename... Rests>
+struct product_helper<R<X...>, R<H>, Rests...> {
+  using type1 = R<typename concatenation<X, R<H>>::type...>;
+  using type = typename product_helper<type1, Rests...>::type;
+};
+
+template <template <typename...> class R, typename... X,
+          template <typename...> class Head, typename T, typename... Ts,
+          typename... Rests>
+struct product_helper<R<X...>, Head<T, Ts...>, Rests...> {
+  using type1 = R<typename concatenation<X, R<T>>::type...>;
+  using type2 = typename product_helper<R<X...>, R<Ts...>>::type;
+  using type3 = typename concatenation<type1, type2>::type;
+  using type = typename product_helper<type3, Rests...>::type;
+};
+
+template <template <typename...> class R, typename... Ts>
+struct product;
+
+template <template <typename...> class R>
+struct product<R> {  // no input, R specifies the return type
+  using type = R<>;
+};
+
+template <template <typename...> class R, template <typename...> class Head,
+          typename... Ts, typename... Tail>
+struct product<R, Head<Ts...>, Tail...> {  // R is the return type, Head<A...>
+                                           // is the first input list
+  using type = typename product_helper<R<R<Ts>...>, Tail...>::type;
+};
+
+/// Type lists for tests
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
+
+using FundamentalTypes =
+    std::tuple<size_t, float, char, signed char, unsigned char, short int,
+               unsigned short int, int, unsigned int, long int,
+               unsigned long int, long long int, unsigned long long int>;
+using Types = unnamed_type_pack<size_t, float, char, signed char, unsigned char,
+                                short int, unsigned short int, int,
+                                unsigned int, long int, unsigned long int,
+                                long long int, unsigned long long int>;
+
+#else
+
+using FundamentalTypes = std::tuple<float, char, int, unsigned long long int>;
+using Types = unnamed_type_pack<float, char, int, unsigned long long int>;
+
+#endif
+
+// FIXME: hipSYCL has not implemented sycl::marray type yet
+//        The warning is printed from group_shift.cpp and group_permute.cpp
+#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
+using ExtendedTypes =
+    concatenation<FundamentalTypes,
+                  std::tuple<bool, sycl::vec<unsigned int, 4>,
+                             sycl::vec<long long int, 2>>>::type;
+#else
+using ExtendedTypes = concatenation<
+    FundamentalTypes,
+    std::tuple<bool, sycl::vec<unsigned int, 4>, sycl::vec<long long int, 2>,
+               sycl::marray<float, 5>, sycl::marray<short int, 7>>>::type;
+#endif
+
+using CustomTypes = concatenation<ExtendedTypes, util::custom_type>::type;

--- a/tests/group_functions/group_of.cpp
+++ b/tests/group_functions/group_of.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_of.h"
+
+// use wide types to exclude truncation of init values
+using WideTypes = std::tuple<int32_t, uint32_t, int64_t, uint64_t, float>;
+
+TEMPLATE_LIST_TEST_CASE("Group and sub_group joint of bool functions",
+                        "[group_func][type_list][dim]", WideTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check all work group dimensions
+  joint_of_group<1, TestType>(queue);
+  joint_of_group<2, TestType>(queue);
+  joint_of_group<3, TestType>(queue);
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "Group and sub_group of bool functions with predicate functions",
+    "[group_func][type_list][dim]", WideTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check all work group dimensions
+  predicate_function_of_group<1, TestType>(queue);
+  predicate_function_of_group<2, TestType>(queue);
+  predicate_function_of_group<3, TestType>(queue);
+
+  predicate_function_of_sub_group<1, TestType>(queue);
+  predicate_function_of_sub_group<2, TestType>(queue);
+  predicate_function_of_sub_group<3, TestType>(queue);
+}
+
+TEMPLATE_TEST_CASE_SIG("Group and sub_group of bool functions",
+                       "[group_func][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  bool_function_of_group<D>(queue);
+  bool_function_of_sub_group<D>(queue);
+}

--- a/tests/group_functions/group_of.cpp
+++ b/tests/group_functions/group_of.cpp
@@ -23,21 +23,50 @@
 // use wide types to exclude truncation of init values
 using WideTypes = std::tuple<int32_t, uint32_t, int64_t, uint64_t, float>;
 
+static auto queue = sycl_cts::util::get_cts_object::queue();
+
 TEMPLATE_LIST_TEST_CASE("Group and sub_group joint of bool functions",
                         "[group_func][type_list][dim]", WideTypes) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
+  // check type to only print warning once
+  if constexpr (std::is_same_v<TestType, float>) {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
+#endif
+  }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   // check all work group dimensions
   joint_of_group<1, TestType>(queue);
   joint_of_group<2, TestType>(queue);
   joint_of_group<3, TestType>(queue);
+#endif
 }
 
 TEMPLATE_LIST_TEST_CASE(
     "Group and sub_group of bool functions with predicate functions",
     "[group_func][type_list][dim]", WideTypes) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
+  // check type to only print warning once
+  if constexpr (std::is_same_v<TestType, float>) {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
+#endif
+  }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   // check all work group dimensions
   predicate_function_of_group<1, TestType>(queue);
   predicate_function_of_group<2, TestType>(queue);
@@ -46,12 +75,27 @@ TEMPLATE_LIST_TEST_CASE(
   predicate_function_of_sub_group<1, TestType>(queue);
   predicate_function_of_sub_group<2, TestType>(queue);
   predicate_function_of_sub_group<3, TestType>(queue);
+#endif
 }
 
 TEMPLATE_TEST_CASE_SIG("Group and sub_group of bool functions",
                        "[group_func][dim]", ((int D), D), 1, 2, 3) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
+  // check dimension to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
+#endif
+  }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   bool_function_of_group<D>(queue);
   bool_function_of_sub_group<D>(queue);
+#endif
 }

--- a/tests/group_functions/group_of.cpp
+++ b/tests/group_functions/group_of.cpp
@@ -36,9 +36,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub_group joint of bool functions",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -61,9 +62,10 @@ TEMPLATE_LIST_TEST_CASE(
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -89,9 +91,10 @@ TEMPLATE_TEST_CASE_SIG("Group and sub_group of bool functions",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else

--- a/tests/group_functions/group_of.h
+++ b/tests/group_functions/group_of.h
@@ -1,0 +1,520 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_functions_common.h"
+
+template <int D, typename T>
+class joint_of_group_kernel;
+
+/**
+ * @brief Provides test for joint group bool of operations with predicate
+ * functions
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type pointed by Ptr
+ */
+template <int D, typename T>
+void joint_of_group(sycl::queue& queue) {
+  // 6 functions * 4 predicates
+  constexpr int test_matrix = 6;
+  const std::string test_names[test_matrix] = {
+      "bool joint_any_of(group g, Ptr first, Ptr last, Predicate pred)",
+      "bool joint_all_of(group g, Ptr first, Ptr last, Predicate pred)",
+      "bool joint_none_of(group g, Ptr first, Ptr last, Predicate pred)",
+      "bool joint_any_of(sub_group g, Ptr first, Ptr last, Predicate pred)",
+      "bool joint_all_of(sub_group g, Ptr first, Ptr last, Predicate pred)",
+      "bool joint_none_of(sub_group g, Ptr first, Ptr last, Predicate pred)"};
+  constexpr int test_cases = 4;
+  const std::string test_cases_names[test_cases] = {"none true", "one true",
+                                                    "some true", "all true"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
+  for (size_t size : sizes) {
+    std::vector<T> v(size);
+    std::iota(v.begin(), v.end(), 1);
+
+    // array to return results:
+    bool res[test_matrix * test_cases] = {false};
+    {
+      sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
+
+      sycl::buffer<bool, 1> res_sycl(res,
+                                     sycl::range<1>(test_matrix * test_cases));
+
+      queue.submit([&](sycl::handler& cgh) {
+        auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+        sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+        cgh.parallel_for<joint_of_group_kernel<D, T>>(
+            executionRange, [=](sycl::nd_item<D> item) {
+              T* v_begin = v_acc.get_pointer();
+              T* v_end = v_begin + v_acc.size();
+
+              // predicates
+              auto none_true = [&](T i) { return i == 0; };
+              auto one_true = [&](T i) { return i == 1; };
+              auto some_true = [&](T i) { return i > size / 2; };
+              auto all_true = [&](T i) { return i <= size; };
+
+              sycl::group<D> group = item.get_group();
+
+              ASSERT_RETURN_TYPE(
+                  bool, sycl::joint_any_of(group, v_begin, v_end, none_true),
+                  "Return type of joint_any_of(Group g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[0] =
+                  !sycl::joint_any_of(group, v_begin, v_end, none_true);
+              res_acc[1] = sycl::joint_any_of(group, v_begin, v_end, one_true);
+              res_acc[2] = sycl::joint_any_of(group, v_begin, v_end, some_true);
+              res_acc[3] = sycl::joint_any_of(group, v_begin, v_end, all_true);
+
+              ASSERT_RETURN_TYPE(
+                  bool, sycl::joint_all_of(group, v_begin, v_end, none_true),
+                  "Return type of joint_all_of(Group g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[4] =
+                  !sycl::joint_all_of(group, v_begin, v_end, none_true);
+              res_acc[5] = !sycl::joint_all_of(group, v_begin, v_end, one_true);
+              res_acc[6] =
+                  !sycl::joint_all_of(group, v_begin, v_end, some_true);
+              res_acc[7] = sycl::joint_all_of(group, v_begin, v_end, all_true);
+
+              ASSERT_RETURN_TYPE(
+                  bool, sycl::joint_none_of(group, v_begin, v_end, none_true),
+                  "Return type of joint_none_of(Group g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[8] =
+                  sycl::joint_none_of(group, v_begin, v_end, none_true);
+              res_acc[9] =
+                  !sycl::joint_none_of(group, v_begin, v_end, one_true);
+              res_acc[10] =
+                  !sycl::joint_none_of(group, v_begin, v_end, some_true);
+              res_acc[11] =
+                  !sycl::joint_none_of(group, v_begin, v_end, all_true);
+
+              sycl::sub_group sub_group = item.get_sub_group();
+
+              ASSERT_RETURN_TYPE(
+                  bool,
+                  sycl::joint_any_of(sub_group, v_begin, v_end, none_true),
+                  "Return type of joint_any_of(Sub_group g, Ptr first, Ptr "
+                  "last, Predicate pred) is wrong\n");
+              res_acc[12] =
+                  !sycl::joint_any_of(sub_group, v_begin, v_end, none_true);
+              res_acc[13] =
+                  sycl::joint_any_of(sub_group, v_begin, v_end, one_true);
+              res_acc[14] =
+                  sycl::joint_any_of(sub_group, v_begin, v_end, some_true);
+              res_acc[15] =
+                  sycl::joint_any_of(sub_group, v_begin, v_end, all_true);
+
+              ASSERT_RETURN_TYPE(
+                  bool,
+                  sycl::joint_all_of(sub_group, v_begin, v_end, none_true),
+                  "Return type of joint_all_of(Sub_group g, Ptr first, Ptr "
+                  "last, Predicate pred) is wrong\n");
+              res_acc[16] =
+                  !sycl::joint_all_of(sub_group, v_begin, v_end, none_true);
+              res_acc[17] =
+                  !sycl::joint_all_of(sub_group, v_begin, v_end, one_true);
+              res_acc[18] =
+                  !sycl::joint_all_of(sub_group, v_begin, v_end, some_true);
+              res_acc[19] =
+                  sycl::joint_all_of(sub_group, v_begin, v_end, all_true);
+
+              ASSERT_RETURN_TYPE(
+                  bool,
+                  sycl::joint_none_of(sub_group, v_begin, v_end, none_true),
+                  "Return type of joint_none_of(Sub_group g, Ptr first, Ptr "
+                  "last, Predicate pred) is wrong\n");
+              res_acc[20] =
+                  sycl::joint_none_of(sub_group, v_begin, v_end, none_true);
+              res_acc[21] =
+                  !sycl::joint_none_of(sub_group, v_begin, v_end, one_true);
+              res_acc[22] =
+                  !sycl::joint_none_of(sub_group, v_begin, v_end, some_true);
+              res_acc[23] =
+                  !sycl::joint_none_of(sub_group, v_begin, v_end, all_true);
+            });
+      });
+    }
+    int index = 0;
+    for (int i = 0; i < test_matrix; ++i)
+      for (int j = 0; j < test_cases; ++j) {
+        std::string work_group = util::work_group_print(work_group_range);
+        CAPTURE(D, work_group);
+        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                         << " predicate"
+                            " is "
+                         << (res[index] ? "right" : "wrong"));
+        CHECK(res[index++]);
+      }
+  }
+}
+
+template <int D, typename T>
+class predicate_function_of_group_kernel;
+
+/**
+ * @brief Provides test for group bool of operations with predicate functions
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type pointed by Ptr
+ */
+template <int D, typename T>
+void predicate_function_of_group(sycl::queue& queue) {
+  // 3 functions * 4 predicates
+  constexpr int test_matrix = 3;
+  const std::string test_names[test_matrix] = {
+      "bool any_of_group(group g, T x, Predicate pred)",
+      "bool all_of_group(group g, T x, Predicate pred)",
+      "bool none_of_group(group g, T x, Predicate pred)"};
+  constexpr int test_cases = 4;
+  const std::string test_cases_names[test_cases] = {"none true", "one true",
+                                                    "some true", "all true"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results: 4 predicates * 3 functions
+  bool res[test_matrix * test_cases] = {false};
+  {
+    sycl::buffer<bool, 1> res_sycl(res,
+                                   sycl::range<1>(test_matrix * test_cases));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<predicate_function_of_group_kernel<D, T>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            sycl::group<D> group = item.get_group();
+
+            T local_var(item.get_global_linear_id() + 1);
+
+            // predicates
+            auto none_true = [&](T i) { return i == 0; };
+            auto one_true = [&](T i) { return i == 1; };
+            auto some_true = [&](T i) { return i > work_group_size / 2; };
+            auto all_true = [&](T i) { return i <= work_group_size; };
+
+            ASSERT_RETURN_TYPE(bool,
+                               sycl::any_of_group(group, local_var, none_true),
+                               "Return type of any_of_group(group g, T x, "
+                               "Predicate pred) is wrong\n");
+            res_acc[0] = !sycl::any_of_group(group, local_var, none_true);
+            res_acc[1] = sycl::any_of_group(group, local_var, one_true);
+            res_acc[2] = sycl::any_of_group(group, local_var, some_true);
+            res_acc[3] = sycl::any_of_group(group, local_var, all_true);
+
+            ASSERT_RETURN_TYPE(bool,
+                               sycl::all_of_group(group, local_var, none_true),
+                               "Return type of any_of_group(group g, T x, "
+                               "Predicate pred) is wrong\n");
+            res_acc[4] = !sycl::all_of_group(group, local_var, none_true);
+            res_acc[5] = !sycl::all_of_group(group, local_var, one_true);
+            res_acc[6] = !sycl::all_of_group(group, local_var, some_true);
+            res_acc[7] = sycl::all_of_group(group, local_var, all_true);
+
+            ASSERT_RETURN_TYPE(bool,
+                               sycl::none_of_group(group, local_var, none_true),
+                               "Return type of none_of_group(group g, T x, "
+                               "Predicate pred) is wrong\n");
+            res_acc[8] = sycl::none_of_group(group, local_var, none_true);
+            res_acc[9] = !sycl::none_of_group(group, local_var, one_true);
+            res_acc[10] = !sycl::none_of_group(group, local_var, some_true);
+            res_acc[11] = !sycl::none_of_group(group, local_var, all_true);
+          });
+    });
+  }
+  int index = 0;
+  for (int i = 0; i < test_matrix; ++i)
+    for (int j = 0; j < test_cases; ++j) {
+      std::string work_group = util::work_group_print(work_group_range);
+      CAPTURE(D, work_group);
+      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                       << " predicate is " << (res[index] ? "right" : "wrong"));
+      CHECK(res[index++]);
+    }
+}
+
+template <int D, typename T>
+class predicate_function_of_sub_group_kernel;
+
+/**
+ * @brief Provides test for sub_group bool of operations with predicate
+ * functions
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type pointed by Ptr
+ */
+template <int D, typename T>
+void predicate_function_of_sub_group(sycl::queue& queue) {
+  // 3 functions * 4 predicates
+  constexpr int test_matrix = 3;
+  const std::string test_names[test_matrix] = {
+      "bool any_of_group(sub_group g, T x, Predicate pred)",
+      "bool all_of_group(sub_group g, T x, Predicate pred)",
+      "bool none_of_group(sub_group g, T x, Predicate pred)"};
+  constexpr int test_cases = 4;
+  const std::string test_cases_names[test_cases] = {"none true", "one true",
+                                                    "some true", "all true"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+
+  // array to return results: 4 predicates * 3 functions
+  bool res[test_matrix * test_cases] = {false};
+  {
+    sycl::buffer<bool, 1> res_sycl(res,
+                                   sycl::range<1>(test_matrix * test_cases));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<predicate_function_of_sub_group_kernel<
+          D, T>>(executionRange, [=](sycl::nd_item<D> item) {
+        sycl::sub_group sub_group = item.get_sub_group();
+        T size = sub_group.get_local_linear_range();
+
+        T local_var(item.get_global_linear_id() + 1);
+
+        // predicates
+        auto none_true = [&](T i) { return i == 0; };
+        auto one_true = [&](T i) { return i == 1; };
+        auto some_true = [&](T i) { return i > size / 2; };
+        auto all_true = [&](T i) { return i <= size; };
+
+        if (sub_group.get_group_id()[0] == 0) {
+          ASSERT_RETURN_TYPE(
+              bool, sycl::any_of_group(sub_group, local_var, none_true),
+              "Return type of any_of_group(Sub_group g, bool pred) is wrong\n");
+          res_acc[0] = !sycl::any_of_group(sub_group, local_var, none_true);
+          res_acc[1] = sycl::any_of_group(sub_group, local_var, one_true);
+          res_acc[2] = sycl::any_of_group(sub_group, local_var, some_true);
+          res_acc[3] = sycl::any_of_group(sub_group, local_var, all_true);
+
+          ASSERT_RETURN_TYPE(
+              bool, sycl::all_of_group(sub_group, local_var, none_true),
+              "Return type of all_of_group(Sub_group g, bool pred) is wrong\n");
+          res_acc[4] = !sycl::all_of_group(sub_group, local_var, none_true);
+          res_acc[5] = !sycl::all_of_group(sub_group, local_var, one_true);
+          res_acc[6] = !sycl::all_of_group(sub_group, local_var, some_true);
+          res_acc[7] = sycl::all_of_group(sub_group, local_var, all_true);
+
+          ASSERT_RETURN_TYPE(
+              bool, sycl::none_of_group(sub_group, local_var, none_true),
+              "Return type of none_of_group(Sub_group g, bool pred) is "
+              "wrong\n");
+          res_acc[8] = sycl::none_of_group(sub_group, local_var, none_true);
+          res_acc[9] = !sycl::none_of_group(sub_group, local_var, one_true);
+          res_acc[10] = !sycl::none_of_group(sub_group, local_var, some_true);
+          res_acc[11] = !sycl::none_of_group(sub_group, local_var, all_true);
+        }
+      });
+    });
+  }
+  int index = 0;
+  for (int i = 0; i < test_matrix; ++i)
+    for (int j = 0; j < test_cases; ++j) {
+      std::string work_group = util::work_group_print(work_group_range);
+      CAPTURE(D, work_group);
+      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                       << " predicate is " << (res[index] ? "right" : "wrong"));
+      CHECK(res[index++]);
+    }
+}
+
+template <int D>
+class predicate_function_of_group_bool_kernel;
+
+/**
+ * @brief Provides test for group bool of operations
+ * @tparam D Dimension to use for group instance
+ */
+template <int D>
+void bool_function_of_group(sycl::queue& queue) {
+  // 3 functions * 4 predicates
+  constexpr int test_matrix = 3;
+  const std::string test_names[test_matrix] = {
+      "bool any_of_group(group g, bool pred)",
+      "bool all_of_group(group g, bool pred)",
+      "bool none_of_group(group g, bool pred)"};
+  constexpr int test_cases = 4;
+  const std::string test_cases_names[test_cases] = {"none true", "one true",
+                                                    "some true", "all true"};
+
+  using T = size_t;
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results: 4 predicates * 3 functions
+  bool res[test_matrix * test_cases] = {false};
+  {
+    sycl::buffer<bool, 1> res_sycl(res,
+                                   sycl::range<1>(test_matrix * test_cases));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<predicate_function_of_group_bool_kernel<D>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            sycl::group<D> group = item.get_group();
+            T size = group.get_local_linear_range();
+
+            T local_var(item.get_global_linear_id() + 1);
+
+            // predicates
+            auto none_true = [&](T i) { return i == 0; };
+            auto one_true = [&](T i) { return i == 1; };
+            auto some_true = [&](T i) { return i > size / 2; };
+            auto all_true = [&](T i) { return i <= size; };
+
+            ASSERT_RETURN_TYPE(
+                bool, sycl::any_of_group(group, none_true(local_var)),
+                "Return type of any_of_group(Group g, bool pred) is wrong\n");
+            res_acc[0] = !sycl::any_of_group(group, none_true(local_var));
+            res_acc[1] = sycl::any_of_group(group, one_true(local_var));
+            res_acc[2] = sycl::any_of_group(group, some_true(local_var));
+            res_acc[3] = sycl::any_of_group(group, all_true(local_var));
+
+            ASSERT_RETURN_TYPE(
+                bool, sycl::all_of_group(group, none_true(local_var)),
+                "Return type of any_of_group(Group g, bool pred) is wrong\n");
+            res_acc[4] = !sycl::all_of_group(group, none_true(local_var));
+            res_acc[5] = !sycl::all_of_group(group, one_true(local_var));
+            res_acc[6] = !sycl::all_of_group(group, some_true(local_var));
+            res_acc[7] = sycl::all_of_group(group, all_true(local_var));
+
+            ASSERT_RETURN_TYPE(
+                bool, sycl::none_of_group(group, none_true(local_var)),
+                "Return type of none_of_group(Group g, bool pred) is wrong\n");
+            res_acc[8] = sycl::none_of_group(group, none_true(local_var));
+            res_acc[9] = !sycl::none_of_group(group, one_true(local_var));
+            res_acc[10] = !sycl::none_of_group(group, some_true(local_var));
+            res_acc[11] = !sycl::none_of_group(group, all_true(local_var));
+          });
+    });
+  }
+  int index = 0;
+  for (int i = 0; i < test_matrix; ++i)
+    for (int j = 0; j < test_cases; ++j) {
+      std::string work_group = util::work_group_print(work_group_range);
+      CAPTURE(D, work_group);
+      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                       << " predicate is " << (res[index] ? "right" : "wrong"));
+      CHECK(res[index++]);
+    }
+}
+
+template <int D>
+class predicate_function_of_sub_group_bool_kernel;
+
+/**
+ * @brief Provides test for group bool of operations
+ * @tparam D Dimension to use for group instance
+ */
+template <int D>
+void bool_function_of_sub_group(sycl::queue& queue) {
+  // 3 functions * 4 predicates
+  constexpr int test_matrix = 3;
+  const std::string test_names[test_matrix] = {
+      "bool any_of_group(sub_group g, bool pred)",
+      "bool all_of_group(sub_group g, bool pred)",
+      "bool none_of_group(sub_group g, bool pred)"};
+  constexpr int test_cases = 4;
+  const std::string test_cases_names[test_cases] = {"none true", "one true",
+                                                    "some true", "all true"};
+
+  using T = size_t;
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+
+  // array to return results
+  bool res[test_matrix * test_cases] = {false};
+  {
+    sycl::buffer<bool, 1> res_sycl(res,
+                                   sycl::range<1>(test_matrix * test_cases));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<predicate_function_of_sub_group_bool_kernel<
+          D>>(executionRange, [=](sycl::nd_item<D> item) {
+        sycl::sub_group sub_group = item.get_sub_group();
+        T size = sub_group.get_local_linear_range();
+
+        T local_var(sub_group.get_local_linear_id() + 1);
+
+        // predicates
+        auto none_true = [&](T i) { return i == 0; };
+        auto one_true = [&](T i) { return i == 1; };
+        auto some_true = [&](T i) { return i > size / 2; };
+        auto all_true = [&](T i) { return i <= size; };
+
+        // if(sub_group.get_group_linear_id() == 0)
+        {
+          ASSERT_RETURN_TYPE(
+              bool, sycl::any_of_group(sub_group, none_true(local_var)),
+              "Return type of any_of_group(sub_group g, bool pred) is wrong\n");
+          res_acc[0] = !sycl::any_of_group(sub_group, none_true(local_var));
+          res_acc[1] = sycl::any_of_group(sub_group, one_true(local_var));
+          res_acc[2] = sycl::any_of_group(sub_group, some_true(local_var));
+          res_acc[3] = sycl::any_of_group(sub_group, all_true(local_var));
+
+          ASSERT_RETURN_TYPE(
+              bool, sycl::all_of_group(sub_group, none_true(local_var)),
+              "Return type of all_of_group(sub_group g, bool pred) is wrong\n");
+          res_acc[4] = !sycl::all_of_group(sub_group, none_true(local_var));
+          res_acc[5] = !sycl::all_of_group(sub_group, one_true(local_var));
+          res_acc[6] = !sycl::all_of_group(sub_group, some_true(local_var));
+          res_acc[7] = sycl::all_of_group(sub_group, all_true(local_var));
+
+          ASSERT_RETURN_TYPE(
+              bool, sycl::none_of_group(sub_group, none_true(local_var)),
+              "Return type of none_of_group(sub_group g, bool pred) is "
+              "wrong\n");
+          res_acc[8] = sycl::none_of_group(sub_group, none_true(local_var));
+          res_acc[9] = !sycl::none_of_group(sub_group, one_true(local_var));
+          res_acc[10] = !sycl::none_of_group(sub_group, some_true(local_var));
+          res_acc[11] = !sycl::none_of_group(sub_group, all_true(local_var));
+        }
+      });
+    });
+  }
+  int index = 0;
+  for (int i = 0; i < test_matrix; ++i)
+    for (int j = 0; j < test_cases; ++j) {
+      std::string work_group = util::work_group_print(work_group_range);
+      CAPTURE(D, work_group);
+      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                       << " predicate is " << (res[index] ? "right" : "wrong"));
+      CHECK(res[index++]);
+    }
+}

--- a/tests/group_functions/group_permute.cpp
+++ b/tests/group_functions/group_permute.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_permute.h"
+
+// hipSYCL does not permute right 8-bit types inside groups
+TEMPLATE_LIST_TEST_CASE("Group and sub-group permute",
+                        "[group_func][type_list][dim]", CustomTypes) {
+  // check types to only print warning once
+  if constexpr (std::is_same_v<TestType, char>) {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has not implemented sycl::marray type yet. Skipping the test "
+        "cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement permute functions. "
+        "Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement permute functions. "
+        "Skipping the test.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp do not implement permute functions
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check all work group dimensions
+  permute_group<1, TestType>(queue);
+  permute_group<2, TestType>(queue);
+  permute_group<3, TestType>(queue);
+
+  permute_sub_group<1, TestType>(queue);
+  permute_sub_group<2, TestType>(queue);
+  permute_sub_group<3, TestType>(queue);
+#endif
+}

--- a/tests/group_functions/group_permute.h
+++ b/tests/group_functions/group_permute.h
@@ -57,8 +57,8 @@ void permute_group(sycl::queue& queue) {
             using lin_id_type = typename sycl::group<D>::linear_id_type;
             const lin_id_type llid = group.get_local_linear_id();
 
-            T local_var(init_helper<T>(llid + 1));
-            T permuted_var(init_helper<T>(llid + 1));
+            T local_var(splat_init<T>(llid + 1));
+            T permuted_var(splat_init<T>(llid + 1));
 
             ASSERT_RETURN_TYPE(T,
                                sycl::permute_group_by_xor(group, local_var, 0),
@@ -68,7 +68,7 @@ void permute_group(sycl::queue& queue) {
             bool res = true;
             for (lin_id_type mask = 1u; mask > 0; mask <<= 1) {
               permuted_var = sycl::permute_group_by_xor(group, local_var, mask);
-              res &= equal(permuted_var, init_helper<T>((llid ^ mask) + 1)) ||
+              res &= equal(permuted_var, splat_init<T>((llid ^ mask) + 1)) ||
                      ((llid ^ mask) >= group.get_local_linear_range());
             }
             res_acc[0 * work_group_size + llid] = res;
@@ -119,8 +119,8 @@ void permute_sub_group(sycl::queue& queue) {
             using lin_id_type = typename sycl::sub_group::linear_id_type;
             const lin_id_type llid = sub_group.get_local_linear_id();
 
-            T local_var(init_helper<T>(llid + 1));
-            T permuted_var(init_helper<T>(llid + 1));
+            T local_var(splat_init<T>(llid + 1));
+            T permuted_var(splat_init<T>(llid + 1));
 
             ASSERT_RETURN_TYPE(
                 T, sycl::permute_group_by_xor(sub_group, local_var, 0),
@@ -131,7 +131,7 @@ void permute_sub_group(sycl::queue& queue) {
             for (lin_id_type mask = 1u; mask > 0; mask <<= 1) {
               permuted_var =
                   sycl::permute_group_by_xor(sub_group, local_var, mask);
-              res &= equal(permuted_var, init_helper<T>((llid ^ mask) + 1)) ||
+              res &= equal(permuted_var, splat_init<T>((llid ^ mask) + 1)) ||
                      ((llid ^ mask) >= sub_group.get_local_linear_range());
             }
             res_acc[0 * work_group_size + item.get_local_linear_id()] = res;

--- a/tests/group_functions/group_permute.h
+++ b/tests/group_functions/group_permute.h
@@ -1,0 +1,152 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include <valarray>
+
+#include "group_functions_common.h"
+
+template <int D, typename T>
+class permute_group_kernel;
+
+/**
+ * @brief Provides test for permute values inside the group
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type for permutted value
+ */
+template <int D, typename T>
+void permute_group(sycl::queue& queue) {
+  // 1 function
+  constexpr int test_matrix = 1;
+  const std::string test_names[test_matrix] = {
+      "T permute_group_by_xor(group g, T x, group::linear_id_type mask)"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results:
+  std::valarray<bool> res(false, test_matrix * work_group_size);
+  {
+    sycl::buffer<bool, 1> res_sycl(
+        std::begin(res), sycl::range<1>(test_matrix * work_group_size));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<permute_group_kernel<D, T>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            sycl::group<D> group = item.get_group();
+            using lin_id_type = typename sycl::group<D>::linear_id_type;
+            const lin_id_type llid = group.get_local_linear_id();
+
+            T local_var(init_helper<T>(llid + 1));
+            T permuted_var(init_helper<T>(llid + 1));
+
+            ASSERT_RETURN_TYPE(T,
+                               sycl::permute_group_by_xor(group, local_var, 0),
+                               "Return type of permute_group_by_xor(group g, T "
+                               "x, group::linear_id_type mask) is wrong\n");
+
+            bool res = true;
+            for (lin_id_type mask = 1u; mask > 0; mask <<= 1) {
+              permuted_var = sycl::permute_group_by_xor(group, local_var, mask);
+              res &= equal(permuted_var, init_helper<T>((llid ^ mask) + 1)) ||
+                     ((llid ^ mask) >= group.get_local_linear_range());
+            }
+            res_acc[0 * work_group_size + llid] = res;
+          });
+    });
+  }
+  for (int i = 0; i < test_matrix; ++i) {
+    bool result = res[i * work_group_size];
+    for (size_t j = 1; j < work_group_size; ++j)
+      result &= res[i * work_group_size + j];
+
+    std::string work_group = util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
+                     << " is " << (result ? "right" : "wrong"));
+    CHECK(result);
+  }
+}
+
+template <int D, typename T>
+class permute_sub_group_kernel;
+
+template <int D, typename T>
+void permute_sub_group(sycl::queue& queue) {
+  // 1 function
+  constexpr int test_matrix = 1;
+  const std::string test_names[test_matrix] = {
+      "T permute_group_by_xor(sub_group g, T x, sub_group::linear_id_type "
+      "mask)"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results:
+  std::valarray<bool> res(false, test_matrix * work_group_size);
+  {
+    sycl::buffer<bool, 1> res_sycl(
+        std::begin(res), sycl::range<1>(test_matrix * work_group_size));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<permute_sub_group_kernel<D, T>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            sycl::sub_group sub_group = item.get_sub_group();
+            using lin_id_type = typename sycl::sub_group::linear_id_type;
+            const lin_id_type llid = sub_group.get_local_linear_id();
+
+            T local_var(init_helper<T>(llid + 1));
+            T permuted_var(init_helper<T>(llid + 1));
+
+            ASSERT_RETURN_TYPE(
+                T, sycl::permute_group_by_xor(sub_group, local_var, 0),
+                "Return type of permute_group_by_xor(sub_group g, T x, "
+                "sub_group::linear_id_type mask) is wrong\n");
+
+            bool res = true;
+            for (lin_id_type mask = 1u; mask > 0; mask <<= 1) {
+              permuted_var =
+                  sycl::permute_group_by_xor(sub_group, local_var, mask);
+              res &= equal(permuted_var, init_helper<T>((llid ^ mask) + 1)) ||
+                     ((llid ^ mask) >= sub_group.get_local_linear_range());
+            }
+            res_acc[0 * work_group_size + item.get_local_linear_id()] = res;
+          });
+    });
+  }
+  for (int i = 0; i < test_matrix; ++i) {
+    bool result = res[i * work_group_size];
+    for (size_t j = 1; j < work_group_size; ++j)
+      result &= res[i * work_group_size + j];
+
+    std::string work_group = util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
+                     << " is " << (result ? "right" : "wrong"));
+    CHECK(result);
+  }
+}

--- a/tests/group_functions/group_permute_fp16.cpp
+++ b/tests/group_functions/group_permute_fp16.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_permute.h"
+
+TEMPLATE_TEST_CASE_SIG("Group and sub-group permute", "[group_func][fp16][dim]",
+                       ((int D), D), 1, 2, 3) {
+  // check dimensions to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement permute functions. "
+        "Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement permute functions. "
+        "Skipping the test.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp do not implement permute functions
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    permute_group<D, sycl::half>(queue);
+    permute_sub_group<D, sycl::half>(queue);
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}

--- a/tests/group_functions/group_permute_fp64.cpp
+++ b/tests/group_functions/group_permute_fp64.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_permute.h"
+
+TEMPLATE_TEST_CASE_SIG("Group and sub-group permute", "[group_func][fp64][dim]",
+                       ((int D), D), 1, 2, 3) {
+  // check dimensions to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement permute functions. "
+        "Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement permute functions. "
+        "Skipping the test.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp do not implement permute functions
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    permute_group<D, double>(queue);
+    permute_sub_group<D, double>(queue);
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+#endif
+}

--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -67,10 +67,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
   }
 
   // FIXME: DPCPP compile error:
-  //        error: call to function 'joint_reduce' that is neither visible in the
-  //        template definition nor found by argument-dependent lookup
-  //        note: 'joint_reduce' should be declared prior to the call site or in
-  //        namespace 'sycl::ext::oneapi'
+  //        error: call to function 'joint_reduce' that is neither visible
+  //        in the template definition nor found by argument-dependent lookup
+  //        note: 'joint_reduce' should be declared prior to the call site
+  //        or in namespace 'sycl::ext::oneapi'
   // FIXME: Codeplay ComputeCpp - CE 2.11.0
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
   //        clang-8: error: unable to execute command: Segmentation fault

--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -71,9 +71,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
   //        template definition nor found by argument-dependent lookup
   //        note: 'joint_reduce' should be declared prior to the call site or in
   //        namespace 'sycl::ext::oneapi'
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
@@ -116,9 +117,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -150,9 +152,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -187,9 +190,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else

--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -52,24 +52,30 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
         "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, "
         "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
         "Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement joint_reduce without init. Skipping the test "
+        "case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
         "long long int. Skipping the test cases.");
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
 #endif
   }
 
   // FIXME: DPCPP compile error:
-  //  error: call to function 'joint_reduce' that is neither visible in the
-  //  template definition nor found by argument-dependent lookup
-  //  note: 'joint_reduce' should be declared prior to the call site or in
-  //  namespace 'sycl::ext::oneapi'
-#ifdef SYCL_CTS_COMPILING_WITH_DPCPP
-  // check types to only print warning once
-  if constexpr (std::is_same_v<TestType, char>)
-    WARN(
-        "DPCPP does not implement joint_reduce without init. Skipping the test "
-        "case.");
+  //        error: call to function 'joint_reduce' that is neither visible in the
+  //        template definition nor found by argument-dependent lookup
+  //        note: 'joint_reduce' should be declared prior to the call site or in
+  //        namespace 'sycl::ext::oneapi'
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   // check all work group dimensions
@@ -93,6 +99,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
         "hipSYCL has no implementation of T joint_reduce(sub_group g, Ptr "
         "first, Ptr last, T init, "
         "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
@@ -100,13 +110,18 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
     WARN(
         "ComputeCpp cannot handle cases of different types. "
         "Skipping such test cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
     WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
 #endif
   }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -118,6 +133,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
     init_joint_reduce_group<2, T, U>(queue);
     init_joint_reduce_group<3, T, U>(queue);
   }
+#endif
 }
 
 TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions",
@@ -128,13 +144,23 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions",
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
         "long long int. Skipping the test cases.");
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
 #endif
   }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   // check all work group dimensions
   reduce_over_group<1, TestType>(queue);
   reduce_over_group<2, TestType>(queue);
   reduce_over_group<3, TestType>(queue);
+#endif
 }
 
 TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
@@ -155,9 +181,18 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
     WARN(
         "ComputeCpp cannot handle cases of different types. "
         "Skipping such test cases.");
+    WARN(
+        "ComputeCpp fails to compile with segfault in the compiler. "
+        "Skipping the test.");
 #endif
   }
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -169,4 +204,5 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
     init_reduce_over_group<2, T, U>(queue);
     init_reduce_over_group<3, T, U>(queue);
   }
+#endif
 }

--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -1,0 +1,172 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_reduce.h"
+
+static auto queue = sycl_cts::util::get_cts_object::queue();
+
+// FIXME: ComputeCpp does not implement reduce for unsigned long long int and
+//        long long int
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+using ReduceTypes =
+    unnamed_type_pack<size_t, float, char, signed char, unsigned char,
+                      short int, unsigned short int, int, unsigned int,
+                      long int, unsigned long int>;
+#else
+using ReduceTypes = unnamed_type_pack<float, char, int>;
+#endif
+#else
+using ReduceTypes = Types;
+#endif
+
+// 2-dim Cartesian product of type lists
+using prod2 = product<std::tuple, ReduceTypes, ReduceTypes>::type;
+
+// hipSYCL has no implementation over sub-groups
+TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
+                        "[group_func][type_list][dim]", ReduceTypes) {
+  // check types to only print warning once
+  if constexpr (std::is_same_v<TestType, char>) {
+    // FIXME: hipSYCL omission
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has no implementation of "
+        "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, "
+        "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
+        "Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement reduce for unsigned long long int and "
+        "long long int. Skipping the test cases.");
+#endif
+  }
+
+  // FIXME: DPCPP compile error:
+  //  error: call to function 'joint_reduce' that is neither visible in the
+  //  template definition nor found by argument-dependent lookup
+  //  note: 'joint_reduce' should be declared prior to the call site or in
+  //  namespace 'sycl::ext::oneapi'
+#ifdef SYCL_CTS_COMPILING_WITH_DPCPP
+  // check types to only print warning once
+  if constexpr (std::is_same_v<TestType, char>)
+    WARN(
+        "DPCPP does not implement joint_reduce without init. Skipping the test "
+        "case.");
+  return;
+#else
+  // check all work group dimensions
+  joint_reduce_group<1, TestType>(queue);
+  joint_reduce_group<2, TestType>(queue);
+  joint_reduce_group<3, TestType>(queue);
+#endif
+}
+
+// hipSYCL has problems with 16-bit types for Ptr
+TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
+                        "[group_func][type_list][dim]", prod2) {
+  using T = std::tuple_element_t<0, TestType>;
+  using U = std::tuple_element_t<1, TestType>;
+
+  // check types to only print warning once
+  if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
+    // FIXME: hipSYCL omission
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has no implementation of T joint_reduce(sub_group g, Ptr "
+        "first, Ptr last, T init, "
+        "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement reduce for unsigned long long int and "
+        "long long int. Skipping the test cases.");
+    WARN(
+        "ComputeCpp cannot handle cases of different types. "
+        "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  if constexpr (std::is_same_v<T, U>)
+#endif
+  {
+    // check all work group dimensions
+    init_joint_reduce_group<1, T, U>(queue);
+    init_joint_reduce_group<2, T, U>(queue);
+    init_joint_reduce_group<3, T, U>(queue);
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions",
+                        "[group_func][type_list][dim]", ReduceTypes) {
+  // check types to only print warning once
+  if constexpr (std::is_same_v<TestType, char>) {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement reduce for unsigned long long int and "
+        "long long int. Skipping the test cases.");
+#endif
+  }
+
+  // check all work group dimensions
+  reduce_over_group<1, TestType>(queue);
+  reduce_over_group<2, TestType>(queue);
+  reduce_over_group<3, TestType>(queue);
+}
+
+TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
+                        "[group_func][type_list][dim]", prod2) {
+  using T = std::tuple_element_t<0, TestType>;
+  using U = std::tuple_element_t<1, TestType>;
+
+  // check types to only print warning once
+  if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement reduce for unsigned long long int and "
+        "long long int. Skipping the test cases.");
+    WARN(
+        "ComputeCpp cannot handle cases of different types. "
+        "Skipping such test cases.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  if constexpr (std::is_same_v<T, U>)
+#endif
+  {
+    // check all work group dimensions
+    init_reduce_over_group<1, T, U>(queue);
+    init_reduce_over_group<2, T, U>(queue);
+    init_reduce_over_group<3, T, U>(queue);
+  }
+}

--- a/tests/group_functions/group_reduce.h
+++ b/tests/group_functions/group_reduce.h
@@ -1,0 +1,455 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/disabled_for_test_case.h"
+
+#include "group_functions_common.h"
+
+template <int D, typename T>
+class joint_reduce_group_kernel;
+
+/**
+ * @brief Provides test for joint reduce by group
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type for reduced values
+ */
+template <int D, typename T>
+void joint_reduce_group(sycl::queue& queue) {
+  // 2 functions * 2 function objects
+  constexpr int test_matrix = 2;
+  const std::string test_names[test_matrix] = {
+      "std::iterator_traits<Ptr>::value_type joint_reduce(group g, Ptr first, "
+      "Ptr last, BinaryOperation binary_op)",
+      "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, Ptr "
+      "first, Ptr last, BinaryOperation binary_op)"};
+  constexpr int test_cases = 2;
+  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
+  for (size_t size : sizes) {
+    std::vector<T> v(size);
+    std::iota(v.begin(), v.end(), 1);
+
+    // array to return results
+    bool res[test_matrix * test_cases] = {false};
+    {
+      sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
+      sycl::buffer<bool, 1> res_sycl(res,
+                                     sycl::range<1>(test_matrix * test_cases));
+
+      queue.submit([&](sycl::handler& cgh) {
+        auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+        sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+        cgh.parallel_for<joint_reduce_group_kernel<D, T>>(
+            executionRange, [=](sycl::nd_item<D> item) {
+              T* v_begin = v_acc.get_pointer();
+              T* v_end = v_begin + v_acc.size();
+              // checks are plagued by UB for too short types
+              // so that the guards are introduced as the second parts in
+              // res_acc calculations
+              size_t reduced;
+
+              sycl::group<D> group = item.get_group();
+
+              ASSERT_RETURN_TYPE(
+                  T, sycl::joint_reduce(group, v_begin, v_end, sycl::plus<T>()),
+                  "Return type of joint_reduce(group g, Ptr first, Ptr last, "
+                  "BinaryOperation binary_op) is wrong\n");
+
+              reduced = size * (size + 1) / 2;
+              res_acc[0] = (reduced == sycl::joint_reduce(group, v_begin, v_end,
+                                                          sycl::plus<T>())) ||
+                           (reduced > util::exact_max<T>);
+
+              reduced = size;
+              res_acc[1] =
+                  (reduced == sycl::joint_reduce(group, v_begin, v_end,
+                                                 sycl::maximum<T>())) ||
+                  (reduced > util::exact_max<T>);
+
+              sycl::sub_group sub_group = item.get_sub_group();
+
+              ASSERT_RETURN_TYPE(
+                  T,
+                  sycl::joint_reduce(sub_group, v_begin, v_end,
+                                     sycl::maximum<T>()),
+                  "Return type of joint_reduce(sub_group g, Ptr first, Ptr "
+                  "last, BinaryOperation binary_op) is wrong\n");
+
+              reduced = size * (size + 1) / 2;
+          // FIXME: hipSYCL has no implementation over sub-groups
+#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
+              res_acc[2] = true;
+#else
+            res_acc[2] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, sycl::plus<T>()))
+              || (reduced > util::exact_max<T>);
+#endif
+
+              reduced = size;
+          // FIXME: hipSYCL has no implementation over sub-groups
+#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
+              res_acc[3] = true;
+#else
+            res_acc[3] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, sycl::maximum<T>()))
+              || (reduced > util::exact_max<T>);
+#endif
+            });
+      });
+    }
+    int index = 0;
+    for (int i = 0; i < test_matrix; ++i)
+      for (int j = 0; j < test_cases; ++j) {
+        std::string work_group = util::work_group_print(work_group_range);
+        CAPTURE(D, work_group, size);
+        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                         << " operation"
+                            " and Ptr = "
+                         << type_name<T>() << "* is "
+                         << (res[index] ? "right" : "wrong"));
+        CHECK(res[index++]);
+      }
+  }
+}
+
+template <int D, typename T, typename U>
+class init_joint_reduce_group_kernel;
+
+/**
+ * @brief Provides test for joint reduce by group with init
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type for init and result values
+ * @tparam U Type for reduced values
+ */
+template <int D, typename T, typename U>
+void init_joint_reduce_group(sycl::queue& queue) {
+  // 2 functions * 2 function objects
+  constexpr int test_matrix = 2;
+  const std::string test_names[test_matrix] = {
+      "T joint_reduce(group g, Ptr first, Ptr last, T init, BinaryOperation "
+      "binary_op)",
+      "T joint_reduce(sub_group g, Ptr first, Ptr last, T init, "
+      "BinaryOperation binary_op)"};
+  constexpr int test_cases = 2;
+  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
+  for (size_t size : sizes) {
+    std::vector<U> v(size);
+    std::iota(v.begin(), v.end(), 1);
+
+    // array to return results
+    bool res[test_matrix * test_cases] = {false};
+    {
+      sycl::buffer<U, 1> v_sycl(v.data(), sycl::range<1>(size));
+      sycl::buffer<bool, 1> res_sycl(res,
+                                     sycl::range<1>(test_matrix * test_cases));
+
+      queue.submit([&](sycl::handler& cgh) {
+        auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+        sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+        cgh.parallel_for<init_joint_reduce_group_kernel<D, T, U>>(
+            executionRange, [=](sycl::nd_item<D> item) {
+              sycl::group<D> group = item.get_group();
+              sycl::sub_group sub_group = item.get_sub_group();
+
+              U* v_begin = v_acc.get_pointer();
+              U* v_end = v_begin + v_acc.size();
+              // checks are plagued by UB for too short types
+              // so that the guards are introduced as the second parts in
+              // res_acc calculations
+              size_t reduced;
+
+              ASSERT_RETURN_TYPE(
+                  T,
+                  sycl::joint_reduce(group, v_begin, v_end, T(1412),
+                                     sycl::plus<T>()),
+                  "Return type of joint_reduce(group g, Ptr first, Ptr last, T "
+                  "init, BinaryOperation binary_op) is wrong\n");
+
+              reduced = size * (size + 1) / 2 + T(1412);
+              res_acc[0] =
+                  (reduced == sycl::joint_reduce(group, v_begin, v_end, T(1412),
+                                                 sycl::plus<T>())) ||
+                  (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
+
+              reduced = 2 * size;
+              res_acc[1] =
+                  (reduced == sycl::joint_reduce(group, v_begin, v_end,
+                                                 T(2 * size),
+                                                 sycl::maximum<T>())) ||
+                  (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
+
+              ASSERT_RETURN_TYPE(
+                  T,
+                  sycl::joint_reduce(sub_group, v_begin, v_end, T(1412),
+                                     sycl::maximum<T>()),
+                  "Return type of joint_reduce(sub_group g, Ptr first, Ptr "
+                  "last, T init, BinaryOperation binary_op) is wrong\n");
+
+              reduced = size * (size + 1) / 2 + T(1412);
+          // FIXME: hipSYCL has no implementation over sub-groups
+#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
+              res_acc[2] = true;
+#else
+            res_acc[2] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, T(1412), sycl::plus<T>()))
+              || (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
+#endif
+
+              reduced = 2 * size;
+          // FIXME: hipSYCL has no implementation over sub-groups
+#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
+              res_acc[3] = true;
+#else
+            res_acc[3] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, T(2 * size), sycl::maximum<T>()))
+              || (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
+#endif
+            });
+      });
+    }
+    int index = 0;
+    for (int i = 0; i < test_matrix; ++i)
+      for (int j = 0; j < test_cases; ++j) {
+        std::string work_group = util::work_group_print(work_group_range);
+        CAPTURE(D, work_group, size);
+        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                         << " operation"
+                            " and Ptr = "
+                         << type_name<U>() << "*, T = " << type_name<T>()
+                         << " is " << (res[index] ? "right" : "wrong"));
+        CHECK(res[index++]);
+      }
+  }
+}
+
+template <int D, typename T>
+class reduce_over_group_kernel;
+
+/**
+ * @brief Provides test for reduce over group values
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type for reduced values
+ */
+template <int D, typename T>
+void reduce_over_group(sycl::queue& queue) {
+  // 2 function * 2 function objects
+  constexpr int test_matrix = 2;
+  const std::string test_names[test_matrix] = {
+      "T reduce_over_group(group g, T x, BinaryOperation binary_op)",
+      "T reduce_over_group(sub_group g, T x, BinaryOperation binary_op)"};
+  constexpr int test_cases = 2;
+  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+
+  // array to return results
+  bool res[test_matrix * test_cases] = {false};
+  {
+    sycl::buffer<bool, 1> res_sycl(res,
+                                   sycl::range<1>(test_matrix * test_cases));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<reduce_over_group_kernel<D, T>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            sycl::group<D> group = item.get_group();
+            size_t group_size = group.get_local_linear_range();
+
+            T local_var = item.get_local_linear_id() + 1;
+            // checks are plagued by UB for too short types
+            // so that the guards are introduced as the second parts in res_acc
+            // calculations
+            size_t reduced;
+
+            ASSERT_RETURN_TYPE(
+                T, sycl::reduce_over_group(group, local_var, sycl::plus<T>()),
+                "Return type of reduce_over_group(group g, T x, "
+                "BinaryOperation binary_op) is wrong\n");
+
+            reduced = group_size * (group_size + 1) / 2;
+            res_acc[0] = (reduced == sycl::reduce_over_group(
+                                         group, local_var, sycl::plus<T>())) ||
+                         (reduced > util::exact_max<T>);
+
+            reduced = group_size;
+            res_acc[1] =
+                (reduced == sycl::reduce_over_group(group, local_var,
+                                                    sycl::maximum<T>())) ||
+                (reduced > util::exact_max<T>);
+
+            sycl::sub_group sub_group = item.get_sub_group();
+            size_t sub_group_size = sub_group.get_local_linear_range();
+
+            local_var = sub_group.get_local_linear_id() + 1;
+
+            ASSERT_RETURN_TYPE(T,
+                               sycl::reduce_over_group(sub_group, local_var,
+                                                       sycl::maximum<T>()),
+                               "Return type of reduce_over_group(sub_group g, "
+                               "T x, BinaryOperation binary_op) is wrong\n");
+
+            reduced = sub_group_size * (sub_group_size + 1) / 2;
+            res_acc[2] =
+                (reduced == sycl::reduce_over_group(sub_group, local_var,
+                                                    sycl::plus<T>())) ||
+                (reduced > util::exact_max<T>);
+
+            reduced = sub_group_size;
+            res_acc[3] =
+                (reduced == sycl::reduce_over_group(sub_group, local_var,
+                                                    sycl::maximum<T>())) ||
+                (reduced > util::exact_max<T>);
+          });
+    });
+  }
+  int index = 0;
+  for (int i = 0; i < test_matrix; ++i)
+    for (int j = 0; j < test_cases; ++j) {
+      std::string work_group = util::work_group_print(work_group_range);
+      CAPTURE(D, work_group);
+      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                       << " operation"
+                          " and T = "
+                       << type_name<T>() << " is "
+                       << (res[index] ? "right" : "wrong"));
+      CHECK(res[index++]);
+    }
+}
+
+template <int D, typename T, typename U>
+class init_reduce_over_group_kernel;
+
+/**
+ * @brief Provides test for reduce over group values with init
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type for group values
+ * @tparam U Type for init and result values
+ */
+template <int D, typename T, typename U>
+void init_reduce_over_group(sycl::queue& queue) {
+  // 2 function * 2 function objects
+  constexpr int test_matrix = 2;
+  const std::string test_names[test_matrix] = {
+      "T reduce_over_group(group g, V x, T init, BinaryOperation binary_op)",
+      "T reduce_over_group(sub_group g, V x, T init, BinaryOperation "
+      "binary_op)"};
+  constexpr int test_cases = 2;
+  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+
+  // array to return results
+  bool res[test_matrix * test_cases] = {false};
+  {
+    sycl::buffer<bool, 1> res_sycl(res,
+                                   sycl::range<1>(test_matrix * test_cases));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<init_reduce_over_group_kernel<D, T, U>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            sycl::group<D> group = item.get_group();
+            size_t group_size = group.get_local_linear_range();
+
+            U local_var = item.get_local_linear_id() + 1;
+            // checks are plagued by UB for too short types
+            // so that the guards are introduced as the second parts in res_acc
+            // calculations
+            size_t reduced;
+
+            ASSERT_RETURN_TYPE(T,
+                               sycl::reduce_over_group(
+                                   group, local_var, T(1412), sycl::plus<T>()),
+                               "Return type of reduce_over_group(group g, V x, "
+                               "T init, BinaryOperation binary_op) is wrong\n");
+
+            reduced = group_size * (group_size + 1) / 2 + T(1412);
+            res_acc[0] =
+                (reduced == sycl::reduce_over_group(group, local_var, T(1412),
+                                                    sycl::plus<T>())) ||
+                (group_size > util::exact_max<U>) ||
+                (reduced > util::exact_max<T>);
+
+            reduced = 2 * group_size;
+            res_acc[1] = (reduced == sycl::reduce_over_group(
+                                         group, local_var, T(2 * group_size),
+                                         sycl::maximum<T>())) ||
+                         (group_size > util::exact_max<U>) ||
+                         (reduced > util::exact_max<T>);
+
+            sycl::sub_group sub_group = item.get_sub_group();
+            size_t sub_group_size = sub_group.get_local_linear_range();
+
+            local_var = sub_group.get_local_linear_id() + 1;
+
+            ASSERT_RETURN_TYPE(
+                T,
+                sycl::reduce_over_group(sub_group, local_var, T(1412),
+                                        sycl::maximum<T>()),
+                "Return type of reduce_over_group(sub_group g, V x, T init, "
+                "BinaryOperation binary_op) is wrong\n");
+
+            reduced = sub_group_size * (sub_group_size + 1) / 2 + T(1412);
+            res_acc[2] = (reduced ==
+                          sycl::reduce_over_group(sub_group, local_var, T(1412),
+                                                  sycl::plus<T>())) ||
+                         (sub_group_size > util::exact_max<U>) ||
+                         (reduced > util::exact_max<T>);
+
+            reduced = 2 * sub_group_size;
+            res_acc[3] =
+                (reduced == sycl::reduce_over_group(sub_group, local_var,
+                                                    T(2 * sub_group_size),
+                                                    sycl::maximum<T>())) ||
+                (sub_group_size > util::exact_max<U>) ||
+                (reduced > util::exact_max<T>);
+          });
+    });
+  }
+  int index = 0;
+  for (int i = 0; i < test_matrix; ++i)
+    for (int j = 0; j < test_cases; ++j) {
+      std::string work_group = util::work_group_print(work_group_range);
+      CAPTURE(D, work_group);
+      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                       << " operation"
+                          " and T = "
+                       << type_name<U>() << ", V = " << type_name<T>() << " is "
+                       << (res[index] ? "right" : "wrong"));
+      CHECK(res[index++]);
+    }
+}

--- a/tests/group_functions/group_reduce_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp16.cpp
@@ -64,10 +64,10 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
 
   // FIXME: ComputeCpp has no half
   // FIXME: DPCPP compile error:
-  //  error: call to function 'joint_reduce' that is neither visible in the
-  //  template definition nor found by argument-dependent lookup
-  //  note: 'joint_reduce' should be declared prior to the call site or in
-  //  namespace 'sycl::ext::oneapi'
+  //        error: call to function 'joint_reduce' that is neither visible
+  //        in the template definition nor found by argument-dependent lookup
+  //        note: 'joint_reduce' should be declared prior to the call site
+  //        or in namespace 'sycl::ext::oneapi'
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;

--- a/tests/group_functions/group_reduce_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp16.cpp
@@ -1,0 +1,198 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_reduce.h"
+
+static auto queue = sycl_cts::util::get_cts_object::queue();
+
+// FIXME: ComputeCpp does not implement reduce for unsigned long long int and
+//        long long int
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+using ReduceTypes =
+    unnamed_type_pack<size_t, float, char, signed char, unsigned char,
+                      short int, unsigned short int, int, unsigned int,
+                      long int, unsigned long int>;
+#else
+using ReduceTypes = unnamed_type_pack<float, char, int>;
+#endif
+#else
+using ReduceTypes = Types;
+#endif
+
+using HalfExtendedTypes = concatenation<ReduceTypes, sycl::half>::type;
+// 2-dim Cartesian product of type lists
+using prod2 = product<std::tuple, HalfExtendedTypes, HalfExtendedTypes>::type;
+
+// hipSYCL has no implementation over sub-groups
+TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
+                       "[group_func][fp16][dim]", ((int D), D), 1, 2, 3) {
+  // check dimensions to only print warning once
+  if constexpr (D == 1) {
+    // FIXME: hipSYCL omission
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has no implementation of "
+        "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, "
+        "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
+        "Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement joint_reduce without init. Skipping the test "
+        "case.");
+#endif
+  }
+
+  // FIXME: ComputeCpp has no half
+  // FIXME: DPCPP compile error:
+  //  error: call to function 'joint_reduce' that is neither visible in the
+  //  template definition nor found by argument-dependent lookup
+  //  note: 'joint_reduce' should be declared prior to the call site or in
+  //  namespace 'sycl::ext::oneapi'
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    joint_reduce_group<D, sycl::half>(queue);
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}
+
+TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
+                        "[group_func][type_list][fp16][dim]", prod2) {
+  using T = std::tuple_element_t<0, TestType>;
+  using U = std::tuple_element_t<1, TestType>;
+
+  // check types to only print warning once
+  if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
+    // FIXME: hipSYCL omission
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has no implementation of T joint_reduce(sub_group g, Ptr "
+        "first, Ptr last, T init, "
+        "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement reduce for unsigned long long int and "
+        "long long int. Skipping the test cases.");
+    WARN(
+        "ComputeCpp cannot handle cases of different types. "
+        "Skipping such test cases.");
+    WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
+#endif
+  }
+
+  // FIXME: ComputeCpp has no half
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  if constexpr (std::is_same_v<T, U>)
+#endif
+  {
+    if (queue.get_device().has(sycl::aspect::fp16)) {
+      if constexpr (std::is_same_v<T, sycl::half> ||
+                    std::is_same_v<U, sycl::half>) {
+        // check all work group dimensions
+        init_joint_reduce_group<1, T, U>(queue);
+        init_joint_reduce_group<2, T, U>(queue);
+        init_joint_reduce_group<3, T, U>(queue);
+      }
+    } else {
+      WARN("Device does not support half precision floating point operations.");
+    }
+  }
+#endif
+}
+
+TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
+                       "[group_func][fp16][dim]", ((int D), D), 1, 2, 3) {
+  // FIXME: ComputeCpp has no half
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+  // check dimensions to only print warning once
+  if constexpr (D == 1)
+    WARN("ComputeCpp cannot handle half type. Skipping the test.");
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    reduce_over_group<D, sycl::half>(queue);
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}
+
+TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
+                        "[group_func][type_list][fp16][dim]", prod2) {
+  using T = std::tuple_element_t<0, TestType>;
+  using U = std::tuple_element_t<1, TestType>;
+
+  // check types to only print warning once
+  if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement reduce for unsigned long long int and "
+        "long long int. Skipping the test cases.");
+    WARN(
+        "ComputeCpp cannot handle cases of different types. "
+        "Skipping such test cases.");
+    WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#endif
+  }
+
+  // FIXME: ComputeCpp has no half
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    if constexpr (std::is_same_v<T, U>)
+#endif
+    {
+      if constexpr (std::is_same_v<T, sycl::half> ||
+                    std::is_same_v<U, sycl::half>) {
+        // check all work group dimensions
+        init_reduce_over_group<1, T, U>(queue);
+        init_reduce_over_group<2, T, U>(queue);
+        init_reduce_over_group<3, T, U>(queue);
+      }
+    }
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -65,7 +65,6 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
 #endif
   }
 
-
   // FIXME: DPCPP compile error:
   //        error: call to function 'joint_reduce' that is neither visible
   //        in the template definition nor found by argument-dependent lookup

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -71,9 +71,10 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
   //        template definition nor found by argument-dependent lookup
   //        note: 'joint_reduce' should be declared prior to the call site or in
   //        namespace 'sycl::ext::oneapi'
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
@@ -116,10 +117,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
-  // check all work group dimensions
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -156,9 +157,10 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -194,9 +196,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 #endif
   }
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -1,0 +1,181 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_reduce.h"
+
+// FIXME: ComputeCpp does not implement reduce for unsigned long long int and
+//        long long int
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+using ReduceTypes =
+    unnamed_type_pack<size_t, float, char, signed char, unsigned char,
+                      short int, unsigned short int, int, unsigned int,
+                      long int, unsigned long int>;
+#else
+using ReduceTypes = unnamed_type_pack<float, char, int>;
+#endif
+#else
+using ReduceTypes = Types;
+#endif
+
+using DoubleExtendedTypes = concatenation<ReduceTypes, double>::type;
+// 2-dim Cartesian product of type lists
+using prod2 =
+    product<std::tuple, DoubleExtendedTypes, DoubleExtendedTypes>::type;
+
+// hipSYCL has no implementation over sub-groups
+TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
+                       "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check dimensions to only print warning once
+  if constexpr (D == 1) {
+    // FIXME: hipSYCL omission
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has no implementation of "
+        "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, "
+        "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
+        "Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement joint_reduce without init. Skipping the test "
+        "case.");
+#endif
+  }
+
+  // FIXME: DPCPP compile error:
+  //  error: call to function 'joint_reduce' that is neither visible in the
+  //  template definition nor found by argument-dependent lookup
+  //  note: 'joint_reduce' should be declared prior to the call site or in
+  //  namespace 'sycl::ext::oneapi'
+#ifdef SYCL_CTS_COMPILING_WITH_DPCPP
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    joint_reduce_group<D, double>(queue);
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+#endif
+}
+
+TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
+                        "[group_func][type_list][fp64][dim]", prod2) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  using T = std::tuple_element_t<0, TestType>;
+  using U = std::tuple_element_t<1, TestType>;
+
+  // check types to only print warning once
+  if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
+    // FIXME: hipSYCL omission
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has no implementation of T joint_reduce(sub_group g, Ptr "
+        "first, Ptr last, T init, "
+        "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement reduce for unsigned long long int and "
+        "long long int. Skipping the test cases.");
+    WARN(
+        "ComputeCpp cannot handle cases of different types. "
+        "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  if constexpr (std::is_same_v<T, U>)
+#endif
+  {
+    if (queue.get_device().has(sycl::aspect::fp64)) {
+      if constexpr (std::is_same_v<T, double> || std::is_same_v<U, double>) {
+        // check all work group dimensions
+        init_joint_reduce_group<1, T, U>(queue);
+        init_joint_reduce_group<2, T, U>(queue);
+        init_joint_reduce_group<3, T, U>(queue);
+      }
+    } else {
+      WARN(
+          "Device does not support double precision floating point "
+          "operations.");
+    }
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
+                       "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    reduce_over_group<D, double>(queue);
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
+                        "[group_func][type_list][fp64][dim]", prod2) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  using T = std::tuple_element_t<0, TestType>;
+  using U = std::tuple_element_t<1, TestType>;
+
+  // check types to only print warning once
+  if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement reduce for unsigned long long int and "
+        "long long int. Skipping the test cases.");
+    WARN(
+        "ComputeCpp cannot handle cases of different types. "
+        "Skipping such test cases.");
+#endif
+  }
+
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    if constexpr (std::is_same_v<T, U>)
+#endif
+    {
+      if constexpr (std::is_same_v<T, double> || std::is_same_v<U, double>) {
+        // check all work group dimensions
+        init_reduce_over_group<1, T, U>(queue);
+        init_reduce_over_group<2, T, U>(queue);
+        init_reduce_over_group<3, T, U>(queue);
+      }
+    }
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+}

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -67,10 +67,10 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
 
 
   // FIXME: DPCPP compile error:
-  //        error: call to function 'joint_reduce' that is neither visible in the
-  //        template definition nor found by argument-dependent lookup
-  //        note: 'joint_reduce' should be declared prior to the call site or in
-  //        namespace 'sycl::ext::oneapi'
+  //        error: call to function 'joint_reduce' that is neither visible
+  //        in the template definition nor found by argument-dependent lookup
+  //        note: 'joint_reduce' should be declared prior to the call site
+  //        or in namespace 'sycl::ext::oneapi'
   // FIXME: Codeplay ComputeCpp - CE 2.11.0
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
   //        clang-8: error: unable to execute command: Segmentation fault

--- a/tests/group_functions/group_reduce_fp64_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp64_fp16.cpp
@@ -23,10 +23,10 @@
 
 #include "group_reduce.h"
 
+static auto queue = sycl_cts::util::get_cts_object::queue();
+
 TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
                        "[group_func][fp16][fp64][dim]", ((int D), D), 1, 2, 3) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
-
   // check dimensions to only print warning once
   if constexpr (D == 1) {
     // FIXME: hipSYCL omission
@@ -69,8 +69,6 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
 
 TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
                        "[group_func][fp16][fp64][dim]", ((int D), D), 1, 2, 3) {
-  auto queue = sycl_cts::util::get_cts_object::queue();
-
   // check dimensions to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)

--- a/tests/group_functions/group_reduce_fp64_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp64_fp16.cpp
@@ -1,0 +1,108 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+// need also double tests enabled
+#ifdef SYCL_CTS_ENABLE_DOUBLE_TESTS
+
+#include "group_reduce.h"
+
+TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
+                       "[group_func][fp16][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check dimensions to only print warning once
+  if constexpr (D == 1) {
+    // FIXME: hipSYCL omission
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has no implementation of T joint_reduce(sub_group g, Ptr "
+        "first, Ptr last, T init, "
+        "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp cannot handle cases of different types. "
+        "Skipping such test cases.");
+    WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
+#endif
+  }
+
+  // FIXME: ComputeCpp has no half
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16) &&
+      queue.get_device().has(sycl::aspect::fp64)) {
+    init_joint_reduce_group<D, sycl::half, double>(queue);
+    init_joint_reduce_group<D, double, sycl::half>(queue);
+  } else {
+    WARN(
+        "Device does not support half and double precision floating point "
+        "operations simultaneously.");
+  }
+#endif
+}
+
+TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
+                       "[group_func][fp16][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check dimensions to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP cannot handle cases of different types. "
+        "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp cannot handle cases of different types. "
+        "Skipping such test cases.");
+    WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#endif
+  }
+
+  // FIXME: ComputeCpp has no half
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16) &&
+      queue.get_device().has(sycl::aspect::fp64)) {
+    init_reduce_over_group<D, sycl::half, double>(queue);
+    init_reduce_over_group<D, double, sycl::half>(queue);
+  } else {
+    WARN(
+        "Device does not support half and double precision floating point "
+        "operations simultaneously.");
+  }
+#endif
+}
+
+#endif

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -1,0 +1,144 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_scan.h"
+
+// FIXME: ComputeCpp does not implement scan for unsigned long long int and long
+// long int
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+using ScanTypes =
+    unnamed_type_pack<size_t, float, char, signed char, unsigned char,
+                      short int, unsigned short int, int, unsigned int,
+                      long int, unsigned long int>;
+#else
+using ScanTypes = unnamed_type_pack<float, char, int>;
+#endif
+#else
+using ScanTypes = Types;
+#endif
+
+static auto queue = sycl_cts::util::get_cts_object::queue();
+static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
+
+TEST_CASE("Group and sub-group joint scan functions",
+          "[group_func][type_list][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL cannot handle cases of different types for InPtr and OutPtr. "
+      "Skipping such test cases.");
+  WARN(
+      "hipSYCL joint_exclusive_scan and joint_inclusive_scan cannot process "
+      "over several sub-groups simultaneously. Using one sub-group only.");
+  WARN("hipSYCL does not support sycl::known_identity_v yet.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
+      "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN("ComputeCpp does not implement joint scan. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp does not implement joint scan
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+  // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  for_all_combinations<invoke_joint_scan_group_same_type>(Dims, ScanTypes{},
+                                                          queue);
+#else
+  for_all_combinations<invoke_joint_scan_group>(Dims, ScanTypes{}, ScanTypes{},
+                                                queue);
+#endif
+}
+
+TEST_CASE("Group and sub-group joint scan functions with init",
+          "[group_func][type_list][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL cannot handle cases of different types for T, *InPtr and "
+      "*OutPtr. Skipping such test cases.");
+  WARN(
+      "hipSYCL joint_exclusive_scan and joint_inclusive_scan with init values "
+      "cannot process over several sub-groups simultaneously. Using one "
+      "sub-group only.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for T, *InPtr and "
+      "*OutPtr. Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN("ComputeCpp does not implement joint scan. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp does not implement joint scan
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+  // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  for_all_combinations<invoke_init_joint_scan_group_same_type>(
+      Dims, ScanTypes{}, queue);
+#else
+  for_all_combinations<invoke_init_joint_scan_group>(
+      Dims, ScanTypes{}, ScanTypes{}, ScanTypes{}, queue);
+#endif
+}
+
+TEST_CASE("Group and sub-group scan functions",
+          "[group_func][type_list][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN(
+      "ComputeCpp does not implement scan for unsigned long long int and "
+      "long long int. Skipping the test cases.");
+#endif
+
+  for_all_combinations<invoke_scan_over_group>(Dims, ScanTypes{}, queue);
+}
+
+TEST_CASE("Group and sub-group scan functions with init",
+          "[group_func][type_list][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
+      "and op are interchanged.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for T and V. Skipping such "
+      "test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN(
+      "ComputeCpp does not implement scan for unsigned long long int and "
+      "long long int. Skipping the test cases.");
+  WARN(
+      "ComputeCpp cannot handle cases of different types for T and V. Skipping "
+      "such test cases.");
+#endif
+
+  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  for_all_combinations<invoke_init_scan_over_group_same_type>(Dims, ScanTypes{},
+                                                              queue);
+#else
+  for_all_combinations<invoke_init_scan_over_group>(Dims, ScanTypes{},
+                                                    ScanTypes{}, queue);
+#endif
+}

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -108,9 +108,19 @@ TEST_CASE("Group and sub-group scan functions",
   WARN(
       "ComputeCpp does not implement scan for unsigned long long int and "
       "long long int. Skipping the test cases.");
+  WARN(
+      "ComputeCpp fails to compile with segfault in the compiler. "
+      "Skipping the test.");
 #endif
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
   for_all_combinations<invoke_scan_over_group>(Dims, ScanTypes{}, queue);
+#endif
 }
 
 TEST_CASE("Group and sub-group scan functions with init",
@@ -130,10 +140,18 @@ TEST_CASE("Group and sub-group scan functions with init",
   WARN(
       "ComputeCpp cannot handle cases of different types for T and V. Skipping "
       "such test cases.");
+  WARN(
+      "ComputeCpp fails to compile with segfault in the compiler. "
+      "Skipping the test.");
 #endif
 
+  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
+  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
+  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   for_all_combinations<invoke_init_scan_over_group_same_type>(Dims, ScanTypes{},
                                                               queue);

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -113,9 +113,10 @@ TEST_CASE("Group and sub-group scan functions",
       "Skipping the test.");
 #endif
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -145,9 +146,10 @@ TEST_CASE("Group and sub-group scan functions with init",
       "Skipping the test.");
 #endif
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -78,7 +78,6 @@ void joint_scan_group(sycl::queue& queue) {
           T* v_begin = v_acc.get_pointer();
           T* v_end = v_begin + v_acc.size();
           U* r_begin = r_acc.get_pointer();
-          ;
           U* r_end;
 
           auto op_plus = sycl::plus<U>();

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -1,0 +1,899 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include <valarray>
+
+#include "group_functions_common.h"
+
+template <int D, typename T, typename U>
+class joint_scan_group_kernel;
+
+/**
+ * @brief Provides test for joint scans
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type pointed by InPtr
+ * @tparam U Type pointed by OutPtr
+ */
+template <int D, typename T, typename U>
+void joint_scan_group(sycl::queue& queue) {
+  // 4 functions * 2 function objects
+  constexpr int test_matrix = 4;
+  const std::string test_names[test_matrix] = {
+      "OutPtr joint_exclusive_scan(group g, InPtr first, InPtr last, OutPtr "
+      "result, BinaryOperation binary_op)",
+      "OutPtr joint_inclusive_scan(group g, InPtr first, InPtr last, OutPtr "
+      "result, BinaryOperation binary_op)",
+      "OutPtr joint_exclusive_scan(sub_group g, InPtr first, InPtr last, "
+      "OutPtr result, BinaryOperation binary_op)",
+      "OutPtr joint_inclusive_scan(sub_group g, InPtr first, InPtr last, "
+      "OutPtr result, BinaryOperation binary_op)"};
+  constexpr int test_cases = 2;
+  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
+  for (size_t size : sizes) {
+    std::vector<T> v(size);
+    std::iota(v.begin(), v.end(), T(1));
+    std::vector<U> r(size, U(-1));
+
+    // array to return results
+    bool res[test_matrix * test_cases] = {false};
+    {
+      sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
+      sycl::buffer<U, 1> r_sycl(r.data(), sycl::range<1>(size));
+
+      sycl::buffer<bool, 1> res_sycl(res,
+                                     sycl::range<1>(test_matrix * test_cases));
+
+      queue.submit([&](sycl::handler& cgh) {
+        auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+        auto r_acc =
+            r_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+        sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+        cgh.parallel_for<joint_scan_group_kernel<
+            D, T, U>>(executionRange, [=](sycl::nd_item<D> item) {
+          T* v_begin = v_acc.get_pointer();
+          T* v_end = v_begin + v_acc.size();
+          U* r_begin = r_acc.get_pointer();
+          ;
+          U* r_end;
+
+          auto op_plus = sycl::plus<U>();
+          auto op_max = sycl::maximum<U>();
+
+          sycl::group<D> group = item.get_group();
+
+          ASSERT_RETURN_TYPE(
+              U*,
+              sycl::joint_exclusive_scan(group, v_begin, v_end, r_begin,
+                                         op_plus),
+              "Return type of joint_exclusive_scan(group g, InPtr first, InPtr "
+              "last, OutPtr result, BinaryOperation binary_op) is wrong\n");
+
+          r_end = sycl::joint_exclusive_scan(group, v_begin, v_end, r_begin,
+                                             op_plus);
+          if (group.get_local_linear_id() == 0) {
+            bool check = (r_begin + r_acc.size() == r_end);
+            // FIXME: hipSYCL does not support sycl::known_identity_v yet
+#if SYCL_CTS_COMPILING_WITH_HIPSYCL
+            U scan = U{};
+#else
+              U scan = sycl::known_identity_v<sycl::plus<U>, U>;
+#endif
+            for (int i = 0; i < size; ++i) {
+              check &= (scan == r_begin[i]);
+              scan = op_plus(scan, v_begin[i]);
+            }
+            res_acc[0] = check;
+          }
+
+          r_end = sycl::joint_exclusive_scan(group, v_begin, v_end, r_begin,
+                                             op_max);
+          if (group.get_local_linear_id() == 0) {
+            bool check = (r_begin + r_acc.size() == r_end);
+            // FIXME: hipSYCL does not support sycl::known_identity_v yet
+#if SYCL_CTS_COMPILING_WITH_HIPSYCL
+            U scan = std::numeric_limits<U>::lowest();
+#else
+              U scan = sycl::known_identity_v<sycl::maximum<U>, U>;
+#endif
+            for (int i = 0; i < size; ++i) {
+              check &= (scan == r_begin[i]);
+              scan = op_max(scan, v_begin[i]);
+            }
+            res_acc[1] = check;
+          }
+
+          ASSERT_RETURN_TYPE(
+              U*,
+              sycl::joint_inclusive_scan(group, v_begin, v_end, r_begin,
+                                         op_plus),
+              "Return type of joint_inclusive_scan(group g, InPtr first, InPtr "
+              "last, OutPtr result, BinaryOperation binary_op) is wrong\n");
+
+          r_end = sycl::joint_inclusive_scan(group, v_begin, v_end, r_begin,
+                                             op_plus);
+          if (group.get_local_linear_id() == 0) {
+            bool check = (r_begin + r_acc.size() == r_end);
+            U scan = U{};
+            for (int i = 0; i < size; ++i) {
+              scan = op_plus(scan, v_begin[i]);
+              check &= (scan == r_begin[i]);
+            }
+            res_acc[2] = check;
+          }
+
+          r_end = sycl::joint_inclusive_scan(group, v_begin, v_end, r_begin,
+                                             op_max);
+          if (group.get_local_linear_id() == 0) {
+            bool check = (r_begin + r_acc.size() == r_end);
+            U scan = v_begin[0];
+            for (int i = 0; i < size; ++i) {
+              scan = op_max(scan, v_begin[i]);
+              check &= (scan == r_begin[i]);
+            }
+            res_acc[3] = check;
+          }
+
+          sycl::sub_group sub_group = item.get_sub_group();
+
+          // FIXME: it should work without (all sub-groups do the same), but in
+          // hipSYCL it leads to errors in the test above (sic!) for res_acc[3]
+#if SYCL_CTS_COMPILING_WITH_HIPSYCL
+          if (sub_group.get_group_linear_id() == 0)
+#endif
+          {
+            ASSERT_RETURN_TYPE(U*,
+                               sycl::joint_exclusive_scan(
+                                   sub_group, v_begin, v_end, r_begin, op_plus),
+                               "Return type of joint_exclusive_scan(sub_group "
+                               "g, InPtr first, InPtr last, OutPtr result, "
+                               "BinaryOperation binary_op) is wrong\n");
+
+            r_end = sycl::joint_exclusive_scan(sub_group, v_begin, v_end,
+                                               r_begin, op_plus);
+            if (sub_group.get_local_linear_id() == 0) {
+              bool check = (r_begin + r_acc.size() == r_end);
+              // FIXME: hipSYCL does not support sycl::known_identity_v yet
+#if SYCL_CTS_COMPILING_WITH_HIPSYCL
+              U scan = U{};
+#else
+              U scan = sycl::known_identity_v<sycl::plus<U>, U>;
+#endif
+              for (int i = 0; i < size; ++i) {
+                check &= (scan == r_begin[i]);
+                scan = op_plus(scan, v_begin[i]);
+              }
+              res_acc[4] = check;
+            }
+
+            r_end = sycl::joint_exclusive_scan(sub_group, v_begin, v_end,
+                                               r_begin, op_max);
+            if (sub_group.get_local_linear_id() == 0) {
+              bool check = (r_begin + r_acc.size() == r_end);
+              // FIXME: hipSYCL does not support sycl::known_identity_v yet
+#if SYCL_CTS_COMPILING_WITH_HIPSYCL
+              U scan = std::numeric_limits<U>::lowest();
+#else
+              U scan = sycl::known_identity_v<sycl::maximum<U>, U>;
+#endif
+              for (int i = 0; i < size; ++i) {
+                check &= (scan == r_begin[i]);
+                scan = op_max(scan, v_begin[i]);
+              }
+              res_acc[5] = check;
+            }
+
+            ASSERT_RETURN_TYPE(U*,
+                               sycl::joint_inclusive_scan(
+                                   sub_group, v_begin, v_end, r_begin, op_plus),
+                               "Return type of joint_inclusive_scan(sub_group "
+                               "g, InPtr first, InPtr last, OutPtr result, "
+                               "BinaryOperation binary_op) is wrong\n");
+
+            r_end = sycl::joint_inclusive_scan(sub_group, v_begin, v_end,
+                                               r_begin, op_plus);
+            if (sub_group.get_local_linear_id() == 0) {
+              bool check = (r_begin + r_acc.size() == r_end);
+              U scan = U{};
+              for (int i = 0; i < size; ++i) {
+                scan = op_plus(scan, v_begin[i]);
+                check &= (scan == r_begin[i]);
+              }
+              res_acc[6] = check;
+            }
+
+            r_end = sycl::joint_inclusive_scan(sub_group, v_begin, v_end,
+                                               r_begin, op_max);
+            if (sub_group.get_local_linear_id() == 0) {
+              bool check = (r_begin + r_acc.size() == r_end);
+              U scan = v_begin[0];
+              for (int i = 0; i < size; ++i) {
+                scan = op_max(scan, v_begin[i]);
+                check &= (scan == r_begin[i]);
+              }
+              res_acc[7] = check;
+            }
+          }
+        });
+      });
+    }
+    int index = 0;
+    for (int i = 0; i < test_matrix; ++i)
+      for (int j = 0; j < test_cases; ++j) {
+        std::string work_group = util::work_group_print(work_group_range);
+        CAPTURE(D, work_group, size);
+        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                         << " operation"
+                            " and In = "
+                         << type_name<T>() << ", Out = " << type_name<U>()
+                         << " is " << (res[index] ? "right" : "wrong"));
+        CHECK(res[index++]);
+      }
+  }
+}
+
+template <typename DimensionT, typename T, typename U>
+class invoke_joint_scan_group {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue) { joint_scan_group<D, T, U>(queue); }
+};
+
+// FIXME: Helper for implementations that cannot handle cases of different types
+template <typename DimensionT, typename T>
+class invoke_joint_scan_group_same_type {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue) { joint_scan_group<D, T, T>(queue); }
+};
+
+template <int D, typename T, typename U, typename I>
+class init_joint_scan_group_kernel;
+
+/**
+ * @brief Provides test for joint scans with init
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type pointed by InPtr
+ * @tparam U Type pointed by OutPtr
+ * @tparam I Type used for init value
+ */
+template <int D, typename T, typename U, typename I>
+void init_joint_scan_group(sycl::queue& queue) {
+  // 4 functions * 2 function objects
+  constexpr int test_matrix = 4;
+  const std::string test_names[test_matrix] = {
+      "OutPtr joint_exclusive_scan(group g, InPtr first, InPtr last, OutPtr "
+      "result, T init, BinaryOperation binary_op)",
+      "OutPtr joint_inclusive_scan(group g, InPtr first, InPtr last, OutPtr "
+      "result, BinaryOperation binary_op, T init)",
+      "OutPtr joint_exclusive_scan(sub_group g, InPtr first, InPtr last, "
+      "OutPtr result, T init, BinaryOperation binary_op)",
+      "OutPtr joint_inclusive_scan(sub_group g, InPtr first, InPtr last, "
+      "OutPtr result, BinaryOperation binary_op, T init)"};
+  constexpr int test_cases = 2;
+  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
+  for (size_t size : sizes) {
+    std::vector<T> v(size);
+    std::iota(v.begin(), v.end(), 1);
+    std::vector<U> r(size, U(-1));
+
+    // array to return results
+    bool res[test_matrix * test_cases] = {false};
+    {
+      sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
+      sycl::buffer<U, 1> r_sycl(r.data(), sycl::range<1>(size));
+
+      sycl::buffer<bool, 1> res_sycl(res,
+                                     sycl::range<1>(test_matrix * test_cases));
+
+      queue.submit([&](sycl::handler& cgh) {
+        auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+        auto r_acc =
+            r_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+        sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+        cgh.parallel_for<init_joint_scan_group_kernel<D, T, U, I>>(
+            executionRange, [=](sycl::nd_item<D> item) {
+              T* v_begin = v_acc.get_pointer();
+              T* v_end = v_begin + v_acc.size();
+              U* r_begin = r_acc.get_pointer();
+              ;
+              U* r_end;
+
+              auto op_plus = sycl::plus<I>();
+              auto op_max = sycl::maximum<I>();
+
+              sycl::group<D> group = item.get_group();
+
+              ASSERT_RETURN_TYPE(
+                  U*,
+                  sycl::joint_exclusive_scan(group, v_begin, v_end, r_begin,
+                                             I(1412), op_max),
+                  "Return type of joint_exclusive_scan(group g, InPtr first, "
+                  "InPtr last, OutPtr result, T init, BinaryOperation "
+                  "binary_op) is wrong\n");
+
+              r_end = sycl::joint_exclusive_scan(group, v_begin, v_end, r_begin,
+                                                 I(1412), op_plus);
+              if (group.get_local_linear_id() == 0) {
+                bool check = (r_begin + r_acc.size() == r_end);
+                I scan = I(1412);
+                for (int i = 0; i < size; ++i) {
+                  check &= (U(scan) == r_begin[i]);
+                  scan = op_plus(scan, v_begin[i]);
+                }
+                res_acc[0] = check;
+              }
+
+              r_end = sycl::joint_exclusive_scan(group, v_begin, v_end, r_begin,
+                                                 I(42), op_max);
+              if (group.get_local_linear_id() == 0) {
+                bool check = (r_begin + r_acc.size() == r_end);
+                I scan = I(42);
+                for (int i = 0; i < size; ++i) {
+                  check &= (U(scan) == r_begin[i]);
+                  scan = op_max(scan, v_begin[i]);
+                }
+                res_acc[1] = check;
+              }
+
+              ASSERT_RETURN_TYPE(
+                  U*,
+                  sycl::joint_inclusive_scan(group, v_begin, v_end, r_begin,
+                                             op_plus, I(1412)),
+                  "Return type of joint_inclusive_scan(group g, InPtr first, "
+                  "InPtr last, OutPtr result, BinaryOperation binary_op, T "
+                  "init) is wrong\n");
+
+              r_end = sycl::joint_inclusive_scan(group, v_begin, v_end, r_begin,
+                                                 op_plus, I(1412));
+              if (group.get_local_linear_id() == 0) {
+                bool check = (r_begin + r_acc.size() == r_end);
+                I scan = I(1412);
+                for (int i = 0; i < size; ++i) {
+                  scan = op_plus(scan, v_begin[i]);
+                  check &= (U(scan) == r_begin[i]);
+                }
+                res_acc[2] = check;
+              }
+
+              r_end = sycl::joint_inclusive_scan(group, v_begin, v_end, r_begin,
+                                                 op_max, I(42));
+              if (group.get_local_linear_id() == 0) {
+                bool check = (r_begin + r_acc.size() == r_end);
+                I scan = I(42);
+                for (int i = 0; i < size; ++i) {
+                  scan = op_max(scan, v_begin[i]);
+                  check &= (U(scan) == r_begin[i]);
+                }
+                res_acc[3] = check;
+              }
+
+              sycl::sub_group sub_group = item.get_sub_group();
+
+          // FIXME: it should work without (all sub-groups do the same), but in
+          // hipSYCL it leads to errors in the test above (sic!) for res_acc[3]
+#if SYCL_CTS_COMPILING_WITH_HIPSYCL
+              if (sub_group.get_group_linear_id() == 0)
+#endif
+              {
+                ASSERT_RETURN_TYPE(
+                    U*,
+                    sycl::joint_exclusive_scan(sub_group, v_begin, v_end,
+                                               r_begin, I(1412), op_max),
+                    "Return type of joint_exclusive_scan(sub_group g, InPtr "
+                    "first, InPtr last, OutPtr result, T init, BinaryOperation "
+                    "binary_op) is wrong\n");
+
+                r_end = sycl::joint_exclusive_scan(sub_group, v_begin, v_end,
+                                                   r_begin, I(1412), op_plus);
+                if (sub_group.get_local_linear_id() == 0) {
+                  bool check = (r_begin + r_acc.size() == r_end);
+                  I scan = I(1412);
+                  for (int i = 0; i < size; ++i) {
+                    check &= (U(scan) == r_begin[i]);
+                    scan = op_plus(scan, v_begin[i]);
+                  }
+                  res_acc[4] = check;
+                }
+
+                r_end = sycl::joint_exclusive_scan(sub_group, v_begin, v_end,
+                                                   r_begin, I(4), op_max);
+                if (sub_group.get_local_linear_id() == 0) {
+                  bool check = (r_begin + r_acc.size() == r_end);
+                  I scan = I(4);
+                  for (int i = 0; i < size; ++i) {
+                    check &= (U(scan) == r_begin[i]);
+                    scan = op_max(scan, v_begin[i]);
+                  }
+                  res_acc[5] = check;
+                }
+
+                ASSERT_RETURN_TYPE(
+                    U*,
+                    sycl::joint_inclusive_scan(sub_group, v_begin, v_end,
+                                               r_begin, op_plus, I(1412)),
+                    "Return type of joint_inclusive_scan(sub_group g, InPtr "
+                    "first, InPtr last, OutPtr result, BinaryOperation "
+                    "binary_op, T init) is wrong\n");
+
+                r_end = sycl::joint_inclusive_scan(sub_group, v_begin, v_end,
+                                                   r_begin, op_plus, I(1412));
+                if (sub_group.get_local_linear_id() == 0) {
+                  bool check = (r_begin + r_acc.size() == r_end);
+                  I scan = I(1412);
+                  for (int i = 0; i < size; ++i) {
+                    scan = op_plus(scan, v_begin[i]);
+                    check &= (U(scan) == r_begin[i]);
+                  }
+                  res_acc[6] = check;
+                }
+
+                r_end = sycl::joint_inclusive_scan(sub_group, v_begin, v_end,
+                                                   r_begin, op_max, I(4));
+                if (sub_group.get_local_linear_id() == 0) {
+                  bool check = (r_begin + r_acc.size() == r_end);
+                  I scan = I(4);
+                  for (int i = 0; i < size; ++i) {
+                    scan = op_max(scan, v_begin[i]);
+                    check &= (U(scan) == r_begin[i]);
+                  }
+                  res_acc[7] = check;
+                }
+              }
+            });
+      });
+    }
+    int index = 0;
+    for (int i = 0; i < test_matrix; ++i)
+      for (int j = 0; j < test_cases; ++j) {
+        std::string work_group = util::work_group_print(work_group_range);
+        CAPTURE(D, work_group, size);
+        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                         << " operation"
+                            " and In = "
+                         << type_name<T>() << ", Out = " << type_name<U>()
+                         << ", T = " << type_name<I>() << " is "
+                         << (res[index] ? "right" : "wrong"));
+        CHECK(res[index++]);
+      }
+  }
+}
+
+template <typename DimensionT, typename T, typename U, typename I>
+class invoke_init_joint_scan_group {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue) {
+    init_joint_scan_group<D, T, U, I>(queue);
+  }
+};
+
+// FIXME: Helper for implementations that cannot handle cases of different types
+template <typename DimensionT, typename T>
+class invoke_init_joint_scan_group_same_type {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue) {
+    init_joint_scan_group<D, T, T, T>(queue);
+  }
+};
+
+template <int D, typename T>
+class scan_over_group_kernel;
+
+/**
+ * @brief Provides test for scans over group values
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type used for value
+ */
+template <int D, typename T>
+void scan_over_group(sycl::queue& queue) {
+  // 4 functions * 2 function objects
+  constexpr int test_matrix = 4;
+  const std::string test_names[test_matrix] = {
+      "T exclusive_scan_over_group(group g, T x, BinaryOperation binary_op)",
+      "T inclusive_scan_over_group(group g, T x, BinaryOperation binary_op)",
+      "T exclusive_scan_over_group(sub_group g, T x, BinaryOperation "
+      "binary_op)",
+      "T inclusive_scan_over_group(sub_group g, T x, BinaryOperation "
+      "binary_op)"};
+  constexpr int test_cases = 2;
+  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results:
+  std::valarray<bool> res(false, test_matrix * test_cases * work_group_size);
+  {
+    sycl::buffer<bool, 1> res_sycl(
+        std::begin(res),
+        sycl::range<1>(test_matrix * test_cases * work_group_size));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<scan_over_group_kernel<D, T>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            T local_var;
+            T scan_result;
+            // checks are plagued by UB for too short types
+            // so that the guards are introduced as the second parts in
+            // local_res calculations
+            size_t llid;
+            bool local_res;
+
+            auto op_plus = sycl::plus<T>();
+            auto op_max = sycl::maximum<T>();
+
+            sycl::group<D> group = item.get_group();
+
+            llid = item.get_local_linear_id();
+            local_var = T(llid + 1);
+
+            ASSERT_RETURN_TYPE(
+                T, sycl::exclusive_scan_over_group(group, local_var, op_plus),
+                "Return type of exclusive_scan_over_group(group g, T x, "
+                "BinaryOperation binary_op) is wrong\n");
+
+            scan_result =
+                sycl::exclusive_scan_over_group(group, local_var, op_plus);
+            local_res = (scan_result == local_var * (local_var - 1) / 2) ||
+                        (llid * (llid + 1) / 2 > util::exact_max<T>);
+            res_acc[0 * work_group_size + llid] = local_res;
+
+            scan_result =
+                sycl::exclusive_scan_over_group(group, local_var, op_max);
+            local_res =
+                (scan_result == (llid == 0 ? std::numeric_limits<T>::lowest()
+                                           : local_var - 1)) ||
+                (llid + 1 > util::exact_max<T>);
+            res_acc[1 * work_group_size + llid] = local_res;
+
+            ASSERT_RETURN_TYPE(
+                T, sycl::inclusive_scan_over_group(group, local_var, op_max),
+                "Return type of inclusive_scan_over_group(group g, T x, "
+                "BinaryOperation binary_op) is wrong\n");
+
+            scan_result =
+                sycl::inclusive_scan_over_group(group, local_var, op_plus);
+            local_res = (scan_result == local_var * (local_var + 1) / 2) ||
+                        ((llid + 1) * (llid + 2) / 2 > util::exact_max<T>);
+            res_acc[2 * work_group_size + llid] = local_res;
+
+            scan_result =
+                sycl::inclusive_scan_over_group(group, local_var, op_max);
+            local_res =
+                (scan_result == local_var) || (llid + 1 > util::exact_max<T>);
+            res_acc[3 * work_group_size + llid] = local_res;
+
+            sycl::sub_group sub_group = item.get_sub_group();
+
+            llid = sub_group.get_local_linear_id();
+            local_var = T(llid + 1);
+
+            ASSERT_RETURN_TYPE(
+                T,
+                sycl::exclusive_scan_over_group(sub_group, local_var, op_plus),
+                "Return type of exclusive_scan_over_group(sub_group g, T x, "
+                "BinaryOperation binary_op) is wrong\n");
+
+            scan_result =
+                sycl::exclusive_scan_over_group(sub_group, local_var, op_plus);
+            local_res = (scan_result == local_var * (local_var - 1) / 2) ||
+                        (llid * (llid + 1) / 2 > util::exact_max<T>);
+            res_acc[4 * work_group_size + item.get_local_linear_id()] =
+                local_res;
+
+            scan_result =
+                sycl::exclusive_scan_over_group(sub_group, local_var, op_max);
+            local_res =
+                (scan_result == (llid == 0 ? std::numeric_limits<T>::lowest()
+                                           : local_var - 1)) ||
+                (llid + 1 > util::exact_max<T>);
+            res_acc[5 * work_group_size + item.get_local_linear_id()] =
+                local_res;
+
+            ASSERT_RETURN_TYPE(
+                T,
+                sycl::inclusive_scan_over_group(sub_group, local_var, op_max),
+                "Return type of inclusive_scan_over_group(sub_group g, T x, "
+                "BinaryOperation binary_op) is wrong\n");
+
+            scan_result =
+                sycl::inclusive_scan_over_group(sub_group, local_var, op_plus);
+            local_res = (scan_result == local_var * (local_var + 1) / 2) ||
+                        ((llid + 1) * (llid + 2) / 2 > util::exact_max<T>);
+            res_acc[6 * work_group_size + item.get_local_linear_id()] =
+                local_res;
+
+            scan_result =
+                sycl::inclusive_scan_over_group(sub_group, local_var, op_max);
+            local_res =
+                (scan_result == local_var) || (llid + 1 > util::exact_max<T>);
+            res_acc[7 * work_group_size + item.get_local_linear_id()] =
+                local_res;
+          });
+    });
+  }
+  int index = 0;
+  for (int i = 0; i < test_matrix; ++i)
+    for (int j = 0; j < test_cases; ++j) {
+      bool result = res[index * work_group_size];
+      for (size_t k = 1; k < work_group_size; ++k)
+        result &= res[index * work_group_size + k];
+
+      std::string work_group = util::work_group_print(work_group_range);
+      CAPTURE(D, work_group);
+      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                       << " operation"
+                          " and T = "
+                       << type_name<T>() << " is "
+                       << (result ? "right" : "wrong"));
+      CHECK(result);
+      ++index;
+    }
+}
+
+template <typename DimensionT, typename T>
+class invoke_scan_over_group {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue) { scan_over_group<D, T>(queue); }
+};
+
+template <int D, typename T, typename U>
+class init_scan_over_group_kernel;
+
+// FIXME: hipSYCL has wrong arguments order: init and op are interchanged
+#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
+template <typename Group, typename V, typename T, typename BinaryOperation>
+T inclusive_scan_over_group_impl(Group g, V x, BinaryOperation binary_op,
+                                 T init) {
+  return sycl::inclusive_scan_over_group(g, x, init, binary_op);
+}
+#else
+template <typename Group, typename V, typename T, typename BinaryOperation>
+T inclusive_scan_over_group_impl(Group g, V x, BinaryOperation binary_op,
+                                 T init) {
+  return sycl::inclusive_scan_over_group(g, x, binary_op, init);
+}
+#endif
+
+// many errors with short types for hipSYCL
+// it means conversion and calculation patterns are not OK
+/**
+ * @brief Provides test for scans over group with an init value
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type used for init value and result
+ * @tparam U Type used for group values
+ */
+template <int D, typename T, typename U>
+void init_scan_over_group(sycl::queue& queue) {
+  // 4 functions * 2 function objects
+  constexpr int test_matrix = 4;
+  const std::string test_names[test_matrix] = {
+      "T exclusive_scan_over_group(group g, V x, T init, BinaryOperation "
+      "binary_op)",
+      "T inclusive_scan_over_group(group g, V x, BinaryOperation binary_op, T "
+      "init)",
+      "T exclusive_scan_over_group(sub_group g, V x, T init, BinaryOperation "
+      "binary_op)",
+      "T inclusive_scan_over_group(sub_group g, V x, BinaryOperation "
+      "binary_op, T init)"};
+  constexpr int test_cases = 2;
+  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results:
+  std::valarray<bool> res(false, test_matrix * test_cases * work_group_size);
+  {
+    sycl::buffer<bool, 1> res_sycl(
+        std::begin(res),
+        sycl::range<1>(test_matrix * test_cases * work_group_size));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<init_scan_over_group_kernel<
+          D, T, U>>(executionRange, [=](sycl::nd_item<D> item) {
+        T init;
+        U local_var;
+        // checks are plagued by UB for too short types
+        // so that the guards are introduced as the second parts in
+        // local_res calculations
+        size_t llid;
+        size_t scan_result;
+        bool local_res;
+
+        auto op_plus = sycl::plus<T>();
+        auto op_max = sycl::maximum<T>();
+
+        sycl::group<D> group = item.get_group();
+
+        llid = group.get_local_linear_id();
+        local_var = U(llid + 1);
+
+        ASSERT_RETURN_TYPE(
+            T, sycl::exclusive_scan_over_group(group, local_var, init, op_plus),
+            "Return type of exclusive_scan_over_group(group g, V x, T "
+            "init, BinaryOperation binary_op) is wrong\n");
+
+        // hipSYCL converts init from T to V
+        init = T(1412);
+
+        scan_result = llid * (llid + 1) / 2 + init;
+        local_res = (scan_result == sycl::exclusive_scan_over_group(
+                                        group, local_var, init, op_plus)) ||
+                    (scan_result > util::exact_max<T>) ||
+                    (llid > util::exact_max<U>);
+        res_acc[0 * work_group_size + llid] = local_res;
+
+        init = T(42);
+
+        scan_result = (llid > init ? llid : static_cast<size_t>(init));
+        local_res = (scan_result == sycl::exclusive_scan_over_group(
+                                        group, local_var, init, op_max)) ||
+                    (scan_result > util::exact_max<T>) ||
+                    (llid > util::exact_max<U>);
+        res_acc[1 * work_group_size + llid] = local_res;
+
+        ASSERT_RETURN_TYPE(
+            T, inclusive_scan_over_group_impl(group, local_var, op_max, init),
+            "Return type of inclusive_scan_over_group(group g, V x, "
+            "BinaryOperation binary_op, T init) is wrong\n");
+
+        init = T(1412);
+
+        scan_result = (llid + 1) * (llid + 2) / 2 + init;
+        local_res = (scan_result == inclusive_scan_over_group_impl(
+                                        group, local_var, op_plus, init)) ||
+                    (scan_result > util::exact_max<T>) ||
+                    (llid + 1 > util::exact_max<U>);
+        res_acc[2 * work_group_size + llid] = local_res;
+
+        init = T(42);
+
+        scan_result = (llid + 1 > init ? llid + 1 : static_cast<size_t>(init));
+        local_res = (scan_result == inclusive_scan_over_group_impl(
+                                        group, local_var, op_max, init)) ||
+                    (scan_result > util::exact_max<T>) ||
+                    (llid + 1 > util::exact_max<U>);
+        res_acc[3 * work_group_size + llid] = local_res;
+
+        sycl::sub_group sub_group = item.get_sub_group();
+
+        llid = sub_group.get_local_linear_id();
+        local_var = U(llid + 1);
+
+        ASSERT_RETURN_TYPE(
+            T,
+            sycl::exclusive_scan_over_group(sub_group, local_var, init,
+                                            op_plus),
+            "Return type of exclusive_scan_over_group(sub_group g, V x, T "
+            "init, BinaryOperation binary_op) is wrong\n");
+
+        // hipSYCL converts init from T to V=uint8_t, and calculates in V,
+        // not in T, for T=floats, V=int hipSYCL uses 0 instead of init!
+        init = T(1412);
+
+        scan_result = llid * (llid + 1) / 2 + init;
+        local_res = (scan_result == sycl::exclusive_scan_over_group(
+                                        sub_group, local_var, init, op_plus)) ||
+                    (scan_result > util::exact_max<T>) ||
+                    (llid > util::exact_max<U>);
+        res_acc[4 * work_group_size + item.get_local_linear_id()] = local_res;
+
+        init = T(4);
+
+        scan_result = (llid > init ? llid : static_cast<size_t>(init));
+        local_res = (scan_result == sycl::exclusive_scan_over_group(
+                                        sub_group, local_var, init, op_max)) ||
+                    (scan_result > util::exact_max<T>) ||
+                    (llid > util::exact_max<U>);
+        res_acc[5 * work_group_size + item.get_local_linear_id()] = local_res;
+
+        ASSERT_RETURN_TYPE(
+            T,
+            inclusive_scan_over_group_impl(sub_group, local_var, op_max, init),
+            "Return type of inclusive_scan_over_group(sub_group g, V x, "
+            "BinaryOperation binary_op, T init) is wrong\n");
+
+        init = T(1412);
+
+        scan_result = (llid + 1) * (llid + 2) / 2 + init;
+        local_res = (scan_result == inclusive_scan_over_group_impl(
+                                        sub_group, local_var, op_plus, init)) ||
+                    (scan_result > util::exact_max<T>) ||
+                    (llid + 1 > util::exact_max<U>);
+        res_acc[6 * work_group_size + item.get_local_linear_id()] = local_res;
+
+        init = T(4);
+
+        scan_result = (llid + 1 > init ? llid + 1 : static_cast<size_t>(init));
+        local_res = (scan_result == inclusive_scan_over_group_impl(
+                                        sub_group, local_var, op_max, init)) ||
+                    (scan_result > util::exact_max<T>) ||
+                    (llid + 1 > util::exact_max<U>);
+        res_acc[7 * work_group_size + item.get_local_linear_id()] = local_res;
+      });
+    });
+  }
+  int index = 0;
+  for (int i = 0; i < test_matrix; ++i)
+    for (int j = 0; j < test_cases; ++j) {
+      bool result = res[index * work_group_size];
+      for (size_t k = 1; k < work_group_size; ++k)
+        result &= res[index * work_group_size + k];
+
+      std::string work_group = util::work_group_print(work_group_range);
+      CAPTURE(D, work_group);
+      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                       << " operation"
+                          " and T = "
+                       << type_name<T>() << ", V = " << type_name<U>() << " is "
+                       << (result ? "right" : "wrong"));
+      CHECK(result);
+      ++index;
+    }
+}
+
+template <typename DimensionT, typename T, typename U>
+class invoke_init_scan_over_group {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue) { init_scan_over_group<D, T, U>(queue); }
+};
+
+// FIXME: Helper for implementations that cannot handle cases of different types
+template <typename DimensionT, typename T>
+class invoke_init_scan_over_group_same_type {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue) { init_scan_over_group<D, T, T>(queue); }
+};

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -20,9 +20,6 @@
 
 #include "group_scan.h"
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
-
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
@@ -40,6 +37,9 @@ using ScanTypes = Types;
 
 using HalfType = unnamed_type_pack<sycl::half>;
 using HalfExtendedTypes = concatenation<ScanTypes, sycl::half>::type;
+
+static auto queue = sycl_cts::util::get_cts_object::queue();
+static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 
 TEST_CASE("Group and sub-group joint scan functions",
           "[group_func][type_list][fp16][dim]") {

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -1,0 +1,174 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_scan.h"
+
+static auto queue = sycl_cts::util::get_cts_object::queue();
+static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
+
+// FIXME: ComputeCpp does not implement scan for unsigned long long int and long
+// long int
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+using ScanTypes =
+    unnamed_type_pack<size_t, float, char, signed char, unsigned char,
+                      short int, unsigned short int, int, unsigned int,
+                      long int, unsigned long int>;
+#else
+using ScanTypes = unnamed_type_pack<float, char, int>;
+#endif
+#else
+using ScanTypes = Types;
+#endif
+
+using HalfType = unnamed_type_pack<sycl::half>;
+using HalfExtendedTypes = concatenation<ScanTypes, sycl::half>::type;
+
+TEST_CASE("Group and sub-group joint scan functions",
+          "[group_func][type_list][fp16][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL cannot handle cases of different types for InPtr and OutPtr. "
+      "Skipping such test cases.");
+  WARN(
+      "hipSYCL joint_exclusive_scan and joint_inclusive_scan cannot process "
+      "over several sub-groups simultaneously. Using one sub-group only.");
+  WARN("hipSYCL does not support sycl::known_identity_v yet.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
+      "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN("ComputeCpp does not implement joint scan. Skipping the test.");
+  WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp does not implement joint scan and half type
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    for_all_combinations<invoke_joint_scan_group_same_type>(Dims, HalfType{},
+                                                            queue);
+#else
+    for_all_combinations_with<invoke_joint_scan_group, sycl::half>(
+        Dims, HalfExtendedTypes{}, HalfExtendedTypes{}, queue);
+#endif
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}
+
+TEST_CASE("Group and sub-group joint scan functions with init",
+          "[group_func][type_list][fp16][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL cannot handle cases of different types for T, *InPtr and "
+      "*OutPtr. Skipping such test cases.");
+  WARN(
+      "hipSYCL joint_exclusive_scan and joint_inclusive_scan with init values "
+      "cannot process over several sub-groups simultaneously. Using one "
+      "sub-group only.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for T, *InPtr and "
+      "*OutPtr. Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN("ComputeCpp does not implement joint scan. Skipping the test.");
+  WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp does not implement joint scan and half type
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    for_all_combinations<invoke_init_joint_scan_group_same_type>(
+        Dims, HalfType{}, queue);
+#else
+    for_all_combinations_with<invoke_init_joint_scan_group, sycl::half>(
+        Dims, HalfExtendedTypes{}, HalfExtendedTypes{}, HalfExtendedTypes{},
+        queue);
+#endif
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}
+
+TEST_CASE("Group and sub-group scan functions", "[group_func][fp16][dim]") {
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+  WARN("ComputeCpp cannot handle half type. Skipping the test.");
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    for_all_combinations<invoke_scan_over_group>(Dims, HalfType{}, queue);
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}
+
+TEST_CASE("Group and sub-group scan functions with init",
+          "[group_func][type_list][fp16][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
+      "and op are interchanged.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for T and V. Skipping such "
+      "test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN(
+      "ComputeCpp does not implement scan for unsigned long long int and "
+      "long long int. Skipping the test cases.");
+  WARN(
+      "ComputeCpp cannot handle cases of different types for T and V. Skipping "
+      "such test cases.");
+  WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp has no half
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    for_all_combinations<invoke_init_scan_over_group_same_type>(
+        Dims, HalfType{}, queue);
+#else
+    for_all_combinations_with<invoke_init_scan_over_group, sycl::half>(
+        Dims, HalfExtendedTypes{}, HalfExtendedTypes{}, queue);
+#endif
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -125,9 +125,10 @@ TEST_CASE("Group and sub-group scan functions", "[group_func][fp64][dim]") {
       "Skipping the test.");
 #endif
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -161,9 +162,10 @@ TEST_CASE("Group and sub-group scan functions with init",
       "Skipping the test.");
 #endif
 
-  // FIXME: clang-8: error: unable to execute command: Segmentation fault (core dumped)
-  //        clang-8: error: spirv-ll-tool command failed due to signal (use -v to see invocation)
-  //        Codeplay ComputeCpp - CE 2.11.0 Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  // FIXME: Codeplay ComputeCpp - CE 2.11.0
+  //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
+  //        clang-8: error: unable to execute command: Segmentation fault
+  //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -1,0 +1,161 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_scan.h"
+
+static auto queue = sycl_cts::util::get_cts_object::queue();
+static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
+
+// FIXME: ComputeCpp does not implement scan for unsigned long long int and long
+// long int
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+using ScanTypes =
+    unnamed_type_pack<size_t, float, char, signed char, unsigned char,
+                      short int, unsigned short int, int, unsigned int,
+                      long int, unsigned long int>;
+#else
+using ScanTypes = unnamed_type_pack<float, char, int>;
+#endif
+#else
+using ScanTypes = Types;
+#endif
+
+using DoubleType = unnamed_type_pack<double>;
+using DoubleExtendedTypes = concatenation<ScanTypes, double>::type;
+
+TEST_CASE("Group and sub-group joint scan functions",
+          "[group_func][type_list][fp64][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL cannot handle cases of different types for InPtr and OutPtr. "
+      "Skipping such test cases.");
+  WARN(
+      "hipSYCL joint_exclusive_scan and joint_inclusive_scan cannot process "
+      "over several sub-groups simultaneously. Using one sub-group only.");
+  WARN("hipSYCL does not support sycl::known_identity_v yet.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
+      "Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN("ComputeCpp does not implement joint scan. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp does not implement joint scan
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    for_all_combinations<invoke_joint_scan_group_same_type>(Dims, DoubleType{},
+                                                            queue);
+#else
+    for_all_combinations_with<invoke_joint_scan_group, double>(
+        Dims, DoubleExtendedTypes{}, DoubleExtendedTypes{}, queue);
+#endif
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+#endif
+}
+
+TEST_CASE("Group and sub-group joint scan functions with init",
+          "[group_func][type_list][fp64][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL cannot handle cases of different types for T, *InPtr and "
+      "*OutPtr. Skipping such test cases.");
+  WARN(
+      "hipSYCL joint_exclusive_scan and joint_inclusive_scan with init values "
+      "cannot process over several sub-groups simultaneously. Using one "
+      "sub-group only.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for T, *InPtr and "
+      "*OutPtr. Skipping such test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN("ComputeCpp does not implement joint scan. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp does not implement joint scan
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    for_all_combinations<invoke_init_joint_scan_group_same_type>(
+        Dims, DoubleType{}, queue);
+#else
+    for_all_combinations_with<invoke_init_joint_scan_group, double>(
+        Dims, DoubleExtendedTypes{}, DoubleExtendedTypes{},
+        DoubleExtendedTypes{}, queue);
+#endif
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+#endif
+}
+
+TEST_CASE("Group and sub-group scan functions", "[group_func][fp64][dim]") {
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    for_all_combinations<invoke_scan_over_group>(Dims, DoubleType{}, queue);
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+}
+
+TEST_CASE("Group and sub-group scan functions with init",
+          "[group_func][type_list][fp64][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
+      "and op are interchanged.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for T and V. Skipping such "
+      "test cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN(
+      "ComputeCpp does not implement scan for unsigned long long int and "
+      "long long int. Skipping the test cases.");
+  WARN(
+      "ComputeCpp cannot handle cases of different types for T and V. Skipping "
+      "such test cases.");
+#endif
+
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    for_all_combinations<invoke_init_scan_over_group_same_type>(
+        Dims, DoubleType{}, queue);
+#else
+    for_all_combinations_with<invoke_init_scan_over_group, double>(
+        Dims, DoubleExtendedTypes{}, DoubleExtendedTypes{}, queue);
+#endif
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+}

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -23,9 +23,6 @@
 
 #include "group_scan.h"
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
-
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
@@ -43,6 +40,9 @@ using ScanTypes = Types;
 
 using DoubleHalfTypes = unnamed_type_pack<double, sycl::half>;
 using DoubleHalfExtendedTypes = concatenation<ScanTypes, DoubleHalfTypes>::type;
+
+static auto queue = sycl_cts::util::get_cts_object::queue();
+static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 
 TEST_CASE("Group and sub-group joint scan functions",
           "[group_func][fp16][fp64][dim]") {

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -1,0 +1,165 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+// need also double tests enabled
+#ifdef SYCL_CTS_ENABLE_DOUBLE_TESTS
+
+#include "group_scan.h"
+
+static auto queue = sycl_cts::util::get_cts_object::queue();
+static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
+
+// FIXME: ComputeCpp does not implement scan for unsigned long long int and long
+// long int
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+using ScanTypes =
+    unnamed_type_pack<size_t, float, char, signed char, unsigned char,
+                      short int, unsigned short int, int, unsigned int,
+                      long int, unsigned long int>;
+#else
+using ScanTypes = unnamed_type_pack<float, char, int>;
+#endif
+#else
+using ScanTypes = Types;
+#endif
+
+using DoubleHalfTypes = unnamed_type_pack<double, sycl::half>;
+using DoubleHalfExtendedTypes = concatenation<ScanTypes, DoubleHalfTypes>::type;
+
+TEST_CASE("Group and sub-group joint scan functions",
+          "[group_func][fp16][fp64][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL cannot handle cases of different types for InPtr and OutPtr. "
+      "Skipping the test.");
+  WARN(
+      "hipSYCL joint_exclusive_scan and joint_inclusive_scan cannot process "
+      "over several sub-groups simultaneously. Using one sub-group only.");
+  WARN("hipSYCL does not support sycl::known_identity_v yet.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
+      "Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN("ComputeCpp does not implement joint scan. Skipping the test.");
+  WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp does not implement joint scan and half type
+  // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP) ||   \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16) &&
+      queue.get_device().has(sycl::aspect::fp64)) {
+    // here DoubleHalfTypes can be used as only half+double combinations are
+    // untested
+    for_all_combinations_with_two<invoke_joint_scan_group, double, sycl::half>(
+        Dims, DoubleHalfTypes{}, DoubleHalfTypes{}, queue);
+  } else {
+    WARN(
+        "Device does not support half and double precision floating point "
+        "operations simultaneously.");
+  }
+#endif
+}
+
+TEST_CASE("Group and sub-group joint scan functions with init",
+          "[group_func][type_list][fp16][fp64][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL cannot handle cases of different types for T, *InPtr and "
+      "*OutPtr. Skipping the test.");
+  WARN(
+      "hipSYCL joint_exclusive_scan and joint_inclusive_scan with init values "
+      "cannot process over several sub-groups simultaneously. Using one "
+      "sub-group only.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for T, *InPtr and "
+      "*OutPtr. Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN("ComputeCpp does not implement joint scan. Skipping the test.");
+  WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp does not implement joint scan and half type
+  // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_DPCPP) ||   \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16) &&
+      queue.get_device().has(sycl::aspect::fp64)) {
+    for_all_combinations_with_two<invoke_init_joint_scan_group, double,
+                                  sycl::half>(Dims, DoubleHalfExtendedTypes{},
+                                              DoubleHalfExtendedTypes{},
+                                              DoubleHalfExtendedTypes{}, queue);
+  } else {
+    WARN(
+        "Device does not support half and double precision floating point "
+        "operations simultaneously.");
+  }
+#endif
+}
+
+TEST_CASE("Group and sub-group scan functions with init",
+          "[group_func][fp16][fp64][dim]") {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+  WARN(
+      "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
+      "and op are interchanged.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  WARN(
+      "DPCPP cannot handle cases of different types for T and V. Skipping the "
+      "test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  WARN(
+      "ComputeCpp cannot handle cases of different types for T and V. Skipping "
+      "the test.");
+  WARN("ComputeCpp cannot handle half type. Skipping the test.");
+#endif
+
+  // FIXME: ComputeCpp has no half
+  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  if (queue.get_device().has(sycl::aspect::fp16) &&
+      queue.get_device().has(sycl::aspect::fp64)) {
+    // here DoubleHalfTypes can be used as only half+double combinations are
+    // untested
+    for_all_combinations_with_two<invoke_init_scan_over_group, double,
+                                  sycl::half>(Dims, DoubleHalfTypes{},
+                                              DoubleHalfTypes{}, queue);
+  } else {
+    WARN(
+        "Device does not support half and double precision floating point "
+        "operations simultaneously.");
+  }
+#endif
+}
+
+#endif

--- a/tests/group_functions/group_shift.cpp
+++ b/tests/group_functions/group_shift.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_shift.h"
+
+// errors in hipSYCL with bool and 8-bit types - only in group shifts
+TEMPLATE_LIST_TEST_CASE("Group and sub-group shift",
+                        "[group_func][type_list][dim]", CustomTypes) {
+  // check types to only print warning once
+  if constexpr (std::is_same_v<TestType, char>) {
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
+    WARN(
+        "hipSYCL has not implemented sycl::marray type yet. Skipping the test "
+        "cases.");
+#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement shift functions. "
+        "Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement shift functions. "
+        "Skipping the test.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp do not implement shift functions
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  // check all work group dimensions
+  shift_group<1, TestType>(queue);
+  shift_group<2, TestType>(queue);
+  shift_group<3, TestType>(queue);
+
+  shift_sub_group<1, TestType>(queue);
+  shift_sub_group<2, TestType>(queue);
+  shift_sub_group<3, TestType>(queue);
+#endif
+}

--- a/tests/group_functions/group_shift.h
+++ b/tests/group_functions/group_shift.h
@@ -60,8 +60,8 @@ void shift_group(sycl::queue& queue) {
             const typename sycl::group<D>::linear_id_type llid =
                 item.get_local_linear_id();
 
-            T local_var(init_helper<T>(llid + 1));
-            T shifted_var(init_helper<T>(llid + 1));
+            T local_var(splat_init<T>(llid + 1));
+            T shifted_var(splat_init<T>(llid + 1));
 
             ASSERT_RETURN_TYPE(
                 T, sycl::shift_group_left(group, local_var),
@@ -69,7 +69,7 @@ void shift_group(sycl::queue& queue) {
 
             shifted_var = sycl::shift_group_left(group, local_var);
             res_acc[0 * work_group_size + llid] =
-                equal(shifted_var, init_helper<T>(llid + 2)) ||
+                equal(shifted_var, splat_init<T>(llid + 2)) ||
                 (llid + 1 >= group.get_local_linear_range());
 
             ASSERT_RETURN_TYPE(T, sycl::shift_group_left(group, local_var, 3),
@@ -78,7 +78,7 @@ void shift_group(sycl::queue& queue) {
 
             shifted_var = sycl::shift_group_left(group, local_var, 3);
             res_acc[1 * work_group_size + llid] =
-                equal(shifted_var, init_helper<T>(llid + 4)) ||
+                equal(shifted_var, splat_init<T>(llid + 4)) ||
                 (llid + 3 >= group.get_local_linear_range());
 
             ASSERT_RETURN_TYPE(
@@ -87,7 +87,7 @@ void shift_group(sycl::queue& queue) {
 
             shifted_var = sycl::shift_group_right(group, local_var);
             res_acc[2 * work_group_size + llid] =
-                equal(shifted_var, init_helper<T>(llid)) || (llid < 1);
+                equal(shifted_var, splat_init<T>(llid)) || (llid < 1);
 
             ASSERT_RETURN_TYPE(T, sycl::shift_group_right(group, local_var, 2),
                                "Return type of shift_group_right(group g, T x, "
@@ -95,7 +95,7 @@ void shift_group(sycl::queue& queue) {
 
             shifted_var = sycl::shift_group_right(group, local_var, 2);
             res_acc[3 * work_group_size + llid] =
-                equal(shifted_var, init_helper<T>(llid - 1)) || (llid < 2);
+                equal(shifted_var, splat_init<T>(llid - 1)) || (llid < 2);
           });
     });
   }
@@ -145,8 +145,8 @@ void shift_sub_group(sycl::queue& queue) {
         const sycl::sub_group::linear_id_type llid =
             sub_group.get_local_linear_id();
 
-        T local_var(init_helper<T>(llid + 1));
-        T shifted_var(init_helper<T>(llid + 1));
+        T local_var(splat_init<T>(llid + 1));
+        T shifted_var(splat_init<T>(llid + 1));
 
         ASSERT_RETURN_TYPE(
             T, sycl::shift_group_left(sub_group, local_var),
@@ -154,7 +154,7 @@ void shift_sub_group(sycl::queue& queue) {
 
         shifted_var = sycl::shift_group_left(sub_group, local_var);
         res_acc[0 * work_group_size + item.get_local_linear_id()] =
-            equal(shifted_var, init_helper<T>(llid + 2)) ||
+            equal(shifted_var, splat_init<T>(llid + 2)) ||
             (llid + 1 >= sub_group.get_local_linear_range());
 
         ASSERT_RETURN_TYPE(T, sycl::shift_group_left(sub_group, local_var, 3),
@@ -163,7 +163,7 @@ void shift_sub_group(sycl::queue& queue) {
 
         shifted_var = sycl::shift_group_left(sub_group, local_var, 3);
         res_acc[1 * work_group_size + item.get_local_linear_id()] =
-            equal(shifted_var, init_helper<T>(llid + 4)) ||
+            equal(shifted_var, splat_init<T>(llid + 4)) ||
             (llid + 3 >= sub_group.get_local_linear_range());
 
         ASSERT_RETURN_TYPE(
@@ -172,7 +172,7 @@ void shift_sub_group(sycl::queue& queue) {
 
         shifted_var = sycl::shift_group_right(sub_group, local_var);
         res_acc[2 * work_group_size + item.get_local_linear_id()] =
-            equal(shifted_var, init_helper<T>(llid)) || (llid < 1);
+            equal(shifted_var, splat_init<T>(llid)) || (llid < 1);
 
         ASSERT_RETURN_TYPE(T, sycl::shift_group_right(sub_group, local_var, 2),
                            "Return type of shift_group_right(sub_group g, T x, "
@@ -180,7 +180,7 @@ void shift_sub_group(sycl::queue& queue) {
 
         shifted_var = sycl::shift_group_right(sub_group, local_var, 2);
         res_acc[3 * work_group_size + item.get_local_linear_id()] =
-            equal(shifted_var, init_helper<T>(llid - 1)) || (llid < 2);
+            equal(shifted_var, splat_init<T>(llid - 1)) || (llid < 2);
       });
     });
   }

--- a/tests/group_functions/group_shift.h
+++ b/tests/group_functions/group_shift.h
@@ -1,0 +1,198 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include <valarray>
+
+#include "group_functions_common.h"
+
+template <int D, typename T>
+class shift_group_kernel;
+
+/**
+ * @brief Provides test for shift (shuffle) values inside the group
+ * @tparam D Dimension to use for group instance
+ * @tparam T Type for shifted value
+ */
+template <int D, typename T>
+void shift_group(sycl::queue& queue) {
+  // 4 functions
+  constexpr int test_matrix = 4;
+  const std::string test_names[test_matrix] = {
+      "T shift_group_left(group g, T x)",
+      "T shift_group_left(group g, T x, group::linear_id_type delta)",
+      "T shift_group_right(group g, T x)",
+      "T shift_group_right(group g, T x, group::linear_id_type delta)"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results:
+  std::valarray<bool> res(false, test_matrix * work_group_size);
+  {
+    sycl::buffer<bool, 1> res_sycl(
+        std::begin(res), sycl::range<1>(test_matrix * work_group_size));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<shift_group_kernel<D, T>>(
+          executionRange, [=](sycl::nd_item<D> item) {
+            sycl::group<D> group = item.get_group();
+            const typename sycl::group<D>::linear_id_type llid =
+                item.get_local_linear_id();
+
+            T local_var(init_helper<T>(llid + 1));
+            T shifted_var(init_helper<T>(llid + 1));
+
+            ASSERT_RETURN_TYPE(
+                T, sycl::shift_group_left(group, local_var),
+                "Return type of shift_group_left(group g, T x) is wrong\n");
+
+            shifted_var = sycl::shift_group_left(group, local_var);
+            res_acc[0 * work_group_size + llid] =
+                equal(shifted_var, init_helper<T>(llid + 2)) ||
+                (llid + 1 >= group.get_local_linear_range());
+
+            ASSERT_RETURN_TYPE(T, sycl::shift_group_left(group, local_var, 3),
+                               "Return type of shift_group_left(group g, T x, "
+                               "group::linear_id_type delta) is wrong\n");
+
+            shifted_var = sycl::shift_group_left(group, local_var, 3);
+            res_acc[1 * work_group_size + llid] =
+                equal(shifted_var, init_helper<T>(llid + 4)) ||
+                (llid + 3 >= group.get_local_linear_range());
+
+            ASSERT_RETURN_TYPE(
+                T, sycl::shift_group_right(group, local_var),
+                "Return type of shift_group_right(group g, T x) is wrong\n");
+
+            shifted_var = sycl::shift_group_right(group, local_var);
+            res_acc[2 * work_group_size + llid] =
+                equal(shifted_var, init_helper<T>(llid)) || (llid < 1);
+
+            ASSERT_RETURN_TYPE(T, sycl::shift_group_right(group, local_var, 2),
+                               "Return type of shift_group_right(group g, T x, "
+                               "group::linear_id_type delta) is wrong\n");
+
+            shifted_var = sycl::shift_group_right(group, local_var, 2);
+            res_acc[3 * work_group_size + llid] =
+                equal(shifted_var, init_helper<T>(llid - 1)) || (llid < 2);
+          });
+    });
+  }
+  for (int i = 0; i < test_matrix; ++i) {
+    bool result = res[i * work_group_size];
+    for (size_t j = 1; j < work_group_size; ++j)
+      result &= res[i * work_group_size + j];
+
+    std::string work_group = util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
+                     << " is " << (result ? "right" : "wrong"));
+    CHECK(result);
+  }
+}
+
+template <int D, typename T>
+class shift_sub_group_kernel;
+
+template <int D, typename T>
+void shift_sub_group(sycl::queue& queue) {
+  // 4 functions
+  constexpr int test_matrix = 4;
+  const std::string test_names[test_matrix] = {
+      "T shift_group_left(sub_group g, T x)",
+      "T shift_group_left(sub_group g, T x, sub_group::linear_id_type delta)",
+      "T shift_group_right(sub_group g, T x)",
+      "T shift_group_right(sub_group g, T x, sub_group::linear_id_type delta)"};
+
+  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
+
+  // array to return results:
+  std::valarray<bool> res(false, test_matrix * work_group_size);
+  {
+    sycl::buffer<bool, 1> res_sycl(
+        std::begin(res), sycl::range<1>(test_matrix * work_group_size));
+
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
+
+      cgh.parallel_for<shift_sub_group_kernel<
+          D, T>>(executionRange, [=](sycl::nd_item<D> item) {
+        sycl::sub_group sub_group = item.get_sub_group();
+        const sycl::sub_group::linear_id_type llid =
+            sub_group.get_local_linear_id();
+
+        T local_var(init_helper<T>(llid + 1));
+        T shifted_var(init_helper<T>(llid + 1));
+
+        ASSERT_RETURN_TYPE(
+            T, sycl::shift_group_left(sub_group, local_var),
+            "Return type of shift_group_left(sub_group g, T x) is wrong\n");
+
+        shifted_var = sycl::shift_group_left(sub_group, local_var);
+        res_acc[0 * work_group_size + item.get_local_linear_id()] =
+            equal(shifted_var, init_helper<T>(llid + 2)) ||
+            (llid + 1 >= sub_group.get_local_linear_range());
+
+        ASSERT_RETURN_TYPE(T, sycl::shift_group_left(sub_group, local_var, 3),
+                           "Return type of shift_group_left(sub_group g, T x, "
+                           "sub_group::linear_id_type delta) is wrong\n");
+
+        shifted_var = sycl::shift_group_left(sub_group, local_var, 3);
+        res_acc[1 * work_group_size + item.get_local_linear_id()] =
+            equal(shifted_var, init_helper<T>(llid + 4)) ||
+            (llid + 3 >= sub_group.get_local_linear_range());
+
+        ASSERT_RETURN_TYPE(
+            T, sycl::shift_group_right(sub_group, local_var),
+            "Return type of shift_group_right(sub_group g, T x) is wrong\n");
+
+        shifted_var = sycl::shift_group_right(sub_group, local_var);
+        res_acc[2 * work_group_size + item.get_local_linear_id()] =
+            equal(shifted_var, init_helper<T>(llid)) || (llid < 1);
+
+        ASSERT_RETURN_TYPE(T, sycl::shift_group_right(sub_group, local_var, 2),
+                           "Return type of shift_group_right(sub_group g, T x, "
+                           "sub_group::linear_id_type delta) is wrong\n");
+
+        shifted_var = sycl::shift_group_right(sub_group, local_var, 2);
+        res_acc[3 * work_group_size + item.get_local_linear_id()] =
+            equal(shifted_var, init_helper<T>(llid - 1)) || (llid < 2);
+      });
+    });
+  }
+  for (int i = 0; i < test_matrix; ++i) {
+    bool result = res[i * work_group_size];
+    for (size_t j = 1; j < work_group_size; ++j)
+      result &= res[i * work_group_size + j];
+
+    std::string work_group = util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
+                     << " is " << (result ? "right" : "wrong"));
+    CHECK(result);
+  }
+}

--- a/tests/group_functions/group_shift_fp16.cpp
+++ b/tests/group_functions/group_shift_fp16.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_shift.h"
+
+TEMPLATE_TEST_CASE_SIG("Group and sub-group shift", "[group_func][fp16][dim]",
+                       ((int D), D), 1, 2, 3) {
+  // check dimensions to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement shift functions. "
+        "Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement shift functions. "
+        "Skipping the test.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp do not implement shift functions
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp16)) {
+    shift_group<D, sycl::half>(queue);
+    shift_sub_group<D, sycl::half>(queue);
+  } else {
+    WARN("Device does not support half precision floating point operations.");
+  }
+#endif
+}

--- a/tests/group_functions/group_shift_fp64.cpp
+++ b/tests/group_functions/group_shift_fp64.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "group_shift.h"
+
+TEMPLATE_TEST_CASE_SIG("Group and sub-group shift", "[group_func][fp64][dim]",
+                       ((int D), D), 1, 2, 3) {
+  // check dimensions to only print warning once
+  if constexpr (D == 1) {
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    WARN(
+        "DPCPP does not implement shift functions. "
+        "Skipping the test.");
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    WARN(
+        "ComputeCpp does not implement shift functions. "
+        "Skipping the test.");
+#endif
+  }
+
+  // FIXME: DPCPP and ComputeCpp do not implement shift functions
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  return;
+#else
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+  if (queue.get_device().has(sycl::aspect::fp64)) {
+    shift_group<D, double>(queue);
+    shift_sub_group<D, double>(queue);
+  } else {
+    WARN("Device does not support double precision floating point operations.");
+  }
+#endif
+}

--- a/tests/group_functions/group_trait.cpp
+++ b/tests/group_functions/group_trait.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+
+#include "group_functions_common.h"
+
+TEST_CASE("Group type trait", "[group_func]") {
+#ifdef SYCL_CTS_COMPILING_WITH_DPCPP
+  WARN("DPCPP does not implement sycl::is_group. Skipping the test case.");
+#else
+  // positive testing
+  CHECK(std::is_base_of_v<std::true_type, sycl::is_group<sycl::group<1>>>);
+  CHECK(std::is_base_of_v<std::true_type, sycl::is_group<sycl::group<2>>>);
+  CHECK(std::is_base_of_v<std::true_type, sycl::is_group<sycl::group<3>>>);
+  CHECK(std::is_base_of_v<std::true_type, sycl::is_group<sycl::sub_group>>);
+
+  // negative testing
+  CHECK(std::is_base_of_v<std::false_type, sycl::is_group<sycl::nd_range<3>>>);
+#endif
+
+  // positive testing
+  CHECK(sycl::is_group_v<sycl::group<1>>);
+  CHECK(sycl::is_group_v<sycl::group<2>>);
+  CHECK(sycl::is_group_v<sycl::group<3>>);
+  CHECK(sycl::is_group_v<sycl::sub_group>);
+
+  // negative testing
+  CHECK_FALSE(sycl::is_group_v<sycl::nd_range<2>>);
+}

--- a/tests/group_functions/type_coverage.h
+++ b/tests/group_functions/type_coverage.h
@@ -1,0 +1,690 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Provide common functions for type coverage
+//
+*******************************************************************************/
+
+/**
+ * FIXME: this is an extended (and also partial) copy of type_coverage.h
+ * with marray parts removed for hipSYCL compilation
+ * and with for_all_combinations_with/for_all_combinations_with_two added
+ */
+
+#ifndef __SYCLCTS_TESTS_COMMON_TYPE_COVERAGE_H
+#define __SYCLCTS_TESTS_COMMON_TYPE_COVERAGE_H
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include <sycl/sycl.hpp>
+
+#include "../../util/type_traits.h"
+
+#include "catch2/catch_tostring.hpp"
+
+#include <cstddef>  // for std::size_t
+
+/**
+ * @brief Retrieve type name; by default just forward the given one
+ */
+template <typename T>
+struct type_name_string {
+  static std::string get(std::string dataType) { return dataType; }
+};
+
+/**
+ * @brief Specialization of type name retrieve for sycl::vec class
+ * @param T Type of the data stored in vector
+ * @param nElements Number of elements stored in vector
+ */
+template <typename T, size_t nElements>
+struct type_name_string<sycl::vec<T, nElements>> {
+  static std::string get(const std::string &dataType) {
+    return "sycl::vec<" + dataType + "," + std::to_string(nElements) + ">";
+  }
+};
+
+/**
+ * @brief Specialization of type name retrieve for std::array class
+ * @param T Type of the data stored in std::array
+ * @param nElements Number of elements stored in std::array
+ */
+template <typename T, size_t nElements>
+struct type_name_string<std::array<T, nElements>> {
+  static std::string get(const std::string &dataType) {
+    return "std::array<" + dataType + "," + std::to_string(nElements) + ">";
+  }
+};
+
+/**
+ * @brief Specialization of type name retrieve for std::optional class
+ * @param T Type of the data stored in std::optional
+ */
+template <typename T>
+struct type_name_string<std::optional<T>> {
+  static std::string get(const std::string &dataType) {
+    return "std::optional<" + dataType + ">";
+  }
+};
+
+/**
+ * @brief Specialization of type name retrieve for std::pair class
+ * @param T Type of the data stored in std::pair
+ */
+template <typename T>
+struct type_name_string<std::pair<T, T>> {
+  static std::string get(const std::string &dataType) {
+    return "std::pair<" + dataType + "," + dataType + ">";
+  }
+};
+
+/**
+ * @brief Specialization of type name retrieve for std::tuple class
+ * @param T Type of the data stored in std::tuple
+ */
+template <typename T>
+struct type_name_string<std::tuple<T, T>> {
+  static std::string get(const std::string &dataType) {
+    return "std::tuple<" + dataType + "," + dataType + ">";
+  }
+};
+
+/**
+ * @brief Specialization of type name retrieve for std::variant class
+ * @param T Type of the data stored in std::variant
+ */
+template <typename T>
+struct type_name_string<std::variant<T>> {
+  static std::string get(const std::string &dataType) {
+    return "std::variant<" + dataType + ">";
+  }
+};
+
+/**
+ * @brief Type pack to store types
+ */
+template <typename... T>
+struct type_pack {};
+
+/**
+ * @brief Generic type pack with no specific type names provided
+ */
+template <typename... Types>
+struct unnamed_type_pack {
+  static_assert(sizeof...(Types) > 0, "Empty pack is not supported");
+
+  // Syntax sugar to align usage with the named_type_pack
+  static auto inline generate() { return unnamed_type_pack<Types...>{}; }
+};
+
+/**
+ * @brief Generic type pack with specific type names provided
+ */
+template <typename... Types>
+class named_type_pack {
+  template <typename... nameListT>
+  named_type_pack(nameListT &&... nameList)
+      : names{std::forward<nameListT>(nameList)...} {}
+  static_assert(sizeof...(Types) > 0, "Empty pack is not supported");
+
+  template <typename T>
+  static inline auto generate_name() {
+    if constexpr (has_static_member::to_string<T>::value) {
+      const auto result = T::to_string();
+      static_assert(std::is_same_v<decltype(result), const std::string>,
+                    "Unexpected return type for the T::to_string() method");
+      return result;
+    } else {
+      constexpr auto always_false = !std::is_same_v<T, T>;
+      static_assert(always_false,
+                    "There is no static method T::to_string() for this type");
+    }
+  }
+
+ public:
+  // We need a specific names to differentiate types on logic level, with no
+  // dependency on actual type implementation and typeid
+  const std::string names[sizeof...(Types)];
+
+  // Factory function to properly generate the type pack
+  //
+  // There are two possible use-cases for generation:
+  // - either each type has a corresponding name provided,
+  // - or each type have a static T::to_string() method available
+  //
+  // For example:
+  //   struct var_decl {
+  //     static std::string to_string() { return "variable declaration"; }
+  //   };
+  //   struct rval_in_expr {
+  //     static std::string to_string() { return "rvalue in an expression"; }
+  //   };
+  //   const auto types =
+  //      named_type_pack<char, signed char>::generate("char", "signed char");
+  //   const auto contexts =
+  //      named_type_pack<var_decl, rval_in_expr>::generate();
+  //
+  template <typename... nameListT>
+  static auto generate(nameListT &&... nameList) {
+    if constexpr (sizeof...(nameListT) == 0) {
+      // No names provided explicitly, try to generate them
+      return named_type_pack<Types...>(generate_name<Types>()...);
+    } else {
+      // Make requirement explicit to have more clear error message
+      static_assert(sizeof...(Types) == sizeof...(nameListT));
+      return named_type_pack<Types...>(std::forward<nameListT>(nameList)...);
+    }
+  }
+};
+
+/**
+ * @brief Generic value pack to use for any type of compile-time lists
+ */
+template <typename T, T... values>
+struct value_pack {
+  // Factory function to generate the corresponding type pack with no names
+  // stored
+  //
+  // Might be useful to store plain integral values or enumeration values.
+  // For example:
+  //   const auto bytes = value_pack<int, 1, 2, 8>::generate_unnamed();
+  //
+  static inline auto generate_unnamed() {
+    return unnamed_type_pack<std::integral_constant<T, values>...>::generate();
+  }
+
+  // Factory function to generate the type pack with stringified values stored
+  // within.
+  // For example:
+  //   enum class {read, write};
+  //   template <mode ... values>
+  //   using modes = value_pack<mode, values...>;
+  //   const auto modes = modes<mode::read, mode::write>::generate_named();
+  static inline auto generate_named() {
+    return named_type_pack<std::integral_constant<T, values>...>::generate(
+        Catch::StringMaker<T>::convert(values)...);
+  }
+
+  // Factory function to generate the type pack with names given for each value
+  //
+  // For example:
+  //   enum class ctx : int {
+  //     var_decl = 0,
+  //     rval_in_expr
+  //   };
+  //   const auto contexts =
+  //     value_pack<ctx, ctx::var_decl, ctx::rval_in_expr>::generate_named(
+  //         "variable declaration", "rvalue in an expression");
+  //
+  template <typename... argsT>
+  static inline auto generate_named(argsT &&... args) {
+    return named_type_pack<std::integral_constant<T, values>...>::generate(
+        std::forward<argsT>(args)...);
+  }
+};
+
+/**
+ * @brief Shortcut for type packs with integers. No overhead as alias doesn't
+ * declare a new type. Mostly use for the dimensions.
+ */
+template <int... values>
+using integer_pack = value_pack<int, values...>;
+
+namespace sfinae {
+namespace details {
+template <typename T>
+struct is_type_pack_t : std::false_type {};
+
+template <typename... Types>
+struct is_type_pack_t<named_type_pack<Types...>> : std::true_type {};
+
+template <typename... Types>
+struct is_type_pack_t<unnamed_type_pack<Types...>> : std::true_type {};
+}  // namespace details
+
+template <typename T>
+using is_not_a_type_pack =
+    std::enable_if_t<!details::is_type_pack_t<T>::value, bool>;
+
+}  // namespace sfinae
+
+/**
+ * @brief present_in is true if the first type is present
+ * in the following list of types, otherwise it is false.
+ * Inspired by xskxzr and Leedehai from https://stackoverflow.com/a/52380813
+ */
+
+template <typename T, typename X, typename... Rs>
+static constexpr bool present_in = present_in<T, Rs...>;
+
+template <typename T, typename X, typename... Rs>
+static constexpr bool present_in<T, T, X, Rs...> = true;
+
+template <typename T, typename X>
+static constexpr bool present_in<T, X> = std::is_same_v<T, X>;
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief Overload to handle cases where no runtime arguments provided with
+ * unnamed type packs
+ */
+template <template <typename...> class Action, typename Needed,
+          typename... ActionArgsT>
+inline void for_all_combinations_with() {
+  if constexpr (present_in<Needed, ActionArgsT...>) Action<ActionArgsT...>{}();
+}
+
+/**
+ * @brief Generic function to run specific action for every combination of each
+ * of the types given by appropriate type pack instances with one type
+ * needed to be present in any of the instances.
+ * Virtually any combination of named and unnamed type packs is supported.
+ * Supports different types of compile-time value lists via value pack.
+ * @tparam Action Functor template for action to run
+ * @tparam Needed Type needed to be present inside the functor template
+ * instantiation
+ * @tparam ActionArgsT Parameter pack to use for functor template instantiation
+ * @tparam HeadT The type of the first non-pack argument during the recursion
+ * @tparam ArgsT Parameter pack with types of arguments for functor
+ * @param head The first non-pack argument to pass into the functor
+ * @param args The rest of the arguments to pass into the functor
+ */
+template <template <typename...> class Action, typename Needed,
+          typename... ActionArgsT, typename HeadT, typename... ArgsT,
+          sfinae::is_not_a_type_pack<HeadT> = true>
+inline void for_all_combinations_with(HeadT &&head, ArgsT &&... args) {
+  // The first non-pack argument passed into the for_all_combinations stops the
+  // recursion
+  if constexpr (present_in<Needed, ActionArgsT...>)
+    Action<ActionArgsT...>{}(std::forward<HeadT>(head),
+                             std::forward<ArgsT>(args)...);
+}
+
+/**
+ * @brief Overload to handle the iteration over the types within the named type
+ * pack
+ */
+template <template <typename...> class Action, typename Needed,
+          typename... ActionArgsT, typename... HeadTypes, typename... ArgsT>
+inline void for_all_combinations_with(const named_type_pack<HeadTypes...> &head,
+                                      ArgsT &&... args) {
+  // Run the next level of recursion for each type from the head named_type_pack
+  // instance. Each recursion level unfolds the first argument passed and adds a
+  // type name as the last argument.
+  size_t type_name_index = 0;
+
+  ((for_all_combinations_with<Action, Needed, ActionArgsT..., HeadTypes>(
+        std::forward<ArgsT>(args)..., head.names[type_name_index]),
+    ++type_name_index),
+   ...);
+  // The unary right fold expression is used for parameter pack expansion.
+  // Every expression with comma operator is strictly sequenced, so we can
+  // increment safely. And of course the fold expression would not be optimized
+  // out due to side-effects.
+  // Additional pair of brackets is required because of precedence of increment
+  // operator relative to the comma operator.
+  //
+  // Note that there is actually no difference in left or right fold expression
+  // for the comma operator, as it would give the same order of actions
+  // execution and the same order of the type name index increment: both the
+  // "(expr0, (exr1, expr2))" and "((expr0, expr1), expr2)" would give the same
+  //  result as simple "expr0, expr1, expr2"
+  assert((type_name_index == sizeof...(HeadTypes)) && "Pack expansion failed");
+}
+
+/**
+ * @brief Overload to handle the iteration over the types within the unnamed
+ * type pack
+ */
+template <template <typename...> class Action, typename Needed,
+          typename... ActionArgsT, typename... HeadTypes, typename... ArgsT>
+inline void for_all_combinations_with(
+    const unnamed_type_pack<HeadTypes...> &head, ArgsT &&... args) {
+  // Using fold expression to iterate over all types within type pack
+
+  size_t typeNameIndex = 0;
+
+  ((for_all_combinations_with<Action, Needed, ActionArgsT..., HeadTypes>(
+        std::forward<ArgsT>(args)...),
+    ++typeNameIndex),
+   ...);
+  // Ensure there is no silent miss for coverage
+  assert((typeNameIndex == sizeof...(HeadTypes)) && "Pack expansion failed");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief Overload to handle cases where no runtime arguments provided with
+ * unnamed type packs
+ */
+template <template <typename...> class Action, typename Needed1,
+          typename Needed2, typename... ActionArgsT>
+inline void for_all_combinations_with_two() {
+  if constexpr (present_in<Needed1, ActionArgsT...> &&
+                present_in<Needed2, ActionArgsT...>)
+    Action<ActionArgsT...>{}();
+}
+
+/**
+ * @brief Generic function to run specific action for every combination of each
+ * of the types given by appropriate type pack instances with two types
+ * needed to be present in any of the instances.
+ * Virtually any combination of named and unnamed type packs is supported.
+ * Supports different types of compile-time value lists via value pack.
+ * @tparam Action Functor template for action to run
+ * @tparam Needed1 First type needed to be present inside the functor template
+ * instantiation
+ * @tparam Needed2 Second type needed to be present inside the functor template
+ * instantiation
+ * @tparam ActionArgsT Parameter pack to use for functor template instantiation
+ * @tparam HeadT The type of the first non-pack argument during the recursion
+ * @tparam ArgsT Parameter pack with types of arguments for functor
+ * @param head The first non-pack argument to pass into the functor
+ * @param args The rest of the arguments to pass into the functor
+ */
+template <template <typename...> class Action, typename Needed1,
+          typename Needed2, typename... ActionArgsT, typename HeadT,
+          typename... ArgsT, sfinae::is_not_a_type_pack<HeadT> = true>
+inline void for_all_combinations_with_two(HeadT &&head, ArgsT &&... args) {
+  // The first non-pack argument passed into the for_all_combinations stops the
+  // recursion
+  if constexpr (present_in<Needed1, ActionArgsT...> &&
+                present_in<Needed2, ActionArgsT...>)
+    Action<ActionArgsT...>{}(std::forward<HeadT>(head),
+                             std::forward<ArgsT>(args)...);
+}
+
+/**
+ * @brief Overload to handle the iteration over the types within the named type
+ * pack
+ */
+template <template <typename...> class Action, typename Needed1,
+          typename Needed2, typename... ActionArgsT, typename... HeadTypes,
+          typename... ArgsT>
+inline void for_all_combinations_with_two(
+    const named_type_pack<HeadTypes...> &head, ArgsT &&... args) {
+  // Run the next level of recursion for each type from the head named_type_pack
+  // instance. Each recursion level unfolds the first argument passed and adds a
+  // type name as the last argument.
+  size_t type_name_index = 0;
+
+  ((for_all_combinations_with_two<Action, Needed1, Needed2, ActionArgsT...,
+                                  HeadTypes>(std::forward<ArgsT>(args)...,
+                                             head.names[type_name_index]),
+    ++type_name_index),
+   ...);
+  // The unary right fold expression is used for parameter pack expansion.
+  // Every expression with comma operator is strictly sequenced, so we can
+  // increment safely. And of course the fold expression would not be optimized
+  // out due to side-effects.
+  // Additional pair of brackets is required because of precedence of increment
+  // operator relative to the comma operator.
+  //
+  // Note that there is actually no difference in left or right fold expression
+  // for the comma operator, as it would give the same order of actions
+  // execution and the same order of the type name index increment: both the
+  // "(expr0, (exr1, expr2))" and "((expr0, expr1), expr2)" would give the same
+  //  result as simple "expr0, expr1, expr2"
+  assert((type_name_index == sizeof...(HeadTypes)) && "Pack expansion failed");
+}
+
+/**
+ * @brief Overload to handle the iteration over the types within the unnamed
+ * type pack
+ */
+template <template <typename...> class Action, typename Needed1,
+          typename Needed2, typename... ActionArgsT, typename... HeadTypes,
+          typename... ArgsT>
+inline void for_all_combinations_with_two(
+    const unnamed_type_pack<HeadTypes...> &head, ArgsT &&... args) {
+  // Using fold expression to iterate over all types within type pack
+
+  size_t typeNameIndex = 0;
+
+  ((for_all_combinations_with_two<Action, Needed1, Needed2, ActionArgsT...,
+                                  HeadTypes>(std::forward<ArgsT>(args)...),
+    ++typeNameIndex),
+   ...);
+  // Ensure there is no silent miss for coverage
+  assert((typeNameIndex == sizeof...(HeadTypes)) && "Pack expansion failed");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief Overload to handle cases where no runtime arguments provided with
+ * unnamed type packs
+ */
+template <template <typename...> class Action, typename... ActionArgsT>
+inline void for_all_combinations() {
+  Action<ActionArgsT...>{}();
+}
+
+/**
+ * @brief Generic function to run specific action for every combination of each
+ * of the types given by appropriate type pack instances. Virtually any
+ * combination of named and unnamed type packs is supported. Supports different
+ * types of compile-time value lists via value pack.
+ * @tparam Action Functor template for action to run
+ * @tparam ActionArgsT Parameter pack to use for functor template instantiation
+ * @tparam HeadT The type of the first non-pack argument during the recursion
+ * @tparam ArgsT Parameter pack with types of arguments for functor
+ * @param head The first non-pack argument to pass into the functor
+ * @param args The rest of the arguments to pass into the functor
+ */
+template <template <typename...> class Action, typename... ActionArgsT,
+          typename HeadT, typename... ArgsT,
+          sfinae::is_not_a_type_pack<HeadT> = true>
+inline void for_all_combinations(HeadT &&head, ArgsT &&... args) {
+  // The first non-pack argument passed into the for_all_combinations stops the
+  // recursion
+  Action<ActionArgsT...>{}(std::forward<HeadT>(head),
+                           std::forward<ArgsT>(args)...);
+}
+
+/**
+ * @brief Overload to handle the iteration over the types within the named type
+ * pack
+ */
+template <template <typename...> class Action, typename... ActionArgsT,
+          typename... HeadTypes, typename... ArgsT>
+inline void for_all_combinations(const named_type_pack<HeadTypes...> &head,
+                                 ArgsT &&... args) {
+  // Run the next level of recursion for each type from the head named_type_pack
+  // instance. Each recursion level unfolds the first argument passed and adds a
+  // type name as the last argument.
+  size_t type_name_index = 0;
+
+  ((for_all_combinations<Action, ActionArgsT..., HeadTypes>(
+        std::forward<ArgsT>(args)..., head.names[type_name_index]),
+    ++type_name_index),
+   ...);
+  // The unary right fold expression is used for parameter pack expansion.
+  // Every expression with comma operator is strictly sequenced, so we can
+  // increment safely. And of course the fold expression would not be optimized
+  // out due to side-effects.
+  // Additional pair of brackets is required because of precedence of increment
+  // operator relative to the comma operator.
+  //
+  // Note that there is actually no difference in left or right fold expression
+  // for the comma operator, as it would give the same order of actions
+  // execution and the same order of the type name index increment: both the
+  // "(expr0, (exr1, expr2))" and "((expr0, expr1), expr2)" would give the same
+  //  result as simple "expr0, expr1, expr2"
+  assert((type_name_index == sizeof...(HeadTypes)) && "Pack expansion failed");
+}
+
+/**
+ * @brief Overload to handle the iteration over the types within the unnamed
+ * type pack
+ */
+template <template <typename...> class Action, typename... ActionArgsT,
+          typename... HeadTypes, typename... ArgsT>
+inline void for_all_combinations(const unnamed_type_pack<HeadTypes...> &head,
+                                 ArgsT &&... args) {
+  // Using fold expression to iterate over all types within type pack
+
+  size_t typeNameIndex = 0;
+
+  ((for_all_combinations<Action, ActionArgsT..., HeadTypes>(
+        std::forward<ArgsT>(args)...),
+    ++typeNameIndex),
+   ...);
+  // Ensure there is no silent miss for coverage
+  assert((typeNameIndex == sizeof...(HeadTypes)) && "Pack expansion failed");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief Run action for each of types given by type_pack instance
+ * @tparam action Functor template for action to run
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam types Deduced from type_pack parameter pack for list of types to use
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
+inline void for_all_types(const type_pack<types...> &, argsT &&... args) {
+  // run action for each type from types... parameter pack
+  // Using fold expression to iterate over all types within type pack
+
+  size_t typeNameIndex = 0;
+
+  ((action<types, actionArgsT...>{}(std::forward<argsT>(args)...),
+    ++typeNameIndex),
+   ...);
+
+  // Ensure there is no silent miss for coverage
+  assert((typeNameIndex == sizeof...(types)) && "Pack expansion failed");
+}
+
+/**
+ * @brief Run action for each of types given by named_type_pack instance
+ * @tparam action Functor template for action to run
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam types Deduced from type_pack parameter pack for list of types to use
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param typeList Named type pack instance with type names stored
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
+inline void for_all_types(const named_type_pack<types...> &typeList,
+                          argsT &&... args) {
+  // run action for each type from types... parameter pack
+  // Using fold expression to iterate over all types within type pack
+
+  size_t typeNameIndex = 0;
+
+  ((action<types, actionArgsT...>{}(std::forward<argsT>(args)...,
+                                    typeList.names[typeNameIndex]),
+    ++typeNameIndex),
+   ...);
+
+  // Ensure there is no silent miss for coverage
+  assert((typeNameIndex == sizeof...(types)) && "Pack expansion failed");
+}
+
+/**
+ * @brief Run action for type and for all vectors of this type
+ * @tparam action Functor template for action to run
+ * @tparam T Type to instantiate functor template with
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action, typename T,
+          typename... actionArgsT, typename... argsT>
+void for_type_and_vectors(argsT &&... args) {
+  static const auto types = type_pack<
+      T, typename sycl::template vec<T, 1>, typename sycl::template vec<T, 2>,
+      typename sycl::template vec<T, 3>, typename sycl::template vec<T, 4>,
+      typename sycl::template vec<T, 8>, typename sycl::template vec<T, 16>>{};
+  // Use type_pack without names here for lazy log message construction
+  for_all_types<action, actionArgsT...>(types, std::forward<argsT>(args)...);
+}
+
+/**
+ * @brief Run action for each of types and vectors of types given by
+ *        named_type_pack instance
+ * @tparam action Functor template for action to run
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam types Deduced from type_pack parameter pack for list of types to use
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param typeList Named type pack instance with underlying type names stored
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
+void for_all_types_and_vectors(const named_type_pack<types...> &typeList,
+                               argsT &&... args) {
+  // run action for each type from types... parameter pack
+  // Using fold expression to iterate over all types within type pack
+
+  size_t typeNameIndex = 0;
+
+  ((for_type_and_vectors<action, types, actionArgsT...>(
+        std::forward<argsT>(args)..., typeList.names[typeNameIndex]),
+    ++typeNameIndex),
+   ...);
+
+  // Ensure there is no silent miss for coverage
+  assert((typeNameIndex == sizeof...(types)) && "Pack expansion failed");
+}
+
+/**
+ * @brief Run action for std device_copyable containers with type T
+ * @tparam action Functor template for action to run
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action, typename T,
+          typename... actionArgsT, typename... argsT>
+void for_device_copyable_std_containers(argsT &&... args) {
+  constexpr std::size_t medium_array_size = 5;
+  for_all_types<action, actionArgsT...>(
+      type_pack<std::array<T, medium_array_size>, std::optional<T>,
+                std::pair<T, T>, std::tuple<T, T>,
+                std::variant<T, std::conditional_t<!std::is_same_v<T, int>, int,
+                                                   char>>>{},
+      std::forward<argsT>(args)...);
+}
+
+/**
+ * @brief Run action for std device_copyable containers with types from given
+ * named_type_pack
+ * @tparam action Functor template for action to run
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam types Deduced from type_pack parameter pack for list of types to use
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param typeList Named type pack instance with underlying type names stored
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
+void for_all_device_copyable_std_containers(
+    const named_type_pack<types...> &typeList, argsT &&... args) {
+  // run action for each type from types... parameter pack
+  // Using fold expression to iterate over all types within type pack
+
+  size_t typeNameIndex = 0;
+
+  ((for_device_copyable_std_containers<action, types, actionArgsT...>(
+        std::forward<argsT>(args)..., typeList.names[typeNameIndex]),
+    ++typeNameIndex),
+   ...);
+
+  // Ensure there is no silent miss for coverage
+  assert((typeNameIndex == sizeof...(types)) && "Pack expansion failed");
+}
+
+#endif  // __SYCLCTS_TESTS_COMMON_TYPE_COVERAGE_H

--- a/tests/group_functions/type_coverage.h
+++ b/tests/group_functions/type_coverage.h
@@ -243,14 +243,29 @@ template <typename... Types>
 struct is_type_pack_t<named_type_pack<Types...>> : std::true_type {};
 
 template <typename... Types>
+struct is_type_pack_t<named_type_pack<Types...>> : std::true_type {};
+
+template <typename... Types>
 struct is_type_pack_t<unnamed_type_pack<Types...>> : std::true_type {};
+
+template <typename... Types>
+struct is_type_pack_t<named_type_pack<Types...>&> : std::true_type {};
+
+template <typename... Types>
+struct is_type_pack_t<unnamed_type_pack<Types...>&> : std::true_type {};
+
+template <typename... Types>
+struct is_type_pack_t<const named_type_pack<Types...>> : std::true_type {};
+
+template <typename... Types>
+struct is_type_pack_t<const unnamed_type_pack<Types...>> : std::true_type {};
+
+template <typename... Types>
+struct is_type_pack_t<const named_type_pack<Types...>&> : std::true_type {};
+
+template <typename... Types>
+struct is_type_pack_t<const unnamed_type_pack<Types...>&> : std::true_type {};
 }  // namespace details
-
-template <typename T>
-using is_not_a_type_pack =
-    std::enable_if_t<!details::is_type_pack_t<T>::value, bool>;
-
-}  // namespace sfinae
 
 /**
  * @brief present_in is true if the first type is present

--- a/tests/group_functions/type_coverage.h
+++ b/tests/group_functions/type_coverage.h
@@ -127,7 +127,7 @@ struct unnamed_type_pack {
 template <typename... Types>
 class named_type_pack {
   template <typename... nameListT>
-  named_type_pack(nameListT &&... nameList)
+  named_type_pack(nameListT &&...nameList)
       : names{std::forward<nameListT>(nameList)...} {}
   static_assert(sizeof...(Types) > 0, "Empty pack is not supported");
 
@@ -169,7 +169,7 @@ class named_type_pack {
   //      named_type_pack<var_decl, rval_in_expr>::generate();
   //
   template <typename... nameListT>
-  static auto generate(nameListT &&... nameList) {
+  static auto generate(nameListT &&...nameList) {
     if constexpr (sizeof...(nameListT) == 0) {
       // No names provided explicitly, try to generate them
       return named_type_pack<Types...>(generate_name<Types>()...);
@@ -221,7 +221,7 @@ struct value_pack {
   //         "variable declaration", "rvalue in an expression");
   //
   template <typename... argsT>
-  static inline auto generate_named(argsT &&... args) {
+  static inline auto generate_named(argsT &&...args) {
     return named_type_pack<std::integral_constant<T, values>...>::generate(
         std::forward<argsT>(args)...);
   }
@@ -297,7 +297,7 @@ inline void for_all_combinations_with() {
 template <template <typename...> class Action, typename Needed,
           typename... ActionArgsT, typename HeadT, typename... ArgsT,
           sfinae::is_not_a_type_pack<HeadT> = true>
-inline void for_all_combinations_with(HeadT &&head, ArgsT &&... args) {
+inline void for_all_combinations_with(HeadT &&head, ArgsT &&...args) {
   // The first non-pack argument passed into the for_all_combinations stops the
   // recursion
   if constexpr (present_in<Needed, ActionArgsT...>)
@@ -312,7 +312,7 @@ inline void for_all_combinations_with(HeadT &&head, ArgsT &&... args) {
 template <template <typename...> class Action, typename Needed,
           typename... ActionArgsT, typename... HeadTypes, typename... ArgsT>
 inline void for_all_combinations_with(const named_type_pack<HeadTypes...> &head,
-                                      ArgsT &&... args) {
+                                      ArgsT &&...args) {
   // Run the next level of recursion for each type from the head named_type_pack
   // instance. Each recursion level unfolds the first argument passed and adds a
   // type name as the last argument.
@@ -344,7 +344,7 @@ inline void for_all_combinations_with(const named_type_pack<HeadTypes...> &head,
 template <template <typename...> class Action, typename Needed,
           typename... ActionArgsT, typename... HeadTypes, typename... ArgsT>
 inline void for_all_combinations_with(
-    const unnamed_type_pack<HeadTypes...> &head, ArgsT &&... args) {
+    const unnamed_type_pack<HeadTypes...> &head, ArgsT &&...args) {
   // Using fold expression to iterate over all types within type pack
 
   size_t typeNameIndex = 0;
@@ -391,7 +391,7 @@ inline void for_all_combinations_with_two() {
 template <template <typename...> class Action, typename Needed1,
           typename Needed2, typename... ActionArgsT, typename HeadT,
           typename... ArgsT, sfinae::is_not_a_type_pack<HeadT> = true>
-inline void for_all_combinations_with_two(HeadT &&head, ArgsT &&... args) {
+inline void for_all_combinations_with_two(HeadT &&head, ArgsT &&...args) {
   // The first non-pack argument passed into the for_all_combinations stops the
   // recursion
   if constexpr (present_in<Needed1, ActionArgsT...> &&
@@ -408,7 +408,7 @@ template <template <typename...> class Action, typename Needed1,
           typename Needed2, typename... ActionArgsT, typename... HeadTypes,
           typename... ArgsT>
 inline void for_all_combinations_with_two(
-    const named_type_pack<HeadTypes...> &head, ArgsT &&... args) {
+    const named_type_pack<HeadTypes...> &head, ArgsT &&...args) {
   // Run the next level of recursion for each type from the head named_type_pack
   // instance. Each recursion level unfolds the first argument passed and adds a
   // type name as the last argument.
@@ -442,7 +442,7 @@ template <template <typename...> class Action, typename Needed1,
           typename Needed2, typename... ActionArgsT, typename... HeadTypes,
           typename... ArgsT>
 inline void for_all_combinations_with_two(
-    const unnamed_type_pack<HeadTypes...> &head, ArgsT &&... args) {
+    const unnamed_type_pack<HeadTypes...> &head, ArgsT &&...args) {
   // Using fold expression to iterate over all types within type pack
 
   size_t typeNameIndex = 0;
@@ -481,7 +481,7 @@ inline void for_all_combinations() {
 template <template <typename...> class Action, typename... ActionArgsT,
           typename HeadT, typename... ArgsT,
           sfinae::is_not_a_type_pack<HeadT> = true>
-inline void for_all_combinations(HeadT &&head, ArgsT &&... args) {
+inline void for_all_combinations(HeadT &&head, ArgsT &&...args) {
   // The first non-pack argument passed into the for_all_combinations stops the
   // recursion
   Action<ActionArgsT...>{}(std::forward<HeadT>(head),
@@ -495,7 +495,7 @@ inline void for_all_combinations(HeadT &&head, ArgsT &&... args) {
 template <template <typename...> class Action, typename... ActionArgsT,
           typename... HeadTypes, typename... ArgsT>
 inline void for_all_combinations(const named_type_pack<HeadTypes...> &head,
-                                 ArgsT &&... args) {
+                                 ArgsT &&...args) {
   // Run the next level of recursion for each type from the head named_type_pack
   // instance. Each recursion level unfolds the first argument passed and adds a
   // type name as the last argument.
@@ -527,7 +527,7 @@ inline void for_all_combinations(const named_type_pack<HeadTypes...> &head,
 template <template <typename...> class Action, typename... ActionArgsT,
           typename... HeadTypes, typename... ArgsT>
 inline void for_all_combinations(const unnamed_type_pack<HeadTypes...> &head,
-                                 ArgsT &&... args) {
+                                 ArgsT &&...args) {
   // Using fold expression to iterate over all types within type pack
 
   size_t typeNameIndex = 0;
@@ -552,7 +552,7 @@ inline void for_all_combinations(const unnamed_type_pack<HeadTypes...> &head,
  */
 template <template <typename, typename...> class action,
           typename... actionArgsT, typename... types, typename... argsT>
-inline void for_all_types(const type_pack<types...> &, argsT &&... args) {
+inline void for_all_types(const type_pack<types...> &, argsT &&...args) {
   // run action for each type from types... parameter pack
   // Using fold expression to iterate over all types within type pack
 
@@ -578,7 +578,7 @@ inline void for_all_types(const type_pack<types...> &, argsT &&... args) {
 template <template <typename, typename...> class action,
           typename... actionArgsT, typename... types, typename... argsT>
 inline void for_all_types(const named_type_pack<types...> &typeList,
-                          argsT &&... args) {
+                          argsT &&...args) {
   // run action for each type from types... parameter pack
   // Using fold expression to iterate over all types within type pack
 
@@ -603,7 +603,7 @@ inline void for_all_types(const named_type_pack<types...> &typeList,
  */
 template <template <typename, typename...> class action, typename T,
           typename... actionArgsT, typename... argsT>
-void for_type_and_vectors(argsT &&... args) {
+void for_type_and_vectors(argsT &&...args) {
   static const auto types = type_pack<
       T, typename sycl::template vec<T, 1>, typename sycl::template vec<T, 2>,
       typename sycl::template vec<T, 3>, typename sycl::template vec<T, 4>,
@@ -625,7 +625,7 @@ void for_type_and_vectors(argsT &&... args) {
 template <template <typename, typename...> class action,
           typename... actionArgsT, typename... types, typename... argsT>
 void for_all_types_and_vectors(const named_type_pack<types...> &typeList,
-                               argsT &&... args) {
+                               argsT &&...args) {
   // run action for each type from types... parameter pack
   // Using fold expression to iterate over all types within type pack
 
@@ -649,7 +649,7 @@ void for_all_types_and_vectors(const named_type_pack<types...> &typeList,
  */
 template <template <typename, typename...> class action, typename T,
           typename... actionArgsT, typename... argsT>
-void for_device_copyable_std_containers(argsT &&... args) {
+void for_device_copyable_std_containers(argsT &&...args) {
   constexpr std::size_t medium_array_size = 5;
   for_all_types<action, actionArgsT...>(
       type_pack<std::array<T, medium_array_size>, std::optional<T>,
@@ -672,7 +672,7 @@ void for_device_copyable_std_containers(argsT &&... args) {
 template <template <typename, typename...> class action,
           typename... actionArgsT, typename... types, typename... argsT>
 void for_all_device_copyable_std_containers(
-    const named_type_pack<types...> &typeList, argsT &&... args) {
+    const named_type_pack<types...> &typeList, argsT &&...args) {
   // run action for each type from types... parameter pack
   // Using fold expression to iterate over all types within type pack
 

--- a/tests/group_functions/type_coverage.h
+++ b/tests/group_functions/type_coverage.h
@@ -243,16 +243,13 @@ template <typename... Types>
 struct is_type_pack_t<named_type_pack<Types...>> : std::true_type {};
 
 template <typename... Types>
-struct is_type_pack_t<named_type_pack<Types...>> : std::true_type {};
-
-template <typename... Types>
 struct is_type_pack_t<unnamed_type_pack<Types...>> : std::true_type {};
 
 template <typename... Types>
-struct is_type_pack_t<named_type_pack<Types...>&> : std::true_type {};
+struct is_type_pack_t<named_type_pack<Types...> &> : std::true_type {};
 
 template <typename... Types>
-struct is_type_pack_t<unnamed_type_pack<Types...>&> : std::true_type {};
+struct is_type_pack_t<unnamed_type_pack<Types...> &> : std::true_type {};
 
 template <typename... Types>
 struct is_type_pack_t<const named_type_pack<Types...>> : std::true_type {};
@@ -261,11 +258,17 @@ template <typename... Types>
 struct is_type_pack_t<const unnamed_type_pack<Types...>> : std::true_type {};
 
 template <typename... Types>
-struct is_type_pack_t<const named_type_pack<Types...>&> : std::true_type {};
+struct is_type_pack_t<const named_type_pack<Types...> &> : std::true_type {};
 
 template <typename... Types>
-struct is_type_pack_t<const unnamed_type_pack<Types...>&> : std::true_type {};
+struct is_type_pack_t<const unnamed_type_pack<Types...> &> : std::true_type {};
 }  // namespace details
+
+template <typename T>
+using is_not_a_type_pack =
+    std::enable_if_t<!details::is_type_pack_t<T>::value, bool>;
+
+}  // namespace sfinae
 
 /**
  * @brief present_in is true if the first type is present

--- a/util/type_names.h
+++ b/util/type_names.h
@@ -48,6 +48,7 @@ std::string type_name() {
   /* float types */
   MAKENAME(float);
   MAKENAME(double);
+  MAKESYCLNAME(half);
 
   /* scalar types */
   MAKESTDNAME(int8_t);


### PR DESCRIPTION
Many improvements by Nol Moonen.

There are many guards as none of the implementations passes the tests (and even compiles, the way suggested by the WG). All known failures as of now (Jan 2023) are printed out as warnings, and indicated in the code of tests by `FIXME` comments. Fully conformant implementation should pass tests with all the guards removed.