### PR TITLE
Fix array initialization in multi_ptr for no default ctor

### DIFF
--- a/tests/multi_ptr/multi_ptr_common.h
+++ b/tests/multi_ptr/multi_ptr_common.h
@@ -163,6 +163,26 @@ struct check_pointer {
   }
 };
 
+/** @brief Initializes all elements in a container with 0
+ */
+template <typename T, int N, int... Vals>
+struct zero_init_container : zero_init_container<T, N - 1, 0, Vals...> {};
+template <typename T, int... Vals>
+struct zero_init_container<T, 0, Vals...> {
+  using elem_type = typename T::value_type;
+  static inline constexpr T value = {elem_type{Vals}...};
+};
+
+/** @brief Initializes an std::array with either 0's or using the default
+ * constructor
+ */
+template <typename T, int N>
+struct init_array : zero_init_container<std::array<T, N>, N> {};
+template <int N>
+struct init_array<user_def_types::def_cnstr, N> {
+  static inline constexpr std::array<user_def_types::def_cnstr, N> value;
+};
+
 }  // namespace multi_ptr_common
 
 #endif  // SYCL_CTS_TEST_MULTI_PTR_MULTI_PTR_COMMON_H

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -162,14 +162,15 @@ class run_multi_ptr_comparison_op_test {
         } else if constexpr (space ==
                              sycl::access::address_space::private_space) {
           cgh.single_task([=] {
-            T priv_arr[m_values_arr_size];
+            std::array<T, m_values_arr_size> priv_arr(
+                multi_ptr_common::init_array<T, m_values_arr_size>::value);
             for (size_t i = 0; i < m_values_arr_size; ++i)
               value_operations::assign(priv_arr[i], array_acc[i]);
             sycl::multi_ptr<T, sycl::access::address_space::private_space,
                             decorated>
                 priv_arr_mptr = sycl::address_space_cast<
                     sycl::access::address_space::private_space, decorated>(
-                    priv_arr);
+                    priv_arr.data());
             test_action(priv_arr_mptr, test_result_acc);
           });
         } else {


### PR DESCRIPTION
The `multi_ptr` tests may run with `no_def_cnstr` but will fail to compile due to the existence of uninitialized arrays in certain tests requiring the default constructor. This commit adds an initializer for these arrays, skipping initialization for `def_cnstr` as it has no constructor accepting an integer.