### PR TITLE
Fix USM queue shortcuts check for bool

### DIFF
--- a/tests/queue/queue_shortcuts_usm.h
+++ b/tests/queue/queue_shortcuts_usm.h
@@ -71,7 +71,7 @@ struct runner_memcpy {
 
     // check the result
     for (unsigned int i = 0; i < element_count; i++) {
-      CHECK(((t_test + static_cast<int>(i)) == h_actual[i]));
+      CHECK((static_cast<T>(t_test + static_cast<int>(i)) == h_actual[i]));
     }
 
     sycl::free(d_dest, queue);


### PR DESCRIPTION
The copied values are filled using a customized version of iota to allow for bool type. This ends up filling every element after the 0th with ones, but they are then compared with a sequence of integers. Fix this by casting the expected value to the type being checked.