### PR TITLE
Add test plan for extention sycl_ext_oneapi_weak_object

### DIFF
--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -19,7 +19,7 @@ All of the tests should use `#ifdef SYCL_EXT_ONEAPI_WEAK_OBJECT` so they can be 
 if feature is not supported.
 
 === Type coverage
-All of the tests for `weak_object` described below are performed using each of the following `typename SyclObject`:
+All of the tests for `weak_object` described below are performed using each of the following `typename SYCLObjT`:
 
 * `buffer<int>`         +
 * `accessor<int>`       +
@@ -104,7 +104,7 @@ General checks for all of created `weak_object`. First initialize `ret` using `t
 
 * If the weak_object was constructed with an underlying SYCL object `SyclObj`, check that:
 ** `ret.value() == SYCLObj`
-** `std::is_same_v<decltype(ret.value(), SyclObject)>`
+** `std::is_same_v<decltype(ret.value(), SYCLObjT)>`
 ** Call `lock` and verify that the value it returns compares equal to `SyclObj`.
 ** Call `reset`, and then verify that `expired()` returns `false`.
 
@@ -114,20 +114,23 @@ General checks for all of created `weak_object`. First initialize `ret` using `t
 
 === Constructors
 
-Create instances of `weak_object` using: +
-`constexpr weak_object()` +
-`weak_object(const SyclObject &SYCLObj)` +
-`weak_object(const weak_object &Other)` +
-`weak_object(weak_object &&Other)` +
+* Create SYCL object of type `SyclObjT`, call it `SyclObject`.
+* Create temporary `weak_object` object from `SyclObject`, call it `WeakObjectOther`.
+* Create empty weak object using `constexpr weak_object()` constructor, call it `w_empty`.
+* Create `weak_object` using `weak_object(const SyclObject &SYCLObj)` constructor and passing `SyclObject`, call it 'w_obj'.
+* Create `weak_object` using `weak_object(const weak_object &Other)` constructor and passing `WeakObjectOther`, call it 'w_copy'.
+* Create `weak_object` using `weak_object(weak_object &&Other)` constructor and passing `std::move(WeakObjectOther)`, call it 'w_move'.
 
 Perform tests described above in the "API" section.
 
 === Copy and move assignment operators
 
-Use the existing instances of `weak_object` from the previous section, copy or move them into another objects using following operators: +
-`weak_object &operator=(const SyclObject &SYCLObj)` +
-`weak_object &operator=(const weak_object &Other)` +
-`weak_object &operator=(weak_object &&Other)`
+* Create SYCL object of type `SyclObjT`, call it `SyclObject`.
+* Create temporary `weak_object` object from `SyclObject`, call it `WeakObjectOther`.
+* Declare three uninitialized instances of `weak_object`, call them `w_obj`, `w_copy` and `w_move`.
+* Assign `SyclObject` to `w_obj` using `weak_object &operator=(const SyclObject &SYCLObj)` operator.
+* Assign `WeakObjectOther` to `w_copy` using `weak_object &operator=(const weak_object &Other)` operator.
+* Assign `std::move(WeakObjectOther)` to `w_move` using `weak_object &operator=(weak_object &&Other)` operator.
 
 Perform tests described above in the "API" section.
 
@@ -143,25 +146,67 @@ Using the objects created in the "Constructors" section, do the following:
 
 === Expiring
 
-* Create local scope with `SyclObject` and assign it to `weak_object` that is outside this scope. Check that `expired()` returns `false` now and `true` after `SyclObject` is destroyed outside the scope
+* Create local scope with `SYCLObjT` object and assign it to `weak_object` that is outside this scope. Check that `expired()` returns `false` now and `true` after `SYCLObjT` object was destroyed outside the scope.
 
-* Check that `expire()` returns `bool` type using `std::is_same_v`
+* Check that `expired()` returns `bool` type using `std::is_same_v`
 
-=== owner_before and owner_less
+=== owner_before and ext_oneap_owner_before
 
-Create two pairs of `weak_object` objects, the first of which encapsulate the same SYCLObj, and the second are empty
+* Verify that `owner_before` compares equivalent for two weak objects that both refer to the same underlying SYCL object:
+  ** Create a SYCL object of type `SyclObjT`. Call it `SyclObject`.
+  ** Create two weak_object objects from SyclObject. Call them `w1` and `w2`.
+  ** Verify that `w1.owner_before(w2) == false` and `w2.owner_before(w1) == false`.
+  ** Verify that `w1.owner_before(SyclObject) == false` and `w2.owner_before(SyclObject) == false`.
+  ** Verify that `SyclObject.ext_oneapi_owner_before(w1) == false` and
+  ** Verify that `SyclObject.ext_oneapi_owner_before(w2) == false`.
 
