### PR TITLE
Add tests for any_device_has and all_devices_have

### DIFF
--- a/test_plans/any_device_has_all_devices_have.asciidoc
+++ b/test_plans/any_device_has_all_devices_have.asciidoc
@@ -34,8 +34,14 @@ Tests described below are performed for following aspects:
 
 == Tests
 
-* Check each device to see if it has aspect `A`.
-* If some device has aspect `A`, check that `any_device_has_v<A>` is `true`
-and `any_device_has<A>` inherits from `std::true_type`.
-* If some device does not have aspect `A`, check that `all_devices_have_v<A>` is `false`
-and `all_devices_have<A>` inherits from `std::false_type`.
+* The test defines an empty kernel K as a mechanism to determine which devices are supported by the compilation environment.
+* At runtime, iterate over all devices returned by device::get_devices. For each device `D`:
+** Check if `is_compatible<K>(D)` is `true`. Since kernel `K` is empty, it should be compatible with any device that is supported by the compilation environment.
+** For each aspect `A` check if `D.has_aspect(A)` is `true`.
+** If `(is_compatible<K>(D) && D.has(A))` is `true`, then `any_device_has_v<A>` must be `true` and `any_device_has<A>` must inherit from `std::true_type`.
+** If `any_device_has_v<A>` is `false` then `(is_compatible<K>(D) && D.has(A))` must be `false`.
+** If `(is_compatible<K>(D) && !D.has(A))` is `true`, then `all_devices_have_v<A>` must be `false`
+and `all_devices_have<A>` must inherit from `std::false_type`.
+** If `all_devices_have_v<A>` is `true` then `(is_compatible<K>(D) && D.has(A))` or `(!is_compatible<K>(D) && !D.has(A))` must be `true`.
+
+

--- a/test_plans/any_device_has_all_devices_have.asciidoc
+++ b/test_plans/any_device_has_all_devices_have.asciidoc
@@ -42,6 +42,6 @@ Tests described below are performed for following aspects:
 ** If `any_device_has_v<A>` is `false` then `(is_compatible<K>(D) && D.has(A))` must be `false`.
 ** If `(is_compatible<K>(D) && !D.has(A))` is `true`, then `all_devices_have_v<A>` must be `false`
 and `all_devices_have<A>` must inherit from `std::false_type`.
-** If `all_devices_have_v<A>` is `true` then `(is_compatible<K>(D) && D.has(A))` or `(!is_compatible<K>(D) && !D.has(A))` must be `true`.
+** If `all_devices_have_v<A>` is `true` then `(D.has(A) || !is_compatible<K>(D))` must be `true`.
 
 

--- a/tests/device_selector/device_selector_aspect.cpp
+++ b/tests/device_selector/device_selector_aspect.cpp
@@ -433,7 +433,7 @@ class check_any_device_has_all_devices_have {
             std::is_base_of_v<std::false_type, sycl::all_devices_have<aspect>>);
         CHECK_FALSE(sycl::all_devices_have_v<aspect>);
       }
-      if (sycl::all_devices_have_v<aspect>) CHECK(has_aspect || !compatible);
+      if (sycl::all_devices_have_v<aspect>) CHECK((has_aspect || !compatible));
     }
   }
 };

