### PR TITLE
Fixed allocation of too large buffer on the device for the group_barrier test (hipsycl, computecpp)

### DIFF
--- a/tests/group_functions/group_barrier.cpp
+++ b/tests/group_functions/group_barrier.cpp
@@ -24,7 +24,7 @@
 #include "group_functions_common.h"
 
 /** Returns maximum int32_t elements which can be allocated in device global or
- * local memory. */
+    local memory. */
 template <typename DeviceMemoryInfoAspect>
 inline uint64_t max_elements_in_device_memory() {
   using el_type = int32_t;

--- a/tests/group_functions/group_barrier.cpp
+++ b/tests/group_functions/group_barrier.cpp
@@ -90,17 +90,20 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
 
   using el_type = int32_t;
   sycl::device device = queue.get_device();
-  
-  uint64_t global_mem_size_in_bytes = device.get_info<sycl::info::device::max_mem_alloc_size>();
-  uint64_t global_mem_size_in_elements = global_mem_size_in_bytes / sizeof(el_type);
 
-  uint64_t local_mem_size_in_bytes = device.get_info<sycl::info::device::local_mem_size>();
-  uint64_t local_mem_size_in_elements = local_mem_size_in_bytes / sizeof(el_type);
+  uint64_t global_mem_size_in_bytes =
+      device.get_info<sycl::info::device::max_mem_alloc_size>();
+  uint64_t global_mem_size_in_elements =
+      global_mem_size_in_bytes / sizeof(el_type);
 
-  uint64_t work_items_limit = std::min(
-      global_mem_size_in_elements, local_mem_size_in_elements);
-  
-  
+  uint64_t local_mem_size_in_bytes =
+      device.get_info<sycl::info::device::local_mem_size>();
+  uint64_t local_mem_size_in_elements =
+      local_mem_size_in_bytes / sizeof(el_type);
+
+  uint64_t work_items_limit =
+      std::min(global_mem_size_in_elements, local_mem_size_in_elements);
+
   sycl::range<D> work_group_range =
       util::work_group_range<D>(queue, work_items_limit);
   size_t work_group_size = work_group_range.size();

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -99,7 +99,9 @@ inline sycl::range<3> get_default_range() {
  * @tparam Dimensions Dimension to use for group instance
  */
 template <int Dimensions>
-sycl::range<Dimensions> work_group_range(sycl::queue queue) {
+sycl::range<Dimensions> work_group_range(
+    sycl::queue queue,
+    uint64_t work_items_limit = std::numeric_limits<uint64_t>::max()) {
   // query device for work-group sizes
   size_t max_work_item_sizes[Dimensions];
   {
@@ -118,8 +120,9 @@ sycl::range<Dimensions> work_group_range(sycl::queue queue) {
       max_work_item_sizes[i] = sizes.get(i);
     }
   }
-  size_t max_work_group_size =
-      queue.get_device().get_info<sycl::info::device::max_work_group_size>();
+  size_t max_work_group_size = std::min(
+      queue.get_device().get_info<sycl::info::device::max_work_group_size>(),
+      work_items_limit);
 
   // make work-group size as much square/cubic as possible
   size_t work_group_sizes[Dimensions] = {


### PR DESCRIPTION
The work group size is limited for group_barrier test because of out of memory exceptions was being thrown at runtime due to large buffer size which depends on the size of the work group.