-* Check that `owner_before(const weak_object &Other)` returns `false` with passing second `weak_object` for both pairs
+* Verify that `owner_before` compares equivalent for two weak objects that are both empty:
+  ** Create a SYCL object of type `SyclObjT`. Call it `SyclObject`.
+  ** Create two empty weak_object objects by using the default constructor. Call them `w1` and `w2`.
+  ** Verify that `w1.owner_before(w2) == false` and `w2.owner_before(w1) == false`.
+  ** Verify that `SyclObject.ext_oneapi_owner_before(w1) == true` or
+  ** Verify that `SyclObject.ext_oneapi_owner_before(w2) == true`.
 
-* CHeck that `owner_before(const SyclObject &Other)`returns `false` with passing referred SyclObj for both pairs
+* Verify that `owner_before` has some order for two weak object that refer to different underlying SYCL objects:
+  ** Create two SYCL objects of type `SyclObjT`. Call them `SyclObject1` and `SyclObject2`.
+  ** Create a `weak_object` object from `SyclObject1` and another from `SyclObject2`. Call them `w1` and `w2`.
+  ** Verify that exactly one of the following is `true` for weak objects:
+    *** `w1.owner_before(w2) == true && w2.owner_before(w1) == false`, or
+    *** `w1.owner_before(w2) == false && w2.owner_before(w1) == true`.
+  ** Verify that exactly one of the following is `true` for SYCL objects:
+    *** `SyclObject1.ext_aoneapi_owner_before(w2) == true && SyclObject2.ext_aoneapi_owner_before(w1) == false`, or
+    *** `SyclObject1.ext_aoneapi_owner_before(w2) == false && SyclObject2.ext_aoneapi_owner_before(w1) == true`.
+  ** Verify that `w1.owner_before(SyclObject2) == w1.owner_before(w2)`
+  ** Verify that `w2.owner_before(SyclObject1) == w2.owner_before(w1)`
+  ** Verify that `SyclObject1.ext_oneapi_owner_before(SyclObject2) == Sycl_object1.ext_oneapi_owner_before(w2)`
+  ** Verify that `SyclObject2.ext_oneapi_owner_before(SyclObject1) == Sycl_object2.ext_oneapi_owner_before(w1)`
 
-* Check that `owner_less{}(const T &lhs, const T &rhs)` +
-`owner_less{}(const weak_object<T> &lhs, const weak_object<T> &rhs)` +
-`owner_less{}(const T &lhs, const weak_object<T> &rhs)` +
-`owner_less{}(const weak_object<T> &lhs, const T &rhs)` +
-return `false` if `lhs` and `rhs` `weak_object` or `SYCLObj` they refers are both the same or empty
+=== owner_less
 
-=== ext_oneapi_owner_before
-Create `SyclObject` and `weak_object` which encapsulate it.
+Similar to previous section.
 
-* Check that `SyclObject::ext_oneapi_owner_before` returns `false` with passing created `weak_object`
+* Verify that `owner_less` compares equivalent for two weak objects that both refer to the same underlying SYCL object:
+  ** Create a SYCL object of type `SyclObjT`. Call it `SyclObject`.
+  ** Create two weak_object objects from SyclObject. Call them `w1` and `w2`.
+  ** Verify that:
+    *** `ext::oneapi::owner_less(w1, w2) == false`.
+    *** `ext::oneapi::owner_less(w2, w1) == false`.
+    *** `ext::oneapi::owner_less(w1, SyclObject) == false`.
+    *** `ext::oneapi::owner_less(SyclObject, w1) == false`.
+    *** `ext::oneapi::owner_less(w2, SyclObject) == false`.
+    *** `ext::oneapi::owner_less(SyclObject, w2) == false`.
+
+* Verify that `owner_less` compares equivalent for two weak objects that are both empty:
+  ** Create a SYCL object of type `SyclObjT`. Call it `SyclObject`.
+  ** Create two empty weak_object objects by using the default constructor. Call them `w1` and `w2`.
+  ** Verify that `ext::oneapi::owner_less(w1, w2) == false`.
+  ** Verify that `ext::oneapi::owner_less(w1, SyclObject) == true` or `ext::oneapi::owner_less(w2, SyclObject) == true`
+
+* Verify that `owner_less` has some order for two weak object that refer to different underlying SYCL objects:
+  ** Create two SYCL objects of type `SyclObjT`. Call them `SyclObject1` and `SyclObject2`.
+  ** Create a `weak_object` object from `SyclObject1` and another from `SyclObject2`. Call them `w1` and `w2`.
+  ** Verify that exactly one of the following is `true` for weak objects:
+    *** `ext::oneapi::owner_less(w1, w2) == true && `ext::oneapi::owner_less(w2, w1) == false` or
+    *** `ext::oneapi::owner_less(w1, w2) == false && `ext::oneapi::owner_less(w2, w1) == true`
+  ** Verify that `ext::oneapi::owner_less(w1, SyclObject2) == ext::oneapi::owner_less(w1, w2)`
+  ** Verify that `ext::oneapi::owner_less(w2, SyclObject1) == ext::oneapi::owner_less(w2, w1)`

