### PR TITLE
Fix group_functions tests. Enable group_shift and group_pemute tests.

### DIFF
--- a/tests/group_functions/group_barrier.cpp
+++ b/tests/group_functions/group_barrier.cpp
@@ -32,6 +32,7 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
 
   // FIXME: hipSYCL and DPCPP have no implemented
   //  atomic_fence_scope_capabilities query
+  //  Issue to link https://github.com/intel/llvm/issues/8323
 #if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
       defined(SYCL_CTS_COMPILING_WITH_DPCPP))
   std::vector<sycl::memory_scope> supported_barriers =

--- a/tests/group_functions/group_broadcast.cpp
+++ b/tests/group_functions/group_broadcast.cpp
@@ -21,6 +21,7 @@
 #include "group_broadcast.h"
 
 // FIXME: DPCPP does not implement group_broadcast for sycl::vec
+// Link to issue https://github.com/intel/llvm/issues/8349
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
 using BroadcastTypes =
     concatenation<FundamentalTypes, std::tuple<bool, sycl::marray<float, 5>,
@@ -48,6 +49,7 @@ TEMPLATE_LIST_TEST_CASE("Group broadcast", "[group_func][type_list][dim]",
   // check type to only print warning once
   if constexpr (std::is_same_v<TestType, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8349
     WARN(
         "DPCPP does not implement group_broadcast for vec types. "
         "Skipping those test cases.");
@@ -81,6 +83,7 @@ TEMPLATE_LIST_TEST_CASE("Sub-group broadcast and select",
   // check type to only print warning once
   if constexpr (std::is_same_v<TestType, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8349
     WARN(
         "DPCPP does not implement group_broadcast for vec types. "
         "Skipping those test cases.");

--- a/tests/group_functions/group_permute.cpp
+++ b/tests/group_functions/group_permute.cpp
@@ -29,10 +29,6 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group permute",
     WARN(
         "hipSYCL has not implemented sycl::marray type yet. Skipping the test "
         "cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    WARN(
-        "DPCPP does not implement permute functions. "
-        "Skipping the test.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement permute functions. "
@@ -40,17 +36,16 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group permute",
 #endif
   }
 
-  // FIXME: DPCPP and ComputeCpp do not implement permute functions
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp do not implement permute functions
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   // check all work group dimensions
-  permute_group<1, TestType>(queue);
-  permute_group<2, TestType>(queue);
-  permute_group<3, TestType>(queue);
+//  permute_group<1, TestType>(queue);
+//  permute_group<2, TestType>(queue);
+//  permute_group<3, TestType>(queue);
 
   permute_sub_group<1, TestType>(queue);
   permute_sub_group<2, TestType>(queue);

--- a/tests/group_functions/group_permute.cpp
+++ b/tests/group_functions/group_permute.cpp
@@ -42,11 +42,6 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group permute",
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
 
-  // check all work group dimensions
-//  permute_group<1, TestType>(queue);
-//  permute_group<2, TestType>(queue);
-//  permute_group<3, TestType>(queue);
-
   permute_sub_group<1, TestType>(queue);
   permute_sub_group<2, TestType>(queue);
   permute_sub_group<3, TestType>(queue);

--- a/tests/group_functions/group_permute.h
+++ b/tests/group_functions/group_permute.h
@@ -22,72 +22,11 @@
 
 #include "group_functions_common.h"
 
-template <int D, typename T>
-class permute_group_kernel;
-
 /**
  * @brief Provides test for permute values inside the group
  * @tparam D Dimension to use for group instance
  * @tparam T Type for permutted value
  */
-template <int D, typename T>
-void permute_group(sycl::queue& queue) {
-  // 1 function
-  constexpr int test_matrix = 1;
-  const std::string test_names[test_matrix] = {
-      "T permute_group_by_xor(group g, T x, group::linear_id_type mask)"};
-
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
-  size_t work_group_size = work_group_range.size();
-
-  // array to return results:
-  std::valarray<bool> res(false, test_matrix * work_group_size);
-  {
-    sycl::buffer<bool, 1> res_sycl(
-        std::begin(res), sycl::range<1>(test_matrix * work_group_size));
-
-    queue.submit([&](sycl::handler& cgh) {
-      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
-      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
-
-      cgh.parallel_for<permute_group_kernel<D, T>>(
-          executionRange, [=](sycl::nd_item<D> item) {
-            sycl::group<D> group = item.get_group();
-            using lin_id_type = typename sycl::group<D>::linear_id_type;
-            const lin_id_type llid = group.get_local_linear_id();
-
-            T local_var(splat_init<T>(llid + 1));
-            T permuted_var(splat_init<T>(llid + 1));
-
-            ASSERT_RETURN_TYPE(T,
-                               sycl::permute_group_by_xor(group, local_var, 0),
-                               "Return type of permute_group_by_xor(group g, T "
-                               "x, group::linear_id_type mask) is wrong\n");
-
-            bool res = true;
-            for (lin_id_type mask = 1u; mask > 0; mask <<= 1) {
-              permuted_var = sycl::permute_group_by_xor(group, local_var, mask);
-              res &= equal(permuted_var, splat_init<T>((llid ^ mask) + 1)) ||
-                     ((llid ^ mask) >= group.get_local_linear_range());
-            }
-            res_acc[0 * work_group_size + llid] = res;
-          });
-    });
-  }
-  for (int i = 0; i < test_matrix; ++i) {
-    bool result = res[i * work_group_size];
-    for (size_t j = 1; j < work_group_size; ++j)
-      result &= res[i * work_group_size + j];
-
-    std::string work_group = util::work_group_print(work_group_range);
-    CAPTURE(D, work_group);
-    INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
-                     << " is " << (result ? "right" : "wrong"));
-    CHECK(result);
-  }
-}
-
 template <int D, typename T>
 class permute_sub_group_kernel;
 

--- a/tests/group_functions/group_permute.h
+++ b/tests/group_functions/group_permute.h
@@ -22,11 +22,6 @@
 
 #include "group_functions_common.h"
 
-/**
- * @brief Provides test for permute values inside the group
- * @tparam D Dimension to use for group instance
- * @tparam T Type for permutted value
- */
 template <int D, typename T>
 class permute_sub_group_kernel;
 

--- a/tests/group_functions/group_permute_fp16.cpp
+++ b/tests/group_functions/group_permute_fp16.cpp
@@ -24,26 +24,20 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group permute", "[group_func][fp16][dim]",
                        ((int D), D), 1, 2, 3) {
   // check dimensions to only print warning once
   if constexpr (D == 1) {
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    WARN(
-        "DPCPP does not implement permute functions. "
-        "Skipping the test.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement permute functions. "
         "Skipping the test.");
 #endif
   }
 
-  // FIXME: DPCPP and ComputeCpp do not implement permute functions
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp do not implement permute functions
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    permute_group<D, sycl::half>(queue);
     permute_sub_group<D, sycl::half>(queue);
   } else {
     WARN("Device does not support half precision floating point operations.");

--- a/tests/group_functions/group_permute_fp64.cpp
+++ b/tests/group_functions/group_permute_fp64.cpp
@@ -24,26 +24,20 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group permute", "[group_func][fp64][dim]",
                        ((int D), D), 1, 2, 3) {
   // check dimensions to only print warning once
   if constexpr (D == 1) {
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    WARN(
-        "DPCPP does not implement permute functions. "
-        "Skipping the test.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement permute functions. "
         "Skipping the test.");
 #endif
   }
 
-  // FIXME: DPCPP and ComputeCpp do not implement permute functions
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp do not implement permute functions
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    permute_group<D, double>(queue);
     permute_sub_group<D, double>(queue);
   } else {
     WARN("Device does not support double precision floating point operations.");

--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -53,6 +53,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
         "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
         "Skipping the test case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8348
     WARN(
         "DPCPP does not implement joint_reduce without init. Skipping the test "
         "case.");
@@ -75,6 +76,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
   //        clang-8: error: unable to execute command: Segmentation fault
   //        clang-8: error: spirv-ll-tool command failed due to signal
+  // Link to issue https://github.com/intel/llvm/issues/8348
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
@@ -101,6 +103,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
         "first, Ptr last, T init, "
         "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
         "DPCPP cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -125,6 +128,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
   return;
 #else
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   if constexpr (std::is_same_v<T, U>)
@@ -174,6 +178,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
   // check types to only print warning once
   if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
         "DPCPP cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -198,6 +203,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
   return;
 #else
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   if constexpr (std::is_same_v<T, U>)

--- a/tests/group_functions/group_reduce_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp16.cpp
@@ -56,6 +56,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN("ComputeCpp cannot handle half type. Skipping the test.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8348
     WARN(
         "DPCPP does not implement joint_reduce without init. Skipping the test "
         "case.");
@@ -68,6 +69,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
   //        in the template definition nor found by argument-dependent lookup
   //        note: 'joint_reduce' should be declared prior to the call site
   //        or in namespace 'sycl::ext::oneapi'
+  // Link to issue https://github.com/intel/llvm/issues/8348
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
@@ -102,6 +104,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
         "Skipping such test cases.");
     WARN("ComputeCpp cannot handle half type. Skipping the test.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
         "DPCPP cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -113,6 +116,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
   return;
 #else
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   if constexpr (std::is_same_v<T, U>)
@@ -158,6 +162,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
   // check types to only print warning once
   if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
         "DPCPP cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -178,6 +183,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 #else
   if (queue.get_device().has(sycl::aspect::fp16)) {
     // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+    // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     if constexpr (std::is_same_v<T, U>)

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -55,6 +55,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
         "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
         "Skipping the test case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8348
     WARN(
         "DPCPP does not implement joint_reduce without init. Skipping the test "
         "case.");
@@ -74,6 +75,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
   //        clang-8: error: unable to execute command: Segmentation fault
   //        clang-8: error: spirv-ll-tool command failed due to signal
+  // Link to issue https://github.com/intel/llvm/issues/8348
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
@@ -100,6 +102,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
         "first, Ptr last, T init, "
         "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
         "DPCPP cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -124,6 +127,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
   return;
 #else
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   if constexpr (std::is_same_v<T, U>)
@@ -179,6 +183,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
   // check types to only print warning once
   if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
         "DPCPP cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -204,6 +209,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 #else
   if (queue.get_device().has(sycl::aspect::fp64)) {
     // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+    // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     if constexpr (std::is_same_v<T, U>)

--- a/tests/group_functions/group_reduce_fp64_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp64_fp16.cpp
@@ -41,6 +41,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
         "Skipping such test cases.");
     WARN("ComputeCpp cannot handle half type. Skipping the test.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
         "DPCPP cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -51,6 +52,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
@@ -72,6 +74,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
   // check dimensions to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
         "DPCPP cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -87,6 +90,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -49,6 +49,7 @@ TEST_CASE("Group and sub-group joint scan functions",
       "over several sub-groups simultaneously. Using one sub-group only.");
   WARN("hipSYCL does not support sycl::known_identity_v yet.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
       "Skipping such test cases.");
@@ -60,6 +61,7 @@ TEST_CASE("Group and sub-group joint scan functions",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
   // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #elif defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
     defined(SYCL_CTS_COMPILING_WITH_DPCPP)
   for_all_combinations<invoke_joint_scan_group_same_type>(Dims, ScanTypes{},
@@ -81,6 +83,7 @@ TEST_CASE("Group and sub-group joint scan functions with init",
       "cannot process over several sub-groups simultaneously. Using one "
       "sub-group only.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T, *InPtr and "
       "*OutPtr. Skipping such test cases.");
@@ -92,6 +95,7 @@ TEST_CASE("Group and sub-group joint scan functions with init",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
   // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #elif defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
     defined(SYCL_CTS_COMPILING_WITH_DPCPP)
   for_all_combinations<invoke_init_joint_scan_group_same_type>(
@@ -131,6 +135,7 @@ TEST_CASE("Group and sub-group scan functions with init",
       "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
       "and op are interchanged.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T and V. Skipping such "
       "test cases.");
@@ -153,6 +158,7 @@ TEST_CASE("Group and sub-group scan functions with init",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   for_all_combinations<invoke_init_scan_over_group_same_type>(Dims, ScanTypes{},

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -52,6 +52,7 @@ TEST_CASE("Group and sub-group joint scan functions",
       "over several sub-groups simultaneously. Using one sub-group only.");
   WARN("hipSYCL does not support sycl::known_identity_v yet.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
       "Skipping such test cases.");
@@ -66,6 +67,7 @@ TEST_CASE("Group and sub-group joint scan functions",
 #else
   if (queue.get_device().has(sycl::aspect::fp16)) {
     // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+    // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
     defined(SYCL_CTS_COMPILING_WITH_DPCPP)
     for_all_combinations<invoke_joint_scan_group_same_type>(Dims, HalfType{},
@@ -91,6 +93,7 @@ TEST_CASE("Group and sub-group joint scan functions with init",
       "cannot process over several sub-groups simultaneously. Using one "
       "sub-group only.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T, *InPtr and "
       "*OutPtr. Skipping such test cases.");
@@ -105,6 +108,7 @@ TEST_CASE("Group and sub-group joint scan functions with init",
 #else
   if (queue.get_device().has(sycl::aspect::fp16)) {
     // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+    // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
     defined(SYCL_CTS_COMPILING_WITH_DPCPP)
     for_all_combinations<invoke_init_joint_scan_group_same_type>(
@@ -140,6 +144,7 @@ TEST_CASE("Group and sub-group scan functions with init",
       "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
       "and op are interchanged.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T and V. Skipping such "
       "test cases.");
@@ -159,6 +164,7 @@ TEST_CASE("Group and sub-group scan functions with init",
 #else
   if (queue.get_device().has(sycl::aspect::fp16)) {
     // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+    // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     for_all_combinations<invoke_init_scan_over_group_same_type>(

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -52,6 +52,7 @@ TEST_CASE("Group and sub-group joint scan functions",
       "over several sub-groups simultaneously. Using one sub-group only.");
   WARN("hipSYCL does not support sycl::known_identity_v yet.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
       "Skipping such test cases.");
@@ -65,6 +66,7 @@ TEST_CASE("Group and sub-group joint scan functions",
 #else
   if (queue.get_device().has(sycl::aspect::fp64)) {
     // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+    // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
     defined(SYCL_CTS_COMPILING_WITH_DPCPP)
     for_all_combinations<invoke_joint_scan_group_same_type>(Dims, DoubleType{},
@@ -90,6 +92,7 @@ TEST_CASE("Group and sub-group joint scan functions with init",
       "cannot process over several sub-groups simultaneously. Using one "
       "sub-group only.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T, *InPtr and "
       "*OutPtr. Skipping such test cases.");
@@ -103,6 +106,7 @@ TEST_CASE("Group and sub-group joint scan functions with init",
 #else
   if (queue.get_device().has(sycl::aspect::fp64)) {
     // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+    // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
     defined(SYCL_CTS_COMPILING_WITH_DPCPP)
     for_all_combinations<invoke_init_joint_scan_group_same_type>(
@@ -147,6 +151,7 @@ TEST_CASE("Group and sub-group scan functions with init",
       "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
       "and op are interchanged.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T and V. Skipping such "
       "test cases.");
@@ -171,6 +176,7 @@ TEST_CASE("Group and sub-group scan functions with init",
 #else
   if (queue.get_device().has(sycl::aspect::fp64)) {
     // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+    // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     for_all_combinations<invoke_init_scan_over_group_same_type>(

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -55,6 +55,7 @@ TEST_CASE("Group and sub-group joint scan functions",
       "over several sub-groups simultaneously. Using one sub-group only.");
   WARN("hipSYCL does not support sycl::known_identity_v yet.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
       "Skipping the test.");
@@ -65,6 +66,7 @@ TEST_CASE("Group and sub-group joint scan functions",
 
   // FIXME: ComputeCpp does not implement joint scan and half type
   // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
     defined(SYCL_CTS_COMPILING_WITH_DPCPP) ||   \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -95,6 +97,7 @@ TEST_CASE("Group and sub-group joint scan functions with init",
       "cannot process over several sub-groups simultaneously. Using one "
       "sub-group only.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T, *InPtr and "
       "*OutPtr. Skipping the test.");
@@ -105,6 +108,7 @@ TEST_CASE("Group and sub-group joint scan functions with init",
 
   // FIXME: ComputeCpp does not implement joint scan and half type
   // FIXME: hipSYCL and DPCPP cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
     defined(SYCL_CTS_COMPILING_WITH_DPCPP) ||   \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -131,6 +135,7 @@ TEST_CASE("Group and sub-group scan functions with init",
       "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
       "and op are interchanged.");
 #elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T and V. Skipping the "
       "test.");
@@ -143,6 +148,7 @@ TEST_CASE("Group and sub-group scan functions with init",
 
   // FIXME: ComputeCpp has no half
   // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
+  // Link to issue https://github.com/intel/llvm/issues/8341
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;

--- a/tests/group_functions/group_shift.cpp
+++ b/tests/group_functions/group_shift.cpp
@@ -29,10 +29,6 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group shift",
     WARN(
         "hipSYCL has not implemented sycl::marray type yet. Skipping the test "
         "cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    WARN(
-        "DPCPP does not implement shift functions. "
-        "Skipping the test.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement shift functions. "
@@ -40,17 +36,11 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group shift",
 #endif
   }
 
-  // FIXME: DPCPP and ComputeCpp do not implement shift functions
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp do not implement shift functions
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
-
-  // check all work group dimensions
-  shift_group<1, TestType>(queue);
-  shift_group<2, TestType>(queue);
-  shift_group<3, TestType>(queue);
 
   shift_sub_group<1, TestType>(queue);
   shift_sub_group<2, TestType>(queue);

--- a/tests/group_functions/group_shift.h
+++ b/tests/group_functions/group_shift.h
@@ -22,96 +22,11 @@
 
 #include "group_functions_common.h"
 
-template <int D, typename T>
-class shift_group_kernel;
-
 /**
  * @brief Provides test for shift (shuffle) values inside the group
  * @tparam D Dimension to use for group instance
  * @tparam T Type for shifted value
  */
-template <int D, typename T>
-void shift_group(sycl::queue& queue) {
-  // 4 functions
-  constexpr int test_matrix = 4;
-  const std::string test_names[test_matrix] = {
-      "T shift_group_left(group g, T x)",
-      "T shift_group_left(group g, T x, group::linear_id_type delta)",
-      "T shift_group_right(group g, T x)",
-      "T shift_group_right(group g, T x, group::linear_id_type delta)"};
-
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
-  size_t work_group_size = work_group_range.size();
-
-  // array to return results:
-  std::valarray<bool> res(false, test_matrix * work_group_size);
-  {
-    sycl::buffer<bool, 1> res_sycl(
-        std::begin(res), sycl::range<1>(test_matrix * work_group_size));
-
-    queue.submit([&](sycl::handler& cgh) {
-      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
-      sycl::nd_range<D> executionRange(work_group_range, work_group_range);
-
-      cgh.parallel_for<shift_group_kernel<D, T>>(
-          executionRange, [=](sycl::nd_item<D> item) {
-            sycl::group<D> group = item.get_group();
-            const typename sycl::group<D>::linear_id_type llid =
-                item.get_local_linear_id();
-
-            T local_var(splat_init<T>(llid + 1));
-            T shifted_var(splat_init<T>(llid + 1));
-
-            ASSERT_RETURN_TYPE(
-                T, sycl::shift_group_left(group, local_var),
-                "Return type of shift_group_left(group g, T x) is wrong\n");
-
-            shifted_var = sycl::shift_group_left(group, local_var);
-            res_acc[0 * work_group_size + llid] =
-                equal(shifted_var, splat_init<T>(llid + 2)) ||
-                (llid + 1 >= group.get_local_linear_range());
-
-            ASSERT_RETURN_TYPE(T, sycl::shift_group_left(group, local_var, 3),
-                               "Return type of shift_group_left(group g, T x, "
-                               "group::linear_id_type delta) is wrong\n");
-
-            shifted_var = sycl::shift_group_left(group, local_var, 3);
-            res_acc[1 * work_group_size + llid] =
-                equal(shifted_var, splat_init<T>(llid + 4)) ||
-                (llid + 3 >= group.get_local_linear_range());
-
-            ASSERT_RETURN_TYPE(
-                T, sycl::shift_group_right(group, local_var),
-                "Return type of shift_group_right(group g, T x) is wrong\n");
-
-            shifted_var = sycl::shift_group_right(group, local_var);
-            res_acc[2 * work_group_size + llid] =
-                equal(shifted_var, splat_init<T>(llid)) || (llid < 1);
-
-            ASSERT_RETURN_TYPE(T, sycl::shift_group_right(group, local_var, 2),
-                               "Return type of shift_group_right(group g, T x, "
-                               "group::linear_id_type delta) is wrong\n");
-
-            shifted_var = sycl::shift_group_right(group, local_var, 2);
-            res_acc[3 * work_group_size + llid] =
-                equal(shifted_var, splat_init<T>(llid - 1)) || (llid < 2);
-          });
-    });
-  }
-  for (int i = 0; i < test_matrix; ++i) {
-    bool result = res[i * work_group_size];
-    for (size_t j = 1; j < work_group_size; ++j)
-      result &= res[i * work_group_size + j];
-
-    std::string work_group = util::work_group_print(work_group_range);
-    CAPTURE(D, work_group);
-    INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
-                     << " is " << (result ? "right" : "wrong"));
-    CHECK(result);
-  }
-}
-
 template <int D, typename T>
 class shift_sub_group_kernel;
 

--- a/tests/group_functions/group_shift.h
+++ b/tests/group_functions/group_shift.h
@@ -22,11 +22,6 @@
 
 #include "group_functions_common.h"
 
-/**
- * @brief Provides test for shift (shuffle) values inside the group
- * @tparam D Dimension to use for group instance
- * @tparam T Type for shifted value
- */
 template <int D, typename T>
 class shift_sub_group_kernel;
 

--- a/tests/group_functions/group_shift_fp16.cpp
+++ b/tests/group_functions/group_shift_fp16.cpp
@@ -24,26 +24,20 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group shift", "[group_func][fp16][dim]",
                        ((int D), D), 1, 2, 3) {
   // check dimensions to only print warning once
   if constexpr (D == 1) {
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    WARN(
-        "DPCPP does not implement shift functions. "
-        "Skipping the test.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement shift functions. "
         "Skipping the test.");
 #endif
   }
 
-  // FIXME: DPCPP and ComputeCpp do not implement shift functions
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp do not implement shift functions
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    shift_group<D, sycl::half>(queue);
     shift_sub_group<D, sycl::half>(queue);
   } else {
     WARN("Device does not support half precision floating point operations.");

--- a/tests/group_functions/group_shift_fp64.cpp
+++ b/tests/group_functions/group_shift_fp64.cpp
@@ -24,26 +24,20 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group shift", "[group_func][fp64][dim]",
                        ((int D), D), 1, 2, 3) {
   // check dimensions to only print warning once
   if constexpr (D == 1) {
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    WARN(
-        "DPCPP does not implement shift functions. "
-        "Skipping the test.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement shift functions. "
         "Skipping the test.");
 #endif
   }
 
-  // FIXME: DPCPP and ComputeCpp do not implement shift functions
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp do not implement shift functions
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    shift_group<D, double>(queue);
     shift_sub_group<D, double>(queue);
   } else {
     WARN("Device does not support double precision floating point operations.");


### PR DESCRIPTION
Removed `group_permute` tests for `sycl::group` according to SYCL2020 specification [4.17.4.3. permute](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_permute)
`1. Constraints: Available only if std::is_same_v<std::decay_t<Group>, sub_group> is true and T is a trivially copyable type.`

Removed `group_shift` tests for `sycl::group` according to SYCL2020 specification [4.17.4.2. shift_left and shift_right](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_shift_left_and_shift_right)
`1. Constraints: Available only if std::is_same_v<std::decay_t<Group>, sub_group> is true and T is a trivially copyable type.`