### PR TITLE
Re-worked scan group tests to compare to the results of std::exclusive_scan and std::inclusive_scan

### DIFF
--- a/tests/common/disabled_for_test_case.h
+++ b/tests/common/disabled_for_test_case.h
@@ -10,9 +10,9 @@
 #define __SYCLCTS_TESTS_COMMON_DISABLED_FOR_TEST_CASE_H
 
 // This is required for detecting the active SYCL implementation
-#include <sycl/sycl.hpp>
-
 #include "macro_utils.h"
+#include <catch2/catch_test_macros.hpp>
+#include <sycl/sycl.hpp>
 
 // TODO: Add other Catch2 test case variants, as needed
 

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -18,7 +18,9 @@
 //
 *******************************************************************************/
 
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
+#endif
 #include "../common/disabled_for_test_case.h"
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -18,12 +18,9 @@
 //
 *******************************************************************************/
 
+#include "../common/disabled_for_test_case.h"
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
-#endif
-#include "../common/common.h"
-#include "../common/disabled_for_test_case.h"
-#include "type_coverage.h"
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
@@ -42,7 +39,7 @@ using ScanTypes = Types;
 
 static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
-
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 // FIXME: known_identity is not impemented yet for hipSYCL.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group joint scan functions", "[group_func][type_list][dim]")({

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -21,7 +21,9 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
 #endif
+#include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
+#include "type_coverage.h"
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -135,7 +135,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 });
 
 // FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
-// and op are interchanged. known_identity is not impemented yet.
+// and op are interchanged. known_identity is not implemented yet.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][type_list][dim]")({

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -39,8 +39,9 @@ using ScanTypes = Types;
 static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 
-TEST_CASE("Group and sub-group joint scan functions",
-          "[group_func][type_list][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group joint scan functions", "[group_func][type_list][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   WARN(
       "hipSYCL cannot handle cases of different types for InPtr and OutPtr. "
@@ -71,10 +72,12 @@ TEST_CASE("Group and sub-group joint scan functions",
   for_all_combinations<invoke_joint_scan_group>(Dims, ScanTypes{}, ScanTypes{},
                                                 queue);
 #endif
-}
+});
 
-TEST_CASE("Group and sub-group joint scan functions with init",
-          "[group_func][type_list][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group joint scan functions with init",
+ "[group_func][type_list][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   WARN(
       "hipSYCL cannot handle cases of different types for T, *InPtr and "
@@ -105,10 +108,11 @@ TEST_CASE("Group and sub-group joint scan functions with init",
   for_all_combinations<invoke_init_joint_scan_group>(
       Dims, ScanTypes{}, ScanTypes{}, ScanTypes{}, queue);
 #endif
-}
+});
 
-TEST_CASE("Group and sub-group scan functions",
-          "[group_func][type_list][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group scan functions", "[group_func][type_list][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN(
       "ComputeCpp does not implement scan for unsigned long long int and "
@@ -127,10 +131,10 @@ TEST_CASE("Group and sub-group scan functions",
 #else
   for_all_combinations<invoke_scan_over_group>(Dims, ScanTypes{}, queue);
 #endif
-}
+});
 
 // FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
-// and op are interchanged
+// and op are interchanged. known_identity is not impemented yet.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][type_list][dim]")({

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -19,6 +19,7 @@
 *******************************************************************************/
 
 #include "group_scan.h"
+#include "../common/disabled_for_test_case.h"
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
@@ -128,13 +129,12 @@ TEST_CASE("Group and sub-group scan functions",
 #endif
 }
 
