### PR TITLE
Enabled exceptions tests partially

### DIFF
--- a/ci/dpcpp.filter
+++ b/ci/dpcpp.filter
@@ -1,3 +1,2 @@
-exceptions
 math_builtin_api
 image_accessor

--- a/tests/exceptions/exceptions_constructors.cpp
+++ b/tests/exceptions/exceptions_constructors.cpp
@@ -203,9 +203,8 @@ TEST_CASE("Constructors for sycl::exception with sycl::errc error codes",
 }
 
 #ifdef SYCL_BACKEND_OPENCL
-// !FIXME Disabled for dpcpp until error_category_for() is implemented according
-// to SYCL 2020 specification (4.13.2. Exception class interface)
-// https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:exception.class
+// !FIXME Disabled until issue
+// https://github.com/KhronosGroup/SYCL-Docs/issues/182 is not resolved.
 DISABLED_FOR_TEST_CASE(DPCPP)
 ("Constructors for sycl::exception with OpenCL error code", "[exception]")({
   auto prefer_open_cl = [](const sycl::device& d) -> int {

--- a/tests/exceptions/exceptions_constructors.cpp
+++ b/tests/exceptions/exceptions_constructors.cpp
@@ -2,15 +2,31 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 //  Provides tests for sycl::exception constructors
 //
 *******************************************************************************/
+
 #include "../../util/sycl_exceptions.h"
 #include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers.hpp"
+#include "../common/disabled_for_test_case.h"
+
 #include "exceptions.h"
 
-namespace exception_constructors {
+namespace exception_constructors_test {
 
 /**
  * @brief The function helps to verify that exception was constructed correctly.
@@ -187,8 +203,11 @@ TEST_CASE("Constructors for sycl::exception with sycl::errc error codes",
 }
 
 #ifdef SYCL_BACKEND_OPENCL
-TEST_CASE("Constructors for sycl::exception with OpenCL error code",
-          "[exception]") {
+// !FIXME Disabled for dpcpp until error_category_for() is implemented according
+// to SYCL 2020 specification (4.13.2. Exception class interface)
+// https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:exception.class
+DISABLED_FOR_TEST_CASE(DPCPP)("Constructors for sycl::exception with OpenCL error code",
+          "[exception]")({
   auto prefer_open_cl = [](const sycl::device& d) -> int {
     return d.get_backend() == sycl::backend::opencl;
   };
@@ -299,11 +318,11 @@ TEST_CASE("Constructors for sycl::exception with OpenCL error code",
     check_exception(e, std_errc,
                     sycl::error_category_for<sycl::backend::opencl>(), ctx);
   }
-}
+});
 #endif
 
 TEST_CASE("sycl::exception is derived from std::exception", "[exception]") {
   CHECK(std::is_base_of_v<std::exception, sycl::exception>);
 }
 
-}  // namespace exception_constructors
+}  // namespace exception_constructors_test

--- a/tests/exceptions/exceptions_constructors.cpp
+++ b/tests/exceptions/exceptions_constructors.cpp
@@ -21,8 +21,8 @@
 *******************************************************************************/
 
 #include "../../util/sycl_exceptions.h"
-#include "catch2/catch_test_macros.hpp"
 #include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
 
 #include "exceptions.h"
 
@@ -206,8 +206,8 @@ TEST_CASE("Constructors for sycl::exception with sycl::errc error codes",
 // !FIXME Disabled for dpcpp until error_category_for() is implemented according
 // to SYCL 2020 specification (4.13.2. Exception class interface)
 // https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:exception.class
-DISABLED_FOR_TEST_CASE(DPCPP)("Constructors for sycl::exception with OpenCL error code",
-          "[exception]")({
+DISABLED_FOR_TEST_CASE(DPCPP)
+("Constructors for sycl::exception with OpenCL error code", "[exception]")({
   auto prefer_open_cl = [](const sycl::device& d) -> int {
     return d.get_backend() == sycl::backend::opencl;
   };

--- a/tests/exceptions/exceptions_errc_for.cpp
+++ b/tests/exceptions/exceptions_errc_for.cpp
@@ -38,9 +38,8 @@ bool check_opencl_supporting(const sycl::queue &q) {
 template <template <sycl::backend> class arg>
 struct check_template_exists {};
 
-// !FIXME Disabled for dpcpp until error_category_for() is implemented according
-// to SYCL 2020 specification (4.13.2. Exception class interface)
-// https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:exception.class
+// !FIXME Disabled until issue
+// https://github.com/KhronosGroup/SYCL-Docs/issues/182 is not resolved.
 DISABLED_FOR_TEST_CASE(DPCPP)
 ("Check sycl::exception sycl::errc_for enum", "[exception]")({
   if (false ==

--- a/tests/exceptions/exceptions_errc_for.cpp
+++ b/tests/exceptions/exceptions_errc_for.cpp
@@ -20,8 +20,8 @@
 //
 *******************************************************************************/
 
-#include "catch2/catch_test_macros.hpp"
 #include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
 
 #include "exceptions.h"
 
@@ -41,9 +41,10 @@ struct check_template_exists {};
 // !FIXME Disabled for dpcpp until error_category_for() is implemented according
 // to SYCL 2020 specification (4.13.2. Exception class interface)
 // https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:exception.class
-DISABLED_FOR_TEST_CASE(DPCPP)("Check sycl::exception sycl::errc_for enum",
-        "[exception]")({
-  if (false == check_opencl_supporting(sycl_cts::util::get_cts_object::queue())) {
+DISABLED_FOR_TEST_CASE(DPCPP)
+("Check sycl::exception sycl::errc_for enum", "[exception]")({
+  if (false ==
+      check_opencl_supporting(sycl_cts::util::get_cts_object::queue())) {
     SKIP("OpenCL backend is not supported on this device");
     return;
   }
@@ -55,18 +56,26 @@ DISABLED_FOR_TEST_CASE(DPCPP)("Check sycl::exception sycl::errc_for enum",
   // check that sycl::errc_for is enum and scoped enum
   {
     INFO("sycl::errc_for is not enum");
-    CHECK( true == std::is_enum_v<sycl_errc_enum_t>);
+    CHECK(true == std::is_enum_v<sycl_errc_enum_t>);
   }
   {
-    INFO("sycl::errc_for is not a scoped enum cause it can be implicitly converted to int");
-    CHECK( false == std::is_convertible_v<sycl_errc_enum_t, std::underlying_type<sycl_errc_enum_t>>);
+    INFO(
+        "sycl::errc_for is not a scoped enum cause it can be implicitly "
+        "converted to int");
+    CHECK(false ==
+          std::is_convertible_v<sycl_errc_enum_t,
+                                std::underlying_type<sycl_errc_enum_t>>);
   }
   const auto errc_value{static_cast<sycl_errc_enum_t>(0)};
   std::error_code err_code(errc_value,
                            sycl::error_category_for<sycl::backend::opencl>());
   {
-    INFO("error_code::default_error_condition() is not equal to std::error_condition");
-    CHECK(err_code.default_error_condition() == std::error_condition(errc_value, sycl::error_category_for<sycl::backend::opencl>()));
+    INFO(
+        "error_code::default_error_condition() is not equal to "
+        "std::error_condition");
+    CHECK(err_code.default_error_condition() ==
+          std::error_condition(
+              errc_value, sycl::error_category_for<sycl::backend::opencl>()));
   }
   {
     INFO("sycl::errc_for is not a error code enumeration");
@@ -77,7 +86,9 @@ DISABLED_FOR_TEST_CASE(DPCPP)("Check sycl::exception sycl::errc_for enum",
     CHECK(false == std::is_error_condition_enum_v<sycl_errc_enum_t>);
   }
   {
-    INFO("sycl::error_category_for<sycl::backend::opencl> name is not equal to \"opencl\"");
+    INFO(
+        "sycl::error_category_for<sycl::backend::opencl> name is not equal to "
+        "\"opencl\"");
     CHECK(sycl::error_category_for<sycl::backend::opencl>().name() == "opencl");
   }
 #endif  // SYCL_BACKEND_OPENCL

--- a/tests/exceptions/exceptions_errc_for.cpp
+++ b/tests/exceptions/exceptions_errc_for.cpp
@@ -2,88 +2,85 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 //  Provides tests for sycl::errc_for
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+#include "../common/disabled_for_test_case.h"
+
 #include "exceptions.h"
 
-#define TEST_NAME exceptions_errc_for
+namespace exceptions_errc_for_test {
 
-namespace TEST_NAMESPACE {
-
-template <template <sycl::backend> class arg>
-struct check_template_exists {};
-
-bool check_opencl_supporting(const sycl::queue &q,
-                             sycl_cts::util::logger &log) {
+bool check_opencl_supporting(const sycl::queue &q) {
   bool opencl_supported{false};
 #ifdef SYCL_BACKEND_OPENCL
   opencl_supported = q.get_backend() == sycl::backend::opencl;
 #endif  // SYCL_BACKEND_OPENCL
-  if (!opencl_supported) {
-    log.note("OpenCL backend is not supported on this device");
-  }
   return opencl_supported;
 }
 
-using namespace sycl_cts;
+template <template <sycl::backend> class arg>
+struct check_template_exists {};
 
-/** Test instance
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
+// !FIXME Disabled for dpcpp until error_category_for() is implemented according
+// to SYCL 2020 specification (4.13.2. Exception class interface)
+// https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:exception.class
+DISABLED_FOR_TEST_CASE(DPCPP)("Check sycl::exception sycl::errc_for enum",
+        "[exception]")({
+  if (false == check_opencl_supporting(sycl_cts::util::get_cts_object::queue())) {
+    SKIP("OpenCL backend is not supported on this device");
+    return;
   }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
-    if (!check_opencl_supporting(util::get_cts_object::queue(), log)) {
-      return;
-    }
-    // check that sycl::errc_for exist
-    check_template_exists<sycl::errc_for>();
+  // check that sycl::errc_for exist
+  check_template_exists<sycl::errc_for>();
 
 #ifdef SYCL_BACKEND_OPENCL
-    using sycl_errc_enum_t = sycl::errc_for<sycl::backend::opencl>;
-    // check that sycl::errc_for is enum and scoped enum
-    if (!std::is_enum_v<sycl_errc_enum_t>) {
-      FAIL(log, "sycl::errc_for is not enum");
-    } else if (!std::is_convertible_v<sycl_errc_enum_t,
-                                      std::underlying_type<sycl_errc_enum_t>>) {
-      FAIL(log,
-           "sycl::errc_for is not a scoped enum cause he can't be implicitly "
-           "converted to int");
-    }
-    const auto errc_value{static_cast<sycl_errc_enum_t>(0)};
-    std::error_code err_code(errc_value,
-                             sycl::error_category_for<sycl::backend::opencl>());
-    if (err_code.default_error_condition() !=
-        std::error_condition(
-            errc_value, sycl::error_category_for<sycl::backend::opencl>())) {
-      FAIL(log,
-           "error_code::default_error_condition() is not equal to "
-           "std::error_condition");
-    }
-    if (!std::is_error_code_enum_v<sycl_errc_enum_t>) {
-      FAIL(log, "sycl::errc_for is not a error code enumeration");
-    }
-    if (std::is_error_condition_enum_v<sycl_errc_enum_t>) {
-      FAIL(log, "sycl::errc_for is a error condition enumeration");
-    }
-    if (sycl::error_category_for<sycl::backend::opencl>().name() != "opencl") {
-      FAIL(log,
-           "sycl::error_category_for<sycl::backend::opencl> name is not "
-           "equal to \"opencl\"");
-    }
-#endif  // SYCL_BACKEND_OPENCL
+  using sycl_errc_enum_t = sycl::errc_for<sycl::backend::opencl>;
+  // check that sycl::errc_for is enum and scoped enum
+  {
+    INFO("sycl::errc_for is not enum");
+    CHECK( true == std::is_enum_v<sycl_errc_enum_t>);
   }
-};
+  {
+    INFO("sycl::errc_for is not a scoped enum cause it can be implicitly converted to int");
+    CHECK( false == std::is_convertible_v<sycl_errc_enum_t, std::underlying_type<sycl_errc_enum_t>>);
+  }
+  const auto errc_value{static_cast<sycl_errc_enum_t>(0)};
+  std::error_code err_code(errc_value,
+                           sycl::error_category_for<sycl::backend::opencl>());
+  {
+    INFO("error_code::default_error_condition() is not equal to std::error_condition");
+    CHECK(err_code.default_error_condition() == std::error_condition(errc_value, sycl::error_category_for<sycl::backend::opencl>()));
+  }
+  {
+    INFO("sycl::errc_for is not a error code enumeration");
+    CHECK(std::is_error_code_enum_v<sycl_errc_enum_t>);
+  }
+  {
+    INFO("sycl::errc_for is a error condition enumeration");
+    CHECK(false == std::is_error_condition_enum_v<sycl_errc_enum_t>);
+  }
+  {
+    INFO("sycl::error_category_for<sycl::backend::opencl> name is not equal to \"opencl\"");
+    CHECK(sycl::error_category_for<sycl::backend::opencl>().name() == "opencl");
+  }
+#endif  // SYCL_BACKEND_OPENCL
+});
 
-util::test_proxy<TEST_NAME> proxy;
-
-}  // namespace TEST_NAMESPACE
+}  // namespace exceptions_errc_for_test


### PR DESCRIPTION
Part of tests are disabled (errc_for and part of constructors tests) until issue  [#182](https://github.com/KhronosGroup/SYCL-Docs/issues/182) , that concerns them is not resolved.