--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -21,12 +21,20 @@ if feature is not supported.
 === Type coverage
 All of the tests for `weak_object` described below are performed using each of the following `typename SyclObject`:
 
-* `accessor<int>`
-* `buffer<int>`
-* `multi_ptr<int, access::address_space::global_space>`
-* `queue`
-* `stream`
-* `vec<int, 1>`
+`accessor<int>`
+`buffer<int>`
+`context`
+`device`
+`device_image<bundle_state::executable>`
+`event`,
+`host_accessor<int>`
+`kernel`
+`kernel_id`
+`kernel_bundle<bundle_state::executable>`
+`local_accessor<int>`
+`platform`
+`queue`
+`stream`
 
 == Objects creation
 
@@ -52,13 +60,13 @@ Create instances of `weak_object` using: +
 
 === Copy and move assignment operators
 
-Use existing instances of `weak_object` to copy or move them into other objects +
+Use the existing instances of `weak_object` from the previous section other than empty object to copy or move them into other objects +
 `weak_object &operator=(const SyclObject &SYCLObj)` +
 `weak_object &operator=(const weak_object &Other)` +
 `weak_object &operator=(weak_object &&Other)`
 
 * Check that resulting object are the same with initial object using `std::is_same_v`
-* Check that `lock()` member function returns same results both in initial and new objects using `==` operator
+* Check that `try_lock()` member function returns same results both in initial and new objects using `==` operator
 * Check that `expired()` returns `false`
 
 === Reset, swap and expired member functions

--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -23,10 +23,10 @@ All of the tests for `weak_object` described below are performed using each of t
 
 * `accessor<int>`
 * `buffer<int>`
-* `multi_ptr<int>`
+* `multi_ptr<int, access::address_space::global_space>`
 * `queue`
 * `stream`
-* `vec<int>`
+* `vec<int, 1>`
 
 == Objects creation
 
@@ -34,7 +34,7 @@ All of the tests for `weak_object` described below using empty or non-empty obje
 
 * Empty `weak_object` created by using `constexpr weak_object()` constructor
 
-* Non-empty `weak_object` created by using `weak_object(const SyclObject &SYCLObj)` constructor
+* Non-empty `weak_object` created by using `weak_object(const SyclObject &SYCLObj)` constructor, where `SyclObject` was created using default class constructor or with sample data
 
 == Tests
 
@@ -46,9 +46,9 @@ Create instances of `weak_object` using: +
 `weak_object(const weak_object &Other)` +
 `weak_object(weak_object &&Other)` +
 
-* Check that using `object_type` is the same type with `SyclObject` using `std::is_same_v`
-* Check that `try_lock()` returns same object with same value and type using `==` and `std::is_same_v` respectivly
-* Check that `expire()` returns `false` for non-empty objects
+* Check that `object_type` is the same type with `SyclObject` using `std::is_same_v`
+* Check that `try_lock()` returns same `SyclObject` with same value and type using `==` and `std::is_same_v` respectively for non-empty and `std::nullopt` for empty objects
+* Check that `expired()` returns `true` for empty and `false` for non-empty objects
 
 === Copy and move assignment operators
 
@@ -59,9 +59,9 @@ Use existing instances of `weak_object` to copy or move them into other objects 
 
 * Check that resulting object are the same with initial object using `std::is_same_v`
 * Check that `lock()` member function returns same results both in initial and new objects using `==` operator
-* Check that `expire()` returns `false`
+* Check that `expired()` returns `false`
 
-=== Release, exchange and expired member functios
+=== Reset, swap and expired member functions
 
 * For empty `weak_object`:
     ** check that `expired()` returns `true`
