### PR TITLE
Add test plan for parallel_for simplifications

### DIFF
--- a/test_plans/parallel_for_simplifications.asciidoc
+++ b/test_plans/parallel_for_simplifications.asciidoc
@@ -1,0 +1,29 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for parallel_for simplifications
+
+The `parallel_for` overload without an offset can be called with either a number or a braced-init-list with 1-3 elements.
+It's described in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_parallel_for_invoke
+
+== Testing scope
+
+=== Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line
+
+== Tests
+
+For following kernel invocations:
+
+* `parallel_for(N, some_kernel)` with array size is `N`
+* `parallel_for({N}, some_kernel)` with array size is `N`
+* `parallel_for({N1, N2}, some_kernel)` with array size is `N1 * N2`
+* `parallel_for({N1, N2, N3}, some_kernel)` with array size is `N1 * N2 * N3`
+
+With `N, N1 = 2`, `N2 = 3`, `N3 = 5`.
+
+* Create an array of corresponding size and buffer for access to it.
+* Invoke `some_kernel` that takes `item` argument and fills buffer via accessor with linear_id of the `item`.
+* Check that all elements of array is equal to its index.


### PR DESCRIPTION
In SYCL 2020 the `parallel_for` interface has been simplified in some forms to accept a braced initializer list in place of a range.
It's described in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_parallel_for_invoke

Test plan to check these overloads.