-TEST_CASE("Group and sub-group scan functions with init",
-          "[group_func][type_list][dim]") {
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
-  WARN(
-      "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
-      "and op are interchanged.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+// FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
+// and op are interchanged
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group scan functions with init",
+ "[group_func][type_list][dim]")({
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
   // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T and V. Skipping such "
@@ -167,4 +167,4 @@ TEST_CASE("Group and sub-group scan functions with init",
   for_all_combinations<invoke_init_scan_over_group>(Dims, ScanTypes{},
                                                     ScanTypes{}, queue);
 #endif
-}
+});

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -134,15 +134,8 @@ void check_scan(sycl::queue& queue, size_t size,
   std::vector<U> reference_e(size, U(-1));
   std::vector<U> reference_i(size, U(-1));
 
-// FIXME: known_identity is not implemented in hipSYCL yet
-#if SYCL_CTS_COMPILING_WITH_HIPSYCL
-  I init_value = (with_init) ? I(init)
-                 : (std::is_same_v<OpT, sycl::plus<U>>)
-                     ? I{}
-                     : std::numeric_limits<I>::lowest();
-#else
   I init_value = (with_init) ? I(init) : sycl::known_identity<OpT, I>::value;
-#endif
+
   std::exclusive_scan(v.begin(), v.end(), reference_e.begin(), init_value, op);
   std::inclusive_scan(v.begin(), v.end(), reference_i.begin(), op, init_value);
   for (int i = 0; i < size; i++) {
@@ -378,15 +371,8 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op) {
   CHECK(ret_type_e);
   CHECK(ret_type_i);
 
-// FIXME: known_identity is not implemented in hipSYCL yet
-#if SYCL_CTS_COMPILING_WITH_HIPSYCL
-  T init_value = (with_init) ? T(init)
-                 : (std::is_same_v<OpT, sycl::plus<T>>)
-                     ? T{}
-                     : std::numeric_limits<T>::lowest();
-#else
   T init_value = (with_init) ? T(init) : sycl::known_identity<OpT, T>::value;
-#endif
+
   for (int i = 0; i < range_size; i++) {
     int shift = i - local_id[i];
     ;

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -134,6 +134,7 @@ void check_scan(sycl::queue& queue, size_t size,
   std::vector<U> reference_e(size, U(-1));
   std::vector<U> reference_i(size, U(-1));
 
+// FIXME: known_identity is not implemented in hipSYCL yet
 #if SYCL_CTS_COMPILING_WITH_HIPSYCL
   I init_value = (with_init) ? I(init)
                  : (std::is_same_v<OpT, sycl::plus<U>>)
@@ -294,25 +295,10 @@ template <int D, typename T, typename Group, bool with_init, typename U,
           typename OpT>
 class scan_over_group_kernel;
 
-// FIXME: hipSYCL has wrong arguments order: init and op are interchanged
-#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
-template <typename Group, typename V, typename T, typename BinaryOperation>
-auto inclusive_scan_over_group_impl(Group g, V x, BinaryOperation binary_op,
-                                    T init) {
-  return sycl::inclusive_scan_over_group(g, x, init, binary_op);
-}
-#else
-template <typename Group, typename V, typename T, typename BinaryOperation>
-auto inclusive_scan_over_group_impl(Group g, V x, BinaryOperation binary_op,
-                                    T init) {
-  return sycl::inclusive_scan_over_group(g, x, binary_op, init);
-}
-#endif
-
 template <bool with_init, typename T, typename U, typename Group, typename OpT>
 auto inclusive_scan_over_group_helper(Group group, U x, OpT op) {
   if constexpr (with_init) {
-    return inclusive_scan_over_group_impl(group, x, op, T(init));
+    return sycl::inclusive_scan_over_group(group, x, op, T(init));
   } else
     return sycl::inclusive_scan_over_group(group, x, op);
 }
@@ -392,6 +378,7 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op) {
   CHECK(ret_type_e);
   CHECK(ret_type_i);
 
+// FIXME: known_identity is not implemented in hipSYCL yet
 #if SYCL_CTS_COMPILING_WITH_HIPSYCL
   T init_value = (with_init) ? T(init)
                  : (std::is_same_v<OpT, sycl::plus<T>>)

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -150,14 +150,14 @@ void check_scan(sycl::queue& queue, size_t size,
       INFO("Result: " + std::to_string(res_e[i]));
       INFO("Expected: " + std::to_string(reference_e[i]));
       // ulp is i because there can be different rounding mods
-      CHECK(compare_with_ulp(res_e[i], reference_e[i], i));
+      CHECK(is_equal_with_ulp(res_e[i], reference_e[i], i));
     }
     {
       INFO("Check joint_inclusive_scan for element " + std::to_string(i));
       INFO("Result: " + std::to_string(res_i[i]));
       INFO("Expected: " + std::to_string(reference_i[i]));
       // ulp is i because there can be different rounding mods
-      CHECK(compare_with_ulp(res_i[i], reference_i[i], i));
+      CHECK(is_equal_with_ulp(res_i[i], reference_i[i], i));
     }
   }
 }
@@ -412,7 +412,7 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op) {
       INFO("Result: " + std::to_string(res_e[i]));
       INFO("Expected: " + std::to_string(reference[i - shift]));
       // ulp is i - shift because there can be different rounding mods
-      CHECK(compare_with_ulp(res_e[i], reference[i - shift], i - shift));
+      CHECK(is_equal_with_ulp(res_e[i], reference[i - shift], i - shift));
     }
     {
       INFO("Check inclusive_scan_over_group for element " + std::to_string(i));
@@ -422,7 +422,7 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op) {
       INFO("Result: " + std::to_string(res_i[i]));
       INFO("Expected: " + std::to_string(reference[i - shift]));
       // ulp is i - shift because there can be different rounding mods
-      CHECK(compare_with_ulp(res_i[i], reference[i - shift], i - shift));
+      CHECK(is_equal_with_ulp(res_i[i], reference[i - shift], i - shift));
     }
   }
 }

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -163,7 +163,8 @@ void check_scan(sycl::queue& queue, size_t size,
 template <int D, typename T, typename U>
 void joint_scan_group(sycl::queue& queue) {
   INFO(" with type " + type_name<T>());
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
+  sycl::range<D> work_group_range =
+      sycl_cts::util::work_group_range<D>(queue, test_size);
 
   size_t work_group_size = work_group_range.size();
 
@@ -228,7 +229,8 @@ class init_joint_scan_group_kernel;
 template <int D, typename T, typename U, typename I>
 void init_joint_scan_group(sycl::queue& queue) {
   INFO(" with type " + type_name<T>());
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
+  sycl::range<D> work_group_range =
+      sycl_cts::util::work_group_range<D>(queue, test_size);
   sycl::nd_range<D> executionRange(work_group_range, work_group_range);
 
   size_t work_group_size = work_group_range.size();
@@ -406,7 +408,8 @@ template <int D, typename T>
 void scan_over_group(sycl::queue& queue) {
   INFO(" with type " + type_name<T>());
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
+  sycl::range<D> work_group_range =
+      sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   SECTION("Check scan_over_group for group with sycl::plus") {
@@ -452,7 +455,8 @@ template <int D, typename T, typename U>
 void init_scan_over_group(sycl::queue& queue) {
   INFO(" with types " + type_name<T>() + " and " + type_name<U>());
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
+  sycl::range<D> work_group_range =
+      sycl_cts::util::work_group_range<D>(queue, test_size);
 
   SECTION("Check scan_over_group for group with sycl::plus") {
     check_scan_over_group<D, T, sycl::group<D>, true, U>(

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -376,7 +376,6 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op) {
 
   for (int i = 0; i < range_size; i++) {
     int shift = i - local_id[i];
-    ;
     auto startIter = v.begin() + shift;
     {
       INFO("Check exclusive_scan_over_group for element " + std::to_string(i));

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -18,7 +18,9 @@
 //
 *******************************************************************************/
 
+#include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
+#include "type_coverage.h"
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
 #endif

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -19,7 +19,9 @@
 *******************************************************************************/
 
 #include "../common/disabled_for_test_case.h"
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
+#endif
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -42,8 +42,10 @@ using HalfExtendedTypes = concatenation<ScanTypes, sycl::half>::type;
 static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 
-TEST_CASE("Group and sub-group joint scan functions",
-          "[group_func][type_list][fp16][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group joint scan functions",
+ "[group_func][type_list][fp16][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   WARN(
       "hipSYCL cannot handle cases of different types for InPtr and OutPtr. "
@@ -81,10 +83,12 @@ TEST_CASE("Group and sub-group joint scan functions",
     WARN("Device does not support half precision floating point operations.");
   }
 #endif
-}
+});
 
-TEST_CASE("Group and sub-group joint scan functions with init",
-          "[group_func][type_list][fp16][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group joint scan functions with init",
+ "[group_func][type_list][fp16][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   WARN(
       "hipSYCL cannot handle cases of different types for T, *InPtr and "
@@ -123,9 +127,11 @@ TEST_CASE("Group and sub-group joint scan functions with init",
     WARN("Device does not support half precision floating point operations.");
   }
 #endif
-}
+});
 
-TEST_CASE("Group and sub-group scan functions", "[group_func][fp16][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group scan functions", "[group_func][fp16][dim]")({
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
   WARN("ComputeCpp cannot handle half type. Skipping the test.");
   return;
@@ -136,10 +142,10 @@ TEST_CASE("Group and sub-group scan functions", "[group_func][fp16][dim]") {
     WARN("Device does not support half precision floating point operations.");
   }
 #endif
-}
+});
 
 // FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
-// and op are interchanged
+// and op are interchanged. known_identity is not impemented yet.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][type_list][fp16][dim]")({

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -18,6 +18,7 @@
 //
 *******************************************************************************/
 
+#include "../common/disabled_for_test_case.h"
 #include "group_scan.h"
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
@@ -137,13 +138,12 @@ TEST_CASE("Group and sub-group scan functions", "[group_func][fp16][dim]") {
 #endif
 }
 
-TEST_CASE("Group and sub-group scan functions with init",
-          "[group_func][type_list][fp16][dim]") {
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
-  WARN(
-      "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
-      "and op are interchanged.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+// FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
+// and op are interchanged
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group scan functions with init",
+ "[group_func][type_list][fp16][dim]")({
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
   // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T and V. Skipping such "
@@ -177,4 +177,4 @@ TEST_CASE("Group and sub-group scan functions with init",
     WARN("Device does not support half precision floating point operations.");
   }
 #endif
-}
+});

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -23,7 +23,6 @@
 #include "type_coverage.h"
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
-#endif
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
@@ -45,7 +44,7 @@ using HalfExtendedTypes = concatenation<ScanTypes, sycl::half>::type;
 
 static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
-
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 // FIXME: known_identity is not impemented yet for hipSYCL.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group joint scan functions",

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -19,8 +19,9 @@
 *******************************************************************************/
 
 #include "../common/disabled_for_test_case.h"
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
-
+#endif
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -18,7 +18,9 @@
 //
 *******************************************************************************/
 
+#include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
+#include "type_coverage.h"
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
 #endif

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -42,8 +42,10 @@ using DoubleExtendedTypes = concatenation<ScanTypes, double>::type;
 static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 
-TEST_CASE("Group and sub-group joint scan functions",
-          "[group_func][type_list][fp64][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group joint scan functions",
+ "[group_func][type_list][fp64][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   WARN(
       "hipSYCL cannot handle cases of different types for InPtr and OutPtr. "
@@ -80,10 +82,12 @@ TEST_CASE("Group and sub-group joint scan functions",
     WARN("Device does not support double precision floating point operations.");
   }
 #endif
-}
+});
 
-TEST_CASE("Group and sub-group joint scan functions with init",
-          "[group_func][type_list][fp64][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group joint scan functions with init",
+ "[group_func][type_list][fp64][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   WARN(
       "hipSYCL cannot handle cases of different types for T, *InPtr and "
@@ -121,9 +125,11 @@ TEST_CASE("Group and sub-group joint scan functions with init",
     WARN("Device does not support double precision floating point operations.");
   }
 #endif
-}
+});
 
-TEST_CASE("Group and sub-group scan functions", "[group_func][fp64][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group scan functions", "[group_func][fp64][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN(
       "ComputeCpp fails to compile with segfault in the compiler. "
@@ -143,10 +149,10 @@ TEST_CASE("Group and sub-group scan functions", "[group_func][fp64][dim]") {
     WARN("Device does not support double precision floating point operations.");
   }
 #endif
-}
+});
 
 // FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
