### PR TITLE
Fix exception with get_kernel_bundle

### DIFF
--- a/tests/kernel_bundle/get_kernel_bundle.h
+++ b/tests/kernel_bundle/get_kernel_bundle.h
@@ -180,7 +180,6 @@ inline void run_test_for_all_overload_types(
     const std::vector<sycl::kernel_id> &user_defined_kernel_ids) {
   const auto context{queue.get_context()};
   const auto device{queue.get_device()};
-  const size_t number_devices{context.get_devices().size()};
   constexpr unsigned int kernel_descriptor_count =
       sizeof...(KernelDescriptorsT);
 
@@ -224,7 +223,7 @@ inline void run_test_for_all_overload_types(
     auto kernel_bundle{sycl::get_kernel_bundle<BundleState>(
         context, context.get_devices(), selector)};
     for_all_types<kernel_bundle::verify_that_kernel_in_bundle>(
-        kernel_descriptors, log, kernel_bundle, number_devices);
+        kernel_descriptors, log, kernel_bundle, context.get_devices());
     CHECK((has_kernel.all() && has_kernel_dev.all()));
   }
   {
@@ -235,7 +234,7 @@ inline void run_test_for_all_overload_types(
     has_kernel_dev.reset();
     auto kernel_bundle{sycl::get_kernel_bundle<BundleState>(context, selector)};
     for_all_types<kernel_bundle::verify_that_kernel_in_bundle>(
-        kernel_descriptors, log, kernel_bundle, number_devices);
+        kernel_descriptors, log, kernel_bundle, context.get_devices());
     CHECK((has_kernel.all() && has_kernel_dev.all()));
   }
   {
@@ -245,7 +244,7 @@ inline void run_test_for_all_overload_types(
     auto kernel_bundle{sycl::get_kernel_bundle<BundleState>(
         context, context.get_devices(), user_defined_kernel_ids)};
     for_all_types<kernel_bundle::verify_that_kernel_in_bundle>(
-        kernel_descriptors, log, kernel_bundle, number_devices);
+        kernel_descriptors, log, kernel_bundle, context.get_devices());
   }
   {
     log.note(
@@ -254,7 +253,7 @@ inline void run_test_for_all_overload_types(
     auto kernel_bundle{
         sycl::get_kernel_bundle<BundleState>(context, context.get_devices())};
     for_all_types<kernel_bundle::verify_that_kernel_in_bundle>(
-        kernel_descriptors, log, kernel_bundle, number_devices);
+        kernel_descriptors, log, kernel_bundle, context.get_devices());
   }
   {
     log.note(
@@ -263,7 +262,7 @@ inline void run_test_for_all_overload_types(
     auto kernel_bundle{
         sycl::get_kernel_bundle<BundleState>(context, user_defined_kernel_ids)};
     for_all_types<kernel_bundle::verify_that_kernel_in_bundle>(
-        kernel_descriptors, log, kernel_bundle, number_devices);
+        kernel_descriptors, log, kernel_bundle, context.get_devices());
   }
   {
     log.note(
@@ -271,7 +270,7 @@ inline void run_test_for_all_overload_types(
         "overload");
     auto kernel_bundle{sycl::get_kernel_bundle<BundleState>(context)};
     for_all_types<kernel_bundle::verify_that_kernel_in_bundle>(
-        kernel_descriptors, log, kernel_bundle, number_devices);
+        kernel_descriptors, log, kernel_bundle, context.get_devices());
   }
 }
 

--- a/tests/kernel_bundle/get_kernel_bundle.h
+++ b/tests/kernel_bundle/get_kernel_bundle.h
@@ -23,26 +23,25 @@ inline auto kernels_with_attributes = named_type_pack<
     kernels::kernel_likely_unsupported_sub_group_size_descriptor,
     kernels::kernel_likely_supported_sub_group_size_descriptor,
     kernels::kernel_likely_unsupported_work_group_size_descriptor,
-    kernels::kernel_likely_supported_work_group_size_descriptor>::generate(
-    "kernel_cpu_descriptor",
-    "kernel_gpu_descriptor",
-    "kernel_accelerator_descriptor",
-    "simple_kernel_descriptor",
-    "simple_kernel_descriptor_second",
-    "kernel_likely_unsupported_sub_group_size_descriptor",
-    "kernel_likely_supported_sub_group_size_descriptor",
-    "kernel_likely_unsupported_work_group_size_descriptor",
-    "kernel_likely_supported_work_group_size_descriptor");
+    kernels::kernel_likely_supported_work_group_size_descriptor>::
+    generate("kernel_cpu_descriptor", "kernel_gpu_descriptor",
+             "kernel_accelerator_descriptor", "simple_kernel_descriptor",
+             "simple_kernel_descriptor_second",
+             "kernel_likely_unsupported_sub_group_size_descriptor",
+             "kernel_likely_supported_sub_group_size_descriptor",
+             "kernel_likely_unsupported_work_group_size_descriptor",
+             "kernel_likely_supported_work_group_size_descriptor");
 
 inline auto kernels_without_attributes =
     named_type_pack<kernels::simple_kernel_descriptor,
                     kernels::simple_kernel_descriptor_second,
                     kernels::kernel_fp16_no_attr_descriptor,
                     kernels::kernel_fp64_no_attr_descriptor,
-                    kernels::kernel_atomic64_no_attr_descriptor>::generate(
-        "simple_kernel_descriptor", "simple_kernel_descriptor_second",
-        "kernel_fp16_no_attr_descriptor", "kernel_fp64_no_attr_descriptor",
-        "kernel_atomic64_no_attr_descriptor");
+                    kernels::kernel_atomic64_no_attr_descriptor>::
+        generate("simple_kernel_descriptor", "simple_kernel_descriptor_second",
+                 "kernel_fp16_no_attr_descriptor",
+                 "kernel_fp64_no_attr_descriptor",
+                 "kernel_atomic64_no_attr_descriptor");
 
 template <sycl::bundle_state BundleState>
 class TestCaseDescription

--- a/tests/kernel_bundle/sycl_build_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
+++ b/tests/kernel_bundle/sycl_build_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
@@ -54,8 +54,8 @@ void verify_results(
     util::logger &log, const std::vector<sycl::device> &dev_vector,
     const sycl::context &ctx,
     const sycl::kernel_bundle<sycl::bundle_state::executable> &kernel_bundle) {
-  for_all_types<verify_that_kernel_in_bundle>(
-      kernels_for_link_and_build, log, kernel_bundle, ctx.get_devices().size());
+  for_all_types<verify_that_kernel_in_bundle>(kernels_for_link_and_build, log,
+                                              kernel_bundle, dev_vector);
   if (kernel_bundle.get_context() != ctx) {
     FAIL(log, "Kernel bundle's context does not equal to provided context");
   }
@@ -120,31 +120,11 @@ void run_verification(util::logger &log, sycl::queue &q) {
   auto ctx = q.get_context();
   std::vector<sycl::device> dev_vector{ctx.get_devices()[0]};
 
-  const auto cpu_kernel_id = sycl::get_kernel_id<cpu_kernel>();
-  const auto gpu_kernel_id = sycl::get_kernel_id<gpu_kernel>();
-  const auto accelerator_kernel_id = sycl::get_kernel_id<accelerator_kernel>();
   const auto first_simple_kernel_id =
       sycl::get_kernel_id<first_simple_kernel>();
   const auto second_simple_kernel_id =
       sycl::get_kernel_id<second_simple_kernel>();
-  const auto fp16_kernel_id = sycl::get_kernel_id<fp16_kernel>();
-  const auto fp64_kernel_id = sycl::get_kernel_id<fp64_kernel>();
-  const auto atomic64_kernel_id = sycl::get_kernel_id<atomic64_kernel>();
 
-  auto kb_with_cpu_kernel{
-      sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {cpu_kernel_id})};
-  auto kb_with_gpu_kernel{
-      sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {gpu_kernel_id})};
-  auto kb_with_accelerator_kernel{
-      sycl::get_kernel_bundle<sycl::bundle_state::input>(
-          ctx, {accelerator_kernel_id})};
-  auto kb_with_fp16_kernel{sycl::get_kernel_bundle<sycl::bundle_state::input>(
-      ctx, {fp16_kernel_id})};
-  auto kb_with_fp64_kernel{sycl::get_kernel_bundle<sycl::bundle_state::input>(
-      ctx, {fp64_kernel_id})};
-  auto kb_with_atomic64_kernel{
-      sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx,
-                                                         {atomic64_kernel_id})};
   auto kb_with_first_simple_kernel{
       sycl::get_kernel_bundle<sycl::bundle_state::input>(
           ctx, {first_simple_kernel_id})};
