### PR TITLE
Fix wrong #ifdef in kernel_parameters tests

### DIFF
--- a/tests/kernel/kernel_parameters.cpp
+++ b/tests/kernel/kernel_parameters.cpp
@@ -82,11 +82,11 @@ inline auto get_lightweight_primary_type_pack() {
 inline auto get_primary_type_pack() {
 // FIXME: re-enable when std::pair[], std::tuple[] or std::variant[] is
 // implemented
-#ifdef SYCL_CTS_COMPILING_WITH_DPCPP
+#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
   return get_lightweight_primary_type_pack();
 #else
   return get_full_primary_type_pack();
-#endif  // SYCL_CTS_COMPILING_WITH_DPCPP
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 }
 
 template <typename PrimaryType>


### PR DESCRIPTION
SYCL_CTS_COMPILING_WITH_DPCPP was used erroneously 