@@ -79,7 +79,7 @@ Use existing instances of `weak_object` to copy or move them into other objects 
 
 === Expire
 
-* Create local scope with `SyclObject` and assign it to `weak_object` that is outside this scope. Check that `expired()` returns `false` now and `true` after `SyclObject` is destroyed outside the scope.
+* Create local scope with `SyclObject` and assign it to `weak_object` that is outside this scope. Check that `expired()` returns `false` now and `true` after `SyclObject` is destroyed outside the scope
 
 * Check that `expire()` returns `bool` type using `std::is_same_v`
 

--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -148,24 +148,25 @@ Using the objects created in the "Constructors" section, do the following:
 
 * Create local scope with `SYCLObjT` object and assign it to `weak_object` that is outside this scope. Check that `expired()` returns `false` now and `true` after `SYCLObjT` object was destroyed outside the scope.
 
-* Check that `expired()` returns `bool` type using `std::is_same_v`
+* Check that `expired()` returns `bool` type using `std::is_same_v`.
 
 === owner_before and ext_oneap_owner_before
 
 * Verify that `owner_before` compares equivalent for two weak objects that both refer to the same underlying SYCL object:
   ** Create a SYCL object of type `SyclObjT`. Call it `SyclObject`.
-  ** Create two weak_object objects from SyclObject. Call them `w1` and `w2`.
+  ** Create a copy of `SyclObject` called `SyclObjectOther`.
+  ** Create two weak_object objects from `SyclObject`. Call them `w1` and `w2`.
   ** Verify that `w1.owner_before(w2) == false` and `w2.owner_before(w1) == false`.
   ** Verify that `w1.owner_before(SyclObject) == false` and `w2.owner_before(SyclObject) == false`.
   ** Verify that `SyclObject.ext_oneapi_owner_before(w1) == false` and
   ** Verify that `SyclObject.ext_oneapi_owner_before(w2) == false`.
+  ** Verify that `SyclObjectOther.ext_oneapi_owner_before(SyclObject) == false`.
+  ** Verify that `SyclObject.ext_oneapi_owner_before(SyclObjectOther) == false`.
 
 * Verify that `owner_before` compares equivalent for two weak objects that are both empty:
   ** Create a SYCL object of type `SyclObjT`. Call it `SyclObject`.
   ** Create two empty weak_object objects by using the default constructor. Call them `w1` and `w2`.
   ** Verify that `w1.owner_before(w2) == false` and `w2.owner_before(w1) == false`.
-  ** Verify that `SyclObject.ext_oneapi_owner_before(w1) == true` or
-  ** Verify that `SyclObject.ext_oneapi_owner_before(w2) == true`.
 
 * Verify that `owner_before` has some order for two weak object that refer to different underlying SYCL objects:
   ** Create two SYCL objects of type `SyclObjT`. Call them `SyclObject1` and `SyclObject2`.
@@ -174,12 +175,12 @@ Using the objects created in the "Constructors" section, do the following:
     *** `w1.owner_before(w2) == true && w2.owner_before(w1) == false`, or
     *** `w1.owner_before(w2) == false && w2.owner_before(w1) == true`.
   ** Verify that exactly one of the following is `true` for SYCL objects:
-    *** `SyclObject1.ext_aoneapi_owner_before(w2) == true && SyclObject2.ext_aoneapi_owner_before(w1) == false`, or
-    *** `SyclObject1.ext_aoneapi_owner_before(w2) == false && SyclObject2.ext_aoneapi_owner_before(w1) == true`.
-  ** Verify that `w1.owner_before(SyclObject2) == w1.owner_before(w2)`
-  ** Verify that `w2.owner_before(SyclObject1) == w2.owner_before(w1)`
-  ** Verify that `SyclObject1.ext_oneapi_owner_before(SyclObject2) == Sycl_object1.ext_oneapi_owner_before(w2)`
-  ** Verify that `SyclObject2.ext_oneapi_owner_before(SyclObject1) == Sycl_object2.ext_oneapi_owner_before(w1)`
+    *** `SyclObject1.ext_oneapi_owner_before(w2) == true && SyclObject2.ext_oneapi_owner_before(w1) == false`, or
+    *** `SyclObject1.ext_oneapi_owner_before(w2) == false && SyclObject2.ext_oneapi_owner_before(w1) == true`.
+  ** Verify that `w1.owner_before(SyclObject2) == w1.owner_before(w2)`.
+  ** Verify that `w2.owner_before(SyclObject1) == w2.owner_before(w1)`.
+  ** Verify that `SyclObject1.ext_oneapi_owner_before(SyclObject2) == SyclObject1.ext_oneapi_owner_before(w2)`.
+  ** Verify that `SyclObject2.ext_oneapi_owner_before(SyclObject1) == SyclObject2.ext_oneapi_owner_before(w1)`.
 
 === owner_less
 
