### PR TITLE
Fix and enable tests for optional kernel features

### DIFF
--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -473,6 +473,12 @@ void run_functor(const bool is_exception_expected,
 template <typename KernelName, call_type CallType>
 class kernel_submission_call;
 
+#define ANOTHER_ASPECT(current_aspect)                                    \
+  ((current_aspect == sycl::aspect::fp16)                                 \
+       ? sycl::aspect::fp64                                               \
+       : ((current_aspect == sycl::aspect::fp64) ? sycl::aspect::atomic64 \
+                                                 : sycl::aspect::fp16))
+
 /**
  * @brief The function like macros that helps to define and run kernels through
  * lambda in submission call. Macro generates execution in single_task,
@@ -527,8 +533,9 @@ class kernel_submission_call;
         IS_EXCEPTION_EXPECTED, ERRC, QUEUE, "submission call",              \
         single_task_action, parallel_for_action, parallel_for_action);      \
   }
+
 #endif  // #if !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
         // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
-};      // namespace kernel_features_common
+}  // namespace kernel_features_common
 
 #endif  // SYCL_CTS_TEST_KERNEL_FEATURES_COMMON_H

--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -473,12 +473,6 @@ void run_functor(const bool is_exception_expected,
 template <typename KernelName, call_type CallType>
 class kernel_submission_call;
 
-#define ANOTHER_ASPECT(current_aspect)                                    \
-  ((current_aspect == sycl::aspect::fp16)                                 \
-       ? sycl::aspect::fp64                                               \
-       : ((current_aspect == sycl::aspect::fp64) ? sycl::aspect::atomic64 \
-                                                 : sycl::aspect::fp16))
-
 /**
  * @brief The function like macros that helps to define and run kernels through
  * lambda in submission call. Macro generates execution in single_task,

--- a/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
+++ b/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
@@ -363,7 +363,7 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
 template <typename FeatureTypeT, sycl::aspect FeatureAspectT>
 class kernel_use_another_feature;
 
-DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL, DPCPP)
+DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
 ("Kernel with tested feature but with attribute [[sycl::device_has()]] "
  "for another feature.",
  "[kernel_features]",
@@ -373,12 +373,6 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL, DPCPP)
  (AtomicRefT, sycl::aspect::atomic64))({
   using kname = kernel_use_another_feature<FeatureTypeT, FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
-
-  // Check if the device supports testing feature
-  bool is_exception_expected = true;
-  if (queue.get_device().has(FeatureAspectT)) {
-    is_exception_expected = false;
-  }
 
   // Set expected error code
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
@@ -418,9 +412,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL, DPCPP)
 
   {
     RUN_SUBMISSION_CALL(other_feature_exception_expect, expected_errc, queue,
-                        [[sycl::device_has(AnotherFeatureAspect)]], kname,
-                        USE_FEATURE(FeatureTypeT));
+                        [[sycl::device_has(ANOTHER_ASPECT(FeatureAspectT))]],
+                        kname, USE_FEATURE(FeatureTypeT));
   }
+
 });
 
 #ifdef SYCL_EXTERNAL
@@ -428,7 +423,7 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL, DPCPP)
 template <typename FeatureTypeT, sycl::aspect FeatureAspectT>
 class kernel_use_feature_function_external_decorated_with_attr;
 
-DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL, DPCPP)
+DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
 ("Kernel with attribute [[sycl::device_has()]] for not currently tested "
  "feature but with SYCL_EXTERNAL function with tested feature and "
  "attribute [[sycl::device_has()]] with tested feature that is defined in "
@@ -442,12 +437,6 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL, DPCPP)
       kernel_use_feature_function_external_decorated_with_attr<FeatureTypeT,
                                                                FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
-
-  // Check if the device supports testing feature
-  bool is_exception_expected = true;
-  if (queue.get_device().has(FeatureAspectT)) {
-    is_exception_expected = false;
-  }
 
   // Set expected error code
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
@@ -488,7 +477,7 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL, DPCPP)
   {
     RUN_SUBMISSION_CALL(
         other_feature_exception_expect, expected_errc, queue,
-        [[sycl::device_has(AnotherFeatureAspect)]], kname,
+        [[sycl::device_has(ANOTHER_ASPECT(FeatureAspectT))]], kname,
         use_feature_function_external_decorated<FeatureTypeT,
                                                 FeatureAspectT>());
   }

--- a/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
+++ b/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
@@ -377,7 +377,7 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   // Set expected error code
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
-  constexpr sycl::aspect AnotherFeatureAspect =
+  static constexpr sycl::aspect AnotherFeatureAspect =
       get_another_aspect<FeatureAspectT>();
   bool other_feature_exception_expect = true;
   if (queue.get_device().has(AnotherFeatureAspect) &&
@@ -412,8 +412,8 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
 
   {
     RUN_SUBMISSION_CALL(other_feature_exception_expect, expected_errc, queue,
-                        [[sycl::device_has(ANOTHER_ASPECT(FeatureAspectT))]],
-                        kname, USE_FEATURE(FeatureTypeT));
+                        [[sycl::device_has(AnotherFeatureAspect)]], kname,
+                        USE_FEATURE(FeatureTypeT));
   }
 
 });
@@ -441,7 +441,7 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   // Set expected error code
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
-  constexpr sycl::aspect AnotherFeatureAspect =
+  static constexpr sycl::aspect AnotherFeatureAspect =
       get_another_aspect<FeatureAspectT>();
   bool other_feature_exception_expect = true;
   if (queue.get_device().has(AnotherFeatureAspect) &&
@@ -477,7 +477,7 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   {
     RUN_SUBMISSION_CALL(
         other_feature_exception_expect, expected_errc, queue,
-        [[sycl::device_has(ANOTHER_ASPECT(FeatureAspectT))]], kname,
+        [[sycl::device_has(AnotherFeatureAspect)]], kname,
         use_feature_function_external_decorated<FeatureTypeT,
                                                 FeatureAspectT>());
   }

--- a/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
+++ b/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
@@ -41,8 +41,10 @@ class work_group_decorated_functor {
 using AtomicRefT =
     sycl::atomic_ref<unsigned long long, sycl::memory_order::relaxed,
                      sycl::memory_scope::device>;
+template <int Case>
+class kernel_speculative;
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Speculative compilation with supported feature", "[kernel_features]")({
   auto queue = util::get_cts_object::queue();
   const sycl::errc errc_expected = sycl::errc::success;
@@ -56,9 +58,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
       const auto separate_lambda_item_arg = [](sycl::item<1>) {};
       const auto separate_lambda_group_arg = [](sycl::group<1>) {};
 
-      run_separate_lambda(is_exception_expected, errc_expected, queue,
-                          separate_lambda_no_arg, separate_lambda_item_arg,
-                          separate_lambda_group_arg);
+      run_separate_lambda<kernel_speculative<1>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
+          separate_lambda_item_arg, separate_lambda_group_arg);
     }
 
     {
@@ -68,7 +70,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          NO_ATTRIBUTE, NO_KERNEL_BODY);
+                          NO_ATTRIBUTE, kernel_speculative<1>, NO_KERNEL_BODY);
     }
   }
 
@@ -84,9 +86,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         use_feature_function_non_decorated<sycl::half>();
       };
 
-      run_separate_lambda(is_exception_expected, errc_expected, queue,
-                          separate_lambda_no_arg, separate_lambda_item_arg,
-                          separate_lambda_group_arg);
+      run_separate_lambda<kernel_speculative<2>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
+          separate_lambda_item_arg, separate_lambda_group_arg);
     }
 
     {
@@ -96,7 +98,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          NO_ATTRIBUTE,
+                          NO_ATTRIBUTE, kernel_speculative<2>,
                           use_feature_function_non_decorated<sycl::half>());
     }
   }
@@ -113,9 +115,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         use_feature_function_non_decorated<double>();
       };
 
-      run_separate_lambda(is_exception_expected, errc_expected, queue,
-                          separate_lambda_no_arg, separate_lambda_item_arg,
-                          separate_lambda_group_arg);
+      run_separate_lambda<kernel_speculative<3>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
+          separate_lambda_item_arg, separate_lambda_group_arg);
     }
 
     {
@@ -125,7 +127,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          NO_ATTRIBUTE,
+                          NO_ATTRIBUTE, kernel_speculative<3>,
                           use_feature_function_non_decorated<double>());
     }
   }
@@ -142,9 +144,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
         use_feature_function_non_decorated<AtomicRefT>();
       };
 
-      run_separate_lambda(is_exception_expected, errc_expected, queue,
-                          separate_lambda_no_arg, separate_lambda_item_arg,
-                          separate_lambda_group_arg);
+      run_separate_lambda<kernel_speculative<4>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
+          separate_lambda_item_arg, separate_lambda_group_arg);
     }
 
     {
@@ -154,12 +156,14 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          NO_ATTRIBUTE,
+                          NO_ATTRIBUTE, kernel_speculative<4>,
                           use_feature_function_non_decorated<AtomicRefT>());
     }
   }
 
   constexpr size_t testing_wg_size[2] = {16, 4294967295};
+#define TESTING_WG_SIZE0 16
+#define TESTING_WG_SIZE1 4294967295
   auto max_wg_size =
       queue.get_device().get_info<sycl::info::device::max_work_group_size>();
 
@@ -172,9 +176,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_work_group_size(testing_wg_size[0])]]{};
 
-      run_separate_lambda(is_exception_expected, errc_expected, queue,
-                          separate_lambda_no_arg, separate_lambda_item_arg,
-                          separate_lambda_group_arg);
+      run_separate_lambda<kernel_speculative<5>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
+          separate_lambda_item_arg, separate_lambda_group_arg);
     }
 
     {
@@ -184,8 +188,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_work_group_size(testing_wg_size[0])]],
-                          NO_KERNEL_BODY);
+                          [[sycl::reqd_work_group_size(TESTING_WG_SIZE0)]],
+                          kernel_speculative<5>, NO_KERNEL_BODY);
     }
   }
 
@@ -198,9 +202,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_work_group_size(testing_wg_size[1])]]{};
 
-      run_separate_lambda(is_exception_expected, errc_expected, queue,
-                          separate_lambda_no_arg, separate_lambda_item_arg,
-                          separate_lambda_group_arg);
+      run_separate_lambda<kernel_speculative<6>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
+          separate_lambda_item_arg, separate_lambda_group_arg);
     }
 
     {
@@ -210,12 +214,14 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_work_group_size(testing_wg_size[1])]],
-                          NO_KERNEL_BODY);
+                          [[sycl::reqd_work_group_size(TESTING_WG_SIZE1)]],
+                          kernel_speculative<6>, NO_KERNEL_BODY);
     }
   }
 
   constexpr size_t testing_sg_size[2] = {16, 4099};
+#define TESTING_SG_SIZE0 16
+#define TESTING_SG_SIZE1 4099
   const auto sg_sizes_vec =
       queue.get_device().get_info<sycl::info::device::sub_group_sizes>();
   auto find_res =
@@ -229,9 +235,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_sub_group_size(testing_sg_size[0])]]{};
 
-      run_separate_lambda(is_exception_expected, errc_expected, queue,
-                          separate_lambda_no_arg, separate_lambda_item_arg,
-                          separate_lambda_group_arg);
+      run_separate_lambda<kernel_speculative<7>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
+          separate_lambda_item_arg, separate_lambda_group_arg);
     }
 
     {
@@ -241,8 +247,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_sub_group_size(testing_sg_size[0])]],
-                          NO_KERNEL_BODY);
+                          [[sycl::reqd_sub_group_size(TESTING_SG_SIZE0)]],
+                          kernel_speculative<7>, NO_KERNEL_BODY);
     }
   }
 
@@ -257,9 +263,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_sub_group_size(testing_sg_size[1])]]{};
 
-      run_separate_lambda(is_exception_expected, errc_expected, queue,
-                          separate_lambda_no_arg, separate_lambda_item_arg,
-                          separate_lambda_group_arg);
+      run_separate_lambda<kernel_speculative<8>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
+          separate_lambda_item_arg, separate_lambda_group_arg);
     }
 
     {
@@ -269,8 +275,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_sub_group_size(testing_sg_size[1])]],
-                          NO_KERNEL_BODY);
+                          [[sycl::reqd_sub_group_size(TESTING_SG_SIZE1)]],
+                          kernel_speculative<8>, NO_KERNEL_BODY);
     }
   }
 });

--- a/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
+++ b/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
@@ -161,9 +161,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
     }
   }
 
-  constexpr size_t testing_wg_size[2] = {16, 4294967295};
-#define TESTING_WG_SIZE0 16
-#define TESTING_WG_SIZE1 4294967295
+  static constexpr size_t testing_wg_size[2] = {16, 4294967295};
   auto max_wg_size =
       queue.get_device().get_info<sycl::info::device::max_work_group_size>();
 
@@ -188,7 +186,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_work_group_size(TESTING_WG_SIZE0)]],
+                          [[sycl::reqd_work_group_size(testing_wg_size[0])]],
                           kernel_speculative<5>, NO_KERNEL_BODY);
     }
   }
@@ -214,14 +212,13 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_work_group_size(TESTING_WG_SIZE1)]],
+                          [[sycl::reqd_work_group_size(testing_wg_size[1])]],
                           kernel_speculative<6>, NO_KERNEL_BODY);
     }
   }
 
-  constexpr size_t testing_sg_size[2] = {16, 4099};
-#define TESTING_SG_SIZE0 16
-#define TESTING_SG_SIZE1 4099
+  static constexpr size_t testing_sg_size[2] = {16, 4099};
+
   const auto sg_sizes_vec =
       queue.get_device().get_info<sycl::info::device::sub_group_sizes>();
   auto find_res =
@@ -247,7 +244,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_sub_group_size(TESTING_SG_SIZE0)]],
+                          [[sycl::reqd_sub_group_size(testing_sg_size[0])]],
                           kernel_speculative<7>, NO_KERNEL_BODY);
     }
   }
@@ -275,7 +272,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 
     {
       RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_sub_group_size(TESTING_SG_SIZE1)]],
+                          [[sycl::reqd_sub_group_size(testing_sg_size[1])]],
                           kernel_speculative<8>, NO_KERNEL_BODY);
     }
   }


### PR DESCRIPTION
Fix tests that are using macros to call kernel defined as a lambda.
Added kernel names to speculative compilation test.
Enable tests for DPCPP.