### PR TITLE
Remove illegal accessor cases in multi_ptr_legacy tests

### DIFF
--- a/tests/multi_ptr/multi_ptr_legacy_api_common.h
+++ b/tests/multi_ptr/multi_ptr_legacy_api_common.h
@@ -598,14 +598,16 @@ class pointer_apis {
       queue.submit([&](sycl::handler &handler) {
         auto resAcc =
               resBuff.get_access<sycl::access_mode::read_write>(handler);
-        sycl::accessor<T, 1, sycl::access_mode::read_write,
-                           sycl::target::device>
-            globalAccessor(buffer, handler);
+        constexpr sycl::access_mode access_mode =
+            (std::is_const_v<T>) ? sycl::access_mode::read
+                                 : sycl::access_mode::read_write;
+        sycl::accessor<T, 1, access_mode, sycl::target::device> globalAccessor(
+            buffer, handler);
         sycl::accessor<T, 1, sycl::access_mode::read,
                            sycl::target::constant_buffer>
             constantAccessor(buffer, handler);
-        sycl::accessor<T, 1, sycl::access_mode::read_write,
-                           sycl::target::local>
+        sycl::accessor<data_t, 1, sycl::access_mode::read_write,
+                       sycl::target::local>
             localAccessor(size, handler);
 
         handler.single_task<class kernel0<T, U>>(

--- a/tests/multi_ptr/multi_ptr_legacy_constructors_common.h
+++ b/tests/multi_ptr/multi_ptr_legacy_constructors_common.h
@@ -44,12 +44,16 @@ class pointer_ctors {
     sycl::buffer<T, 1> buffer(data.get(), range);
 
     queue.submit([&](sycl::handler &handler) {
-      sycl::accessor<T, 1, sycl::access_mode::read_write, sycl::target::device>
-          globalAccessor(buffer, handler);
+      constexpr sycl::access_mode access_mode =
+          (std::is_const_v<T>) ? sycl::access_mode::read
+                               : sycl::access_mode::read_write;
+      sycl::accessor<T, 1, access_mode, sycl::target::device> globalAccessor(
+          buffer, handler);
       sycl::accessor<T, 1, sycl::access_mode::read,
                      sycl::target::constant_buffer>
           constantAccessor(buffer, handler);
-      sycl::accessor<T, 1, sycl::access_mode::read_write, sycl::target::local>
+      sycl::accessor<data_t, 1, sycl::access_mode::read_write,
+                     sycl::target::local>
           localAccessor(size, handler);
 
       handler.single_task<class kernel0<T, U>>([=] {


### PR DESCRIPTION
Modify tests because in SYCL 2020 `const` types can only be used with `read` access mode accessors and deprecated accessor with target::local can't be `read`, only `read_write` or `atomic`.

Following discussion in https://github.com/KhronosGroup/SYCL-CTS/pull/504