@@ -187,7 +188,8 @@ Similar to previous section.
 
 * Verify that `owner_less` compares equivalent for two weak objects that both refer to the same underlying SYCL object:
   ** Create a SYCL object of type `SyclObjT`. Call it `SyclObject`.
-  ** Create two weak_object objects from SyclObject. Call them `w1` and `w2`.
+  ** Create a copy of `SyclObject` called `SyclObjectOther`.
+  ** Create two weak_object objects from `SyclObject`. Call them `w1` and `w2`.
   ** Verify that:
     *** `ext::oneapi::owner_less(w1, w2) == false`.
     *** `ext::oneapi::owner_less(w2, w1) == false`.
@@ -195,18 +197,22 @@ Similar to previous section.
     *** `ext::oneapi::owner_less(SyclObject, w1) == false`.
     *** `ext::oneapi::owner_less(w2, SyclObject) == false`.
     *** `ext::oneapi::owner_less(SyclObject, w2) == false`.
+    *** `ext::oneapi::owner_less(SyclObject, SyclObjectOther) == false`.
+    *** `ext::oneapi::owner_less(SyclObjectOther, SyclObject) == false`.
 
 * Verify that `owner_less` compares equivalent for two weak objects that are both empty:
   ** Create a SYCL object of type `SyclObjT`. Call it `SyclObject`.
   ** Create two empty weak_object objects by using the default constructor. Call them `w1` and `w2`.
   ** Verify that `ext::oneapi::owner_less(w1, w2) == false`.
-  ** Verify that `ext::oneapi::owner_less(w1, SyclObject) == true` or `ext::oneapi::owner_less(w2, SyclObject) == true`
+  ** Verify that `ext::oneapi::owner_less(w2, w1) == false`.
 
 * Verify that `owner_less` has some order for two weak object that refer to different underlying SYCL objects:
   ** Create two SYCL objects of type `SyclObjT`. Call them `SyclObject1` and `SyclObject2`.
   ** Create a `weak_object` object from `SyclObject1` and another from `SyclObject2`. Call them `w1` and `w2`.
   ** Verify that exactly one of the following is `true` for weak objects:
-    *** `ext::oneapi::owner_less(w1, w2) == true && `ext::oneapi::owner_less(w2, w1) == false` or
-    *** `ext::oneapi::owner_less(w1, w2) == false && `ext::oneapi::owner_less(w2, w1) == true`
-  ** Verify that `ext::oneapi::owner_less(w1, SyclObject2) == ext::oneapi::owner_less(w1, w2)`
-  ** Verify that `ext::oneapi::owner_less(w2, SyclObject1) == ext::oneapi::owner_less(w2, w1)`
+    *** `ext::oneapi::owner_less(w1, w2) == true && ext::oneapi::owner_less(w2, w1) == false` or
+    *** `ext::oneapi::owner_less(w1, w2) == false && ext::oneapi::owner_less(w2, w1) == true`.
+  ** Verify that `ext::oneapi::owner_less(w1, SyclObject2) == ext::oneapi::owner_less(w1, w2)`.
+  ** Verify that `ext::oneapi::owner_less(w2, SyclObject1) == ext::oneapi::owner_less(w2, w1)`.
+  ** Verify that `ext::oneapi::owner_less(SyclObject1, SyclObject2) == ext::oneapi::owner_less(w1, w2)`.
+  ** Verify that `ext::oneapi::owner_less(SyclObject2, SyclObject1) == ext::oneapi::owner_less(w2, w1)`.

--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -25,7 +25,6 @@ All of the tests for `weak_object` described below are performed using each of t
 * `buffer<int>` +
 * `context` +
 * `device` +
-* `device_image<bundle_state::executable>` +
 * `event` +
 * `host_accessor<int>` +
 * `kernel` +
@@ -42,7 +41,11 @@ All of the tests for `weak_object` described below using empty or non-empty obje
 
 * Empty `weak_object` created by using `constexpr weak_object()` constructor
 
-* Non-empty `weak_object` created by using `weak_object(const SyclObject &SYCLObj)` constructor, where `SyclObject` was created using default class constructor or with sample data
+* Non-empty `weak_object` created by using `weak_object(const SyclObject &SYCLObj)` constructor,
+where `SyclObject` was created using
+    ** Default class constructor
+    ** Sample data constructor
+    ** `get_<typenmane>()` member functions from other objects. For example `device = queue.get_device()`
 
 == Tests
 

