### PR TITLE
Deduction guides tests implementation

### DIFF
--- a/tests/buffer/buffer_deduction_guides.cpp
+++ b/tests/buffer/buffer_deduction_guides.cpp
@@ -2,7 +2,6 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2022-2023 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +44,7 @@ class check_buffer_deduction {
     std::array<T, size> arr = {user_def_types::get_init_value_helper<T>(0),
                                user_def_types::get_init_value_helper<T>(0),
                                user_def_types::get_init_value_helper<T>(0)};
-    typeName = type;
+    type_name = type;
 
     test_inputiterator(arr);
     test_container(arr);
@@ -61,10 +60,10 @@ class check_buffer_deduction {
  private:
   std::allocator<T> std_alloc;
   buffer_allocator<T> buf_alloc;
-  std::string typeName;
+  std::string type_name;
 
   inline void test_inputiterator(std::array<T, size> data) {
-    INFO("buffer_ctors_deduction::test_inputiterator() " + typeName);
+    INFO("buffer_ctors_deduction::test_inputiterator() " + type_name);
     // buffer with no allocator and no property list
     {
       buffer buf(data.begin(), data.end());
@@ -128,7 +127,7 @@ class check_buffer_deduction {
                     user_def_types::get_init_value_helper<T>(0),
                     user_def_types::get_init_value_helper<T>(0)});
 
-    INFO("buffer_ctors_deduction::test_type() " + typeName);
+    INFO("buffer_ctors_deduction::test_type() " + type_name);
     // buffer with no alloccator and no property list
     {
       buffer buf(data.get(), r);
@@ -178,7 +177,7 @@ class check_buffer_deduction {
   }
 
   inline void test_container(std::array<T, size> data) {
-    INFO("buffer_ctors_deduction::test_container() " + typeName);
+    INFO("buffer_ctors_deduction::test_container() " + type_name);
     // buffer with no alloccator and no property list
     {
       buffer buf(data);

--- a/tests/buffer/buffer_deduction_guides.cpp
+++ b/tests/buffer/buffer_deduction_guides.cpp
@@ -1,0 +1,243 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides buffer deduction guides tests
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_list.h"
+
+namespace buffer_deduction_guides {
+using namespace sycl;
+
+// size for container
+constexpr int size = 3;
+
+// create property lists
+std::mutex mutex;
+auto context = sycl_cts::util::get_cts_object::context();
+const property_list props{property::buffer::use_mutex(mutex),
+                          property::buffer::context_bound(context)};
+
+template <typename T>
+class check_buffer_deduction {
+ public:
+  void operator()(const std::string& type) {
+    // create container
+    // using this API because of no_cnstr and no_def_cnstr types
+    std::array<T, size> arr = {user_def_types::get_init_value_helper<T>(0),
+                               user_def_types::get_init_value_helper<T>(0),
+                               user_def_types::get_init_value_helper<T>(0)};
+    typeName = type;
+
+    test_inputiterator(arr);
+    test_container(arr);
+
+    range<1> range1d(size);
+    range<2> range2d(size, size);
+    range<3> range3d(size, size, size);
+    test_type<1>(range1d);
+    test_type<2>(range2d);
+    test_type<3>(range3d);
+  }
+
+ private:
+  std::allocator<T> std_alloc;
+  buffer_allocator<T> buf_alloc;
+  std::string typeName;
+
+  inline void test_inputiterator(std::array<T, size> data) {
+    INFO("buffer_ctors_deduction::test_inputiterator() " + typeName);
+    // buffer with no allocator and no property list
+    {
+      buffer buf(data.begin(), data.end());
+
+      INFO("Incorrect deduction with InputIterator");
+      CHECK(std::is_same_v<decltype(buf),
+                           buffer<typename decltype(data)::value_type, 1>>);
+
+      CHECK(std::is_same_v<typename decltype(buf)::value_type,
+                           typename decltype(data)::value_type>);
+    }
+    // buffer with allocator and no property list
+    {
+      buffer buf_std_alloc(data.begin(), data.end(), std_alloc);
+      buffer buf_buf_alloc(data.begin(), data.end(), buf_alloc);
+
+      INFO("Incorrect deduction with allocator");
+      CHECK(std::is_same_v<
+            decltype(buf_std_alloc),
+            buffer<typename decltype(data)::value_type, 1, std::allocator<T>>>);
+
+      CHECK(std::is_same_v<decltype(buf_buf_alloc),
+                           buffer<typename decltype(data)::value_type, 1,
+                                  buffer_allocator<T>>>);
+
+      CHECK(std::is_same_v<decltype(buf_std_alloc.get_allocator()),
+                           std::allocator<T>>);
+      CHECK(std::is_same_v<decltype(buf_buf_alloc.get_allocator()),
+                           buffer_allocator<T>>);
+    }
+    // buffer with property list and no alloccator
+    {
+      buffer buf_prop(data.begin(), data.end(), props);
+
+      INFO("Incorrect deduction with propery list");
+      CHECK(std::is_same_v<decltype(buf_prop),
+                           buffer<typename decltype(data)::value_type, 1>>);
+    }
+    // buffer with allocator and property list
+    {
+      buffer buf_std_alloc(data.begin(), data.end(), std_alloc, props);
+      buffer buf_buf_alloc(data.begin(), data.end(), buf_alloc, props);
+
+      INFO("Incorrect deduction with property list and allocator");
+      CHECK(std::is_same_v<
+            decltype(buf_std_alloc),
+            buffer<typename decltype(data)::value_type, 1, std::allocator<T>>>);
+
+      CHECK(std::is_same_v<decltype(buf_buf_alloc),
+                           buffer<typename decltype(data)::value_type, 1,
+                                  buffer_allocator<T>>>);
+    }
+  }
+
+  template <int dims>
+  void test_type(const range<dims>& r) {
+    const int arr_size = r.size();
+
+    std::unique_ptr<T[]> data(
+        new T[size]{user_def_types::get_init_value_helper<T>(0),
+                    user_def_types::get_init_value_helper<T>(0),
+                    user_def_types::get_init_value_helper<T>(0)});
+
+    INFO("buffer_ctors_deduction::test_type() " + typeName);
+    // buffer with no alloccator and no property list
+    {
+      buffer buf(data.get(), r);
+      {
+        INFO("Incorrect deduction with T");
+        CHECK(std::is_same_v<decltype(buf), buffer<T, dims>>);
+        CHECK(std::is_same_v<typename decltype(buf)::value_type, T>);
+      }
+      {
+        INFO("Incorrect deduction with range");
+        CHECK(std::is_same_v<decltype(buf.get_range()), range<dims>>);
+      }
+    }
+    // buffer with allocator and no property list
+    {
+      buffer buf_std_alloc(data.get(), r, std_alloc);
+      buffer buf_buf_alloc(data.get(), r, buf_alloc);
+
+      INFO("Incorrect deduction with T");
+      CHECK(std::is_same_v<decltype(buf_std_alloc),
+                           buffer<T, dims, std::allocator<T>>>);
+      CHECK(std::is_same_v<decltype(buf_buf_alloc),
+                           buffer<T, dims, buffer_allocator<T>>>);
+
+      CHECK(std::is_same_v<decltype(buf_std_alloc.get_allocator()),
+                           std::allocator<T>>);
+      CHECK(std::is_same_v<decltype(buf_buf_alloc.get_allocator()),
+                           buffer_allocator<T>>);
+    }
+    // buffer with property list and no alloccator
+    {
+      buffer buf_prop(data.get(), r, props);
+      INFO("Incorrect deductionwith property list");
+      CHECK(std::is_same_v<decltype(buf_prop), buffer<T, dims>>);
+    }
+    // buffer with allocator and property list
+    {
+      buffer buf_std_alloc(data.get(), r, std_alloc, props);
+      buffer buf_buf_alloc(data.get(), r, buf_alloc, props);
+
+      INFO("Incorrect deduction with T");
+      CHECK(std::is_same_v<decltype(buf_std_alloc),
+                           buffer<T, dims, std::allocator<T>>>);
+      CHECK(std::is_same_v<decltype(buf_buf_alloc),
+                           buffer<T, dims, buffer_allocator<T>>>);
+    }
+  }
+
+  inline void test_container(std::array<T, size> data) {
+    INFO("buffer_ctors_deduction::test_container() " + typeName);
+    // buffer with no alloccator and no property list
+    {
+      buffer buf(data);
+
+      INFO("Incorrect deduction with InputIterator");
+      CHECK(std::is_same_v<decltype(buf),
+                           buffer<typename decltype(data)::value_type, 1>>);
+
+      CHECK(std::is_same_v<typename decltype(buf)::value_type,
+                           typename decltype(data)::value_type>);
+
+      CHECK(std::is_same_v<decltype(buf.get_range()), range<1>>);
+    }
+    // buffer with allocator and no property list
+    {
+      buffer buf_std_alloc(data, std_alloc);
+      buffer buf_buf_alloc(data, buf_alloc);
+
+      INFO("Incorrect deduction with allocator");
+      CHECK(std::is_same_v<
+            decltype(buf_std_alloc),
+            buffer<typename decltype(data)::value_type, 1, std::allocator<T>>>);
+
+      CHECK(std::is_same_v<decltype(buf_buf_alloc),
+                           buffer<typename decltype(data)::value_type, 1,
+                                  buffer_allocator<T>>>);
+
+      CHECK(std::is_same_v<decltype(buf_std_alloc.get_allocator()),
+                           std::allocator<T>>);
+      CHECK(std::is_same_v<decltype(buf_buf_alloc.get_allocator()),
+                           buffer_allocator<T>>);
+    }
+    // buffer with property list and no alloccator
+    {
+      buffer buf_prop(data, props);
+
+      INFO("Incorrect deduction with propery list");
+      CHECK(std::is_same_v<decltype(buf_prop),
+                           buffer<typename decltype(data)::value_type, 1>>);
+    }
+    // buffer with allocator and property list
+    {
+      buffer buf_std_alloc(data, std_alloc, props);
+      buffer buf_buf_alloc(data, buf_alloc, props);
+
+      INFO("Incorrect deduction with property list and allocator");
+      CHECK(std::is_same_v<
+            decltype(buf_std_alloc),
+            buffer<typename decltype(data)::value_type, 1, std::allocator<T>>>);
+
+      CHECK(std::is_same_v<decltype(buf_buf_alloc),
+                           buffer<typename decltype(data)::value_type, 1,
+                                  buffer_allocator<T>>>);
+    }
+  }
+};
+
+TEST_CASE("buffer deduction guides", "[buffer]") {
+  for_all_types<check_buffer_deduction>(deduction::vector_types);
+  for_all_types<check_buffer_deduction>(deduction::scalar_types);
+}
+}  // namespace buffer_deduction_guides

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -235,4 +235,26 @@ inline auto get_fp64_type() {
 
 }  // namespace get_cts_types
 
+namespace deduction {
+#if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
+static const auto vector_types =
+    named_type_pack<int, float>::generate(
+        "int", "float");
+#else
+static const auto vector_types =
+    named_type_pack<char, signed char, unsigned char, short int,
+      unsigned short int, unsigned int, long int, unsigned long int,
+      long long int, unsigned long long int, bool, float
+      >::generate(
+      "char", "signed char", "unsigned char", "short int", "unsigned short int",
+      "unsigned int", "long int", "unsigned long int", "long long int",
+      "unsigned long long int", "bool", "float");
+#endif
+
+static const auto scalar_types =
+    named_type_pack<user_struct, user_def_types::no_cnstr, user_def_types::no_def_cnstr
+    >::generate(
+    "user_struct", "no_cnstr", "no_def_cnstr");
+} // namespace deduction
+
 #endif  // __SYCLCTS_TESTS_COMMON_TYPE_LIST_H

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -238,23 +238,26 @@ inline auto get_fp64_type() {
 namespace deduction {
 #if !SYCL_CTS_ENABLE_FULL_CONFORMANCE
 static const auto vector_types =
-    named_type_pack<int, float>::generate(
-        "int", "float");
+    named_type_pack<int, float>::generate("int", "float");
 #else
 static const auto vector_types =
     named_type_pack<char, signed char, unsigned char, short int,
-      unsigned short int, unsigned int, long int, unsigned long int,
-      long long int, unsigned long long int, bool, float
-      >::generate(
-      "char", "signed char", "unsigned char", "short int", "unsigned short int",
-      "unsigned int", "long int", "unsigned long int", "long long int",
-      "unsigned long long int", "bool", "float");
+                    unsigned short int, unsigned int, long int,
+                    unsigned long int, long long int, unsigned long long int,
+                    bool, float>::generate("char", "signed char",
+                                           "unsigned char", "short int",
+                                           "unsigned short int", "unsigned int",
+                                           "long int", "unsigned long int",
+                                           "long long int",
+                                           "unsigned long long int", "bool",
+                                           "float");
 #endif
 
 static const auto scalar_types =
-    named_type_pack<user_struct, user_def_types::no_cnstr, user_def_types::no_def_cnstr
-    >::generate(
-    "user_struct", "no_cnstr", "no_def_cnstr");
-} // namespace deduction
+    named_type_pack<user_struct, user_def_types::no_cnstr,
+                    user_def_types::no_def_cnstr>::generate("user_struct",
+                                                            "no_cnstr",
+                                                            "no_def_cnstr");
+}  // namespace deduction
 
 #endif  // __SYCLCTS_TESTS_COMMON_TYPE_LIST_H

--- a/tests/id/id_deduction_guides.cpp
+++ b/tests/id/id_deduction_guides.cpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides id deduction guides tests
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_list.h"
+
+namespace id_deduction_guides {
+using namespace sycl;
+
+// array with sizes
+constexpr std::size_t N[3] = {4, 8, 10};
+
+template <int dims, class idT>
+void check_id_operator(idT _id) {
+  for (int i = 0; i < dims; ++i) {
+    INFO("operator[] returns wrong value with id<" + std::to_string(dims) +
+         ">");
+    CHECK(_id[i] == N[i]);
+  }
+}
+
+template <int dims, class idT>
+void check_id_type(idT _id) {
+  INFO("Wrong id type, expected id<" + std::to_string(dims) + ">");
+  CHECK(std::is_same_v<idT, id<dims>>);
+}
+
+TEST_CASE("id deduction guides", "[id]") {
+  id id_1d(N[0]);
+  id id_2d(N[0], N[1]);
+  id id_3d(N[0], N[1], N[2]);
+
+  check_id_operator<1>(id_1d);
+  check_id_operator<2>(id_2d);
+  check_id_operator<3>(id_3d);
+
+  check_id_type<1>(id_1d);
+  check_id_type<2>(id_2d);
+  check_id_type<3>(id_3d);
+}
+}  // namespace id_deduction_guides

--- a/tests/id/id_deduction_guides.cpp
+++ b/tests/id/id_deduction_guides.cpp
@@ -2,7 +2,6 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2022-2023 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,14 +27,14 @@ namespace id_deduction_guides {
 using namespace sycl;
 
 // array with sizes
-constexpr std::size_t N[3] = {4, 8, 10};
+constexpr std::size_t n[3] = {4, 8, 10};
 
 template <int dims, class idT>
 void check_id_operator(idT _id) {
   for (int i = 0; i < dims; ++i) {
     INFO("operator[] returns wrong value with id<" + std::to_string(dims) +
          ">");
-    CHECK(_id[i] == N[i]);
+    CHECK(_id[i] == n[i]);
   }
 }
 
@@ -46,9 +45,9 @@ void check_id_type(idT _id) {
 }
 
 TEST_CASE("id deduction guides", "[id]") {
-  id id_1d(N[0]);
-  id id_2d(N[0], N[1]);
-  id id_3d(N[0], N[1], N[2]);
+  id id_1d(n[0]);
+  id id_2d(n[0], n[1]);
+  id id_3d(n[0], n[1], n[2]);
 
   check_id_operator<1>(id_1d);
   check_id_operator<2>(id_2d);

--- a/tests/multi_ptr/multi_ptr_deduction_guides.cpp
+++ b/tests/multi_ptr/multi_ptr_deduction_guides.cpp
@@ -2,7 +2,6 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2022-2023 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +31,7 @@ template <typename T>
 class check_multi_ptr_deduction {
  public:
   void operator()(const std::string& type) {
-    typeName = type;
+    type_name = type;
 
     check_for_space<global>();
     check_for_space<local>();
@@ -44,7 +43,7 @@ class check_multi_ptr_deduction {
   static constexpr access::address_space local =
       access::address_space::local_space;
 
-  std::string typeName;
+  std::string type_name;
 
   template <access::address_space space>
   void check_for_space() {
@@ -71,7 +70,7 @@ class check_multi_ptr_deduction {
 
     std::string mode_str{sycl_cts::get_cts_string::for_mode<Mode>()};
     std::string space_str{(accessor_space == global) ? "global" : "local"};
-    std::string fail_str{"Incorrect deduction with type " + typeName + " in " +
+    std::string fail_str{"Incorrect deduction with type " + type_name + " in " +
                          std::to_string(dims) + " dimensions and " + mode_str +
                          " mode in " + space_str + " space "};
 

--- a/tests/multi_ptr/multi_ptr_deduction_guides.cpp
+++ b/tests/multi_ptr/multi_ptr_deduction_guides.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides multi_ptr deduction guides tests
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/get_cts_string.h"
+#include "multi_ptr_common.h"
+
+namespace multi_ptr_deduction_guides {
+using namespace sycl;
+
+template <typename T>
+class check_multi_ptr_deduction {
+ public:
+  void operator()(const std::string& type) {
+    typeName = type;
+
+    check_for_space<global>();
+    check_for_space<local>();
+  }
+
+ private:
+  static constexpr access::address_space global =
+      access::address_space::global_space;
+  static constexpr access::address_space local =
+      access::address_space::local_space;
+
+  std::string typeName;
+
+  template <access::address_space space>
+  void check_for_space() {
+    check_for_mode<access::mode::read, space>();
+    check_for_mode<access::mode::write, space>();
+    check_for_mode<access::mode::read_write, space>();
+  }
+
+  template <access::mode Mode, access::address_space accessor_space>
+  void check_for_mode() {
+    check_for_dims<1, Mode, accessor_space>();
+    check_for_dims<2, Mode, accessor_space>();
+    check_for_dims<3, Mode, accessor_space>();
+  }
+
+  template <int dims, access::mode Mode, access::address_space accessor_space>
+  void check_for_dims() {
+    using acc_t = std::conditional_t<accessor_space == global,
+                                     accessor<T, dims, Mode, target::device>,
+                                     local_accessor<T, dims>>;
+
+    acc_t _accessor;
+    multi_ptr mptr(_accessor);
+
+    std::string mode_str{sycl_cts::get_cts_string::for_mode<Mode>()};
+    std::string space_str{(accessor_space == global) ? "global" : "local"};
+    std::string fail_str{"Incorrect deduction with type " + typeName + " in " +
+                         std::to_string(dims) + " dimensions and " + mode_str +
+                         " mode in " + space_str + " space "};
+
+    INFO(fail_str);
+    CHECK(std::is_same_v<decltype(mptr),
+                         multi_ptr<T, accessor_space, access::decorated::no>>);
+  }
+};
+
+TEST_CASE("multi_ptr deduction guides", "[test_multi_ptr]") {
+  for_all_types<check_multi_ptr_deduction>(deduction::vector_types);
+  for_all_types<check_multi_ptr_deduction>(deduction::scalar_types);
+}
+}  // namespace multi_ptr_deduction_guides

--- a/tests/range/range_deduction_guides.cpp
+++ b/tests/range/range_deduction_guides.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//   Provides range deduction guides tests
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_list.h"
+
+namespace range_deduction_guides {
+using namespace sycl;
+
+// array with sizes
+constexpr std::size_t N[3] = {4, 8, 10};
+
+template <int dims, class rangeT>
+void check_range_size(rangeT r) {
+  std::size_t expected_size = 1;
+  for (int i = 0; i < dims; ++i) {
+    expected_size *= N[i];
+  }
+
+  INFO("Wrong range size, expected " + std::to_string(expected_size));
+  CHECK(expected_size == r.size());
+}
+
+template <int dims, class rangeT>
+void check_range_operator(rangeT r) {
+  for (int i = 0; i < dims; ++i) {
+    INFO("operator[] returns wrong value with range<" + std::to_string(dims) +
+         ">");
+    CHECK(r[i] == N[i]);
+  }
+}
+
+template <int dims, class rangeT>
+void check_range_type(rangeT r) {
+  INFO("Wrong range type, expected range<" + std::to_string(dims) + ">");
+  CHECK(std::is_same_v<rangeT, range<dims>>);
+}
+
+TEST_CASE("range deduction guides", "[range]") {
+  range range_1d(N[0]);
+  range range_2d(N[0], N[1]);
+  range range_3d(N[0], N[1], N[2]);
+
+  check_range_size<1>(range_1d);
+  check_range_size<2>(range_2d);
+  check_range_size<3>(range_3d);
+
+  check_range_operator<1>(range_1d);
+  check_range_operator<2>(range_2d);
+  check_range_operator<3>(range_3d);
+
+  check_range_type<1>(range_1d);
+  check_range_type<2>(range_2d);
+  check_range_type<3>(range_3d);
+}
+}  // namespace range_deduction_guides

--- a/tests/range/range_deduction_guides.cpp
+++ b/tests/range/range_deduction_guides.cpp
@@ -2,7 +2,6 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2022-2023 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,13 +27,13 @@ namespace range_deduction_guides {
 using namespace sycl;
 
 // array with sizes
-constexpr std::size_t N[3] = {4, 8, 10};
+constexpr std::size_t n[3] = {4, 8, 10};
 
 template <int dims, class rangeT>
 void check_range_size(rangeT r) {
   std::size_t expected_size = 1;
   for (int i = 0; i < dims; ++i) {
-    expected_size *= N[i];
+    expected_size *= n[i];
   }
 
   INFO("Wrong range size, expected " + std::to_string(expected_size));
@@ -46,7 +45,7 @@ void check_range_operator(rangeT r) {
   for (int i = 0; i < dims; ++i) {
     INFO("operator[] returns wrong value with range<" + std::to_string(dims) +
          ">");
-    CHECK(r[i] == N[i]);
+    CHECK(r[i] == n[i]);
   }
 }
 
@@ -57,9 +56,9 @@ void check_range_type(rangeT r) {
 }
 
 TEST_CASE("range deduction guides", "[range]") {
-  range range_1d(N[0]);
-  range range_2d(N[0], N[1]);
-  range range_3d(N[0], N[1], N[2]);
+  range range_1d(n[0]);
+  range range_2d(n[0], n[1]);
+  range range_3d(n[0], n[1], n[2]);
 
   check_range_size<1>(range_1d);
   check_range_size<2>(range_2d);

--- a/tests/vector_deduction_guides/CMakeLists.txt
+++ b/tests/vector_deduction_guides/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB test_cases_list *.cpp)
+
+add_cts_test(${test_cases_list})

--- a/tests/vector_deduction_guides/vec_deduction_guides.cpp
+++ b/tests/vector_deduction_guides/vec_deduction_guides.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides vec deduction guides tests
+//
+*******************************************************************************/
+
+#include "../common/common.h"
+#include "../common/type_list.h"
+
+namespace vec_deduction_guides {
+using namespace sycl;
+
+template <typename T>
+class check_vec_deduction {
+ public:
+  void operator()(const std::string& type) {
+    typeName = type;
+
+    T data[max_size];
+    for (int i = 0; i < max_size; ++i) {
+      data[i] = static_cast<T>(i);
+    }
+
+    vec vec_1n(data[0]);
+    vec vec_2n(data[0], data[1]);
+    vec vec_3n(data[0], data[1], data[2]);
+    vec vec_4n(data[0], data[1], data[2], data[3]);
+    vec vec_8n(data[0], data[1], data[2], data[3], data[4], data[5], data[6],
+               data[7]);
+    vec vec_16n(data[0], data[1], data[2], data[3], data[4], data[5], data[6],
+                data[7], data[8], data[9], data[10], data[11], data[12],
+                data[13], data[14], data[15]);
+
+    check_vector_value(vec_1n);
+    check_vector_value(vec_2n);
+    check_vector_value(vec_3n);
+    check_vector_value(vec_4n);
+    check_vector_value(vec_8n);
+    check_vector_value(vec_16n);
+
+    check_vector_type<1>(vec_1n);
+    check_vector_type<2>(vec_2n);
+    check_vector_type<3>(vec_3n);
+    check_vector_type<4>(vec_4n);
+    check_vector_type<8>(vec_8n);
+    check_vector_type<16>(vec_16n);
+  }
+
+ private:
+  const int max_size = 16;
+  std::string typeName;
+
+  template <int expected_size, class vecT>
+  void check_vector_type(vecT vector) {
+    INFO("Wrong vec type");
+    CHECK(std::is_same_v<vecT, vec<T, expected_size>>);
+  }
+
+  template <class vecT>
+  void check_vector_value(vecT vector) {
+    for (int i = 0; i < vector.size(); ++i) {
+      INFO("Wrong vec value on index " + std::to_string(i) +
+           " with value: " + std::to_string(vector[i]) + " vec type: vec<" +
+           typeName + ", " + std::to_string(vector.size()) + "> ");
+      CHECK(vector[i] == static_cast<T>(i));
+    }
+  }
+};
+
+TEST_CASE("vec deduction guides", "[vec_deduction]") {
+  for_all_types<check_vec_deduction>(deduction::vector_types);
+}
+}  // namespace vec_deduction_guides

--- a/tests/vector_deduction_guides/vec_deduction_guides.cpp
+++ b/tests/vector_deduction_guides/vec_deduction_guides.cpp
@@ -23,6 +23,7 @@
 
 #include "../common/common.h"
 #include "../common/type_list.h"
+#include "../common/disabled_for_test_case.h"
 
 namespace vec_deduction_guides {
 using namespace sycl;
@@ -84,7 +85,9 @@ class check_vec_deduction {
   }
 };
 
-TEST_CASE("vec deduction guides", "[vec_deduction]") {
+// FIXME: re-enable when vec deduction is implemented in hipSYCL
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("vec deduction guides", "[vec_deduction]")({
   for_all_types<check_vec_deduction>(deduction::vector_types);
-}
+});
 }  // namespace vec_deduction_guides

--- a/tests/vector_deduction_guides/vec_deduction_guides.cpp
+++ b/tests/vector_deduction_guides/vec_deduction_guides.cpp
@@ -2,7 +2,6 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
 //  Copyright (c) 2022-2023 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +31,7 @@ template <typename T>
 class check_vec_deduction {
  public:
   void operator()(const std::string& type) {
-    typeName = type;
+    type_name = type;
 
     T data[max_size];
     for (int i = 0; i < max_size; ++i) {
@@ -66,7 +65,7 @@ class check_vec_deduction {
 
  private:
   const int max_size = 16;
-  std::string typeName;
+  std::string type_name;
 
   template <int expected_size, class vecT>
   void check_vector_type(vecT vector) {
@@ -79,7 +78,7 @@ class check_vec_deduction {
     for (int i = 0; i < vector.size(); ++i) {
       INFO("Wrong vec value on index " + std::to_string(i) +
            " with value: " + std::to_string(vector[i]) + " vec type: vec<" +
-           typeName + ", " + std::to_string(vector.size()) + "> ");
+           type_name + ", " + std::to_string(vector.size()) + "> ");
       CHECK(vector[i] == static_cast<T>(i));
     }
   }

--- a/tests/vector_deduction_guides/vec_deduction_guides.cpp
+++ b/tests/vector_deduction_guides/vec_deduction_guides.cpp
@@ -22,8 +22,8 @@
 *******************************************************************************/
 
 #include "../common/common.h"
-#include "../common/type_list.h"
 #include "../common/disabled_for_test_case.h"
+#include "../common/type_list.h"
 
 namespace vec_deduction_guides {
 using namespace sycl;


### PR DESCRIPTION
Added tests for `buffer`, `multi_ptr`, `vec`, `range` and `id` constructors deduction guides according to [test plan](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/deduction_guides.asciidoc )