### PR TITLE
Fix kernel parameters test for array

### DIFF
--- a/tests/kernel/kernel_parameters.cpp
+++ b/tests/kernel/kernel_parameters.cpp
@@ -304,7 +304,7 @@ class named_kernel_test<sycl::id<Dim>> {
 template <typename T>
 class unnamed_kernel_test {
   template <typename BufType>
-  void queue_submit_task(BufType buf_expected, T changed) {
+  void queue_submit_task(BufType buf_expected, T& changed) {
     queue
         .submit([&](sycl::handler& cgh) {
           auto acc_expected =


### PR DESCRIPTION
Adding passing by reference to stop T[] decay to pointer since test should check array as kernel parameter.