@@ -153,9 +133,6 @@ void run_verification(util::logger &log, sycl::queue &q) {
           ctx, {second_simple_kernel_id})};
 
   std::vector<sycl::kernel_bundle<sycl::bundle_state::input>> kernel_bundles{
-      kb_with_cpu_kernel,          kb_with_gpu_kernel,
-      kb_with_accelerator_kernel,  kb_with_fp16_kernel,
-      kb_with_fp64_kernel,         kb_with_atomic64_kernel,
       kb_with_first_simple_kernel, kb_with_second_simple_kernel};
 
   const sycl::kernel_bundle<sycl::bundle_state::input> all_kernel_bundles{

--- a/tests/kernel_bundle/sycl_join_check_kernel_execution.cpp
+++ b/tests/kernel_bundle/sycl_join_check_kernel_execution.cpp
@@ -60,9 +60,12 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using k_name = kb_join_post_exe_kernel;
     auto queue = util::get_cts_object::queue();
     const auto ctx = queue.get_context();
+    const auto dev = queue.get_device();
 
-    auto kb_1 = sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctx);
-    auto kb_2 = sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctx);
+    auto kb_1 =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctx, {dev});
+    auto kb_2 =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctx, {dev});
     auto k_id = sycl::get_kernel_id<k_name>();
 
     auto joined_kb = sycl::join<sycl::bundle_state::executable>({kb_1, kb_2});

