### PR TITLE
Fix fill_init_values for spec_constants tests

### DIFF
--- a/tests/spec_constants/spec_constants_common.h
+++ b/tests/spec_constants/spec_constants_common.h
@@ -59,13 +59,13 @@ template <typename T, int numElements>
 void fill_init_values(sycl::vec<T, numElements> &result, int val) {
   // Fill manually because sycl::vec does not have iterators
   for (int i = 0; i < numElements; ++i) {
-    result[i] = val + i;
+    result[i] = val;
   }
 }
 
 template <typename T, std::size_t numElements>
 void fill_init_values(sycl::marray<T, numElements> &result, int val) {
-  std::iota(result.begin(), result.end(), val);
+  std::fill(result.begin(), result.end(), val);
 }
 
 enum class test_cases_external {


### PR DESCRIPTION
The specializations constant tests use fill_init_values to initialize reference values that are used as expected values when comparing with the default values of specialization constants. However, the current version of fill_init_values fills the individual elements of vectors and marrays with incrementing values, which do not correspond to the default values used for the specialization constants of these sizes. This commit changes them to use the same initial values.