### PR TITLE
Stream semantics update

### DIFF
--- a/tests/stream/stream_semantics.cpp
+++ b/tests/stream/stream_semantics.cpp
@@ -27,9 +27,7 @@ struct storage {
 
   explicit storage(const sycl::stream& stream)
       : size(stream.size()),
-        max_statement_size(stream.get_max_statement_size()
-        ) {
-  }
+        max_statement_size(stream.get_max_statement_size()) {}
 
   // Enable when https://github.com/intel/llvm/issues/8326
   // been solved

--- a/tests/stream/stream_semantics.cpp
+++ b/tests/stream/stream_semantics.cpp
@@ -26,19 +26,8 @@ struct storage {
   std::size_t max_statement_size;
 
   explicit storage(const sycl::stream& stream)
-      : size(
-#ifdef SYCL_CTS_COMPILING_WITH_DPCPP
-            0
-#else
-            stream.size()
-#endif
-            ),
-        max_statement_size(
-#ifdef SYCL_CTS_COMPILING_WITH_DPCPP
-            0
-#else
-            stream.get_max_statement_size()
-#endif
+      : size(stream.size()),
+        max_statement_size(stream.get_max_statement_size()
         ) {
   }
 

--- a/tests/stream/stream_semantics.cpp
+++ b/tests/stream/stream_semantics.cpp
@@ -42,6 +42,8 @@ struct storage {
         ) {
   }
 
+  // Enable when https://github.com/intel/llvm/issues/8326
+  // been solved
   bool check(const sycl::stream& stream) const {
     return
 #ifndef SYCL_CTS_COMPILING_WITH_DPCPP


### PR DESCRIPTION
Added reference to issue, due to which unable to activate check function in stream_semantics.cpp.
Edited storage constructor initializer list, now it works for DPCPP