### PR TITLE
More fixes to device_global tests

### DIFF
--- a/tests/extension/oneapi_device_global/device_global_api_arrow_operator.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_arrow_operator.cpp
@@ -79,7 +79,7 @@ void run_test(util::logger& log, const std::string& type_name) {
             (const_dev_global<T>->a == value_ref_zero_init->a &&
              const_dev_global<T>->b == value_ref_zero_init->b &&
              const_dev_global<T>->c == value_ref_zero_init->c);
-        result_acc[integral(indx::correct_def_val_non_const)] &=
+        result_acc[integral(indx::correct_def_val_non_const)] =
             (dev_global<T>->a == value_ref_zero_init->a &&
              dev_global<T>->b == value_ref_zero_init->b &&
              dev_global<T>->c == value_ref_zero_init->c);

--- a/tests/extension/oneapi_device_global/device_global_api_subscript_operator.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_subscript_operator.cpp
@@ -88,9 +88,9 @@ void run_test(util::logger& log, const std::string& type_name) {
               dev_global<T, sizeOfArray>[i] == value_ref_zero_init;
 
           // Check that array element contains correct type
-          result_acc[integral(indx::same_type_const)] =
-              std::is_same<decltype(const_dev_global<T, sizeOfArray>[i]),
-                           typename device_global<T>::element_type&>::value;
+          result_acc[integral(indx::same_type_const)] = std::is_same<
+              decltype(const_dev_global<T, sizeOfArray>[i]),
+              const typename device_global<T>::element_type&>::value;
           result_acc[integral(indx::same_type_non_const)] =
               std::is_same<decltype(dev_global<T, sizeOfArray>[i]),
                            typename device_global<T>::element_type&>::value;

--- a/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_define_various_ways.cpp
@@ -41,8 +41,25 @@ oneapi::experimental::device_global<T> dev_global;
 }
 struct dum_struct {
   template <typename T>
-  static inline oneapi::experimental::device_global<T> dev_global;
+  static oneapi::experimental::device_global<T> dev_global;
 };
+
+// The static members inside dum_struct must be defined, otherwise they are
+// unresolvable external symbols.
+template <>
+oneapi::experimental::device_global<int> dum_struct::dev_global<int>{};
+template <>
+oneapi::experimental::device_global<int[5]> dum_struct::dev_global<int[5]>{};
+template <>
+oneapi::experimental::device_global<bool> dum_struct::dev_global<bool>{};
+template <>
+oneapi::experimental::device_global<bool[5]> dum_struct::dev_global<bool[5]>{};
+template <>
+oneapi::experimental::device_global<user_def_types::no_cnstr>
+    dum_struct::dev_global<user_def_types::no_cnstr>{};
+template <>
+oneapi::experimental::device_global<user_def_types::no_cnstr[5]>
+    dum_struct::dev_global<user_def_types::no_cnstr[5]>{};
 
 template <typename T>
 struct kernel;


### PR DESCRIPTION
This commit makes the following fixes to a subset of the device_global tests:
* Change the expected type of the subscript operator to const when the device_global is const.
* Replace use of &= with direct assignment in arrow-operator tests.
* Use value_operation::are_equal to correctly compare array values.
* Add additional template arguments to device_globals in select tests to distinguish different test paths and avoid initialization from the previous runs from bleeding into the latter runs.
* Make generator usage in memcpy tests similar to the structure in the copy variant.
* Instantiate static members of dum_struct to avoid them being considered external symbols. To help remind developers to add more instantiations if more types are added to the tests, the inline modifier has been removed from the declaration.