### PR TITLE
Add tests for sycl_ext_oneapi_memcpy2d extension.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_SUB_GROUP_MASK_TESTS
 add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_DEVICE_GLOBAL_TESTS
     "Enable extension oneAPI device_global tests" OFF)
 
+add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_MEMCPY2D_TESTS
+    "Enable extension oneAPI memcpy2d tests" OFF)
+
 # TODO: Deprecated - remove
 add_cts_option(SYCL_CTS_ENABLE_VERBOSE_LOG
     "Enable debug-level logs (deprecated)" OFF)

--- a/tests/extension/oneapi_memcpy2d/CMakeLists.txt
+++ b/tests/extension/oneapi_memcpy2d/CMakeLists.txt
@@ -1,0 +1,5 @@
+if(SYCL_CTS_ENABLE_EXT_ONEAPI_MEMCPY2D_TESTS)
+    file(GLOB test_cases_list *.cpp)
+
+    add_cts_test(${test_cases_list})
+endif()

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_common.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_common.h
@@ -198,6 +198,9 @@ T get_expected_value(size_t address, T& ival, T& chval) {
              : ival;
 }
 
+/**
+ * @brief Function to apply functor for each cell in array
+ */
 template <typename Functor>
 void for_index(Functor&& functor) {
   for (size_t i = 0; i < array_height; ++i) {
@@ -208,6 +211,9 @@ void for_index(Functor&& functor) {
   }
 }
 
+/**
+ * @brief Function for calculating address in array depends on pitch size
+ */
 template <typename T>
 T* get_region_address(T* base, size_t pitch) {
   return base + shift_row * pitch + shift_col;

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_common.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_common.h
@@ -1,0 +1,190 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides common methods for memcpy2d tests
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_EXTENSION_MEMCPY2D_COMMON_H
+#define __SYCLCTS_TESTS_EXTENSION_MEMCPY2D_COMMON_H
+
+#include "../../common/common.h"
+#include "../../common/type_coverage.h"
+
+namespace memcpy2d_common_tests {
+
+constexpr int expected_val = 42;
+constexpr int init_val = 1;
+
+constexpr size_t region_width = 5;
+constexpr size_t region_height = 8;
+
+constexpr size_t src_pitch = 10;
+constexpr size_t dest_pitch = 12;
+
+constexpr size_t array_width = 64;
+constexpr size_t array_height = 64;
+
+constexpr size_t shift_row = 2;
+constexpr size_t shift_col = 2;
+
+enum class pointer_type {
+  host = 0,
+  usm_host = 1,
+  usm_device = 2,
+  usm_shared = 3
+};
+
+struct custom_type {
+  int m_int_field{};
+  bool m_bool_field{};
+
+  custom_type() = default;
+
+  custom_type(int value) {
+    m_int_field = value;
+    m_bool_field = value;
+  }
+
+  friend bool operator==(const custom_type& c_t_l, const custom_type& c_t_r) {
+    return c_t_l.m_int_field == c_t_r.m_int_field &&
+           c_t_l.m_bool_field == c_t_r.m_bool_field;
+  }
+
+  operator int() const { return m_int_field; }
+
+  void operator=(int value) {
+    m_int_field = value;
+    m_bool_field = value;
+  }
+};
+
+/**
+ * @brief Factory function for getting type_pack with pointer types
+ */
+inline auto get_pointer_types() {
+  static const auto pointer_types =
+      value_pack<pointer_type, pointer_type::host, pointer_type::usm_host,
+                 pointer_type::usm_device,
+                 pointer_type::usm_shared>::generate_named();
+  return pointer_types;
+}
+
+/**
+ * @brief Factory function for getting type_pack with generic types
+ */
+inline auto get_conformance_type_pack() {
+  static const auto types = named_type_pack<
+      char, unsigned char, short, unsigned short, int, unsigned int, long,
+      unsigned long, long long, unsigned long long, std::size_t, bool,
+      custom_type>::generate("char", "unsigned char", "short", "unsigned short",
+                             "int", "unsigned int", "long", "unsigned long",
+                             "long long", "unsigned long long", "std::size_t",
+                             "bool", "custom_type");
+  return types;
+}
+
+template <pointer_type PtrType>
+bool check_device_aspect_allocations(sycl::queue& queue) {
+  switch (PtrType) {
+    case pointer_type::host:
+      return true;
+    case pointer_type::usm_host:
+      return queue.get_device().has(sycl::aspect::usm_host_allocations);
+    case pointer_type::usm_device:
+      return queue.get_device().has(sycl::aspect::usm_device_allocations);
+    case pointer_type::usm_shared:
+      return queue.get_device().has(sycl::aspect::usm_shared_allocations);
+  }
+}
+
+template <pointer_type SrcPtrType, pointer_type DestPtrType>
+bool check_device_aspect_allocations(sycl::queue& queue) {
+  return check_device_aspect_allocations<SrcPtrType>(queue) &&
+         check_device_aspect_allocations<DestPtrType>(queue);
+}
+
+/**
+ * @brief Function for allocate memory
+ */
+template <typename T, pointer_type PtrType>
+auto allocate_memory(size_t size, sycl::queue& queue) {
+  if constexpr (pointer_type::host == PtrType) {
+    auto deleter = [&](T* ptr) { delete[] ptr; };
+    return std::unique_ptr<T[], decltype(deleter)>(new T[size], deleter);
+  } else if constexpr (pointer_type::usm_host == PtrType) {
+    auto deleter = [&](T* ptr) { sycl::free(ptr, queue); };
+    return std::unique_ptr<T[], decltype(deleter)>(
+        sycl::malloc_host<T>(size, queue), deleter);
+  } else if constexpr (pointer_type::usm_device == PtrType) {
+    auto deleter = [&](T* ptr) { sycl::free(ptr, queue); };
+    return std::unique_ptr<T[], decltype(deleter)>(
+        sycl::malloc_device<T>(size, queue), deleter);
+  } else {
+    auto deleter = [&](T* ptr) { sycl::free(ptr, queue); };
+    return std::unique_ptr<T[], decltype(deleter)>(
+        sycl::malloc_shared<T>(size, queue), deleter);
+  }
+}
+
+template <typename T, pointer_type PtrType>
+void fill_memory(T* ptr, const T& pattern, size_t count, sycl::queue& queue) {
+  switch (PtrType) {
+    case pointer_type::host:
+    case pointer_type::usm_host:
+    case pointer_type::usm_shared:
+      std::fill(ptr, ptr + count, pattern);
+      break;
+    case pointer_type::usm_device:
+      auto event = queue.fill(ptr, pattern, count);
+      event.wait();
+      break;
+  }
+}
+
+template <pointer_type DestPtrType, typename T>
+void copy_destination_to_host_result(T* src, T* result, size_t size,
+                                     sycl::queue& queue) {
+  if constexpr (DestPtrType == pointer_type::usm_device) {
+    queue.copy(src, result, size);
+    queue.wait();
+  } else {
+    std::copy(src, src + size, result);
+  }
+}
+
+/**
+ * @brief Function to get expected value int the allocated memory cell
+ */
+template <typename T>
+T get_expected_value(size_t address, T& ival, T& chval) {
+  size_t first_row = shift_row;
+  size_t last_row = shift_row + region_height;
+  size_t first_col = shift_col;
+  size_t last_col = shift_col + region_width;
+  size_t row = address / dest_pitch;
+  size_t col = address % dest_pitch;
+  return (row >= first_row && row < last_row && col >= first_col &&
+          col < last_col)
+             ? chval
+             : ival;
+}
+
+}  // namespace memcpy2d_common_tests
+
+#endif  // __SYCLCTS_TESTS_EXTENSION_MEMCPY2D_COMMON_H

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_common.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_common.h
@@ -31,25 +31,34 @@ namespace memcpy2d_common_tests {
 constexpr int expected_val = 42;
 constexpr int init_val = 1;
 
+// Width and height of copied and filled regions
 constexpr size_t region_width = 5;
 constexpr size_t region_height = 8;
 
+// src array width
 constexpr size_t src_pitch = 10;
+
+// dest array width
 constexpr size_t dest_pitch = 12;
 
-constexpr size_t array_width = 64;
-constexpr size_t array_height = 64;
+// src and dest arrays height
+constexpr size_t array_height = 32;
 
+// Down shift of copied and filled regions
 constexpr size_t shift_row = 2;
-constexpr size_t shift_col = 2;
 
+// Right shift of copied and filled regions
+constexpr size_t shift_col = 3;
+
+// enum covers four types of pointers used in the tests
 enum class pointer_type {
-  host = 0,
-  usm_host = 1,
-  usm_device = 2,
-  usm_shared = 3
+  host = 0,        // pointer to host dynamic memory
+  usm_host = 1,    // pointer to host USM
+  usm_device = 2,  // pointer to device USM
+  usm_shared = 3   // pointer to shared USM
 };
 
+// struct custom_type covers check of trivially copyable custom type
 struct custom_type {
   int m_int_field{};
   bool m_bool_field{};
@@ -67,11 +76,6 @@ struct custom_type {
   }
 
   operator int() const { return m_int_field; }
-
-  void operator=(int value) {
-    m_int_field = value;
-    m_bool_field = value;
-  }
 };
 
 /**
@@ -99,6 +103,10 @@ inline auto get_conformance_type_pack() {
   return types;
 }
 
+/**
+ * @brief Function to check if the device can allocate memory according to the
+ * PtrType pointer type
+ */
 template <pointer_type PtrType>
 bool check_device_aspect_allocations(sycl::queue& queue) {
   switch (PtrType) {
@@ -113,6 +121,10 @@ bool check_device_aspect_allocations(sycl::queue& queue) {
   }
 }
 
+/**
+ * @brief Function to check if the device can allocate memory according to the
+ * SrcPtrType and DestPtrType pointer types
+ */
 template <pointer_type SrcPtrType, pointer_type DestPtrType>
 bool check_device_aspect_allocations(sycl::queue& queue) {
   return check_device_aspect_allocations<SrcPtrType>(queue) &&
@@ -120,43 +132,44 @@ bool check_device_aspect_allocations(sycl::queue& queue) {
 }
 
 /**
- * @brief Function for allocate memory
+ * @brief Function to allocate memory with type according to PtrType
  */
 template <typename T, pointer_type PtrType>
 auto allocate_memory(size_t size, sycl::queue& queue) {
   if constexpr (pointer_type::host == PtrType) {
-    auto deleter = [&](T* ptr) { delete[] ptr; };
-    return std::unique_ptr<T[], decltype(deleter)>(new T[size], deleter);
-  } else if constexpr (pointer_type::usm_host == PtrType) {
-    auto deleter = [&](T* ptr) { sycl::free(ptr, queue); };
-    return std::unique_ptr<T[], decltype(deleter)>(
-        sycl::malloc_host<T>(size, queue), deleter);
-  } else if constexpr (pointer_type::usm_device == PtrType) {
-    auto deleter = [&](T* ptr) { sycl::free(ptr, queue); };
-    return std::unique_ptr<T[], decltype(deleter)>(
-        sycl::malloc_device<T>(size, queue), deleter);
+    return std::make_unique<T[]>(size);
   } else {
-    auto deleter = [&](T* ptr) { sycl::free(ptr, queue); };
-    return std::unique_ptr<T[], decltype(deleter)>(
-        sycl::malloc_shared<T>(size, queue), deleter);
+    auto deleter = [=](T* ptr) { sycl::free(ptr, queue); };
+    if constexpr (pointer_type::usm_host == PtrType) {
+      return std::unique_ptr<T[], decltype(deleter)>(
+          sycl::malloc_host<T>(size, queue), deleter);
+    } else if constexpr (pointer_type::usm_device == PtrType) {
+      return std::unique_ptr<T[], decltype(deleter)>(
+          sycl::malloc_device<T>(size, queue), deleter);
+    } else {
+      return std::unique_ptr<T[], decltype(deleter)>(
+          sycl::malloc_shared<T>(size, queue), deleter);
+    }
   }
 }
 
+/**
+ * @brief Function to fill memory with type according to PtrType
+ */
 template <typename T, pointer_type PtrType>
 void fill_memory(T* ptr, const T& pattern, size_t count, sycl::queue& queue) {
-  switch (PtrType) {
-    case pointer_type::host:
-    case pointer_type::usm_host:
-    case pointer_type::usm_shared:
-      std::fill(ptr, ptr + count, pattern);
-      break;
-    case pointer_type::usm_device:
-      auto event = queue.fill(ptr, pattern, count);
-      event.wait();
-      break;
+  if constexpr (PtrType == pointer_type::usm_device) {
+    auto event = queue.fill(ptr, pattern, count);
+    event.wait();
+  } else {
+    std::fill(ptr, ptr + count, pattern);
   }
 }
 
+/**
+ * @brief Function to copy data from memory with type according with PtrType to
+ * result array on host
+ */
 template <pointer_type DestPtrType, typename T>
 void copy_destination_to_host_result(T* src, T* result, size_t size,
                                      sycl::queue& queue) {
@@ -169,7 +182,7 @@ void copy_destination_to_host_result(T* src, T* result, size_t size,
 }
 
 /**
- * @brief Function to get expected value int the allocated memory cell
+ * @brief Function to get expected value in the allocated memory cell
  */
 template <typename T>
 T get_expected_value(size_t address, T& ival, T& chval) {
@@ -184,6 +197,21 @@ T get_expected_value(size_t address, T& ival, T& chval) {
              ? chval
              : ival;
 }
+
+template <typename Functor>
+void for_index(Functor&& functor) {
+  for (size_t i = 0; i < array_height; ++i) {
+    for (size_t j = 0; j < dest_pitch; ++j) {
+      size_t index = j + dest_pitch * i;
+      functor(index);
+    }
+  }
+}
+
+template <typename T>
+T* get_region_address(T* base, size_t pitch) {
+  return base + shift_row * pitch + shift_col;
+};
 
 }  // namespace memcpy2d_common_tests
 

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler.h
@@ -77,21 +77,18 @@ class run_handler_tests {
                                      dest_ptr_type_name)
                   .create()) {
         queue.submit([&](sycl::handler& cgh) {
-          auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
-          auto src_address = src.get() + shift_row * src_pitch + shift_col;
+          auto dest_address = get_region_address(dst.get(), dest_pitch);
+          auto src_address = get_region_address(src.get(), src_pitch);
           cgh.ext_oneapi_memcpy2d(dest_address, dest_pitch, src_address,
                                   src_pitch, region_width, region_height);
         });
         queue.wait();
         copy_destination_to_host_result<DestPtrType>(dst.get(), result,
                                                      result_size, queue);
-        for (size_t i = 0; i < array_height; ++i) {
-          for (size_t j = 0; j < dest_pitch; ++j) {
-            size_t address = j + dest_pitch * i;
-            T val = get_expected_value(address, init_v, expected_v);
-            CHECK(val == result[address]);
-          }
-        }
+        for_index([&](size_t index) {
+          T val = get_expected_value(index, init_v, expected_v);
+          CHECK(val == result[index]);
+        });
       }
     }
     SECTION(sycl_cts::section_name(std::string("Check copy2d with T = ") +
@@ -102,21 +99,18 @@ class run_handler_tests {
                                    dest_ptr_type_name)
                 .create()) {
       queue.submit([&](sycl::handler& cgh) {
-        auto dest_address = dst.get() + (shift_row * dest_pitch + shift_col);
-        auto src_address = src.get() + (shift_row * src_pitch + shift_col);
+        auto dest_address = get_region_address(dst.get(), dest_pitch);
+        auto src_address = get_region_address(src.get(), src_pitch);
         cgh.ext_oneapi_copy2d(src_address, src_pitch, dest_address, dest_pitch,
                               region_width, region_height);
       });
       queue.wait();
       copy_destination_to_host_result<DestPtrType>(dst.get(), result,
                                                    result_size, queue);
-      for (size_t i = 0; i < array_height; ++i) {
-        for (size_t j = 0; j < dest_pitch; ++j) {
-          size_t address = (j + dest_pitch * i);
-          T val = get_expected_value(address, init_v, expected_v);
-          CHECK(val == result[address]);
-        }
-      }
+      for_index([&](size_t index) {
+        T val = get_expected_value(index, init_v, expected_v);
+        CHECK(val == result[index]);
+      });
     }
     if constexpr (std::is_same_v<T, unsigned char>) {
       SECTION(sycl_cts::section_name(std::string("Check memset2d with T = ") +
@@ -127,8 +121,8 @@ class run_handler_tests {
                                      dest_ptr_type_name)
                   .create()) {
         queue.submit([&](sycl::handler& cgh) {
-          auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
-          auto src_address = src.get() + shift_row * src_pitch + shift_col;
+          auto dest_address = get_region_address(dst.get(), dest_pitch);
+          auto src_address = get_region_address(src.get(), src_pitch);
           int value = expected_val;
           cgh.ext_oneapi_memset2d(dest_address, dest_pitch, value, region_width,
                                   region_height);
@@ -136,13 +130,10 @@ class run_handler_tests {
         queue.wait();
         copy_destination_to_host_result<DestPtrType>(dst.get(), result,
                                                      result_size, queue);
-        for (size_t i = 0; i < array_height; ++i) {
-          for (size_t j = 0; j < dest_pitch; ++j) {
-            size_t address = j + dest_pitch * i;
-            T val = get_expected_value(address, init_v, expected_v);
-            CHECK(val == result[address]);
-          }
-        }
+        for_index([&](size_t index) {
+          T val = get_expected_value(index, init_v, expected_v);
+          CHECK(val == result[index]);
+        });
       }
     }
     SECTION(sycl_cts::section_name(std::string("Check fill2d with T = ") +
@@ -153,8 +144,8 @@ class run_handler_tests {
                                    dest_ptr_type_name)
                 .create()) {
       queue.submit([&](sycl::handler& cgh) {
-        auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
-        auto src_address = src.get() + shift_row * src_pitch + shift_col;
+        auto dest_address = get_region_address(dst.get(), dest_pitch);
+        auto src_address = get_region_address(src.get(), src_pitch);
         T value = value_operations::init<T>(expected_val);
         cgh.ext_oneapi_fill2d(dest_address, dest_pitch, value, region_width,
                               region_height);
@@ -162,13 +153,10 @@ class run_handler_tests {
       queue.wait();
       copy_destination_to_host_result<DestPtrType>(dst.get(), result,
                                                    result_size, queue);
-      for (size_t i = 0; i < array_height; ++i) {
-        for (size_t j = 0; j < dest_pitch; ++j) {
-          size_t address = j + dest_pitch * i;
-          T val = get_expected_value(address, init_v, expected_v);
-          CHECK(val == result[address]);
-        }
-      }
+      for_index([&](size_t index) {
+        T val = get_expected_value(index, init_v, expected_v);
+        CHECK(val == result[index]);
+      });
     }
   }
 };

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler.h
@@ -1,0 +1,180 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides class for tests to check handler class functions gained with
+//  oneapi_memcpy2d extension
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_MEMCPY2D_MEMCPY2D_HANDLER_H
+#define SYCL_CTS_MEMCPY2D_MEMCPY2D_HANDLER_H
+
+#include <memory>
+
+#include "catch2/catch_test_macros.hpp"
+
+#include "../../common/section_name_builder.h"
+#include "../../common/value_operations.h"
+
+#include "memcpy2d_common.h"
+
+namespace memcpy2d_handler_tests {
+using namespace memcpy2d_common_tests;
+
+#ifdef SYCL_EXT_ONEAPI_MEMCPY2D
+
+template <typename T, typename SrcPtrT, typename DestPtrT>
+class run_handler_tests {
+  static constexpr pointer_type SrcPtrType = SrcPtrT::value;
+  static constexpr pointer_type DestPtrType = DestPtrT::value;
+
+ public:
+  void operator()(sycl::queue& queue, const std::string& t_name,
+                  const std::string& src_ptr_type_name,
+                  const std::string& dest_ptr_type_name) {
+    if (!check_device_aspect_allocations<SrcPtrType, DestPtrType>(queue)) {
+      SKIP(
+          "Device does not support USM device allocations. "
+          "Skipping the test case.");
+    }
+
+    T init_v = value_operations::init<T>(init_val);
+    T expected_v = value_operations::init<T>(expected_val);
+
+    auto src = allocate_memory<T, SrcPtrType>(src_pitch * array_height, queue);
+    fill_memory<T, SrcPtrType>(src.get(), expected_v, src_pitch * array_height,
+                               queue);
+
+    auto dst =
+        allocate_memory<T, DestPtrType>(dest_pitch * array_height, queue);
+    fill_memory<T, DestPtrType>(dst.get(), init_v, dest_pitch * array_height,
+                                queue);
+
+    constexpr size_t result_size = dest_pitch * array_height;
+    T result[result_size];
+
+    if constexpr (std::is_same_v<T, unsigned char>) {
+      SECTION(sycl_cts::section_name(std::string("Check memcpy2d with T = ") +
+                                     t_name +
+                                     " src_ptr_type = " + src_ptr_type_name +
+                                     " and"
+                                     " dest_ptr_type = " +
+                                     dest_ptr_type_name)
+                  .create()) {
+        queue.submit([&](sycl::handler& cgh) {
+          auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
+          auto src_address = src.get() + shift_row * src_pitch + shift_col;
+          cgh.ext_oneapi_memcpy2d(dest_address, dest_pitch, src_address,
+                                  src_pitch, region_width, region_height);
+        });
+        queue.wait();
+        copy_destination_to_host_result<DestPtrType>(dst.get(), result,
+                                                     result_size, queue);
+        for (size_t i = 0; i < array_height; ++i) {
+          for (size_t j = 0; j < dest_pitch; ++j) {
+            size_t address = j + dest_pitch * i;
+            T val = get_expected_value(address, init_v, expected_v);
+            CHECK(val == result[address]);
+          }
+        }
+      }
+    }
+    SECTION(sycl_cts::section_name(std::string("Check copy2d with T = ") +
+                                   t_name +
+                                   " src_ptr_type = " + src_ptr_type_name +
+                                   " and"
+                                   " dest_ptr_type = " +
+                                   dest_ptr_type_name)
+                .create()) {
+      queue.submit([&](sycl::handler& cgh) {
+        auto dest_address = dst.get() + (shift_row * dest_pitch + shift_col);
+        auto src_address = src.get() + (shift_row * src_pitch + shift_col);
+        cgh.ext_oneapi_copy2d(src_address, src_pitch, dest_address, dest_pitch,
+                              region_width, region_height);
+      });
+      queue.wait();
+      copy_destination_to_host_result<DestPtrType>(dst.get(), result,
+                                                   result_size, queue);
+      for (size_t i = 0; i < array_height; ++i) {
+        for (size_t j = 0; j < dest_pitch; ++j) {
+          size_t address = (j + dest_pitch * i);
+          T val = get_expected_value(address, init_v, expected_v);
+          CHECK(val == result[address]);
+        }
+      }
+    }
+    if constexpr (std::is_same_v<T, unsigned char>) {
+      SECTION(sycl_cts::section_name(std::string("Check memset2d with T = ") +
+                                     t_name +
+                                     " src_ptr_type = " + src_ptr_type_name +
+                                     " and"
+                                     " dest_ptr_type = " +
+                                     dest_ptr_type_name)
+                  .create()) {
+        queue.submit([&](sycl::handler& cgh) {
+          auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
+          auto src_address = src.get() + shift_row * src_pitch + shift_col;
+          int value = expected_val;
+          cgh.ext_oneapi_memset2d(dest_address, dest_pitch, value, region_width,
+                                  region_height);
+        });
+        queue.wait();
+        copy_destination_to_host_result<DestPtrType>(dst.get(), result,
+                                                     result_size, queue);
+        for (size_t i = 0; i < array_height; ++i) {
+          for (size_t j = 0; j < dest_pitch; ++j) {
+            size_t address = j + dest_pitch * i;
+            T val = get_expected_value(address, init_v, expected_v);
+            CHECK(val == result[address]);
+          }
+        }
+      }
+    }
+    SECTION(sycl_cts::section_name(std::string("Check fill2d with T = ") +
+                                   t_name +
+                                   " src_ptr_type = " + src_ptr_type_name +
+                                   " and"
+                                   " dest_ptr_type = " +
+                                   dest_ptr_type_name)
+                .create()) {
+      queue.submit([&](sycl::handler& cgh) {
+        auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
+        auto src_address = src.get() + shift_row * src_pitch + shift_col;
+        T value = value_operations::init<T>(expected_val);
+        cgh.ext_oneapi_fill2d(dest_address, dest_pitch, value, region_width,
+                              region_height);
+      });
+      queue.wait();
+      copy_destination_to_host_result<DestPtrType>(dst.get(), result,
+                                                   result_size, queue);
+      for (size_t i = 0; i < array_height; ++i) {
+        for (size_t j = 0; j < dest_pitch; ++j) {
+          size_t address = j + dest_pitch * i;
+          T val = get_expected_value(address, init_v, expected_v);
+          CHECK(val == result[address]);
+        }
+      }
+    }
+  }
+};
+
+#endif  // SYCL_EXT_ONEAPI_MEMCPY2D
+
+}  // namespace memcpy2d_handler_tests
+
+#endif  // SYCL_CTS_MEMCPY2D_MEMCPY2D_HANDLER_H

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_core.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_core.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check handler class functions with core types gained with
+//  oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_handler.h"
+
+namespace memcpy2d_handler_core_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_handler_tests;
+
+TEST_CASE("Check handler memcpy2d extension. core types.",
+          "[oneapi_memcpy2d]") {
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = get_conformance_type_pack();
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_handler_tests>(type_pack, src_ptr_types,
+                                          dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_handler_core_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions.h
@@ -1,0 +1,174 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides class for tests to check handler class functions exceptions gained
+//  with oneapi_memcpy2d extension
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_MEMCPY2D_MEMCPY2D_HANDLER_EXCEPTIONS_H
+#define SYCL_CTS_MEMCPY2D_MEMCPY2D_HANDLER_EXCEPTIONS_H
+
+#include <memory>
+
+#include "catch2/catch_test_macros.hpp"
+
+#include "../../common/section_name_builder.h"
+#include "../../common/value_operations.h"
+
+#include "../../../util/sycl_exceptions.h"
+
+#include "memcpy2d_common.h"
+
+namespace memcpy2d_handler_exceptions_tests {
+using namespace memcpy2d_common_tests;
+
+#ifdef SYCL_EXT_ONEAPI_MEMCPY2D
+
+template <typename T, typename SrcPtrT, typename DestPtrT>
+class run_handler_exceptions_tests {
+  static constexpr pointer_type SrcPtrType = SrcPtrT::value;
+  static constexpr pointer_type DestPtrType = DestPtrT::value;
+
+ public:
+  void operator()(sycl::queue& queue, const std::string& t_name,
+                  const std::string& src_ptr_type_name,
+                  const std::string& dest_ptr_type_name) {
+    if (!check_device_aspect_allocations<SrcPtrType, DestPtrType>(queue)) {
+      SKIP(
+          "Device does not support USM device allocations. "
+          "Skipping the test case.");
+    }
+
+    T init_v = value_operations::init<T>(init_val);
+    T expected_v = value_operations::init<T>(expected_val);
+
+    constexpr size_t extra_bit = 4;
+
+    auto src = allocate_memory<T, SrcPtrType>(
+        (src_pitch + extra_bit) * array_height, queue);
+    fill_memory<T, SrcPtrType>(src.get(), expected_v,
+                               (src_pitch + extra_bit) * array_height, queue);
+
+    auto dst = allocate_memory<T, DestPtrType>(
+        (dest_pitch + extra_bit) * array_height, queue);
+    fill_memory<T, DestPtrType>(dst.get(), init_v,
+                                (dest_pitch + extra_bit) * array_height, queue);
+
+    if constexpr (std::is_same_v<T, unsigned char>) {
+      SECTION(sycl_cts::section_name(
+                  std::string("Check memcpy2d exception with T = ") + t_name +
+                  " src_ptr_type = " + src_ptr_type_name +
+                  " and"
+                  " dest_ptr_type = " +
+                  dest_ptr_type_name)
+                  .create()) {
+        auto action = [&](auto reg_width) {
+          queue.submit([&](sycl::handler& cgh) {
+            auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
+            auto src_address = src.get() + shift_row * src_pitch + shift_col;
+            cgh.ext_oneapi_memcpy2d(dest_address, dest_pitch, src_address,
+                                    src_pitch, reg_width, region_height);
+          });
+        };
+        CHECK_THROWS_MATCHES(
+            action(src_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        CHECK_THROWS_MATCHES(
+            action(dest_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+      }
+    }
+    SECTION(
+        sycl_cts::section_name(std::string("Check copy2d exception with T = ") +
+                               t_name + " src_ptr_type = " + src_ptr_type_name +
+                               " and"
+                               " dest_ptr_type = " +
+                               dest_ptr_type_name)
+            .create()) {
+      auto action = [&](auto reg_width) {
+        queue.submit([&](sycl::handler& cgh) {
+          auto dest_address = dst.get() + (shift_row * dest_pitch + shift_col);
+          auto src_address = src.get() + (shift_row * src_pitch + shift_col);
+          cgh.ext_oneapi_copy2d(src_address, src_pitch, dest_address,
+                                dest_pitch, reg_width, region_height);
+        });
+      };
+      CHECK_THROWS_MATCHES(
+          action(src_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      CHECK_THROWS_MATCHES(
+          action(dest_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+    }
+    if constexpr (std::is_same_v<T, unsigned char>) {
+      SECTION(sycl_cts::section_name(std::string("Check memset2d with T = ") +
+                                     t_name +
+                                     " src_ptr_type = " + src_ptr_type_name +
+                                     " and"
+                                     " dest_ptr_type = " +
+                                     dest_ptr_type_name)
+                  .create()) {
+        auto action = [&](auto reg_width) {
+          queue.submit([&](sycl::handler& cgh) {
+            auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
+            auto src_address = src.get() + shift_row * src_pitch + shift_col;
+            int value = expected_val;
+            cgh.ext_oneapi_memset2d(dest_address, dest_pitch, value, reg_width,
+                                    region_height);
+          });
+        };
+        CHECK_THROWS_MATCHES(
+            action(src_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        CHECK_THROWS_MATCHES(
+            action(dest_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+      }
+    }
+    SECTION(sycl_cts::section_name(std::string("Check fill2d with T = ") +
+                                   t_name +
+                                   " src_ptr_type = " + src_ptr_type_name +
+                                   " and"
+                                   " dest_ptr_type = " +
+                                   dest_ptr_type_name)
+                .create()) {
+      auto action = [&](auto reg_width) {
+        queue.submit([&](sycl::handler& cgh) {
+          auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
+          auto src_address = src.get() + shift_row * src_pitch + shift_col;
+          T value = value_operations::init<T>(expected_val);
+          cgh.ext_oneapi_fill2d(dest_address, dest_pitch, value, reg_width,
+                                region_height);
+        });
+      };
+      CHECK_THROWS_MATCHES(
+          action(src_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      CHECK_THROWS_MATCHES(
+          action(dest_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+    }
+  }
+};
+
+#endif  // SYCL_EXT_ONEAPI_MEMCPY2D
+
+}  // namespace memcpy2d_handler_exceptions_tests
+
+#endif  // SYCL_CTS_MEMCPY2D_MEMCPY2D_HANDLER_EXCEPTIONS_H

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions.h
@@ -80,15 +80,20 @@ class run_handler_exceptions_tests {
                   .create()) {
         auto action = [&](auto reg_width) {
           queue.submit([&](sycl::handler& cgh) {
-            auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
-            auto src_address = src.get() + shift_row * src_pitch + shift_col;
+            auto dest_address = get_region_address(dst.get(), dest_pitch);
+            auto src_address = get_region_address(src.get(), src_pitch);
             cgh.ext_oneapi_memcpy2d(dest_address, dest_pitch, src_address,
                                     src_pitch, reg_width, region_height);
           });
         };
+        // Check that if reg_width is greater than src_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action(src_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+        // Check that if reg_width is greater than dest_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -103,15 +108,20 @@ class run_handler_exceptions_tests {
             .create()) {
       auto action = [&](auto reg_width) {
         queue.submit([&](sycl::handler& cgh) {
-          auto dest_address = dst.get() + (shift_row * dest_pitch + shift_col);
-          auto src_address = src.get() + (shift_row * src_pitch + shift_col);
+          auto dest_address = get_region_address(dst.get(), dest_pitch);
+          auto src_address = get_region_address(src.get(), src_pitch);
           cgh.ext_oneapi_copy2d(src_address, src_pitch, dest_address,
                                 dest_pitch, reg_width, region_height);
         });
       };
+      // Check that if reg_width is greater than src_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action(src_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+      // Check that if reg_width is greater than dest_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -126,16 +136,15 @@ class run_handler_exceptions_tests {
                   .create()) {
         auto action = [&](auto reg_width) {
           queue.submit([&](sycl::handler& cgh) {
-            auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
-            auto src_address = src.get() + shift_row * src_pitch + shift_col;
+            auto dest_address = get_region_address(dst.get(), dest_pitch);
+            auto src_address = get_region_address(src.get(), src_pitch);
             int value = expected_val;
             cgh.ext_oneapi_memset2d(dest_address, dest_pitch, value, reg_width,
                                     region_height);
           });
         };
-        CHECK_THROWS_MATCHES(
-            action(src_pitch + extra_bit), sycl::exception,
-            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        // Check that if reg_width is greater than dest_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -150,16 +159,15 @@ class run_handler_exceptions_tests {
                 .create()) {
       auto action = [&](auto reg_width) {
         queue.submit([&](sycl::handler& cgh) {
-          auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
-          auto src_address = src.get() + shift_row * src_pitch + shift_col;
+          auto dest_address = get_region_address(dst.get(), dest_pitch);
+          auto src_address = get_region_address(src.get(), src_pitch);
           T value = value_operations::init<T>(expected_val);
           cgh.ext_oneapi_fill2d(dest_address, dest_pitch, value, reg_width,
                                 region_height);
         });
       };
-      CHECK_THROWS_MATCHES(
-          action(src_pitch + extra_bit), sycl::exception,
-          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      // Check that if reg_width is greater than dest_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions_core.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions_core.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check handler class functions exceptions with core types
+//  gained with oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_handler_exceptions.h"
+
+namespace memcpy2d_handler_exceptions_core_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_handler_exceptions_tests;
+
+TEST_CASE("Check handler memcpy2d extension exceptions. core types.",
+          "[oneapi_memcpy2d]") {
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = get_conformance_type_pack();
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_handler_exceptions_tests>(type_pack, src_ptr_types,
+                                                     dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_handler_exceptions_core_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions_fp16.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions_fp16.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check handler class functions exceptions with fp16 type
+//  gained with oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_handler_exceptions.h"
+
+namespace memcpy2d_handler_exceptions_fp16_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_handler_exceptions_tests;
+
+TEST_CASE("Check handler memcpy2d extension exceptions. fp16 type.",
+          "[oneapi_memcpy2d]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    SKIP(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+  }
+
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = named_type_pack<sycl::half>::generate("sycl::half");
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_handler_exceptions_tests>(type_pack, src_ptr_types,
+                                                     dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_handler_exceptions_fp16_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions_fp64.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions_fp64.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check handler class functions exceptions with fp64 type
+//  gained with oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_handler_exceptions.h"
+
+namespace memcpy2d_handler_exceptions_fp64_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_handler_exceptions_tests;
+
+TEST_CASE("Check handler memcpy2d extension exceptions. fp64 type.",
+          "[oneapi_memcpy2d]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+  }
+
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = named_type_pack<double>::generate("double");
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_handler_exceptions_tests>(type_pack, src_ptr_types,
+                                                     dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_handler_exceptions_fp64_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_fp16.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_fp16.cpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check handler class functions with fp16 type gained with
+//  oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_handler.h"
+
+namespace memcpy2d_handler_fp16_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_handler_tests;
+
+TEST_CASE("Check handler memcpy2d extension. fp16 type.", "[oneapi_memcpy2d]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    SKIP(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+  }
+
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = named_type_pack<sycl::half>::generate("sycl::half");
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_handler_tests>(type_pack, src_ptr_types,
+                                          dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_handler_fp16_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_fp64.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_fp64.cpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check handler class functions with fp64 type gained with
+//  oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_handler.h"
+
+namespace memcpy2d_handler_fp64_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_handler_tests;
+
+TEST_CASE("Check handler memcpy2d extension. fp64 type.", "[oneapi_memcpy2d]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+  }
+
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = named_type_pack<double>::generate("double");
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_handler_tests>(type_pack, src_ptr_types,
+                                          dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_handler_fp64_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut.h
@@ -1,0 +1,250 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides class for tests to check queue class functions gained with
+//  oneapi_memcpy2d extension
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_MEMCPY2D_MEMCPY2D_QUEUE_SHORTCUT_H
+#define SYCL_CTS_MEMCPY2D_MEMCPY2D_QUEUE_SHORTCUT_H
+
+#include <memory>
+
+#include "catch2/catch_test_macros.hpp"
+
+#include "../../common/section_name_builder.h"
+#include "../../common/value_operations.h"
+
+#include "memcpy2d_common.h"
+
+namespace memcpy2d_queue_shortcut_tests {
+using namespace memcpy2d_common_tests;
+
+#ifdef SYCL_EXT_ONEAPI_MEMCPY2D
+
+template <typename T, typename SrcPtrT, typename DestPtrT>
+class run_queue_shortcut_tests {
+  static constexpr pointer_type SrcPtrType = SrcPtrT::value;
+  static constexpr pointer_type DestPtrType = DestPtrT::value;
+
+ public:
+  void operator()(sycl::queue& queue, const std::string& t_name,
+                  const std::string& src_ptr_type_name,
+                  const std::string& dest_ptr_type_name) {
+    if (!check_device_aspect_allocations<SrcPtrType, DestPtrType>(queue)) {
+      SKIP(
+          "Device does not support USM device allocations. "
+          "Skipping the test case.");
+    }
+
+    T init_v = value_operations::init<T>(init_val);
+    T expected_v = value_operations::init<T>(expected_val);
+
+    auto src = allocate_memory<T, SrcPtrType>(src_pitch * array_height, queue);
+    fill_memory<T, SrcPtrType>(src.get(), expected_v, src_pitch * array_height,
+                               queue);
+
+    auto dst1 =
+        allocate_memory<T, DestPtrType>(dest_pitch * array_height, queue);
+    fill_memory<T, DestPtrType>(dst1.get(), init_v, dest_pitch * array_height,
+                                queue);
+
+    auto dst2 =
+        allocate_memory<T, DestPtrType>(dest_pitch * array_height, queue);
+    fill_memory<T, DestPtrType>(dst2.get(), init_v, dest_pitch * array_height,
+                                queue);
+
+    auto dst3 =
+        allocate_memory<T, DestPtrType>(dest_pitch * array_height, queue);
+    fill_memory<T, DestPtrType>(dst3.get(), init_v, dest_pitch * array_height,
+                                queue);
+
+    constexpr size_t result_size = dest_pitch * array_height;
+    T result[result_size];
+    T result2[result_size];
+    T result3[result_size];
+
+    if constexpr (std::is_same_v<T, unsigned char>) {
+      SECTION(sycl_cts::section_name(std::string("Check memcpy2d with T = ") +
+                                     t_name +
+                                     " src_ptr_type = " + src_ptr_type_name +
+                                     " and"
+                                     " dest_ptr_type = " +
+                                     dest_ptr_type_name)
+                  .create()) {
+        auto dest_address = dst1.get() + shift_row * dest_pitch + shift_col;
+        auto src_address = src.get() + shift_row * src_pitch + shift_col;
+        auto queue1 =
+            queue.ext_oneapi_memcpy2d(dest_address, dest_pitch, src_address,
+                                      src_pitch, region_width, region_height);
+
+        dest_address = dst2.get() + shift_row * dest_pitch + shift_col;
+        src_address = dst1.get() + shift_row * dest_pitch + shift_col;
+        auto queue2 = queue.ext_oneapi_memcpy2d(
+            dest_address, dest_pitch, src_address, dest_pitch, region_width,
+            region_height, queue1);
+
+        dest_address = dst3.get() + shift_row * dest_pitch + shift_col;
+        src_address = dst2.get() + shift_row * dest_pitch + shift_col;
+        queue.ext_oneapi_memcpy2d(dest_address, dest_pitch, src_address,
+                                  dest_pitch, region_width, region_height,
+                                  {queue1, queue2});
+
+        queue.wait();
+        copy_destination_to_host_result<DestPtrType>(dst3.get(), result,
+                                                     result_size, queue);
+
+        for (size_t i = 0; i < array_height; ++i) {
+          for (size_t j = 0; j < dest_pitch; ++j) {
+            size_t address = j + dest_pitch * i;
+            T val = get_expected_value(address, init_v, expected_v);
+            CHECK(val == result[address]);
+          }
+        }
+      }
+    }
+    SECTION(sycl_cts::section_name(std::string("Check copy2d with T = ") +
+                                   t_name +
+                                   " src_ptr_type = " + src_ptr_type_name +
+                                   " and"
+                                   " dest_ptr_type = " +
+                                   dest_ptr_type_name)
+                .create()) {
+      auto dest_address = dst1.get() + (shift_row * dest_pitch + shift_col);
+      auto src_address = src.get() + (shift_row * src_pitch + shift_col);
+      auto queue1 =
+          queue.ext_oneapi_copy2d(src_address, src_pitch, dest_address,
+                                  dest_pitch, region_width, region_height);
+
+      dest_address = dst2.get() + shift_row * dest_pitch + shift_col;
+      src_address = dst1.get() + shift_row * dest_pitch + shift_col;
+      auto queue2 = queue.ext_oneapi_copy2d(
+          src_address, dest_pitch, dest_address, dest_pitch, region_width,
+          region_height, queue1);
+
+      dest_address = dst3.get() + shift_row * dest_pitch + shift_col;
+      src_address = dst2.get() + shift_row * dest_pitch + shift_col;
+      queue.ext_oneapi_copy2d(src_address, dest_pitch, dest_address, dest_pitch,
+                              region_width, region_height, {queue1, queue2});
+
+      queue.wait();
+      copy_destination_to_host_result<DestPtrType>(dst3.get(), result,
+                                                   result_size, queue);
+
+      for (size_t i = 0; i < array_height; ++i) {
+        for (size_t j = 0; j < dest_pitch; ++j) {
+          size_t address = (j + dest_pitch * i);
+          T val = get_expected_value(address, init_v, expected_v);
+          CHECK(val == result[address]);
+        }
+      }
+    }
+    if constexpr (std::is_same_v<T, unsigned char>) {
+      SECTION(sycl_cts::section_name(std::string("Check memset2d with T = ") +
+                                     t_name +
+                                     " src_ptr_type = " + src_ptr_type_name +
+                                     " and"
+                                     " dest_ptr_type = " +
+                                     dest_ptr_type_name)
+                  .create()) {
+        int value = expected_val;
+
+        auto dest_address = dst1.get() + shift_row * dest_pitch + shift_col;
+        auto src_address = src.get() + shift_row * src_pitch + shift_col;
+        auto queue1 = queue.ext_oneapi_memset2d(dest_address, dest_pitch, value,
+                                                region_width, region_height);
+
+        dest_address = dst2.get() + shift_row * dest_pitch + shift_col;
+        src_address = dst1.get() + shift_row * dest_pitch + shift_col;
+        auto queue2 =
+            queue.ext_oneapi_memset2d(dest_address, dest_pitch, value,
+                                      region_width, region_height, queue1);
+
+        dest_address = dst3.get() + shift_row * dest_pitch + shift_col;
+        src_address = dst2.get() + shift_row * dest_pitch + shift_col;
+        queue.ext_oneapi_memset2d(dest_address, dest_pitch, value, region_width,
+                                  region_height, {queue1, queue2});
+
+        queue.wait();
+        copy_destination_to_host_result<DestPtrType>(dst1.get(), result,
+                                                     result_size, queue);
+        copy_destination_to_host_result<DestPtrType>(dst2.get(), result2,
+                                                     result_size, queue);
+        copy_destination_to_host_result<DestPtrType>(dst3.get(), result3,
+                                                     result_size, queue);
+        for (size_t i = 0; i < array_height; ++i) {
+          for (size_t j = 0; j < dest_pitch; ++j) {
+            size_t address = j + dest_pitch * i;
+            T val = get_expected_value(address, init_v, expected_v);
+            CHECK(val == result[address]);
+            CHECK(val == result2[address]);
+            CHECK(val == result3[address]);
+          }
+        }
+      }
+    }
+    SECTION(sycl_cts::section_name(std::string("Check fill2d with T = ") +
+                                   t_name +
+                                   " src_ptr_type = " + src_ptr_type_name +
+                                   " and"
+                                   " dest_ptr_type = " +
+                                   dest_ptr_type_name)
+                .create()) {
+      T value = value_operations::init<T>(expected_val);
+
+      auto dest_address = dst1.get() + shift_row * dest_pitch + shift_col;
+      auto src_address = src.get() + shift_row * src_pitch + shift_col;
+      auto queue1 = queue.ext_oneapi_fill2d(dest_address, dest_pitch, value,
+                                            region_width, region_height);
+
+      dest_address = dst2.get() + shift_row * dest_pitch + shift_col;
+      src_address = dst1.get() + shift_row * dest_pitch + shift_col;
+      auto queue2 = queue.ext_oneapi_fill2d(
+          dest_address, dest_pitch, value, region_width, region_height, queue1);
+
+      dest_address = dst3.get() + shift_row * dest_pitch + shift_col;
+      src_address = dst2.get() + shift_row * dest_pitch + shift_col;
+      queue.ext_oneapi_fill2d(dest_address, dest_pitch, value, region_width,
+                              region_height, {queue1, queue2});
+
+      queue.wait();
+      copy_destination_to_host_result<DestPtrType>(dst1.get(), result,
+                                                   result_size, queue);
+      copy_destination_to_host_result<DestPtrType>(dst2.get(), result2,
+                                                   result_size, queue);
+      copy_destination_to_host_result<DestPtrType>(dst3.get(), result3,
+                                                   result_size, queue);
+      for (size_t i = 0; i < array_height; ++i) {
+        for (size_t j = 0; j < dest_pitch; ++j) {
+          size_t address = j + dest_pitch * i;
+          T val = get_expected_value(address, init_v, expected_v);
+          CHECK(val == result[address]);
+          CHECK(val == result2[address]);
+          CHECK(val == result3[address]);
+        }
+      }
+    }
+  }
+};
+
+#endif  // SYCL_EXT_ONEAPI_MEMCPY2D
+
+}  // namespace memcpy2d_queue_shortcut_tests
+
+#endif  // SYCL_CTS_MEMCPY2D_MEMCPY2D_QUEUE_SHORTCUT_H

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_core.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_core.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check queue class functions with core types gained with
+//  oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_queue_shortcut.h"
+
+namespace memcpy2d_queue_shortcut_core_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_queue_shortcut_tests;
+
+TEST_CASE("Check queue shortcuts memcpy2d extension. core types.",
+          "[oneapi_memcpy2d]") {
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = get_conformance_type_pack();
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_queue_shortcut_tests>(type_pack, src_ptr_types,
+                                                 dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_queue_shortcut_core_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions.h
@@ -69,8 +69,8 @@ class run_queue_shortcut_exceptions_tests {
     fill_memory<T, DestPtrType>(dst.get(), init_v,
                                 (dest_pitch + extra_bit) * array_height, queue);
 
-    auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
-    auto src_address = src.get() + shift_row * src_pitch + shift_col;
+    auto dest_address = get_region_address(dst.get(), dest_pitch);
+    auto src_address = get_region_address(src.get(), src_pitch);
 
     if constexpr (std::is_same_v<T, unsigned char>) {
       SECTION(sycl_cts::section_name(std::string("Check memcpy2d with T = ") +
@@ -85,9 +85,14 @@ class run_queue_shortcut_exceptions_tests {
                                            src_address, src_pitch, reg_width,
                                            region_height);
         };
+        // Check that if reg_width is greater than src_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action1(src_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+        // Check that if reg_width is greater than dest_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action1(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -98,9 +103,14 @@ class run_queue_shortcut_exceptions_tests {
                                            src_address, src_pitch, reg_width,
                                            region_height, event1);
         };
+        // Check that if reg_width is greater than src_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action2(src_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+        // Check that if reg_width is greater than dest_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action2(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -111,9 +121,14 @@ class run_queue_shortcut_exceptions_tests {
                                     src_pitch, reg_width, region_height,
                                     {event1, event2});
         };
+        // Check that if reg_width is greater than src_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action3(src_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+        // Check that if reg_width is greater than dest_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action3(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -130,9 +145,14 @@ class run_queue_shortcut_exceptions_tests {
         return queue.ext_oneapi_copy2d(src_address, src_pitch, dest_address,
                                        dest_pitch, reg_width, region_height);
       };
+      // Check that if reg_width is greater than src_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action1(src_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+      // Check that if reg_width is greater than dest_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action1(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -143,9 +163,14 @@ class run_queue_shortcut_exceptions_tests {
                                        dest_pitch, reg_width, region_height,
                                        event1);
       };
+      // Check that if reg_width is greater than src_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action2(src_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+      // Check that if reg_width is greater than dest_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action2(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -156,9 +181,14 @@ class run_queue_shortcut_exceptions_tests {
                                        dest_pitch, reg_width, region_height,
                                        {event1, event2});
       };
+      // Check that if reg_width is greater than src_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action3(src_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+      // Check that if reg_width is greater than dest_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action3(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -177,9 +207,8 @@ class run_queue_shortcut_exceptions_tests {
           return queue.ext_oneapi_memset2d(dest_address, dest_pitch, value,
                                            reg_width, region_height);
         };
-        CHECK_THROWS_MATCHES(
-            action1(src_pitch + extra_bit), sycl::exception,
-            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        // Check that if reg_width is greater than dest_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action1(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -189,9 +218,8 @@ class run_queue_shortcut_exceptions_tests {
           return queue.ext_oneapi_memset2d(dest_address, dest_pitch, value,
                                            reg_width, region_height, event1);
         };
-        CHECK_THROWS_MATCHES(
-            action2(src_pitch + extra_bit), sycl::exception,
-            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        // Check that if reg_width is greater than dest_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action2(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -202,9 +230,8 @@ class run_queue_shortcut_exceptions_tests {
                                            reg_width, region_height,
                                            {event1, event2});
         };
-        CHECK_THROWS_MATCHES(
-            action3(src_pitch + extra_bit), sycl::exception,
-            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        // Check that if reg_width is greater than dest_pitch function throws a
+        // synchronous exception with the errc::invalid error code
         CHECK_THROWS_MATCHES(
             action3(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -223,9 +250,8 @@ class run_queue_shortcut_exceptions_tests {
         return queue.ext_oneapi_fill2d(dest_address, dest_pitch, value,
                                        reg_width, region_height);
       };
-      CHECK_THROWS_MATCHES(
-          action1(src_pitch + extra_bit), sycl::exception,
-          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      // Check that if reg_width is greater than dest_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action1(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -235,9 +261,8 @@ class run_queue_shortcut_exceptions_tests {
         return queue.ext_oneapi_fill2d(dest_address, dest_pitch, value,
                                        reg_width, region_height, event1);
       };
-      CHECK_THROWS_MATCHES(
-          action2(src_pitch + extra_bit), sycl::exception,
-          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      // Check that if reg_width is greater than dest_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action2(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -248,9 +273,8 @@ class run_queue_shortcut_exceptions_tests {
                                        reg_width, region_height,
                                        {event1, event2});
       };
-      CHECK_THROWS_MATCHES(
-          action3(src_pitch + extra_bit), sycl::exception,
-          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      // Check that if reg_width is greater than dest_pitch function throws a
+      // synchronous exception with the errc::invalid error code
       CHECK_THROWS_MATCHES(
           action3(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions.h
@@ -1,0 +1,265 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides class for tests to check queue class functions exceptions gained
+//  with oneapi_memcpy2d extension
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_MEMCPY2D_MEMCPY2D_QUEUE_SHORTCUT_EXCEPTIONS_H
+#define SYCL_CTS_MEMCPY2D_MEMCPY2D_QUEUE_SHORTCUT_EXCEPTIONS_H
+
+#include <memory>
+
+#include "catch2/catch_test_macros.hpp"
+
+#include "../../../util/sycl_exceptions.h"
+#include "../../common/section_name_builder.h"
+#include "../../common/value_operations.h"
+
+#include "memcpy2d_common.h"
+
+namespace memcpy2d_queue_shortcut_exceptions_tests {
+using namespace memcpy2d_common_tests;
+
+#ifdef SYCL_EXT_ONEAPI_MEMCPY2D
+
+template <typename T, typename SrcPtrT, typename DestPtrT>
+class run_queue_shortcut_exceptions_tests {
+  static constexpr pointer_type SrcPtrType = SrcPtrT::value;
+  static constexpr pointer_type DestPtrType = DestPtrT::value;
+
+ public:
+  void operator()(sycl::queue& queue, const std::string& t_name,
+                  const std::string& src_ptr_type_name,
+                  const std::string& dest_ptr_type_name) {
+    if (!check_device_aspect_allocations<SrcPtrType, DestPtrType>(queue)) {
+      SKIP(
+          "Device does not support USM device allocations. "
+          "Skipping the test case.");
+    }
+
+    T init_v = value_operations::init<T>(init_val);
+    T expected_v = value_operations::init<T>(expected_val);
+
+    constexpr size_t extra_bit = 4;
+
+    auto src = allocate_memory<T, SrcPtrType>(
+        (src_pitch + extra_bit) * array_height, queue);
+    fill_memory<T, SrcPtrType>(src.get(), expected_v,
+                               (src_pitch + extra_bit) * array_height, queue);
+
+    auto dst = allocate_memory<T, DestPtrType>(
+        (dest_pitch + extra_bit) * array_height, queue);
+    fill_memory<T, DestPtrType>(dst.get(), init_v,
+                                (dest_pitch + extra_bit) * array_height, queue);
+
+    auto dest_address = dst.get() + shift_row * dest_pitch + shift_col;
+    auto src_address = src.get() + shift_row * src_pitch + shift_col;
+
+    if constexpr (std::is_same_v<T, unsigned char>) {
+      SECTION(sycl_cts::section_name(std::string("Check memcpy2d with T = ") +
+                                     t_name +
+                                     " src_ptr_type = " + src_ptr_type_name +
+                                     " and"
+                                     " dest_ptr_type = " +
+                                     dest_ptr_type_name)
+                  .create()) {
+        auto action1 = [&](auto reg_width) {
+          return queue.ext_oneapi_memcpy2d(dest_address, dest_pitch,
+                                           src_address, src_pitch, reg_width,
+                                           region_height);
+        };
+        CHECK_THROWS_MATCHES(
+            action1(src_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        CHECK_THROWS_MATCHES(
+            action1(dest_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+        auto event1 = action1(region_width);
+        auto action2 = [&](auto reg_width) {
+          return queue.ext_oneapi_memcpy2d(dest_address, dest_pitch,
+                                           src_address, src_pitch, reg_width,
+                                           region_height, event1);
+        };
+        CHECK_THROWS_MATCHES(
+            action2(src_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        CHECK_THROWS_MATCHES(
+            action2(dest_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+        auto event2 = action2(region_width);
+        auto action3 = [&](auto reg_width) {
+          queue.ext_oneapi_memcpy2d(dest_address, dest_pitch, src_address,
+                                    src_pitch, reg_width, region_height,
+                                    {event1, event2});
+        };
+        CHECK_THROWS_MATCHES(
+            action3(src_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        CHECK_THROWS_MATCHES(
+            action3(dest_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+      }
+    }
+    SECTION(sycl_cts::section_name(std::string("Check copy2d with T = ") +
+                                   t_name +
+                                   " src_ptr_type = " + src_ptr_type_name +
+                                   " and"
+                                   " dest_ptr_type = " +
+                                   dest_ptr_type_name)
+                .create()) {
+      auto action1 = [&](auto reg_width) {
+        return queue.ext_oneapi_copy2d(src_address, src_pitch, dest_address,
+                                       dest_pitch, reg_width, region_height);
+      };
+      CHECK_THROWS_MATCHES(
+          action1(src_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      CHECK_THROWS_MATCHES(
+          action1(dest_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+      auto event1 = action1(region_width);
+      auto action2 = [&](auto reg_width) {
+        return queue.ext_oneapi_copy2d(src_address, src_pitch, dest_address,
+                                       dest_pitch, reg_width, region_height,
+                                       event1);
+      };
+      CHECK_THROWS_MATCHES(
+          action2(src_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      CHECK_THROWS_MATCHES(
+          action2(dest_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+      auto event2 = action2(region_width);
+      auto action3 = [&](auto reg_width) {
+        return queue.ext_oneapi_copy2d(src_address, src_pitch, dest_address,
+                                       dest_pitch, reg_width, region_height,
+                                       {event1, event2});
+      };
+      CHECK_THROWS_MATCHES(
+          action3(src_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      CHECK_THROWS_MATCHES(
+          action3(dest_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+    }
+    if constexpr (std::is_same_v<T, unsigned char>) {
+      SECTION(sycl_cts::section_name(std::string("Check memset2d with T = ") +
+                                     t_name +
+                                     " src_ptr_type = " + src_ptr_type_name +
+                                     " and"
+                                     " dest_ptr_type = " +
+                                     dest_ptr_type_name)
+                  .create()) {
+        int value = expected_val;
+
+        auto action1 = [&](auto reg_width) {
+          return queue.ext_oneapi_memset2d(dest_address, dest_pitch, value,
+                                           reg_width, region_height);
+        };
+        CHECK_THROWS_MATCHES(
+            action1(src_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        CHECK_THROWS_MATCHES(
+            action1(dest_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+        auto event1 = action1(region_width);
+        auto action2 = [&](auto reg_width) {
+          return queue.ext_oneapi_memset2d(dest_address, dest_pitch, value,
+                                           reg_width, region_height, event1);
+        };
+        CHECK_THROWS_MATCHES(
+            action2(src_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        CHECK_THROWS_MATCHES(
+            action2(dest_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+        auto event2 = action2(region_width);
+        auto action3 = [&](auto reg_width) {
+          return queue.ext_oneapi_memset2d(dest_address, dest_pitch, value,
+                                           reg_width, region_height,
+                                           {event1, event2});
+        };
+        CHECK_THROWS_MATCHES(
+            action3(src_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+        CHECK_THROWS_MATCHES(
+            action3(dest_pitch + extra_bit), sycl::exception,
+            sycl_cts::util::equals_exception(sycl::errc::invalid));
+      }
+    }
+    SECTION(sycl_cts::section_name(std::string("Check fill2d with T = ") +
+                                   t_name +
+                                   " src_ptr_type = " + src_ptr_type_name +
+                                   " and"
+                                   " dest_ptr_type = " +
+                                   dest_ptr_type_name)
+                .create()) {
+      T value = value_operations::init<T>(expected_val);
+
+      auto action1 = [&](auto reg_width) {
+        return queue.ext_oneapi_fill2d(dest_address, dest_pitch, value,
+                                       reg_width, region_height);
+      };
+      CHECK_THROWS_MATCHES(
+          action1(src_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      CHECK_THROWS_MATCHES(
+          action1(dest_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+      auto event1 = action1(region_width);
+      auto action2 = [&](auto reg_width) {
+        return queue.ext_oneapi_fill2d(dest_address, dest_pitch, value,
+                                       reg_width, region_height, event1);
+      };
+      CHECK_THROWS_MATCHES(
+          action2(src_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      CHECK_THROWS_MATCHES(
+          action2(dest_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+
+      auto event2 = action2(region_width);
+      auto action3 = [&](auto reg_width) {
+        return queue.ext_oneapi_fill2d(dest_address, dest_pitch, value,
+                                       reg_width, region_height,
+                                       {event1, event2});
+      };
+      CHECK_THROWS_MATCHES(
+          action3(src_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+      CHECK_THROWS_MATCHES(
+          action3(dest_pitch + extra_bit), sycl::exception,
+          sycl_cts::util::equals_exception(sycl::errc::invalid));
+    }
+  }
+};
+
+#endif  // SYCL_EXT_ONEAPI_MEMCPY2D
+
+}  // namespace memcpy2d_queue_shortcut_exceptions_tests
+
+#endif  // SYCL_CTS_MEMCPY2D_MEMCPY2D_QUEUE_SHORTCUT_EXCEPTIONS_H

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions_core.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions_core.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check queue class functions exceptions with core types
+//  gained with oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_queue_shortcut_exceptions.h"
+
+namespace memcpy2d_queue_shortcut_exceptions_core_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_queue_shortcut_exceptions_tests;
+
+TEST_CASE("Check queue shortcuts memcpy2d extension exceptions. core types.",
+          "[oneapi_memcpy2d]") {
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = get_conformance_type_pack();
+
+  auto queue = sycl_cts::util::get_cts_object::queue();
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_queue_shortcut_exceptions_tests>(
+      type_pack, src_ptr_types, dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_queue_shortcut_exceptions_core_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions_fp16.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions_fp16.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check queue class functions exceptions with fp16 type
+//  gained with oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_queue_shortcut_exceptions.h"
+
+namespace memcpy2d_queue_shortcut_exceptions_core_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_queue_shortcut_exceptions_tests;
+
+TEST_CASE("Check queue shortcuts memcpy2d extension exceptions. fp16 type.",
+          "[oneapi_memcpy2d]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    SKIP(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+  }
+
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = named_type_pack<sycl::half>::generate("sycl::half");
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_queue_shortcut_exceptions_tests>(
+      type_pack, src_ptr_types, dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_queue_shortcut_exceptions_core_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions_fp64.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions_fp64.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check queue class functions exceptions with fp64 type
+//  gained with oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_queue_shortcut_exceptions.h"
+
+namespace memcpy2d_queue_shortcut_exceptions_core_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_queue_shortcut_exceptions_tests;
+
+TEST_CASE("Check queue shortcuts memcpy2d extension exceptions. fp64 type.",
+          "[oneapi_memcpy2d]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+  }
+
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = named_type_pack<double>::generate("double");
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_queue_shortcut_exceptions_tests>(
+      type_pack, src_ptr_types, dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_queue_shortcut_exceptions_core_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_fp16.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_fp16.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check queue class functions with fp16 type gained with
+//  oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_queue_shortcut.h"
+
+namespace memcpy2d_queue_shortcut_fp16_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_queue_shortcut_tests;
+
+TEST_CASE("Check queue shortcuts memcpy2d extension. fp16 type.",
+          "[oneapi_memcpy2d]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    SKIP(
+        "Device does not support half precision floating point operations. "
+        "Skipping the test case.");
+  }
+
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = named_type_pack<sycl::half>::generate("sycl::half");
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_queue_shortcut_tests>(type_pack, src_ptr_types,
+                                                 dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_queue_shortcut_fp16_tests

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_fp64.cpp
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_fp64.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check queue class functions with fp64 type gained with
+//  oneapi_memcpy2d extension
+//
+*******************************************************************************/
+#include "memcpy2d_queue_shortcut.h"
+
+namespace memcpy2d_queue_shortcut_fp64_tests {
+using namespace memcpy2d_common_tests;
+using namespace memcpy2d_queue_shortcut_tests;
+
+TEST_CASE("Check queue shortcuts memcpy2d extension. fp64 tyoe.",
+          "[oneapi_memcpy2d]") {
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point operations. "
+        "Skipping the test case.");
+  }
+
+  auto src_ptr_types = get_pointer_types();
+  auto dest_ptr_types = get_pointer_types();
+  auto type_pack = named_type_pack<double>::generate("double");
+
+#if !defined(SYCL_EXT_ONEAPI_MEMCPY2D)
+  SKIP("SYCL_EXT_ONEAPI_MEMCPY2D is not defined");
+#else
+  for_all_combinations<run_queue_shortcut_tests>(type_pack, src_ptr_types,
+                                                 dest_ptr_types, queue);
+#endif
+}
+
+}  // namespace memcpy2d_queue_shortcut_fp64_tests


### PR DESCRIPTION
Add tests for sycl_ext_oneapi_memcpy2 extension according to test plan [sycl_ext_oneapi_memcpy2 extension](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/memcpy2d.asciidoc) .