### PR TITLE
Remove double from the common type-list for multi_ptr

### DIFF
--- a/tests/multi_ptr/multi_ptr_common.h
+++ b/tests/multi_ptr/multi_ptr_common.h
@@ -103,19 +103,20 @@ using constant_ptr_legacy =
  */
 inline auto get_types() {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  return named_type_pack<bool, float, double, char,   // types grouped
+  return named_type_pack<bool, float, char,           // types grouped
                          signed char, unsigned char,  // by sign
                          short, unsigned short,       //
                          int, unsigned int,           //
                          long, unsigned long,         //
-                         long long, unsigned long long>::generate(
-      "bool",        "float",
-      "double",      "char",
-      "signed char", "unsigned char",
-      "short",       "unsigned short",
-      "int",         "unsigned int",
-      "long",        "unsigned long",
-      "long long",   "unsigned long long");
+                         long long,
+                         unsigned long long>::generate("bool", "float", "char",
+                                                       "signed char",
+                                                       "unsigned char", "short",
+                                                       "unsigned short", "int",
+                                                       "unsigned int", "long",
+                                                       "unsigned long",
+                                                       "long long",
+                                                       "unsigned long long");
 #else
   return named_type_pack<int, float>::generate("int", "float");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE


### PR DESCRIPTION
Most multi_ptr tests have variants for half and doubles. However, the full conformance type-list for multi_ptr tests include double, potentially causing issues on devices that do not support fp64.
This commit removes double from the list of types to test in the common case.