--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -42,7 +42,7 @@ All of the tests for `weak_object` described below using empty or non-empty obje
 * Empty `weak_object` created by using `constexpr weak_object()` constructor
 
 * Non-empty `weak_object` created by using `weak_object(const SyclObject &SYCLObj)` constructor,
-where `SyclObject` was created using
+where `SyclObject` was created using one of the following:
     ** Default class constructor
     ** Sample data constructor
     ** `get_<typenmane>()` member functions from other objects. For example `device = queue.get_device()`

--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -1,0 +1,107 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for weak object
+
+This is a test plan for the APIs described in
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc[SYCL_EXT_ONEAPI_WEAK_OBJECT.asciidoc]
+
+== Testing scope
+
+=== Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line.
+
+=== Feature test macro
+
+All of the tests should use `#ifdef SYCL_EXT_ONEAPI_WEAK_OBJECT` so they can be skipped
+if feature is not supported.
+
+=== Type coverage
+All of the tests for `weak_object` described below are performed using each of the following `typename SyclObject`:
+
+* `accessor<int>`
+* `buffer<int>`
+* `multi_ptr<int>`
+* `queue`
+* `stream`
+* `vec<int>`
+
+== Objects creation
+
+All of the tests for `weak_object` described below using empty or non-empty objects:
+
+* Empty `weak_object` created by using `constexpr weak_object()` constructor
+
+* Non-empty `weak_object` created by using `weak_object(const SyclObject &SYCLObj)` constructor
+
+== Tests
+
+=== Constructors
+
+Create instances of `weak_object` using: +
+`constexpr weak_object()` +
+`weak_object(const SyclObject &SYCLObj)` +
+`weak_object(const weak_object &Other)` +
+`weak_object(weak_object &&Other)` +
+
+* Check that using `object_type` is the same type with `SyclObject` using `std::is_same_v`
+* Check that `try_lock()` returns same object with same value and type using `==` and `std::is_same_v` respectivly
+* Check that `expire()` returns `false` for non-empty objects
+
+=== Copy and move assignment operators
+
+Use existing instances of `weak_object` to copy or move them into other objects +
+`weak_object &operator=(const SyclObject &SYCLObj)` +
+`weak_object &operator=(const weak_object &Other)` +
+`weak_object &operator=(weak_object &&Other)`
+
+* Check that resulting object are the same with initial object using `std::is_same_v`
+* Check that `lock()` member function returns same results both in initial and new objects using `==` operator
+* Check that `expire()` returns `false`
+
+=== Release, exchange and expired member functios
+
+* For empty `weak_object`:
+    ** check that `expired()` returns `true`
+    ** call `swap()` with non-empty `weak_object` and check that `expired()` returns `false`
+    ** call `reset()` and check that `expired()` returns `true` again
+
+* For non-empty `weak_object`
+    ** check that `expired()` returns `false`
+    ** call `swap()` and check that `lock()` returns reference to same object
+    ** call `reset()` and check that `expired()` returns `true`
+
+=== Lock exception
+
+`SyclObject lock() const;` - check throwing `errc::invalid` exception if object is empty
+
+=== Expire
+
+* Create local scope with `SyclObject` and assign it to `weak_object` that is outside this scope. Check that `expired()` returns `false` now and `true` after `SyclObject` is destroyed outside the scope.
+
+* Check that `expire()` returns `bool` type using `std::is_same_v`
+
+=== owner_before and owner_less
+
+Create two `weak_object` referring to two different `SyclObject`
+
+* Check that calling `owner_before(const weak_object &Other)` with passing second object as `Other` returns `true` for first `weak_object` and `false` otherwise
+
+* Check that `owner_before(const SyclObject &Other)` returns `true` if `weak_object` was declared before `Other`
+
+* Check that `owner_less{}(const T &lhs, const T &rhs)` +
+`owner_less{}(const weak_object<T> &lhs, const weak_object<T> &rhs)` +
+`owner_less{}(const T &lhs, const weak_object<T> &rhs)` +
+`owner_less{}(const weak_object<T> &lhs, const T &rhs)` +
+return `true` if `lhs` or object it refers to was first declared and `false` otherwise
+
+=== ext_oneapi_owner_before
+Create two `SyclObject` and `weak_object` referring to first declared `SYCLObject`
+
+* Check that `ext_oneapi_owner_before(const T &Other)` returns `true` for first object and `false` for second
+
+* Check that `ext_oneapi_owner_before(const ext::oneapi::weak_object<T> &Other)` returns `true` for second object and `false` for first (refer to the same object)
+
+Check that `owner_before()`, `owner_less()` and `ext_oneapi_owner_before()` return `bool` type using `std::is_same_v`

