### PR TITLE
Enable reducer tests for dpcpp compiler

### DIFF
--- a/tests/reduction/reducer_api_core.cpp
+++ b/tests/reduction/reducer_api_core.cpp
@@ -68,9 +68,8 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
       std::all_of(results.begin(), results.end(), [](int val) { return val; }));
 });
 
-// FIXME: re-enable when reducer is fully implemented in hipSYCL, ComputeCpp and
-// DPCPP
-DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL, DPCPP)
+// FIXME: re-enable when reducer is fully implemented in hipSYCL, ComputeCpp
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("reducer api core", "[reducer]")({
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
 

--- a/tests/reduction/reducer_api_fp16.cpp
+++ b/tests/reduction/reducer_api_fp16.cpp
@@ -27,9 +27,8 @@
 #endif
 
 #include <string>
-// FIXME: re-enable when reducer is fully implemented in hipSYCL, ComputeCpp and
-// DPCPP
-DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL, DPCPP)
+// FIXME: re-enable when reducer is fully implemented in hipSYCL, ComputeCpp
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("reducer api fp16", "[reducer][fp16]")({
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
   using avaliability = sycl_cts::util::extensions::availability<

--- a/tests/reduction/reducer_api_fp64.cpp
+++ b/tests/reduction/reducer_api_fp64.cpp
@@ -27,9 +27,8 @@
 #endif
 
 #include <string>
-// FIXME: re-enable when reducer is fully implemented in hipSYCL, ComputeCpp and
-// DPCPP
-DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL, DPCPP)
+// FIXME: re-enable when reducer is fully implemented in hipSYCL, ComputeCpp
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("reducer api fp64", "[reducer][fp64]")({
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
   using avaliability = sycl_cts::util::extensions::availability<


### PR DESCRIPTION
Enabled `reducer` api tests. Tests are compiled with dpcpp compiler version [DPC++ daily 2023-02-14](https://github.com/intel/llvm/releases/tag/sycl-nightly%2F20230214). For older compiler version compilation fail is going to happen.