### PR TITLE
To cover gaps in kernel info test

### DIFF
--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -61,8 +61,9 @@ TEST_CASE("Test kernel info", "[kernel]") {
      */
     INFO(
         "Check that exception with error code \"errc::invalid\" is thrown in "
-        "case of invalid usage of "
-        "sycl::info::kernel::num_args descriptor");
+        "case of sycl::info::kernel::num_args descriptor usage with user "
+        "defined kernel which resides in a kernel bundle that was constructed "
+        "without using interoperability function.");
     CHECK_THROWS_MATCHES(incorrect_num_args_usage, sycl::exception,
                          sycl_cts::util::equals_exception(sycl::errc::invalid));
   }
@@ -83,9 +84,10 @@ TEST_CASE("Test kernel info", "[kernel]") {
   if (dev.get_info<sycl::info::device::device_type>() !=
       sycl::info::device_type::custom) {
     INFO(
-        "Check exception with error code \"errc::invalid\" is thrown in case "
-        "of invalid usage of "
-        "sycl::info::kernel_device_specific::global_work_size descriptor");
+        "Check that exception with error code \"errc::invalid\" is thrown in "
+        "case of sycl::info::kernel_device_specific::global_work_size "
+        "descriptor usage with user defined kernel and device which type "
+        "is not custom.");
     CHECK_THROWS_MATCHES(incorrect_global_work_size_usage, sycl::exception,
                          sycl_cts::util::equals_exception(sycl::errc::invalid));
   }

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -51,7 +51,8 @@ TEST_CASE("Test kernel info", "[kernel]") {
 
   {
     INFO(
-        "Exception isn't thrown in case of invalid usage of "
+        "Check that exception with error code \"errc::invalid\" is thrown in "
+        "case of invalid usage of "
         "sycl::info::kernel::num_args descriptor");
     CHECK_THROWS_MATCHES(incorrect_num_args_usage, sycl::exception,
                          sycl_cts::util::equals_exception(sycl::errc::invalid));
@@ -65,7 +66,8 @@ TEST_CASE("Test kernel info", "[kernel]") {
 
   {
     INFO(
-        "Exception isn't thrown in case of invalid usage of "
+        "Check exception with error code \"errc::invalid\" is thrown in case "
+        "of invalid usage of "
         "sycl::info::kernel_device_specific::global_work_size descriptor");
     CHECK_THROWS_MATCHES(incorrect_global_work_size_usage, sycl::exception,
                          sycl_cts::util::equals_exception(sycl::errc::invalid));

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -51,13 +51,13 @@ TEST_CASE("Test kernel info", "[kernel]") {
 
   {
     /** According to SYCL specification info::kernel::num_args descriptor may
-       only be used to query a kernel that resides in a kernel bundle that was
-       constructed using a backend specific interoperability function or to
-       query a device built-in kernel. In other cases an exception with the
-       errc::invalid error code is thrown. We attampt to use
-       info::kernel::num_args descriptor with user defined kernel which resides
-       in a kernel bundle that was constructed without using interoperability
-       function. So we expect that exception will be thrown.
+        only be used to query a kernel that resides in a kernel bundle that was
+        constructed using a backend specific interoperability function or to
+        query a device built-in kernel. In other cases an exception with the
+        errc::invalid error code is thrown. We attempt to use
+        info::kernel::num_args descriptor with user defined kernel which resides
+        in a kernel bundle that was constructed without using interoperability
+        function. So we expect that exception will be thrown.
      */
     INFO(
         "Check that exception with error code \"errc::invalid\" is thrown in "
@@ -74,12 +74,12 @@ TEST_CASE("Test kernel info", "[kernel]") {
             dev);
   };
   /** According to SYCL specification
-     info::kernel_device_specific::global_work_size descriptor may only be used
-     if the device type is device_type::custom or if the kernel is a built-in
-     kernel. In other cases an exception with the errc::invalid error code is
-     thrown. We attampt to use info::kernel_device_specific::global_work_size
-     descriptor with user defined kernel and expect that exception will be
-     thrown if device type is not custom.
+      info::kernel_device_specific::global_work_size descriptor may only be used
+      if the device type is device_type::custom or if the kernel is a built-in
+      kernel. In other cases an exception with the errc::invalid error code is
+      thrown. We attempt to use info::kernel_device_specific::global_work_size
+      descriptor with user defined kernel and expect that exception will be
+      thrown if device type is not custom.
    */
   if (dev.get_info<sycl::info::device::device_type>() !=
       sycl::info::device_type::custom) {

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -19,6 +19,7 @@
 //
 *******************************************************************************/
 
+#include "../../util/sycl_exceptions.h"
 #include "../common/common.h"
 
 // Disable test when compiling with ComputeCpp
@@ -32,7 +33,7 @@ class kernel0;
 
 TEST_CASE("Test kernel info", "[kernel]") {
   auto queue = util::get_cts_object::queue();
-  auto deviceList = queue.get_context().get_devices();
+  auto dev = util::get_cts_object::device();
   auto ctx = queue.get_context();
 
   using k_name = kernel0;
@@ -44,15 +45,51 @@ TEST_CASE("Test kernel info", "[kernel]") {
 
   /** check program info parameters
    */
-  auto uint32Ret = kernel.get_info<sycl::info::kernel::num_args>();
-  check_return_type<uint32_t>(
-      uint32Ret, "sycl::kernel::get_info<sycl::info::kernel::num_args>()");
+  auto incorrect_num_args_usage = [&kernel] {
+    auto uint32Ret = kernel.get_info<sycl::info::kernel::num_args>();
+  };
 
-  auto stringRet = kernel.get_info<sycl::info::kernel::attributes>();
-  check_return_type<std::string>(
-      stringRet, "sycl::kernel::get_info<sycl::info::kernel::attributes>()");
+  {
+    INFO(
+        "Exception isn't thrown in case of invalid usage of "
+        "sycl::info::kernel::num_args descriptor");
+    CHECK_THROWS_MATCHES(incorrect_num_args_usage, sycl::exception,
+                         sycl_cts::util::equals_exception(sycl::errc::invalid));
+  }
 
-  auto dev = util::get_cts_object::device();
+  auto incorrect_global_work_size_usage = [&kernel, &dev] {
+    auto range3Ret =
+        kernel.get_info<sycl::info::kernel_device_specific::global_work_size>(
+            dev);
+  };
+
+  {
+    INFO(
+        "Exception isn't thrown in case of invalid usage of "
+        "sycl::info::kernel_device_specific::global_work_size descriptor");
+    CHECK_THROWS_MATCHES(incorrect_global_work_size_usage, sycl::exception,
+                         sycl_cts::util::equals_exception(sycl::errc::invalid));
+  }
+
+  auto built_in_kernel_ids =
+      dev.get_info<sycl::info::device::built_in_kernel_ids>();
+  if (!built_in_kernel_ids.empty()) {
+    auto built_in_kernel = kb.get_kernel(built_in_kernel_ids[0]);
+
+    auto uint32Ret = built_in_kernel.get_info<sycl::info::kernel::num_args>();
+    check_return_type<uint32_t>(
+        uint32Ret, "sycl::kernel::get_info<sycl::info::kernel::num_args>()");
+
+    auto range3Ret =
+        built_in_kernel
+            .get_info<sycl::info::kernel_device_specific::global_work_size>(
+                dev);
+    check_return_type<sycl::range<3>>(
+        range3Ret,
+        "sycl::kernel::get_info<sycl::info::kernel_device_specific::global_"
+        "work_size>(dev) for built_in_kernel");
+  }
+
   if (dev.get_info<sycl::info::device::device_type>() ==
       sycl::info::device_type::custom) {
     auto range3Ret =
@@ -61,8 +98,12 @@ TEST_CASE("Test kernel info", "[kernel]") {
     check_return_type<sycl::range<3>>(
         range3Ret,
         "sycl::kernel::get_info<sycl::info::kernel_device_specific::global_"
-        "work_size>(dev)");
+        "work_size>(dev) for custom device");
   }
+
+  auto stringRet = kernel.get_info<sycl::info::kernel::attributes>();
+  check_return_type<std::string>(
+      stringRet, "sycl::kernel::get_info<sycl::info::kernel::attributes>()");
 
   auto range3Ret = kernel.get_info<
       sycl::info::kernel_device_specific::compile_work_group_size>(dev);
@@ -132,4 +173,5 @@ TEST_CASE("Test kernel info", "[kernel]") {
 };
 
 } /* namespace kernel_info__ */
+
 #endif // SYCL_CTS_COMPILING_WITH_COMPUTECPP

--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -50,6 +50,15 @@ TEST_CASE("Test kernel info", "[kernel]") {
   };
 
   {
+    /** According to SYCL specification info::kernel::num_args descriptor may
+       only be used to query a kernel that resides in a kernel bundle that was
+       constructed using a backend specific interoperability function or to
+       query a device built-in kernel. In other cases an exception with the
+       errc::invalid error code is thrown. We attampt to use
+       info::kernel::num_args descriptor with user defined kernel which resides
+       in a kernel bundle that was constructed without using interoperability
+       function. So we expect that exception will be thrown.
+     */
     INFO(
         "Check that exception with error code \"errc::invalid\" is thrown in "
         "case of invalid usage of "
@@ -63,8 +72,16 @@ TEST_CASE("Test kernel info", "[kernel]") {
         kernel.get_info<sycl::info::kernel_device_specific::global_work_size>(
             dev);
   };
-
-  {
+  /** According to SYCL specification
+     info::kernel_device_specific::global_work_size descriptor may only be used
+     if the device type is device_type::custom or if the kernel is a built-in
+     kernel. In other cases an exception with the errc::invalid error code is
+     thrown. We attampt to use info::kernel_device_specific::global_work_size
+     descriptor with user defined kernel and expect that exception will be
+     thrown if device type is not custom.
+   */
+  if (dev.get_info<sycl::info::device::device_type>() !=
+      sycl::info::device_type::custom) {
     INFO(
         "Check exception with error code \"errc::invalid\" is thrown in case "
         "of invalid usage of "


### PR DESCRIPTION
Added checks for exceptions in case of incorrect use of kernel information descriptors.
According to "[4.11.13.2. Kernel information descriptors](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#kernel)" section querying a kernel for information using `info::kernel::num_args` and `info::kernel_device_specific::global_work_size`  as info parameters throws an exception if the kernel type for that query is not valid. Added checks that an exception is thrown for these cases.