--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -21,20 +21,20 @@ if feature is not supported.
 === Type coverage
 All of the tests for `weak_object` described below are performed using each of the following `typename SyclObject`:
 
-`accessor<int>`
-`buffer<int>`
-`context`
-`device`
-`device_image<bundle_state::executable>`
-`event`,
-`host_accessor<int>`
-`kernel`
-`kernel_id`
-`kernel_bundle<bundle_state::executable>`
-`local_accessor<int>`
-`platform`
-`queue`
-`stream`
+* `accessor<int>` +
+* `buffer<int>` +
+* `context` +
+* `device` +
+* `device_image<bundle_state::executable>` +
+* `event` +
+* `host_accessor<int>` +
+* `kernel` +
+* `kernel_id` +
+* `kernel_bundle<bundle_state::executable>` +
+* `local_accessor<int>` +
+* `platform` +
+* `queue` +
+* `stream` +
 
 == Objects creation
 

--- a/test_plans/weak_object.asciidoc
+++ b/test_plans/weak_object.asciidoc
@@ -4,7 +4,7 @@
 = Test plan for weak object
 
 This is a test plan for the APIs described in
-https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc[SYCL_EXT_ONEAPI_WEAK_OBJECT.asciidoc]
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc[sycl_ext_oneapi_weak_object]
 
 == Testing scope
 
@@ -21,33 +21,96 @@ if feature is not supported.
 === Type coverage
 All of the tests for `weak_object` described below are performed using each of the following `typename SyclObject`:
 
-* `accessor<int>` +
-* `buffer<int>` +
-* `context` +
-* `device` +
-* `event` +
-* `host_accessor<int>` +
-* `kernel` +
-* `kernel_id` +
-* `kernel_bundle<bundle_state::executable>` +
+* `buffer<int>`         +
+* `accessor<int>`       +
+* `host_accessor<int>`  +
 * `local_accessor<int>` +
-* `platform` +
-* `queue` +
-* `stream` +
+* `context`             +
+* `event`               +
+* `queue`               +
+* `stream`
 
 == Objects creation
 
-All of the tests for `weak_object` described below using empty or non-empty objects:
+All of the tests for `weak_object` described below using SYCL objects and empty or non-empty objects:
+
+* SYCL objects created by using default constructors or passing sample data:
+
+** `buffer<int>`
++
+----
+buffer<int> b{{1}}
+----
+
+** `accessor<int>`
++
+----
+buffer<int> b{{1}};
+accessor a{b}
+----
+
+** `host_accessor<int>`
++
+----
+buffer<int> b{{1}};
+host_accessor a{b}
+----
+
+** `local_accessor<int>`
++
+----
+queue q;
+q.submit([&](handler &cgh) {
+    local_accessor<int> a{{1}, cgh};
+})
+----
+
+** `context`
++
+----
+context c;
+----
+
+** `event`
++
+----
+event e;
+----
+
+** `queue`
++
+----
+queue q;
+----
+
+** `stream`
++
+----
+queue q;
+q.submit([&](handler &cgh) {
+  stream s{1, 1, cgh};
+})
+----
 
 * Empty `weak_object` created by using `constexpr weak_object()` constructor
 
-* Non-empty `weak_object` created by using `weak_object(const SyclObject &SYCLObj)` constructor,
-where `SyclObject` was created using one of the following:
-    ** Default class constructor
-    ** Sample data constructor
-    ** `get_<typenmane>()` member functions from other objects. For example `device = queue.get_device()`
+* Non-empty `weak_object` created by using `weak_object(const SyclObject &SYCLObj)` constructor
 
 == Tests
+
+=== API tests
+
+General checks for all of created `weak_object`. First initialize `ret` using `try_lock()`, then:
+
+* If the weak_object was constructed with an underlying SYCL object `SyclObj`, check that:
+** `ret.value() == SYCLObj`
+** `std::is_same_v<decltype(ret.value(), SyclObject)>`
+** Call `lock` and verify that the value it returns compares equal to `SyclObj`.
+** Call `reset`, and then verify that `expired()` returns `false`.
+
+* If the weak_object was constructed with no underlying SYCL object, check that:
+** `ret.has_value() == false`
+** Call `lock` and verify that it throws `errc::invalid` exception
 
 === Constructors
 
