### PR TITLE
[CI] Enable multi_ptr test compilation with DPC++

### DIFF
--- a/ci/dpcpp.filter
+++ b/ci/dpcpp.filter
@@ -1,4 +1,3 @@
 buffer
 exceptions
-multi_ptr
 reduction


### PR DESCRIPTION
There were some fixes in the past for this test and it passes now.