--- a/tests/device_selector/device_selector_aspect.cpp
+++ b/tests/device_selector/device_selector_aspect.cpp
@@ -406,14 +406,10 @@ class check_any_device_has_all_devices_have {
  public:
   void operator()(const std::string& aspect_name) {
     auto device_has_aspect = [=](auto d) { return d.has(aspect); };
-    auto platforms = sycl::platform::get_platforms();
-    bool any_device = false;
-    bool all_devices = true;
-    for (auto p : platforms) {
-      auto devices = p.get_devices();
-      any_device |= any_of(devices.begin(), devices.end(), device_has_aspect);
-      all_devices &= all_of(devices.begin(), devices.end(), device_has_aspect);
-    }
+    auto devices = sycl::device::get_devices();
+    bool any_device = any_of(devices.begin(), devices.end(), device_has_aspect);
+    bool all_devices =
+        all_of(devices.begin(), devices.end(), device_has_aspect);
     if (any_device) {
       INFO(
           "Check that if some device has aspect A, "

--- a/tests/device_selector/device_selector_aspect.cpp
+++ b/tests/device_selector/device_selector_aspect.cpp
@@ -19,6 +19,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
 #include "../common/type_coverage.h"
 
 #include <random>
@@ -395,6 +396,43 @@ constexpr void check_for_random_set(const named_type_pack<AspectsT...>&) {
   create_random_sets(aspect_tuple, set_sizes);
 }
 
+#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
+/**
+ Functor that checks any_device_has and all_devices_have functionality. */
+template <typename AspectT>
+class check_any_device_has_all_devices_have {
+  static constexpr sycl::aspect aspect = AspectT::value;
+
+ public:
+  void operator()(const std::string& aspect_name) {
+    auto device_has_aspect = [=](auto d) { return d.has(aspect); };
+    auto platforms = sycl::platform::get_platforms();
+    bool any_device = false;
+    bool all_devices = true;
+    for (auto p : platforms) {
+      auto devices = p.get_devices();
+      any_device |= any_of(devices.begin(), devices.end(), device_has_aspect);
+      all_devices &= all_of(devices.begin(), devices.end(), device_has_aspect);
+    }
+    if (any_device) {
+      INFO(
+          "Check that if some device has aspect A, "
+          "any_device_has_v<A> is true.");
+      CHECK(std::is_base_of_v<std::true_type, sycl::any_device_has<aspect>>);
+      CHECK(any_device_has_v < aspect >>);
+    }
+
+    if (!all_devices) {
+      INFO(
+          "Check that if some device does not have aspect A, "
+          "all_devices_have_v<A> is false.");
+      CHECK(std::is_base_of_v<std::false_type, sycl::all_devices_have<aspect>>);
+      CHECK_FALSE(all_devices_have_v < aspect >>);
+    }
+  }
+};
+#endif
+
 TEST_CASE("aspect", "[device_selector]") {
 #if SYCL_CTS_COMPILING_WITH_COMPUTECPP
   WARN("ComputeCPP cannot compare exception code. Workaround is in place.");
@@ -420,5 +458,14 @@ TEST_CASE("aspect", "[device_selector]") {
   constexpr unsigned int random_aspects_count = 100;
   check_for_random_set<random_aspects_count>(aspect_pack);
 }
+
+// FIXME: re-enable when sycl::any_device_has, sycl::all_devices_have are
+// implemented
+DISABLED_FOR_TEST_CASE(DPCPP)
+("Check any_device_has and all_devices_have", "[device_selector]")({
+  const auto aspect_pack = get_aspect_pack();
+
+  for_all_combinations<check_any_device_has_all_devices_have>(aspect_pack);
+});
 
 }  // namespace device_selector_aspect

--- a/tests/device_selector/device_selector_aspect.cpp
+++ b/tests/device_selector/device_selector_aspect.cpp
@@ -19,7 +19,6 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/disabled_for_test_case.h"
 #include "../common/type_coverage.h"
 
 #include <random>
@@ -399,7 +398,6 @@ constexpr void check_for_random_set(const named_type_pack<AspectsT...>&) {
 template <typename AspectT>
 class kernel_aspect;
 
-#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
 /**
  Functor that checks any_device_has and all_devices_have functionality. */
 template <typename AspectT>
@@ -427,7 +425,7 @@ class check_any_device_has_all_devices_have {
           "Check that if some device has aspect A, "
           "any_device_has_v<A> is true.");
       CHECK(std::is_base_of_v<std::true_type, sycl::any_device_has<aspect>>);
-      CHECK(any_device_has_v < aspect >>);
+      CHECK(sycl::any_device_has_v<aspect>);
     }
 
     if (!all_devices) {
@@ -435,11 +433,10 @@ class check_any_device_has_all_devices_have {
           "Check that if some device does not have aspect A, "
           "all_devices_have_v<A> is false.");
       CHECK(std::is_base_of_v<std::false_type, sycl::all_devices_have<aspect>>);
-      CHECK_FALSE(all_devices_have_v < aspect >>);
+      CHECK_FALSE(sycl::all_devices_have_v<aspect>);
     }
   }
 };
-#endif
 
 TEST_CASE("aspect", "[device_selector]") {
 #if SYCL_CTS_COMPILING_WITH_COMPUTECPP
@@ -467,13 +464,10 @@ TEST_CASE("aspect", "[device_selector]") {
   check_for_random_set<random_aspects_count>(aspect_pack);
 }
 
-// FIXME: re-enable when sycl::any_device_has, sycl::all_devices_have are
-// implemented
-DISABLED_FOR_TEST_CASE(DPCPP)
-("Check any_device_has and all_devices_have", "[device_selector]")({
+TEST_CASE("Check any_device_has and all_devices_have", "[device_selector]") {
   const auto aspect_pack = get_aspect_pack();
 
   for_all_combinations<check_any_device_has_all_devices_have>(aspect_pack);
-});
+};
 
 }  // namespace device_selector_aspect

--- a/tests/device_selector/device_selector_aspect.cpp
+++ b/tests/device_selector/device_selector_aspect.cpp
@@ -433,8 +433,7 @@ class check_any_device_has_all_devices_have {
             std::is_base_of_v<std::false_type, sycl::all_devices_have<aspect>>);
         CHECK_FALSE(sycl::all_devices_have_v<aspect>);
       }
-      if (sycl::all_devices_have_v<aspect>)
-        CHECK(((compatible && has_aspect) || (!compatible && !has_aspect)));
+      if (sycl::all_devices_have_v<aspect>) CHECK(has_aspect || !compatible);
     }
   }
 };

