### PR TITLE
Fix conditional inclusion for CTS options

### DIFF
--- a/tests/accessor/accessor_implicit_conversions_fp16.cpp
+++ b/tests/accessor/accessor_implicit_conversions_fp16.cpp
@@ -35,7 +35,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
     return;
   }
 
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   // TODO: implement factory functions for extending type packs and remove
   //       for_all_types/for_type_and_vectors/for_all_types_and_vectors/
   //       for_type_vectors_marray/for_all_types_vectors_marray/
@@ -72,7 +72,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
     return;
   }
 
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   for_type_vectors_marray<run_test_local, sycl::half>("sycl::half");
 #else
   run_test_local<sycl::half>{}("sycl::half");
@@ -89,7 +89,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
     return;
   }
 
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   for_type_vectors_marray<run_test_host, sycl::half>("sycl::half");
 #else
   run_test_host<sycl::half>{}("sycl::half");

--- a/tests/accessor/accessor_implicit_conversions_fp64.cpp
+++ b/tests/accessor/accessor_implicit_conversions_fp64.cpp
@@ -35,7 +35,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
     return;
   }
 
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   for_type_vectors_marray<run_test_generic, double>("double");
 #else
   run_test_generic<double>{}("double");
@@ -52,7 +52,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
     return;
   }
 
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   for_type_vectors_marray<run_test_local, double>("double");
 #else
   run_test_local<double>{}("double");
@@ -69,7 +69,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
     return;
   }
 
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   for_type_vectors_marray<run_test_host, double>("double");
 #else
   run_test_host<double>{}("double");

--- a/tests/marray/marray_alias.cpp
+++ b/tests/marray/marray_alias.cpp
@@ -58,7 +58,7 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, DPCPP)
 
   auto queue = util::get_cts_object::queue();
 
-#ifdef SYCL_CTS_ENABLE_HALF_TESTS
+#if SYCL_CTS_ENABLE_HALF_TESTS
   using availability_fp16 =
       util::extensions::availability<util::extensions::tag::fp16>;
   if (!availability_fp16::check(queue)) {
@@ -70,7 +70,7 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, DPCPP)
   }
 #endif  // SYCL_CTS_ENABLE_HALF_TESTS
 
-#ifdef SYCL_CTS_ENABLE_DOUBLE_TESTS
+#if SYCL_CTS_ENABLE_DOUBLE_TESTS
   using availability_fp64 =
       util::extensions::availability<util::extensions::tag::fp64>;
   if (!availability_fp64::check(queue)) {

--- a/tests/stream/stream_api.cpp
+++ b/tests/stream/stream_api.cpp
@@ -151,7 +151,7 @@ class TEST_NAME : public util::test_base {
 
           /** check get_size()
            */
-#ifdef SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
           {
             auto size = os.get_size();
             check_return_type<size_t>(log, size, "sycl::stream::get_size()");
@@ -174,7 +174,7 @@ class TEST_NAME : public util::test_base {
 
           /** get_max_statement_size()
            */
-#ifdef SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
           {
             auto maxStatementSize = os.get_max_statement_size();
             check_return_type<size_t>(log, maxStatementSize,


### PR DESCRIPTION
Several CTS option macros are defined in the top-level `CMakeLists.txt` using `add_cts_option`. The documentation for the `add_cts_option` function states: 
```cmake
# Important: The preprocessor macro is always set, regardless of its value.
#            Use `#if <OPTION>` instead of `#ifdef <OPTION>`.
```
A quick test indicates that this is indeed required. This PR fixes all violations of this rule.

A related note: the macro `SYCL_CTS_COMPILING_WITH_<IMPLEMENTATION>` is only defined when compiling with `IMPLEMENTATION`. There are many occurrences of `#if SYCL_CTS_COMPILING_WITH_<IMPLEMENTATION>` instead of `#ifdef SYCL_CTS_COMPILING_WITH_<IMPLEMENTATION>` but this is not a problem as the expression evaluates to false if it is not defined. Although it is slightly confusing.