--- a/tests/kernel_bundle/sycl_join_single_kernel_bundle.cpp
+++ b/tests/kernel_bundle/sycl_join_single_kernel_bundle.cpp
@@ -28,6 +28,7 @@ template <sycl::bundle_state State>
 void run_verification(util::logger &log) {
   auto queue = util::get_cts_object::queue();
   const auto ctx = queue.get_context();
+  const auto dev = queue.get_device();
 
   auto kb = sycl::get_kernel_bundle<State>(ctx);
 

--- a/tests/kernel_bundle/sycl_link_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
+++ b/tests/kernel_bundle/sycl_link_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
@@ -108,14 +108,13 @@ void run_verification(util::logger &log, sycl::queue &queue) {
       sycl::compile(sycl::get_kernel_bundle<sycl::bundle_state::input>(
           ctx, {second_simple_kernel_id}))};
 
-  vector_with_object_bundles kernel_bundles{
-      kb_with_first_simple_kernel, kb_with_second_simple_kernel};
+  vector_with_object_bundles kernel_bundles{kb_with_first_simple_kernel,
+                                            kb_with_second_simple_kernel};
   vector_with_object_bundles kernel_bundles_from_input{
       kb_with_first_simple_kernel_from_input,
       kb_with_second_simple_kernel_from_input};
   vector_with_object_bundles mixed_kernel_bundles{
-      kb_with_first_simple_kernel_from_input,
-      kb_with_second_simple_kernel};
+      kb_with_first_simple_kernel_from_input, kb_with_second_simple_kernel};
 
   std::vector<sycl::device> dev_vector{ctx.get_devices()};
   std::vector<sycl::device> current_dev_vector{util::get_cts_object::device()};

