### PR TITLE
Enable queue shortcut tests for DPCPP

### DIFF
--- a/tests/queue/queue_shortcuts_explicit.h
+++ b/tests/queue/queue_shortcuts_explicit.h
@@ -146,9 +146,7 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
       "Skipping the test case.");
 #endif  // SYCL_CTS_COMPILING_WITH_COMPUTECPP
   // ComputeCpp gives an error next time the function is called
-  // DPCPP no member named 'update_host' in 'sycl::queue'
-#if !(defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP) || \
-      defined(SYCL_CTS_COMPILING_WITH_DPCPP))
+#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
   //  update_host
   {
     std::unique_ptr<T[]> src = std::make_unique<T[]>(element_count);
@@ -159,7 +157,7 @@ void test_explicit_copy(sycl::queue q, unsigned int element_count) {
   }
 #else
   WARN(
-      "queue.update_host() test does not compile for ComputeCPP and DPCPP"
+      "queue.update_host() test does not compile for ComputeCPP"
       "Skipping the test case.");
 #endif
   // ComputeCpp function not defined

--- a/tests/queue/queue_shortcuts_explicit_core.cpp
+++ b/tests/queue/queue_shortcuts_explicit_core.cpp
@@ -28,12 +28,10 @@ namespace queue_shortcuts_explicit_core {
 using namespace queue_shortcuts_common;
 using namespace queue_shortcuts_explict;
 
-// DPCPP does not define the explicit copy operations
-DISABLED_FOR_TEST_CASE(DPCPP)
-("queue shortcuts explicit copy core", "[queue]")({
+TEST_CASE("queue shortcuts explicit copy core", "[queue]") {
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
   const auto types = get_types();
   for_all_types<check_queue_shortcuts_explicit_for_type>(types, queue);
-})
+}
 
 }  // namespace queue_shortcuts_explicit_core

--- a/tests/queue/queue_shortcuts_explicit_fp16.cpp
+++ b/tests/queue/queue_shortcuts_explicit_fp16.cpp
@@ -28,9 +28,7 @@ namespace queue_shortcuts_explicit_fp16 {
 using namespace sycl_cts;
 using namespace queue_shortcuts_explict;
 
-// DPCPP does not define the explicit copy operations
-DISABLED_FOR_TEST_CASE(DPCPP)
-("queue shortcuts explicit copy fp16", "[queue]")({
+TEST_CASE("queue shortcuts explicit copy fp16", "[queue]") {
   auto queue = util::get_cts_object::queue();
   using availability =
       util::extensions::availability<util::extensions::tag::fp16>;
@@ -42,6 +40,6 @@ DISABLED_FOR_TEST_CASE(DPCPP)
   }
 
   check_queue_shortcuts_explicit_for_type<sycl::half>{}(queue, "sycl::half");
-})
+}
 
 }  // namespace queue_shortcuts_explicit_fp16

--- a/tests/queue/queue_shortcuts_explicit_fp64.cpp
+++ b/tests/queue/queue_shortcuts_explicit_fp64.cpp
@@ -28,9 +28,7 @@ namespace queue_shortcuts_explicit_fp64 {
 using namespace sycl_cts;
 using namespace queue_shortcuts_explict;
 
-// DPCPP does not define the explicit copy operations
-DISABLED_FOR_TEST_CASE(DPCPP)
-("queue shortcuts explicit copy fp64", "[queue]")({
+TEST_CASE("queue shortcuts explicit copy fp64", "[queue]") {
   auto queue = util::get_cts_object::queue();
   using availability =
       util::extensions::availability<util::extensions::tag::fp64>;
@@ -42,6 +40,6 @@ DISABLED_FOR_TEST_CASE(DPCPP)
   }
 
   check_queue_shortcuts_explicit_for_type<double>{}(queue, "double");
-})
+}
 
 }  // namespace queue_shortcuts_explicit_fp64


### PR DESCRIPTION
This commit enables the queue shortcut tests previously compile-time disabled for DPCPP.