### PR TITLE
Fix and improve reduction testing coverage

### DIFF
--- a/tests/reduction/reduction_common.h
+++ b/tests/reduction/reduction_common.h
@@ -118,16 +118,15 @@ VariableT get_init_value_for_reduction() {
 template <typename VariableT, typename FunctorT, bool UsePropertyFlagT = false>
 VariableT get_init_value_for_expected_value() {
   VariableT init_value{};
-  if constexpr (std::is_same_v<VariableT, bool>)
-    get_init_value_bool<FunctorT, UsePropertyFlagT>(init_value);
-  else if constexpr (UsePropertyFlagT) {
+  if constexpr (UsePropertyFlagT) {
     // case when using reduction with initialize_to_identity
     if constexpr (sycl::has_known_identity<FunctorT, VariableT>::value)
       init_value = sycl::known_identity<FunctorT, VariableT>::value;
     else
       init_value = identity_value;
   } else {
-    init_value = init_value_without_property_case;
+    // otherwise it should use the same intial value as the reduction.
+    init_value = get_init_value_for_reduction<VariableT, FunctorT>();
   }
   return init_value;
 }

--- a/tests/reduction/reduction_common.h
+++ b/tests/reduction/reduction_common.h
@@ -125,7 +125,7 @@ VariableT get_init_value_for_expected_value() {
     else
       init_value = identity_value;
   } else {
-    // otherwise it should use the same intial value as the reduction.
+    // Otherwise it should use the same initial value as the reduction.
     init_value = get_init_value_for_reduction<VariableT, FunctorT>();
   }
   return init_value;

--- a/tests/reduction/reduction_without_identity_param_fp16.cpp
+++ b/tests/reduction/reduction_without_identity_param_fp16.cpp
@@ -31,6 +31,10 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 
   run_tests_for_all_functors<sycl::half, run_test_without_property>()(
       reduction_common::range, queue, "sycl::half");
+  run_tests_for_all_functors<sycl::half, run_test_without_property>()(
+      reduction_common::nd_range, queue, "sycl::half");
+  run_tests_for_all_functors<sycl::half, run_test_with_property>()(
+      reduction_common::range, queue, "sycl::half");
   run_tests_for_all_functors<sycl::half, run_test_with_property>()(
       reduction_common::nd_range, queue, "sycl::half");
 });

--- a/tests/reduction/reduction_without_identity_param_fp64.cpp
+++ b/tests/reduction/reduction_without_identity_param_fp64.cpp
@@ -31,6 +31,10 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 
   run_tests_for_all_functors<double, run_test_without_property>()(
       reduction_common::range, queue, "double");
+  run_tests_for_all_functors<double, run_test_without_property>()(
+      reduction_common::nd_range, queue, "double");
+  run_tests_for_all_functors<double, run_test_with_property>()(
+      reduction_common::range, queue, "double");
   run_tests_for_all_functors<double, run_test_with_property>()(
       reduction_common::nd_range, queue, "double");
 });


### PR DESCRIPTION
This commit makes the following fixes and adjustments to the reduction tests:
 * Adds missing test case combinations of range type and `initialize_to_property` usage for `half` and `double` types.
 * Avoid using `initialize_to_property` for identityless test cases.
 * Use the correct initial value for expected reduction results with booleans.