### PR TITLE
Fix hardcoded group size in buffer tests

### DIFF
--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -23,6 +23,7 @@
 #define __SYCLCTS_TESTS_BUFFER_API_COMMON_H
 
 #include "../common/common.h"
+#include "../common/get_group_range.h"
 
 namespace buffer_api_common {
 using namespace sycl_cts;
@@ -480,24 +481,27 @@ class check_buffer_linearization {
  public:
   void operator()(util::logger &log) {
     constexpr int size = 8;
-    // clang-format off
-    sycl::nd_range<1> range1d(sycl::range<1>{size},
-                              sycl::range<1>{size});
-    sycl::nd_range<2> range2d(sycl::range<2>{size, size},
-                              sycl::range<2>{size, size});
-    sycl::nd_range<3> range3d(sycl::range<3>{size, size, size},
-                              sycl::range<3>{size, size, size});
-    // clang-format on
+    auto q = util::get_cts_object::queue();
+    sycl::range<1> range1d = sycl_cts::util::work_group_range<1>(q);
+    sycl::range<2> range2d = sycl_cts::util::work_group_range<2>(q);
+    sycl::range<3> range3d = sycl_cts::util::work_group_range<3>(q);
+
+    sycl::nd_range<1> nd_range1d(range1d, range1d);
+    sycl::nd_range<2> nd_range2d(range2d, range2d);
+    sycl::nd_range<3> nd_range3d(range3d, range3d);
 
     INFO("testing: sycl::buffer_allocator<size_t>");
-    test_buffer_linearization<1, sycl::buffer_allocator<size_t>>(log, range1d);
-    test_buffer_linearization<2, sycl::buffer_allocator<size_t>>(log, range2d);
-    test_buffer_linearization<3, sycl::buffer_allocator<size_t>>(log, range3d);
+    test_buffer_linearization<1, sycl::buffer_allocator<size_t>>(log,
+                                                                 nd_range1d);
+    test_buffer_linearization<2, sycl::buffer_allocator<size_t>>(log,
+                                                                 nd_range2d);
+    test_buffer_linearization<3, sycl::buffer_allocator<size_t>>(log,
+                                                                 nd_range3d);
 
     INFO("testing: std::allocator<size_t>");
-    test_buffer_linearization<1, std::allocator<size_t>>(log, range1d);
-    test_buffer_linearization<2, std::allocator<size_t>>(log, range2d);
-    test_buffer_linearization<3, std::allocator<size_t>>(log, range3d);
+    test_buffer_linearization<1, std::allocator<size_t>>(log, nd_range1d);
+    test_buffer_linearization<2, std::allocator<size_t>>(log, nd_range2d);
+    test_buffer_linearization<3, std::allocator<size_t>>(log, nd_range3d);
   }
 
  private:

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -480,15 +480,27 @@ public:
 class check_buffer_linearization {
  public:
   void operator()(util::logger &log) {
-    constexpr int size = 8;
+    constexpr int g_size = 4;  // global range size
+    constexpr int l_size = 2;  // local range size
     auto q = util::get_cts_object::queue();
-    sycl::range<1> range1d = sycl_cts::util::work_group_range<1>(q);
-    sycl::range<2> range2d = sycl_cts::util::work_group_range<2>(q);
-    sycl::range<3> range3d = sycl_cts::util::work_group_range<3>(q);
 
-    sycl::nd_range<1> nd_range1d(range1d, range1d);
-    sycl::nd_range<2> nd_range2d(range2d, range2d);
-    sycl::nd_range<3> nd_range3d(range3d, range3d);
+    // global ranges
+    sycl::range<1> g_range1d = sycl_cts::util::work_group_range<1>(q, g_size);
+    sycl::range<2> g_range2d =
+        sycl_cts::util::work_group_range<2>(q, g_size * g_size);
+    sycl::range<3> g_range3d =
+        sycl_cts::util::work_group_range<3>(q, g_size * g_size * g_size);
+
+    // local ranges
+    sycl::range<1> l_range1d = sycl_cts::util::work_group_range<1>(q, l_size);
+    sycl::range<2> l_range2d =
+        sycl_cts::util::work_group_range<2>(q, l_size * l_size);
+    sycl::range<3> l_range3d =
+        sycl_cts::util::work_group_range<3>(q, l_size * l_size * l_size);
+
+    sycl::nd_range<1> nd_range1d(g_range1d, l_range1d);
+    sycl::nd_range<2> nd_range2d(g_range2d, l_range2d);
+    sycl::nd_range<3> nd_range3d(g_range3d, l_range3d);
 
     INFO("testing: sycl::buffer_allocator<size_t>");
     test_buffer_linearization<1, sycl::buffer_allocator<size_t>>(log,

--- a/tests/common/get_group_range.h
+++ b/tests/common/get_group_range.h
@@ -56,7 +56,6 @@ template <int Dimensions>
 sycl::range<Dimensions> work_group_range(
     sycl::queue queue,
     uint64_t work_items_limit = std::numeric_limits<uint64_t>::max()) {
-
   // query device for work-group sizes
   size_t max_work_item_sizes[Dimensions];
   {

--- a/tests/common/get_group_range.h
+++ b/tests/common/get_group_range.h
@@ -48,14 +48,14 @@ inline sycl::range<3> get_default_range() {
 /**
  * @brief Provides range for maximal size work-group
  *        supported by device of a given queue.
- *        Multidimentional work-group range is made
- *        as hyper-cybic as possible
+ *        Multidimensional work-group range is made
+ *        as hypercybic as possible
  * @tparam Dimensions Dimension to use for group instance
  */
 template <int Dimensions>
 sycl::range<Dimensions> work_group_range(
     sycl::queue queue,
-    uint64_t work_items_limit = std::numeric_limits<uint64_t>::max()) {
+    size_t work_items_limit = std::numeric_limits<size_t>::max()) {
   // query device for work-group sizes
   size_t max_work_item_sizes[Dimensions];
   {

--- a/tests/common/get_group_range.h
+++ b/tests/common/get_group_range.h
@@ -1,0 +1,122 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2020-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#ifndef __SYCLCTS_TESTS_COMMON_GET_GROUP_RANGE_H
+#define __SYCLCTS_TESTS_COMMON_GET_GROUP_RANGE_H
+
+namespace sycl_cts {
+namespace util {
+/**
+ * Since \p sycl::range by standard provides no default constructor,
+ * this function returns a \p sycl::range with 1 for each dimension. */
+template <int Dimensions>
+sycl::range<Dimensions> get_default_range();
+
+template <>
+inline sycl::range<1> get_default_range() {
+  return sycl::range<1>{1};
+}
+
+template <>
+inline sycl::range<2> get_default_range() {
+  return sycl::range<2>{1, 1};
+}
+
+template <>
+inline sycl::range<3> get_default_range() {
+  return sycl::range<3>{1, 1, 1};
+}
+
+/**
+ * @brief Provides range for maximal size work-group
+ *        supported by device of a given queue.
+ *        Multidimentional work-group range is made
+ *        as hyper-cybic as possible
+ * @tparam Dimensions Dimension to use for group instance
+ */
+template <int Dimensions>
+sycl::range<Dimensions> work_group_range(
+    sycl::queue queue,
+    uint64_t work_items_limit = std::numeric_limits<uint64_t>::max()) {
+
+  // query device for work-group sizes
+  size_t max_work_item_sizes[Dimensions];
+  {
+    // FIXME: hipSYCL and ComputeCPP do not implement
+    //        sycl::info::device::max_work_item_sizes<3> property
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    sycl::id<3> sizes =
+        queue.get_device().get_info<sycl::info::device::max_work_item_sizes>();
+#else
+    sycl::id<3> sizes =
+        queue.get_device()
+            .get_info<sycl::info::device::max_work_item_sizes<3> >();
+#endif
+    for (int i = 0; i < Dimensions; ++i) {
+      max_work_item_sizes[i] = sizes.get(i);
+    }
+  }
+  size_t max_work_group_size = std::min(
+      queue.get_device().get_info<sycl::info::device::max_work_group_size>(),
+      work_items_limit);
+
+  // make work-group size as much square/cubic as possible
+  size_t work_group_sizes[Dimensions] = {
+      std::min(max_work_item_sizes[0], max_work_group_size)};
+  if constexpr (Dimensions > 1) {
+    size_t rest_work_group_size = max_work_group_size;
+    for (int cur_D = Dimensions; cur_D > 1; --cur_D) {
+      size_t pref_size = pow(rest_work_group_size, 1. / cur_D) + 1;
+      pref_size = std::min(pref_size, max_work_item_sizes[cur_D - 1]);
+      // in the worst case of prime rest_work_group_size pref_size comes to 1
+      while (rest_work_group_size % pref_size != 0) {
+        --pref_size;
+      }
+      work_group_sizes[cur_D - 1] = pref_size;
+      rest_work_group_size /= pref_size;
+    }
+    work_group_sizes[0] =
+        std::min(max_work_item_sizes[0], rest_work_group_size);
+  }
+
+  sycl::range<Dimensions> work_group_range = get_default_range<Dimensions>();
+  for (int i = 0; i < Dimensions; ++i)
+    work_group_range[i] = work_group_sizes[i];
+
+  return work_group_range;
+}
+
+/**
+ * @brief Provides group size pretty printing
+ * @tparam D Dimension of group instance
+ */
+template <int D>
+std::string work_group_print(const sycl::range<D>& work_group_range) {
+  std::string res("{ " + std::to_string(work_group_range[0]));
+  for (int i = 1; i < D; ++i) res += ", " + std::to_string(work_group_range[i]);
+  res += " }";
+  return res;
+}
+}  // namespace util
+}  // namespace sycl_cts
+
+#endif  // __SYCLCTS_TESTS_COMMON_GET_GROUP_RANGE_H

--- a/tests/group_functions/group_barrier.cpp
+++ b/tests/group_functions/group_barrier.cpp
@@ -111,7 +111,7 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
       std::min(global_mem_size_in_elements, local_mem_size_in_elements);
 
   sycl::range<D> work_group_range =
-      util::work_group_range<D>(queue, work_items_limit);
+      sycl_cts::util::work_group_range<D>(queue, work_items_limit);
   size_t work_group_size = work_group_range.size();
 
   std::vector<int32_t> v(work_group_size, 0);
@@ -243,7 +243,7 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
 
   for (int i = 0; i < group_barrier_variants; ++i) {
     bool result = std::get<s::test>(group_barriers[i]);
-    std::string work_group = util::work_group_print(work_group_range);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
     CAPTURE(D, work_group);
     INFO("Result of group_barrier invocation for group and "
          << group_barriers_names[i] << " memory scope is "
@@ -252,7 +252,7 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
   }
   for (int i = 0; i < sub_group_barrier_variants; ++i) {
     bool result = std::get<s::test>(sub_group_barriers[i]);
-    std::string work_group = util::work_group_print(work_group_range);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
     CAPTURE(D, work_group);
     INFO("Result of group_barrier invocation for sub-group and "
          << sub_group_barriers_names[i] << " memory scope is "

--- a/tests/group_functions/group_broadcast.h
+++ b/tests/group_functions/group_broadcast.h
@@ -37,7 +37,7 @@ void broadcast_group(sycl::queue& queue) {
       "T group_broadcast(group g, T x, group::linear_id_type local_linear_id)",
       "T group_broadcast(group g, T x, group::id_type local_id)"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   // array to return results
@@ -105,7 +105,7 @@ void broadcast_group(sycl::queue& queue) {
                              splat_init<T>(work_group_size)};
 
   for (int i = 0; i < test_matrix; ++i) {
-    std::string work_group = util::work_group_print(work_group_range);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
     CAPTURE(D, work_group);
     INFO("Return value of "
          << test_names[i] << " with T = " << type_name<T>() << " is "
@@ -128,7 +128,7 @@ void broadcast_sub_group(sycl::queue& queue) {
       "T group_broadcast(sub_group g, T x, sub_group::id_type local_id)",
       "T select_from_group(sub_group g, T x, sub_group::id_type local_id)"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
 
   // array to return results
   T res[test_matrix + 1] = {splat_init<T>(0)};
@@ -203,7 +203,7 @@ void broadcast_sub_group(sycl::queue& queue) {
   }
   T expected[test_matrix] = {splat_init<T>(1), res[4], res[4], res[4]};
   for (int i = 0; i < test_matrix; ++i) {
-    std::string work_group = util::work_group_print(work_group_range);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
     CAPTURE(D, work_group);
     INFO("Return value of "
          << test_names[i] << " with T = " << type_name<T>() << " is "

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -19,6 +19,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
+#include "../common/get_group_range.h"
 #include "type_coverage.h"
 
 #include <catch2/catch_template_test_macros.hpp>
@@ -70,98 +71,6 @@ T splat_init(const U init) {
 }
 
 namespace util {
-/**
- * Since \p sycl::range by standard provides no default constructor,
- * this function returns a \p sycl::range with 1 for each dimension. */
-template <int Dimensions>
-sycl::range<Dimensions> get_default_range();
-
-template <>
-inline sycl::range<1> get_default_range() {
-  return sycl::range<1>{1};
-}
-
-template <>
-inline sycl::range<2> get_default_range() {
-  return sycl::range<2>{1, 1};
-}
-
-template <>
-inline sycl::range<3> get_default_range() {
-  return sycl::range<3>{1, 1, 1};
-}
-
-/**
- * @brief Provides range for maximal size work-group
- *        supported by device of a given queue.
- *        Multidimentional work-group range is made
- *        as hyper-cybic as possible
- * @tparam Dimensions Dimension to use for group instance
- */
-template <int Dimensions>
-sycl::range<Dimensions> work_group_range(
-    sycl::queue queue,
-    uint64_t work_items_limit = std::numeric_limits<uint64_t>::max()) {
-  // query device for work-group sizes
-  size_t max_work_item_sizes[Dimensions];
-  {
-    // FIXME: hipSYCL and ComputeCPP do not implement
-    //        sycl::info::device::max_work_item_sizes<3> property
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
-    sycl::id<3> sizes =
-        queue.get_device().get_info<sycl::info::device::max_work_item_sizes>();
-#else
-    sycl::id<3> sizes =
-        queue.get_device()
-            .get_info<sycl::info::device::max_work_item_sizes<3>>();
-#endif
-    for (int i = 0; i < Dimensions; ++i) {
-      max_work_item_sizes[i] = sizes.get(i);
-    }
-  }
-  size_t max_work_group_size = std::min(
-      queue.get_device().get_info<sycl::info::device::max_work_group_size>(),
-      work_items_limit);
-
-  // make work-group size as much square/cubic as possible
-  size_t work_group_sizes[Dimensions] = {
-      std::min(max_work_item_sizes[0], max_work_group_size)};
-  if constexpr (Dimensions > 1) {
-    size_t rest_work_group_size = max_work_group_size;
-    for (int cur_D = Dimensions; cur_D > 1; --cur_D) {
-      size_t pref_size = pow(rest_work_group_size, 1. / cur_D) + 1;
-      pref_size = std::min(pref_size, max_work_item_sizes[cur_D - 1]);
-      // in the worst case of prime rest_work_group_size pref_size comes to 1
-      while (rest_work_group_size % pref_size != 0) {
-        --pref_size;
-      }
-      work_group_sizes[cur_D - 1] = pref_size;
-      rest_work_group_size /= pref_size;
-    }
-    work_group_sizes[0] =
-        std::min(max_work_item_sizes[0], rest_work_group_size);
-  }
-
-  sycl::range<Dimensions> work_group_range = get_default_range<Dimensions>();
-  for (int i = 0; i < Dimensions; ++i)
-    work_group_range[i] = work_group_sizes[i];
-
-  return work_group_range;
-}
-
-/**
- * @brief Provides group size pretty printing
- * @tparam D Dimension of group instance
- */
-template <int D>
-std::string work_group_print(const sycl::range<D>& work_group_range) {
-  std::string res("{ " + std::to_string(work_group_range[0]));
-  for (int i = 1; i < D; ++i) res += ", " + std::to_string(work_group_range[i]);
-  res += " }";
-  return res;
-}
-
 /** @brief A user-defined class with several scalar member variables, default
  *         constructor and some overloaded operators.
  */

--- a/tests/group_functions/group_of.h
+++ b/tests/group_functions/group_of.h
@@ -44,7 +44,7 @@ void joint_of_group(sycl::queue& queue) {
   const std::string test_cases_names[test_cases] = {"none true", "one true",
                                                     "some true", "all true"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -162,7 +162,8 @@ void joint_of_group(sycl::queue& queue) {
     int index = 0;
     for (int i = 0; i < test_matrix; ++i)
       for (int j = 0; j < test_cases; ++j) {
-        std::string work_group = util::work_group_print(work_group_range);
+        std::string work_group =
+            sycl_cts::util::work_group_print(work_group_range);
         CAPTURE(D, work_group);
         INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                          << " predicate"
@@ -193,7 +194,7 @@ void predicate_function_of_group(sycl::queue& queue) {
   const std::string test_cases_names[test_cases] = {"none true", "one true",
                                                     "some true", "all true"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   // array to return results: 4 predicates * 3 functions
@@ -251,7 +252,8 @@ void predicate_function_of_group(sycl::queue& queue) {
   int index = 0;
   for (int i = 0; i < test_matrix; ++i)
     for (int j = 0; j < test_cases; ++j) {
-      std::string work_group = util::work_group_print(work_group_range);
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
       CAPTURE(D, work_group);
       INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                        << " predicate is " << (res[index] ? "right" : "wrong"));
@@ -280,7 +282,7 @@ void predicate_function_of_sub_group(sycl::queue& queue) {
   const std::string test_cases_names[test_cases] = {"none true", "one true",
                                                     "some true", "all true"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
 
   // array to return results: 4 predicates * 3 functions
   bool res[test_matrix * test_cases] = {false};
@@ -338,7 +340,8 @@ void predicate_function_of_sub_group(sycl::queue& queue) {
   int index = 0;
   for (int i = 0; i < test_matrix; ++i)
     for (int j = 0; j < test_cases; ++j) {
-      std::string work_group = util::work_group_print(work_group_range);
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
       CAPTURE(D, work_group);
       INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                        << " predicate is " << (res[index] ? "right" : "wrong"));
@@ -367,7 +370,7 @@ void bool_function_of_group(sycl::queue& queue) {
 
   using T = size_t;
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   // array to return results: 4 predicates * 3 functions
@@ -423,7 +426,8 @@ void bool_function_of_group(sycl::queue& queue) {
   int index = 0;
   for (int i = 0; i < test_matrix; ++i)
     for (int j = 0; j < test_cases; ++j) {
-      std::string work_group = util::work_group_print(work_group_range);
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
       CAPTURE(D, work_group);
       INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                        << " predicate is " << (res[index] ? "right" : "wrong"));
@@ -452,7 +456,7 @@ void bool_function_of_sub_group(sycl::queue& queue) {
 
   using T = size_t;
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
 
   // array to return results
   bool res[test_matrix * test_cases] = {false};
@@ -511,7 +515,8 @@ void bool_function_of_sub_group(sycl::queue& queue) {
   int index = 0;
   for (int i = 0; i < test_matrix; ++i)
     for (int j = 0; j < test_cases; ++j) {
-      std::string work_group = util::work_group_print(work_group_range);
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
       CAPTURE(D, work_group);
       INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                        << " predicate is " << (res[index] ? "right" : "wrong"));

--- a/tests/group_functions/group_permute.h
+++ b/tests/group_functions/group_permute.h
@@ -33,7 +33,7 @@ void permute_sub_group(sycl::queue& queue) {
       "T permute_group_by_xor(sub_group g, T x, sub_group::linear_id_type "
       "mask)"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   // array to return results:
@@ -77,7 +77,7 @@ void permute_sub_group(sycl::queue& queue) {
     for (size_t j = 1; j < work_group_size; ++j)
       result &= res[i * work_group_size + j];
 
-    std::string work_group = util::work_group_print(work_group_range);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
     CAPTURE(D, work_group);
     INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
                      << " is " << (result ? "right" : "wrong"));

--- a/tests/group_functions/group_reduce.h
+++ b/tests/group_functions/group_reduce.h
@@ -42,7 +42,7 @@ void joint_reduce_group(sycl::queue& queue) {
   constexpr int test_cases = 2;
   const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -122,7 +122,8 @@ void joint_reduce_group(sycl::queue& queue) {
     int index = 0;
     for (int i = 0; i < test_matrix; ++i)
       for (int j = 0; j < test_cases; ++j) {
-        std::string work_group = util::work_group_print(work_group_range);
+        std::string work_group =
+            sycl_cts::util::work_group_print(work_group_range);
         CAPTURE(D, work_group, size);
         INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                          << " operation"
@@ -155,7 +156,7 @@ void init_joint_reduce_group(sycl::queue& queue) {
   constexpr int test_cases = 2;
   const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -238,7 +239,8 @@ void init_joint_reduce_group(sycl::queue& queue) {
     int index = 0;
     for (int i = 0; i < test_matrix; ++i)
       for (int j = 0; j < test_cases; ++j) {
-        std::string work_group = util::work_group_print(work_group_range);
+        std::string work_group =
+            sycl_cts::util::work_group_print(work_group_range);
         CAPTURE(D, work_group, size);
         INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                          << " operation"
@@ -268,7 +270,7 @@ void reduce_over_group(sycl::queue& queue) {
   constexpr int test_cases = 2;
   const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
 
   // array to return results
   bool res[test_matrix * test_cases] = {false};
@@ -336,7 +338,8 @@ void reduce_over_group(sycl::queue& queue) {
   int index = 0;
   for (int i = 0; i < test_matrix; ++i)
     for (int j = 0; j < test_cases; ++j) {
-      std::string work_group = util::work_group_print(work_group_range);
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
       CAPTURE(D, work_group);
       INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                        << " operation"
@@ -367,7 +370,7 @@ void init_reduce_over_group(sycl::queue& queue) {
   constexpr int test_cases = 2;
   const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
 
   // array to return results
   bool res[test_matrix * test_cases] = {false};
@@ -443,7 +446,8 @@ void init_reduce_over_group(sycl::queue& queue) {
   int index = 0;
   for (int i = 0; i < test_matrix; ++i)
     for (int j = 0; j < test_cases; ++j) {
-      std::string work_group = util::work_group_print(work_group_range);
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
       CAPTURE(D, work_group);
       INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                        << " operation"

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -47,7 +47,7 @@ void joint_scan_group(sycl::queue& queue) {
   constexpr int test_cases = 2;
   const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -243,7 +243,8 @@ void joint_scan_group(sycl::queue& queue) {
     int index = 0;
     for (int i = 0; i < test_matrix; ++i)
       for (int j = 0; j < test_cases; ++j) {
-        std::string work_group = util::work_group_print(work_group_range);
+        std::string work_group =
+            sycl_cts::util::work_group_print(work_group_range);
         CAPTURE(D, work_group, size);
         INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                          << " operation"
@@ -298,7 +299,7 @@ void init_joint_scan_group(sycl::queue& queue) {
   constexpr int test_cases = 2;
   const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -479,7 +480,8 @@ void init_joint_scan_group(sycl::queue& queue) {
     int index = 0;
     for (int i = 0; i < test_matrix; ++i)
       for (int j = 0; j < test_cases; ++j) {
-        std::string work_group = util::work_group_print(work_group_range);
+        std::string work_group =
+            sycl_cts::util::work_group_print(work_group_range);
         CAPTURE(D, work_group, size);
         INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                          << " operation"
@@ -535,7 +537,7 @@ void scan_over_group(sycl::queue& queue) {
   constexpr int test_cases = 2;
   const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   // array to return results:
@@ -660,7 +662,8 @@ void scan_over_group(sycl::queue& queue) {
       for (size_t k = 1; k < work_group_size; ++k)
         result &= res[index * work_group_size + k];
 
-      std::string work_group = util::work_group_print(work_group_range);
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
       CAPTURE(D, work_group);
       INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                        << " operation"
@@ -722,7 +725,7 @@ void init_scan_over_group(sycl::queue& queue) {
   constexpr int test_cases = 2;
   const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   // array to return results:
@@ -868,7 +871,8 @@ void init_scan_over_group(sycl::queue& queue) {
       for (size_t k = 1; k < work_group_size; ++k)
         result &= res[index * work_group_size + k];
 
-      std::string work_group = util::work_group_print(work_group_range);
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
       CAPTURE(D, work_group);
       INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
                        << " operation"

--- a/tests/group_functions/group_shift.h
+++ b/tests/group_functions/group_shift.h
@@ -35,7 +35,7 @@ void shift_sub_group(sycl::queue& queue) {
       "T shift_group_right(sub_group g, T x)",
       "T shift_group_right(sub_group g, T x, sub_group::linear_id_type delta)"};
 
-  sycl::range<D> work_group_range = util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
 
   // array to return results:
@@ -99,7 +99,7 @@ void shift_sub_group(sycl::queue& queue) {
     for (size_t j = 1; j < work_group_size; ++j)
       result &= res[i * work_group_size + j];
 
-    std::string work_group = util::work_group_print(work_group_range);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
     CAPTURE(D, work_group);
     INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
                      << " is " << (result ? "right" : "wrong"));


### PR DESCRIPTION
Request of work items adjusts to the available capabilities of underlying device in buffer tests.

Function to query available amount of work items moved from tests/group_functions/group_functions_common.h to
tests/common/get_group_range.h.