--- a/tests/kernel_bundle/sycl_link_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
+++ b/tests/kernel_bundle/sycl_link_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
@@ -66,8 +66,8 @@ void verify_results(
     util::logger &log, const std::vector<sycl::device> &dev_vector,
     const sycl::context &ctx,
     const sycl::kernel_bundle<sycl::bundle_state::executable> &kernel_bundle) {
-  for_all_types<verify_that_kernel_in_bundle>(
-      kernels_for_link_and_build, log, kernel_bundle, ctx.get_devices().size());
+  for_all_types<verify_that_kernel_in_bundle>(kernels_for_link_and_build, log,
+                                              kernel_bundle, dev_vector);
   if (kernel_bundle.get_context() != ctx) {
     FAIL(log, "Kernel bundle's context does not equal to provided context");
   }
@@ -89,33 +89,11 @@ void verify_results(
 void run_verification(util::logger &log, sycl::queue &queue) {
   auto ctx = queue.get_context();
 
-  const sycl::kernel_id cpu_kernel_id{sycl::get_kernel_id<cpu_kernel>()};
-  const sycl::kernel_id gpu_kernel_id{sycl::get_kernel_id<gpu_kernel>()};
-  const sycl::kernel_id accelerator_kernel_id{
-      sycl::get_kernel_id<accelerator_kernel>()};
   const sycl::kernel_id first_simple_kernel_id{
       sycl::get_kernel_id<first_simple_kernel>()};
   const sycl::kernel_id second_simple_kernel_id{
       sycl::get_kernel_id<second_simple_kernel>()};
-  const sycl::kernel_id fp16_kernel_id{sycl::get_kernel_id<fp16_kernel>()};
-  const sycl::kernel_id fp64_kernel_id{sycl::get_kernel_id<fp64_kernel>()};
-  const sycl::kernel_id atomic64_kernel_id{
-      sycl::get_kernel_id<atomic64_kernel>()};
 
-  auto kb_with_cpu_kernel{sycl::get_kernel_bundle<sycl::bundle_state::object>(
-      ctx, {cpu_kernel_id})};
-  auto kb_with_gpu_kernel{sycl::get_kernel_bundle<sycl::bundle_state::object>(
-      ctx, {gpu_kernel_id})};
-  auto kb_with_accelerator_kernel{
-      sycl::get_kernel_bundle<sycl::bundle_state::object>(
-          ctx, {accelerator_kernel_id})};
-  auto kb_with_fp16_kernel{sycl::get_kernel_bundle<sycl::bundle_state::object>(
-      ctx, {fp16_kernel_id})};
-  auto kb_with_fp64_kernel{sycl::get_kernel_bundle<sycl::bundle_state::object>(
-      ctx, {fp64_kernel_id})};
-  auto kb_with_atomic64_kernel{
-      sycl::get_kernel_bundle<sycl::bundle_state::object>(
-          ctx, {atomic64_kernel_id})};
   auto kb_with_first_simple_kernel{
       sycl::get_kernel_bundle<sycl::bundle_state::object>(
           ctx, {first_simple_kernel_id})};
@@ -123,24 +101,6 @@ void run_verification(util::logger &log, sycl::queue &queue) {
       sycl::get_kernel_bundle<sycl::bundle_state::object>(
           ctx, {second_simple_kernel_id})};
 
-  auto kb_with_cpu_kernel_from_input{
-      sycl::compile(sycl::get_kernel_bundle<sycl::bundle_state::input>(
-          ctx, {cpu_kernel_id}))};
-  auto kb_with_gpu_kernel_from_input{
-      sycl::compile(sycl::get_kernel_bundle<sycl::bundle_state::input>(
-          ctx, {gpu_kernel_id}))};
-  auto kb_with_accelerator_kernel_from_input{
-      sycl::compile(sycl::get_kernel_bundle<sycl::bundle_state::input>(
-          ctx, {accelerator_kernel_id}))};
-  auto kb_with_fp16_kernel_from_input{
-      sycl::compile(sycl::get_kernel_bundle<sycl::bundle_state::input>(
-          ctx, {fp16_kernel_id}))};
-  auto kb_with_fp64_kernel_from_input{
-      sycl::compile(sycl::get_kernel_bundle<sycl::bundle_state::input>(
-          ctx, {fp64_kernel_id}))};
-  auto kb_with_atomic64_kernel_from_input{
-      sycl::compile(sycl::get_kernel_bundle<sycl::bundle_state::input>(
-          ctx, {atomic64_kernel_id}))};
   auto kb_with_first_simple_kernel_from_input{
       sycl::compile(sycl::get_kernel_bundle<sycl::bundle_state::input>(
           ctx, {first_simple_kernel_id}))};
@@ -149,37 +109,24 @@ void run_verification(util::logger &log, sycl::queue &queue) {
           ctx, {second_simple_kernel_id}))};
 
   vector_with_object_bundles kernel_bundles{
-      kb_with_cpu_kernel,          kb_with_gpu_kernel,
-      kb_with_accelerator_kernel,  kb_with_fp16_kernel,
-      kb_with_fp64_kernel,         kb_with_atomic64_kernel,
       kb_with_first_simple_kernel, kb_with_second_simple_kernel};
   vector_with_object_bundles kernel_bundles_from_input{
-      kb_with_cpu_kernel_from_input,
-      kb_with_gpu_kernel_from_input,
-      kb_with_accelerator_kernel_from_input,
-      kb_with_fp16_kernel_from_input,
-      kb_with_fp64_kernel_from_input,
-      kb_with_atomic64_kernel_from_input,
       kb_with_first_simple_kernel_from_input,
       kb_with_second_simple_kernel_from_input};
   vector_with_object_bundles mixed_kernel_bundles{
-      kb_with_cpu_kernel,
-      kb_with_gpu_kernel_from_input,
-      kb_with_accelerator_kernel,
-      kb_with_fp16_kernel,
-      kb_with_fp64_kernel_from_input,
-      kb_with_atomic64_kernel,
       kb_with_first_simple_kernel_from_input,
       kb_with_second_simple_kernel};
 
   std::vector<sycl::device> dev_vector{ctx.get_devices()};
+  std::vector<sycl::device> current_dev_vector{util::get_cts_object::device()};
 
   log.note("Verify link(vector<kernel_bundle<>>, vector<device>) overload");
-  verify_results(log, dev_vector, ctx, sycl::link(kernel_bundles, dev_vector));
-  verify_results(log, dev_vector, ctx,
-                 sycl::link(kernel_bundles_from_input, dev_vector));
-  verify_results(log, dev_vector, ctx,
-                 sycl::link(mixed_kernel_bundles, dev_vector));
+  verify_results(log, current_dev_vector, ctx,
+                 sycl::link(kernel_bundles, current_dev_vector));
+  verify_results(log, current_dev_vector, ctx,
+                 sycl::link(kernel_bundles_from_input, current_dev_vector));
+  verify_results(log, current_dev_vector, ctx,
+                 sycl::link(mixed_kernel_bundles, current_dev_vector));
 
   log.note("Verify link(vector<kernel_bundle<>>) overload");
   verify_results(log, dev_vector, ctx, sycl::link(kernel_bundles));
@@ -188,17 +135,17 @@ void run_verification(util::logger &log, sycl::queue &queue) {
 
   log.note("Verify link(kernel_bundle<>, vector<device>) overload");
   verify_results(
-      log, dev_vector, ctx,
+      log, current_dev_vector, ctx,
       sycl::link(sycl::join<sycl::bundle_state::object>(kernel_bundles),
-                 dev_vector));
-  verify_results(log, dev_vector, ctx,
+                 current_dev_vector));
+  verify_results(log, current_dev_vector, ctx,
                  sycl::link(sycl::join<sycl::bundle_state::object>(
                                 kernel_bundles_from_input),
-                            dev_vector));
+                            current_dev_vector));
   verify_results(
-      log, dev_vector, ctx,
+      log, current_dev_vector, ctx,
       sycl::link(sycl::join<sycl::bundle_state::object>(mixed_kernel_bundles),
-                 dev_vector));
+                 current_dev_vector));
 
   log.note("Verify link(kernel_bundle<>) overload");
   verify_results(

--- a/tests/kernel_bundle/use_kernel_bundle.h
+++ b/tests/kernel_bundle/use_kernel_bundle.h
@@ -86,12 +86,15 @@ template <typename KernelT>
 inline sycl::kernel_bundle<sycl::bundle_state::executable> get_non_empty_bundle(
     const sycl::context &ctx) {
   auto kernel_id = sycl::get_kernel_id<KernelT>();
-  auto k_bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
-      ctx, ctx.get_devices(), {kernel_id});
-  if (k_bundle.empty()) {
-    throw sycl_cts::util::skip_check("Test skipped due to bundle is empty");
+  try {
+    auto k_bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+        ctx, ctx.get_devices(), {kernel_id});
+    return k_bundle;
+  } catch (const sycl::exception &e) {
+    if (sycl::errc::invalid == e.code())
+      SKIP(
+          "Test skipped because no device is compatible with requested kernel");
   }
-  return k_bundle;
 }
 
 /** @brief Constructing kernel bundle with built-in kernels

--- a/tests/kernel_bundle/use_kernel_bundle.h
+++ b/tests/kernel_bundle/use_kernel_bundle.h
@@ -46,9 +46,9 @@ static const std::string skip_test_for_builtin_kernels_msg{
 inline auto user_def_kernels =
     named_type_pack<kernels::kernel_cpu_descriptor,
                     kernels::kernel_gpu_descriptor,
-                    kernels::kernel_accelerator_descriptor>::generate(
-        "kernel_cpu_descriptor", "kernel_gpu_descriptor",
-        "kernel_accelerator_descriptor");
+                    kernels::kernel_accelerator_descriptor>::
+        generate("kernel_cpu_descriptor", "kernel_gpu_descriptor",
+                 "kernel_accelerator_descriptor");
 
 template <sycl::bundle_state BundleState>
 class TestCaseDescription


### PR DESCRIPTION
Since `get_kernel_bundle` can throw an exception if required kernel is not compatible with any available device, remove kernels with restrictions from link and build tests and add safeguard in use_kernel_bundle tests.