--- a/tests/device_selector/device_selector_aspect.cpp
+++ b/tests/device_selector/device_selector_aspect.cpp
@@ -421,6 +421,10 @@ class check_any_device_has_all_devices_have {
         any_of(devices.begin(), devices.end(), exec_device_has_aspect);
     bool all_devices =
         all_of(devices.begin(), devices.end(), exec_device_has_aspect);
+    // Check only positive case because any_device_has_v is true if the
+    // compilation environment supports any device with aspect in question but
+    // compilation environment could support some devices that are not present
+    // on the system.
     if (any_device) {
       INFO(
           "Check that if some device has aspect A, "
@@ -428,7 +432,9 @@ class check_any_device_has_all_devices_have {
       CHECK(std::is_base_of_v<std::true_type, sycl::any_device_has<aspect>>);
       CHECK(sycl::any_device_has_v<aspect>);
     }
-
+    // Check only negative case because there can be device in compilation
+    // environment that doesn't support aspect in question but not present in
+    // the system and therefore didn't affect value of all_devices.
     if (!all_devices) {
       INFO(
           "Check that if some device does not have aspect A, "

--- a/tests/device_selector/device_selector_aspect.cpp
+++ b/tests/device_selector/device_selector_aspect.cpp
@@ -19,6 +19,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
 #include "../common/type_coverage.h"
 
 #include <random>
@@ -397,7 +398,7 @@ constexpr void check_for_random_set(const named_type_pack<AspectsT...>&) {
 
 template <typename AspectT>
 class kernel_aspect;
-
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  Functor that checks any_device_has and all_devices_have functionality. */
 template <typename AspectT>
@@ -437,7 +438,7 @@ class check_any_device_has_all_devices_have {
     }
   }
 };
-
+#endif
 TEST_CASE("aspect", "[device_selector]") {
 #if SYCL_CTS_COMPILING_WITH_COMPUTECPP
   WARN("ComputeCPP cannot compare exception code. Workaround is in place.");
@@ -464,10 +465,13 @@ TEST_CASE("aspect", "[device_selector]") {
   check_for_random_set<random_aspects_count>(aspect_pack);
 }
 
-TEST_CASE("Check any_device_has and all_devices_have", "[device_selector]") {
+// FIXME: re-enable when any_device_has and all_devices_have are implemented for
+// ComputeCpp
+DISABLED_FOR_TEST_CASE(ComputeCpp)
+("Check any_device_has and all_devices_have", "[device_selector]")({
   const auto aspect_pack = get_aspect_pack();
 
   for_all_combinations<check_any_device_has_all_devices_have>(aspect_pack);
-};
+});
 
 }  // namespace device_selector_aspect


### PR DESCRIPTION
Add test for any_device_has and all_devices_have according to [test plan](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/any_device_has_all_devices_have.asciidoc).

Only devices that support the trivial kernel is considered to make sure they are supported by the code that the compiler generates, to align with that clarification https://github.com/KhronosGroup/SYCL-Docs/pull/370