-// and op are interchanged
+// and op are interchanged. known_identity is not impemented yet.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][type_list][fp64][dim]")({

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -18,6 +18,7 @@
 //
 *******************************************************************************/
 
+#include "../common/disabled_for_test_case.h"
 #include "group_scan.h"
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
@@ -144,13 +145,12 @@ TEST_CASE("Group and sub-group scan functions", "[group_func][fp64][dim]") {
 #endif
 }
 
-TEST_CASE("Group and sub-group scan functions with init",
-          "[group_func][type_list][fp64][dim]") {
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
-  WARN(
-      "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
-      "and op are interchanged.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+// FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
+// and op are interchanged
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group scan functions with init",
+ "[group_func][type_list][fp64][dim]")({
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
   // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T and V. Skipping such "
@@ -189,4 +189,4 @@ TEST_CASE("Group and sub-group scan functions with init",
     WARN("Device does not support double precision floating point operations.");
   }
 #endif
-}
+});

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -23,7 +23,7 @@
 #include "type_coverage.h"
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
-#endif
+
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
@@ -44,7 +44,7 @@ using DoubleExtendedTypes = concatenation<ScanTypes, double>::type;
 
 static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
-
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 // FIXME: known_identity is not impemented yet for hipSYCL.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group joint scan functions",

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -45,8 +45,9 @@ using DoubleHalfExtendedTypes = concatenation<ScanTypes, DoubleHalfTypes>::type;
 static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 
-TEST_CASE("Group and sub-group joint scan functions",
-          "[group_func][fp16][fp64][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group joint scan functions", "[group_func][fp16][fp64][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   WARN(
       "hipSYCL cannot handle cases of different types for InPtr and OutPtr. "
@@ -85,10 +86,12 @@ TEST_CASE("Group and sub-group joint scan functions",
         "operations simultaneously.");
   }
 #endif
-}
+});
 
-TEST_CASE("Group and sub-group joint scan functions with init",
-          "[group_func][type_list][fp16][fp64][dim]") {
+// FIXME: known_identity is not impemented yet for hipSYCL.
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group joint scan functions with init",
+ "[group_func][type_list][fp16][fp64][dim]")({
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   WARN(
       "hipSYCL cannot handle cases of different types for T, *InPtr and "
@@ -127,10 +130,10 @@ TEST_CASE("Group and sub-group joint scan functions with init",
         "operations simultaneously.");
   }
 #endif
-}
+});
 
 // FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
-// and op are interchanged
+// and op are interchanged. known_identity is not impemented yet.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][fp16][fp64][dim]")({

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -21,7 +21,9 @@
 // need also double tests enabled
 #ifdef SYCL_CTS_ENABLE_DOUBLE_TESTS
 
+#include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
+#include "type_coverage.h"
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
 #endif

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -26,7 +26,7 @@
 #include "type_coverage.h"
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
-#endif
+
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
@@ -47,7 +47,7 @@ using DoubleHalfExtendedTypes = concatenation<ScanTypes, DoubleHalfTypes>::type;
 
 static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
-
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 // FIXME: known_identity is not impemented yet for hipSYCL.
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group joint scan functions", "[group_func][fp16][fp64][dim]")({

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -21,6 +21,7 @@
 // need also double tests enabled
 #ifdef SYCL_CTS_ENABLE_DOUBLE_TESTS
 
+#include "../common/disabled_for_test_case.h"
 #include "group_scan.h"
 
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
@@ -128,13 +129,12 @@ TEST_CASE("Group and sub-group joint scan functions with init",
 #endif
 }
 
-TEST_CASE("Group and sub-group scan functions with init",
-          "[group_func][fp16][fp64][dim]") {
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
-  WARN(
-      "hipSYCL has wrong arguments order in inclusive_scan_over_group: init "
-      "and op are interchanged.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+// FIXME: hipSYCL has wrong arguments order for inclusive_scan_over_group: init
+// and op are interchanged
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("Group and sub-group scan functions with init",
+ "[group_func][fp16][fp64][dim]")({
+#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
   // Link to issue https://github.com/intel/llvm/issues/8341
   WARN(
       "DPCPP cannot handle cases of different types for T and V. Skipping the "
@@ -166,6 +166,6 @@ TEST_CASE("Group and sub-group scan functions with init",
         "operations simultaneously.");
   }
 #endif
-}
+});
 
 #endif

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -22,8 +22,9 @@
 #ifdef SYCL_CTS_ENABLE_DOUBLE_TESTS
 
 #include "../common/disabled_for_test_case.h"
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 #include "group_scan.h"
-
+#endif
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP

--- a/util/accuracy.h
+++ b/util/accuracy.h
@@ -60,7 +60,9 @@ inline sycl::half get_ulp_sycl<sycl::half>(sycl::half x) {
 template <typename T>
 bool is_equal_with_ulp(T actual, T expected, unsigned int ulpsExpected) {
   if (actual == expected) return true;
-  if constexpr (!std::is_integral_v<T>) {
+  if constexpr (std::is_integral_v<T>)
+    return false;
+  else {
     const T difference = static_cast<T>(std::fabs(actual - expected));
     const T differenceExpected = ulpsExpected * get_ulp_sycl(expected);
 
@@ -71,7 +73,6 @@ bool is_equal_with_ulp(T actual, T expected, unsigned int ulpsExpected) {
            (actual - differenceExpected == expected) ||
            (expected - differenceExpected == actual);
   }
-  return false;
 }
 
 #endif  // __SYCLCTS_UTIL_ACCURACY_H

--- a/util/accuracy.h
+++ b/util/accuracy.h
@@ -49,4 +49,22 @@ inline sycl::half get_ulp_sycl<sycl::half>(sycl::half x) {
   return static_cast<sycl::half>(ulp * multiplier);
 }
 
+template <typename T>
+bool compare_with_ulp(T actual, T expected, unsigned int ulpsExpected) {
+  if (actual == expected)
+    return true;
+  else if constexpr (!std::is_integral_v<T>) {
+    const T difference = static_cast<T>(std::fabs(actual - expected));
+    const T differenceExpected = ulpsExpected * get_ulp_sycl(expected);
+
+    return (difference <= differenceExpected)
+           // for close to inf cases
+           || (actual + differenceExpected == expected) ||
+           (expected + differenceExpected == actual) ||
+           (actual - differenceExpected == expected) ||
+           (expected - differenceExpected == actual);
+  }
+  return false;
+}
+
 #endif // __SYCLCTS_UTIL_ACCURACY_H

--- a/util/accuracy.h
+++ b/util/accuracy.h
@@ -51,28 +51,4 @@ inline sycl::half get_ulp_sycl<sycl::half>(sycl::half x) {
   return static_cast<sycl::half>(ulp * multiplier);
 }
 
-/**
- * @brief Uses provided allowed difference in ULPs to calculate max allowed
- *        difference between actual and expected values to consider them equal.
- *        Returns whether the values are equal by such definition.
- *        If type T is integral, result of exact comparing is returned.
- */
-template <typename T>
-bool is_equal_with_ulp(T actual, T expected, unsigned int ulpsExpected) {
-  if (actual == expected) return true;
-  if constexpr (std::is_integral_v<T>)
-    return false;
-  else {
-    const T difference = static_cast<T>(std::fabs(actual - expected));
-    const T differenceExpected = ulpsExpected * get_ulp_sycl(expected);
-
-    return (difference <= differenceExpected)
-           // for close to inf cases
-           || (actual + differenceExpected == expected) ||
-           (expected + differenceExpected == actual) ||
-           (actual - differenceExpected == expected) ||
-           (expected - differenceExpected == actual);
-  }
-}
-
 #endif  // __SYCLCTS_UTIL_ACCURACY_H

--- a/util/accuracy.h
+++ b/util/accuracy.h
@@ -49,11 +49,17 @@ inline sycl::half get_ulp_sycl<sycl::half>(sycl::half x) {
   return static_cast<sycl::half>(ulp * multiplier);
 }
 
+/**
+ * @brief Uses provided allowed difference in ULPs to calculate max allowed
+ *        difference between actual and expected values to consider them equal.
+ *        Returns whether the values are equal by such definition.
+ *        If type T is integral, result of exact comparing is returned.
+ */
 template <typename T>
-bool compare_with_ulp(T actual, T expected, unsigned int ulpsExpected) {
+bool is_equal_with_ulp(T actual, T expected, unsigned int ulpsExpected) {
   if (actual == expected)
     return true;
-  else if constexpr (!std::is_integral_v<T>) {
+  if constexpr (!std::is_integral_v<T>) {
     const T difference = static_cast<T>(std::fabs(actual - expected));
     const T differenceExpected = ulpsExpected * get_ulp_sycl(expected);
 

--- a/util/accuracy.h
+++ b/util/accuracy.h
@@ -17,7 +17,8 @@
  *        See Jean-Michel Muller "On the definition of ulp (x)", definition 7
  *        Using std functions.
  */
-template <typename T> T get_ulp_std(T x) {
+template <typename T>
+T get_ulp_std(T x) {
   const T inf = std::numeric_limits<T>::infinity();
   const T negative = std::fabs(std::nextafter(x, -inf) - x);
   const T positive = std::fabs(std::nextafter(x, inf) - x);
@@ -35,7 +36,8 @@ inline sycl::half get_ulp_std<sycl::half>(sycl::half x) {
  *        See Jean-Michel Muller "On the definition of ulp (x)", definition 7
  *        Using sycl functions.
  */
-template <typename T> T get_ulp_sycl(T x) {
+template <typename T>
+T get_ulp_sycl(T x) {
   const T inf = std::numeric_limits<T>::infinity();
   const T negative = sycl::fabs(sycl::nextafter(x, -inf) - x);
   const T positive = sycl::fabs(sycl::nextafter(x, inf) - x);
@@ -57,8 +59,7 @@ inline sycl::half get_ulp_sycl<sycl::half>(sycl::half x) {
  */
 template <typename T>
 bool is_equal_with_ulp(T actual, T expected, unsigned int ulpsExpected) {
-  if (actual == expected)
-    return true;
+  if (actual == expected) return true;
   if constexpr (!std::is_integral_v<T>) {
     const T difference = static_cast<T>(std::fabs(actual - expected));
     const T differenceExpected = ulpsExpected * get_ulp_sycl(expected);
@@ -73,4 +74,4 @@ bool is_equal_with_ulp(T actual, T expected, unsigned int ulpsExpected) {
   return false;
 }
 
-#endif // __SYCLCTS_UTIL_ACCURACY_H
+#endif  // __SYCLCTS_UTIL_ACCURACY_H


### PR DESCRIPTION
Re-worked tests to use results of std::exclusive_scan and std::inclusive_scan as reference values.
Refactor code to reduce repeating of similar lines.
