### PR TITLE
Fix device_image_semantics and kernel_bundle_semantics tests

### DIFF
--- a/tests/kernel_bundle/device_image_semantics.cpp
+++ b/tests/kernel_bundle/device_image_semantics.cpp
@@ -41,8 +41,10 @@ struct storage {
 
 TEST_CASE("device_image common reference semantics", "[device_image]") {
   sycl::context context = sycl_cts::util::get_cts_object::context();
+  sycl::device device = sycl_cts::util::get_cts_object::device();
   sycl::kernel_bundle<sycl::bundle_state::executable> kernel_bundle =
-      sycl::get_kernel_bundle<sycl::bundle_state::executable>(context);
+      sycl::get_kernel_bundle<dummy_kernel, sycl::bundle_state::executable>(
+          context, {device});
   // only accessible as const reference
   const sycl::device_image<sycl::bundle_state::executable>& device_image =
       kernel_bundle.begin()[0];

--- a/tests/kernel_bundle/kernel_bundle_semantics.cpp
+++ b/tests/kernel_bundle/kernel_bundle_semantics.cpp
@@ -22,6 +22,8 @@
 #include "../common/semantics_reference.h"
 #include "kernel_bundle.h"
 
+struct dummy_kernel;
+
 struct storage {
   bool is_empty;
   std::size_t device_count;
@@ -43,11 +45,13 @@ struct storage {
 
 TEST_CASE("kernel_bundle common reference semantics", "[kernel_bundle]") {
   sycl::context context = sycl_cts::util::get_cts_object::context();
+  sycl::device device = sycl_cts::util::get_cts_object::device();
   sycl::kernel_bundle<sycl::bundle_state::executable> kernel_bundle =
-      sycl::get_kernel_bundle<sycl::bundle_state::executable>(context);
+      sycl::get_kernel_bundle<dummy_kernel, sycl::bundle_state::executable>(
+          context, {device});
   common_reference_semantics::check_host<storage>(kernel_bundle,
                                                   "kernel_bundle");
 
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
-  sycl_cts::tests::kernel_bundle::define_kernel<class dummy_kernel>(queue);
+  sycl_cts::tests::kernel_bundle::define_kernel<dummy_kernel>(queue);
 }


### PR DESCRIPTION
To make sure that test are getting correct device_image and kernel_bundle for semantics checks.