@@ -57,38 +120,28 @@ Create instances of `weak_object` using: +
 `weak_object(const weak_object &Other)` +
 `weak_object(weak_object &&Other)` +
 
-* Check that `object_type` is the same type with `SyclObject` using `std::is_same_v`
-* Check that `try_lock()` returns same `SyclObject` with same value and type using `==` and `std::is_same_v` respectively for non-empty and `std::nullopt` for empty objects
-* Check that `expired()` returns `true` for empty and `false` for non-empty objects
+Perform tests described above in the "API" section.
 
 === Copy and move assignment operators
 
-Use the existing instances of `weak_object` from the previous section other than empty object to copy or move them into other objects +
+Use the existing instances of `weak_object` from the previous section, copy or move them into another objects using following operators: +
 `weak_object &operator=(const SyclObject &SYCLObj)` +
 `weak_object &operator=(const weak_object &Other)` +
 `weak_object &operator=(weak_object &&Other)`
 
-* Check that resulting object are the same with initial object using `std::is_same_v`
-* Check that `try_lock()` member function returns same results both in initial and new objects using `==` operator
-* Check that `expired()` returns `false`
+Perform tests described above in the "API" section.
 
-=== Reset, swap and expired member functions
+=== swap member function
 
-* For empty `weak_object`:
-    ** check that `expired()` returns `true`
-    ** call `swap()` with non-empty `weak_object` and check that `expired()` returns `false`
-    ** call `reset()` and check that `expired()` returns `true` again
+Using the objects created in the "Constructors" section, do the following:
 
-* For non-empty `weak_object`
-    ** check that `expired()` returns `false`
-    ** call `swap()` and check that `lock()` returns reference to same object
-    ** call `reset()` and check that `expired()` returns `true`
+* Create an empty `weak_object` of the same type by using the default constructor.
 
-=== Lock exception
+* Call `swap` on that object, passing the object from the "Constructors" section.
 
-`SyclObject lock() const;` - check throwing `errc::invalid` exception if object is empty
+* Perform tests described above in the "API" section.
 
-=== Expire
+=== Expiring
 
 * Create local scope with `SyclObject` and assign it to `weak_object` that is outside this scope. Check that `expired()` returns `false` now and `true` after `SyclObject` is destroyed outside the scope
 
@@ -96,23 +149,19 @@ Use the existing instances of `weak_object` from the previous section other than
 
 === owner_before and owner_less
 
-Create two `weak_object` referring to two different `SyclObject`
+Create two pairs of `weak_object` objects, the first of which encapsulate the same SYCLObj, and the second are empty
 
-* Check that calling `owner_before(const weak_object &Other)` with passing second object as `Other` returns `true` for first `weak_object` and `false` otherwise
+* Check that `owner_before(const weak_object &Other)` returns `false` with passing second `weak_object` for both pairs
 
-* Check that `owner_before(const SyclObject &Other)` returns `true` if `weak_object` was declared before `Other`
+* CHeck that `owner_before(const SyclObject &Other)`returns `false` with passing referred SyclObj for both pairs
 
 * Check that `owner_less{}(const T &lhs, const T &rhs)` +
 `owner_less{}(const weak_object<T> &lhs, const weak_object<T> &rhs)` +
 `owner_less{}(const T &lhs, const weak_object<T> &rhs)` +
 `owner_less{}(const weak_object<T> &lhs, const T &rhs)` +
-return `true` if `lhs` or object it refers to was first declared and `false` otherwise
+return `false` if `lhs` and `rhs` `weak_object` or `SYCLObj` they refers are both the same or empty
 
 === ext_oneapi_owner_before
-Create two `SyclObject` and `weak_object` referring to first declared `SYCLObject`
+Create `SyclObject` and `weak_object` which encapsulate it.
 
-* Check that `ext_oneapi_owner_before(const T &Other)` returns `true` for first object and `false` for second
-
-* Check that `ext_oneapi_owner_before(const ext::oneapi::weak_object<T> &Other)` returns `true` for second object and `false` for first (refer to the same object)
-
-Check that `owner_before()`, `owner_less()` and `ext_oneapi_owner_before()` return `bool` type using `std::is_same_v`
+* Check that `SyclObject::ext_oneapi_owner_before` returns `false` with passing created `weak_object`


### PR DESCRIPTION
Test plan for sycl_ext_oneapi_weak_object based on [docs](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidocrl)