### PR TITLE
Separate test cases for pointers types in atomic_ref tests

### DIFF
--- a/tests/atomic_ref/atomic_ref_T_op_test.h
+++ b/tests/atomic_ref/atomic_ref_T_op_test.h
@@ -77,13 +77,6 @@ struct run_T_op_test {
 
     for_all_combinations<atomic_ref_T_op_test, T>(memory_orders, memory_scopes,
                                                   address_spaces, type_name);
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_T_op_test, T*>(memory_orders, memory_scopes,
-                                                   address_spaces,
-                                                   type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_T_op_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_T_op_test_pointers.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::operator T() test for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_T_op_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref::operator T() test. pointers types", "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_T_op_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test.h
+++ b/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test.h
@@ -150,13 +150,6 @@ struct run_add_sub_op_all_types_test {
 
     for_all_combinations<atomic_ref_add_sub_op_all_types_test, T>(
         memory_orders, memory_scopes, address_spaces, type_name);
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_add_sub_op_all_types_test, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_pointers.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref operator+=()/operator-=() tests for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_add_sub_op_all_types_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_rer operator+=()/operator-=() test. pointers types",
+ "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_add_sub_op_all_types_test>(
+      type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_assign_op_test.h
+++ b/tests/atomic_ref/atomic_ref_assign_op_test.h
@@ -109,13 +109,6 @@ struct run_assign_op_test {
 
     for_all_combinations<atomic_ref_assign_op_test, T>(
         memory_orders, memory_scopes, address_spaces, type_name);
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_assign_op_test, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_assign_op_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_pointers.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::operator=() tests for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_assign_op_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl, re-enable for dpcpp when atomic_ref<T*>::operator=() is implemented
+DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp, hipSYCL)
+("sycl::atomic_rer::operator=() test. pointers types", "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_assign_op_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_common.h
+++ b/tests/atomic_ref/atomic_ref_common.h
@@ -140,6 +140,42 @@ inline auto get_conformance_type_pack() {
 }
 
 /**
+ * @brief Factory function for getting type_pack with all pointers types
+ */
+inline auto get_full_conformance_pointers_type_pack() {
+  static const auto types =
+      named_type_pack<int*, unsigned int*, long int*, unsigned long int*,
+                      long long*, unsigned long long*, float*,
+                      double*>::generate("int *", "unsigned int *",
+                                         "long int *", "unsigned long int *",
+                                         "long long *", "unsigned long long *",
+                                         "float *", "double *");
+  return types;
+}
+
+/**
+ * @brief Factory function for getting type_pack with generic pointers types
+ */
+inline auto get_lightweight_pointers_type_pack() {
+  static const auto types =
+      named_type_pack<int*, float*>::generate("int *", "float *");
+  return types;
+}
+
+/**
+ * @brief Factory function for getting type_pack with pointers types that
+ * depends on full conformance mode enabling status
+ * @return lightweight or full named_type_pack for pointers types
+ */
+inline auto get_conformance_pointers_type_pack() {
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  return get_full_conformance_pointers_type_pack();
+#else
+  return get_lightweight_pointers_type_pack();
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+}
+
+/**
  * @brief Factory function for getting type_pack with memory_order values
  */
 inline auto get_memory_orders() {

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test.h
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test.h
@@ -364,17 +364,6 @@ struct run_compare_exchange_test {
 
     for_all_combinations<atomic_ref_compare_exchange_test, strong, T>(
         memory_orders, memory_scopes, address_spaces, type_name);
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_compare_exchange_test, weak, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
-
-    for_all_combinations<atomic_ref_compare_exchange_test, strong, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref compare_exchange_strong()/compare_exchange_weak()
+//  tests for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_compare_exchange_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_rer compare_exchange_strong()/compare_exchange_weak() test. "
+ "pointers types",
+ "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_compare_exchange_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_constructors.h
+++ b/tests/atomic_ref/atomic_ref_constructors.h
@@ -160,13 +160,6 @@ struct run_test {
 
     for_all_combinations<run_constructor_tests, T>(memory_orders, memory_scopes,
                                                    address_spaces, type_name);
-
-    if (is_64_bits_pointer<T *>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<run_constructor_tests, T *>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_constructors_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_pointers.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref constructors test for pointers types.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_constructors.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::constructors::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref constructors. pointers types", "[atomic_ref]")({
+  const auto types =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::constructors::run_test>(types);
+});
+
+}  // namespace atomic_ref::tests::constructors::core

--- a/tests/atomic_ref/atomic_ref_exchange_test.h
+++ b/tests/atomic_ref/atomic_ref_exchange_test.h
@@ -107,13 +107,6 @@ struct run_exchange_test {
 
     for_all_combinations<atomic_ref_exchange_test, T>(
         memory_orders, memory_scopes, address_spaces, type_name);
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_exchange_test, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_exchange_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_exchange_test_pointers.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::exchange() tests for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_exchange_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_rer::exchange() test. pointers types", "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_exchange_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test.h
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test.h
@@ -153,13 +153,6 @@ struct run_fetch_add_sub_all_types_test {
 
     for_all_combinations<atomic_ref_fetch_add_sub_all_types_test, T>(
         memory_orders, memory_scopes, address_spaces, type_name);
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_fetch_add_sub_all_types_test, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref fetch_add()/fetch_sub() tests for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_fetch_add_sub_all_types_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_rer fetch_add()/fetch_sub() test. pointers types",
+ "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_fetch_add_sub_all_types_test>(
+      type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test.h
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test.h
@@ -168,17 +168,10 @@ struct run_incr_decr_op_test {
     const auto memory_scopes = get_memory_scopes();
     const auto address_spaces = get_address_spaces();
 
-    if constexpr (std::is_integral_v<T>) {
+    if constexpr (std::is_integral_v<T> or std::is_pointer_v<T>) {
       for_all_combinations<atomic_ref_incr_decr_op_test, T>(
           memory_orders, memory_scopes, address_spaces, type_name);
     }
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_incr_decr_op_test, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref
+//  operator++(int)/operator++()/operator--(int)/operator--() tests
+//  for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_incr_decr_op_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_rer increment/decrement operators test. pointers types",
+ "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_incr_decr_op_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_is_lock_free_test.h
+++ b/tests/atomic_ref/atomic_ref_is_lock_free_test.h
@@ -86,13 +86,6 @@ struct run_is_lock_free_test {
 
     for_all_combinations<atomic_ref_is_lock_free_test, T>(
         memory_orders, memory_scopes, address_spaces, type_name);
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_is_lock_free_test, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_is_lock_free_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_is_lock_free_test_pointers.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::is_lock_free() test for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_is_lock_free_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref::is_lock_free() test. pointers types", "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_is_lock_free_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_store_test.h
+++ b/tests/atomic_ref/atomic_ref_store_test.h
@@ -82,13 +82,6 @@ struct run_store_test {
 
     for_all_combinations<atomic_ref_store_test, T>(memory_orders, memory_scopes,
                                                    address_spaces, type_name);
-
-    if (is_64_bits_pointer<T*>() && device_has_not_aspect_atomic64()) return;
-
-    std::string type_name_for_pointer_types = type_name + "*";
-    for_all_combinations<atomic_ref_store_test, T*>(
-        memory_orders, memory_scopes, address_spaces,
-        type_name_for_pointer_types);
   }
 };
 

--- a/tests/atomic_ref/atomic_ref_store_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_store_test_pointers.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::store() test for pointers types
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+#include "atomic_ref_store_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref::store() test. pointers types", "[atomic_ref]")({
+  const auto type_pack =
+      atomic_ref::tests::common::get_conformance_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_store_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core


### PR DESCRIPTION
Made separate test cases for pointers types similar to `atomic64` types because size of pointers types can be 64 bits wide and could be not supported by device and to make sure that tests for pointers to `atomic64` types will be tested even if `atomic64` aspect is not supported by device and size of pointers types is less than 64 bits. Tests for pointers types will be performed if size of pointers types is less than 64 bits or if device supports `atomic64` aspect.