### PR TITLE
Extend sub_group_mask extension test plan

### DIFF
--- a/test_plans/sub_group_mask.asciidoc
+++ b/test_plans/sub_group_mask.asciidoc
@@ -4,7 +4,7 @@
 = Test plan for sub_group_mask
 
 This is a test plan for the APIs described in
-https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/GroupMask/GroupMask.asciidoc[GroupMask.asciidoc]
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_sub_group_mask.asciidoc[sycl_ext_oneapi_sub_group_mask]
 
 
 == Testing scope

--- a/test_plans/sub_group_mask.asciidoc
+++ b/test_plans/sub_group_mask.asciidoc
@@ -40,7 +40,6 @@ All of the following tests have these initial steps performed in defferent .cpp 
   `device.get_info<sycl::info::device::sub_group_sizes>()` should be used
   to check supported `sub_group` sizes.
 * In lambda function use `nd_item::get_sub_group()` to get `sycl::sub_group` instance.
-* Use `sub_group_ballot` to get `sub_group_mask` instance with predicate suitable for test.
 * Use accessor to buffer for type `bool` to save results.
 * For regular test run check is performed only for leader work-item
 * For full conformance test run check is performed for all work-items.
@@ -85,9 +84,9 @@ and `dim` is `2`, `5`, and `10`.
 
 For `size_t value = [item.get_local_linear_id(), 0b1010...]` and `marray<T, dim> val`:
 * If `CHAR_BIT * sizeof(val) < CHAR_BIT * sizeof(value)`
-  for `N = CHAR_BIT * sizeof(val)` set `N` bits of `val` to `N` bits of `value`.
+  for `N = CHAR_BIT * sizeof(val)` set first `N` bits of `val` to first `N` bits of `value`.
 * If `CHAR_BIT * sizeof(val) >= CHAR_BIT * sizeof(value)`
-  for `N = CHAR_BIT * sizeof(value)` set `N` bits of `val` to `N` bits of `value`.
+  for `N = CHAR_BIT * sizeof(value)` set first `N` bits of `val` to first `N` bits of `value`.
 * Construct `sub_group_mask` instance `s` with `sub_group_mask(val)` ctor.
 * Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`
 
@@ -115,7 +114,7 @@ extension.
 
 Member functions from Table are checked with following steps:
 
-* Use const instance of `sub_group_mask`.
+* Use `sub_group_ballot` to get `sub_group_mask` instance with predicate suitable for test.
 * Check return type.
 * Check that Expression returns Exprected value.
 

--- a/test_plans/sub_group_mask.asciidoc
+++ b/test_plans/sub_group_mask.asciidoc
@@ -54,23 +54,20 @@ Check that member `size_t max_bits` exists.
 Features described in this paragraph are available from revision 2 of the
 extension.
 
-==== sub_group_mask() [[empty_ctor]]
+==== sub_group_mask() [[default_ctor]]
 
 * Construct `sub_group_mask` instance `s` `with sub_group_mask()` ctor.
 * Check that `s.none() == true`.
-* Check that `s.size() == sub_group.max_local_range().size()`.
 
 ==== sub_group_mask(unsigned long long val) [[ull_ctor]]
 
 * Construct `sub_group_mask` instance `s` with `sub_group_mask(unsigned long long val)` ctor
-  and `val == item.get_global_linear_id()`.
-* Extract bits to `unsigned long long` `out` variable with function `s.extract_bits(out)`.
-* Check that `out == val`.
-* Check that `s.size() == sub_group.max_local_range().size()`.
+  and `size_t val` == `[item.get_local_linear_id(), 0b1010...]`.
+* Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`
 
 ==== template <typename T, std::size_t K> sub_group_mask(const sycl::marray<T, K>& val) [[marray_ctor]]
 
-For T equals to integral types below:
+For marray<T, dim> where T equals to integral types below:
 
 * `char`
 * `signed char`
@@ -84,25 +81,26 @@ For T equals to integral types below:
 * `long long int`
 * `unsigned long long int`
 
-And `marray<T, dim>` where T is the integral type above
-and `dim` == `sub_group.max_local_range().size()`.
+and `dim` is `2`, `5`, and `10`.
 
-* Init `marray<T, dim> val` variable with `value = item.get_global_linear_id()%std::numeric_limits<T>::max()`.
+For `size_t value = [item.get_local_linear_id(), 0b1010...]` and `marray<T, dim> val`:
+* If `CHAR_BIT * sizeof(val) < CHAR_BIT * sizeof(value)`
+  for `N = CHAR_BIT * sizeof(val)` set `N` bits of `val` to `N` bits of `value`.
+* If `CHAR_BIT * sizeof(val) >= CHAR_BIT * sizeof(value)`
+  for `N = CHAR_BIT * sizeof(value)` set `N` bits of `val` to `N` bits of `value`.
 * Construct `sub_group_mask` instance `s` with `sub_group_mask(val)` ctor.
-* Extract bits to `marray<T, dim>` `out` variable with function `s.extract_bits(out)`.
-* Check that `out == val`.
-* Check that `s.size() == sub_group.max_local_range().size()`.
+* Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`
 
 ==== sub_group_mask(const sub_group_mask& other)
 
-* Construct `sub_group_mask` instance `s` with every test case described in <<empty_ctor>> <<ull_ctor>> and
+* Construct `sub_group_mask` instance `s` with every test case described in <<default_ctor>> <<ull_ctor>> and
 <<marray_ctor>>.
 * Construct `sub_group_mask` instance `copy` with `sub_group_mask(s)` copy ctor.
 * Apply checks for `copy` as described in the corresponding paragraph.
 
 ==== sub_group_mask& operator=(const sub_group_mask& other)
 
-* Construct `sub_group_mask` instance `s` with every test case described in <<empty_ctor>> <<ull_ctor>> and
+* Construct `sub_group_mask` instance `s` with every test case described in <<default_ctor>> <<ull_ctor>> and
 <<marray_ctor>>..
 * Construct `sub_group_mask` instance `other` with the same size as s.
 * Use `other = s` to assign `other` instance with copy of `s`.

--- a/test_plans/sub_group_mask.asciidoc
+++ b/test_plans/sub_group_mask.asciidoc
@@ -41,7 +41,7 @@ All of the following tests have these initial steps performed in defferent .cpp 
   to check supported `sub_group` sizes.
 * In lambda function use `nd_item::get_sub_group()` to get `sycl::sub_group` instance.
 * Use accessor to buffer for type `bool` to save results.
-* For regular test run check is performed only for leader work-item
+* For regular test run check is performed only for leader work-item.
 * For full conformance test run check is performed for all work-items.
 
 === Test for max_bits
@@ -61,12 +61,12 @@ extension.
 ==== sub_group_mask(unsigned long long val) [[ull_ctor]]
 
 * Construct `sub_group_mask` instance `s` with `sub_group_mask(unsigned long long val)` ctor
-  and `size_t val` == `[item.get_local_linear_id(), 0b1010...]`.
-* Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`
+  and `size_t val`. Where `val` is `item.get_local_linear_id()` and  `0b1010...`.
+* Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`.
 
 ==== template <typename T, std::size_t K> sub_group_mask(const sycl::marray<T, K>& val) [[marray_ctor]]
 
-For marray<T, dim> where T equals to integral types below:
+For `marray<T, dim>` where `T` equals to integral types below:
 
 * `char`
 * `signed char`
@@ -82,13 +82,14 @@ For marray<T, dim> where T equals to integral types below:
 
 and `dim` is `2`, `5`, and `10`.
 
-For `size_t value = [item.get_local_linear_id(), 0b1010...]` and `marray<T, dim> val`:
+* Construct `marray<T, dim>` instance `val` with default ctor.
+* Use initial variable `size_t value` with values `item.get_local_linear_id()` and `0b1010...`.
 * If `CHAR_BIT * sizeof(val) < CHAR_BIT * sizeof(value)`
   for `N = CHAR_BIT * sizeof(val)` set first `N` bits of `val` to first `N` bits of `value`.
 * If `CHAR_BIT * sizeof(val) >= CHAR_BIT * sizeof(value)`
   for `N = CHAR_BIT * sizeof(value)` set first `N` bits of `val` to first `N` bits of `value`.
 * Construct `sub_group_mask` instance `s` with `sub_group_mask(val)` ctor.
-* Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`
+* Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`.
 
 ==== sub_group_mask(const sub_group_mask& other)
 

--- a/test_plans/sub_group_mask.asciidoc
+++ b/test_plans/sub_group_mask.asciidoc
@@ -16,10 +16,17 @@ is selected on the CTS command line.
 
 === Feature test macro
 
-Part of the extension feature is available from revision 1 and tests for it should use
-`#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 1` and can be skipped if the feature is not supported.
-The other part of the feature is available from revision 2 and tests for it should use
-`#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2` and can be skipped if the feature is not supported.
+Part of the extension feature is available from revision 1 of the extension and
+tests for it should use `#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 1` and can be
+skipped if the feature is not supported. That part is described in paragraph
+<<member_functions_rev_1>>.
+
+The other part of the feature is available from revision 2 of the extension and
+tests for it should use `#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2` and can be
+skipped if the feature is not supported. That part is described in paragraph
+<<ctors_rev_2>>.
+
+
 
 == Tests
 
@@ -42,26 +49,26 @@ All of the following tests have these initial steps performed in defferent .cpp 
 
 Check that member `size_t max_bits` exists.
 
-=== Tests for constructors and operator=
+=== Tests for constructors and operator= [[ctors_rev_2]]
 
-==== sub_group_mask()
+Features described in this paragraph are available from revision 2 of the
+extension.
 
-Available from revision 2.
+==== sub_group_mask() [[empty_ctor]]
 
 * Construct `sub_group_mask` instance `s` `with sub_group_mask()` ctor.
 * Check that `s.none() == true`.
 * Check that `s.size() == sub_group.max_local_range().size()`.
 
-==== sub_group_mask(unsigned long long val)
-
-Available from revision 2.
+==== sub_group_mask(unsigned long long val) [[ull_ctor]]
 
 * Construct `sub_group_mask` instance `s` with `sub_group_mask(unsigned long long val)` ctor
   and `val == item.get_global_linear_id()`.
 * Extract bits to `unsigned long long` `out` variable with function `s.extract_bits(out)`.
 * Check that `out == val`.
+* Check that `s.size() == sub_group.max_local_range().size()`.
 
-==== template <typename T, std::size_t K> sub_group_mask(const sycl::marray<T, K>& val)
+==== template <typename T, std::size_t K> sub_group_mask(const sycl::marray<T, K>& val) [[marray_ctor]]
 
 For T equals to integral types below:
 
@@ -84,60 +91,27 @@ and `dim` == `sub_group.max_local_range().size()`.
 * Construct `sub_group_mask` instance `s` with `sub_group_mask(val)` ctor.
 * Extract bits to `marray<T, dim>` `out` variable with function `s.extract_bits(out)`.
 * Check that `out == val`.
+* Check that `s.size() == sub_group.max_local_range().size()`.
 
 ==== sub_group_mask(const sub_group_mask& other)
 
-For T equals to integral types below:
-
-* `char`
-* `signed char`
-* `unsigned char`
-* `short int`
-* `unsigned short int`
-* `int`
-* `unsigned int`
-* `long int`
-* `unsigned long int`
-* `long long int`
-* `unsigned long long int`
-
-And `marray<T, dim>` where T is the integral type above
-and `dim` == `sub_group.max_local_range().size()`.
-
-* Init `marray<T, dim> val` variable with `value = item.get_global_linear_id()%std::numeric_limits<T>::max()`.
-* Construct `sub_group_mask` instance `s` with `sub_group_mask(val)` ctor.
+* Construct `sub_group_mask` instance `s` with every test case described in <<empty_ctor>> <<ull_ctor>> and
+<<marray_ctor>>.
 * Construct `sub_group_mask` instance `copy` with `sub_group_mask(s)` copy ctor.
-* Extract bits to `marray<T, dim>` `out` variable with function `copy.extract_bits(out)`.
-* Check that `out == val`.
+* Apply checks for `copy` as described in the corresponding paragraph.
 
 ==== sub_group_mask& operator=(const sub_group_mask& other)
 
-For T equals to integral types below:
+* Construct `sub_group_mask` instance `s` with every test case described in <<empty_ctor>> <<ull_ctor>> and
+<<marray_ctor>>..
+* Construct `sub_group_mask` instance `other` with the same size as s.
+* Use `other = s` to assign `other` instance with copy of `s`.
+* Apply checks for `other` as described in the corresponding paragraph.
 
-* `char`
-* `signed char`
-* `unsigned char`
-* `short int`
-* `unsigned short int`
-* `int`
-* `unsigned int`
-* `long int`
-* `unsigned long int`
-* `long long int`
-* `unsigned long long int`
+=== Tests for Member Functions [[member_functions_rev_1]]
 
-And `marray<T, dim>` where T is the integral type above
-and `dim` == `sub_group.max_local_range().size()`.
-
-* Init `marray<T, dim> expexted` variable with `value = expected_val`.
-* Init `marray<T, dim> changed` variable with `value = changed_val`.
-* Construct `sub_group_mask` instance `e_mask` with `sub_group_mask(expected)` ctor.
-* Construct `sub_group_mask` instance `ch_mask` with `sub_group_mask(changed)` copy ctor.
-* Use `ch_mask = e_mask` to assign ch_mask instance with copy of e_mask.
-* Extract bits to `marray<T, dim>` `out` variable with function `ch_mask.extract_bits(out)`.
-* Check that `out == expected`.
-
-=== Tests for Member Functions
+Features described in this paragraph are available from revision 1 of the
+extension.
 
 ==== Simple const member functions
 
@@ -147,108 +121,93 @@ Member functions from Table are checked with following steps:
 * Check return type.
 * Check that Expression returns Exprected value.
 
-[%header,cols="2,2,1,1,2,2"]
+[%header,cols="2,2,1,2,2"]
 |===
 |Function
-|Revision
 |Predicate
 |Return type
 |Expression
 |Expected value
 
 |`operator[](id<1> id) const`
-|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask[id(N)]` for `N = 0...sub_group_mask.size - 1`
 |`N%2 == 0`
 
 |`test(id<1> id) const`
-|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask.test(id(N))` for `N = 0...sub_group_mask.size - 1`
 |`N%2 == 0`
 
 |`all() const`
-|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask.all()`
 |`false`
 
 |`all() const`
-|1
 |`true`
 |`bool`
 |`sub_group_mask.all()`
 |`true`
 
 |`any() const`
-|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask.any()`
 |`true`
 
 |`any() const`
-|1
 |`false`
 |`bool`
 |`sub_group_mask.any()`
 |`false`
 
 |`none() const`
-|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask.none()`
 |`false`
 
 |`none() const`
-|1
 |`false`
 |`bool`
 |`sub_group_mask.none()`
 |`true`
 
 |`count() const`
-|1
 |`sub_group.get_local_id().size_t() < sub_group.get_local_range().size_t()/2`
 |`uint32_t`
 |`sub_group_mask.count()`
 |`sub_group.get_local_range().size()/2`
 
 |`size() const`
-|1
 |`true`
 |`uint32_t`
 |`sub_group_mask.size()`
 |`sub_group.get_local_range().size()`
 
 |`find_low() const`
-|1
 |`sub_group.get_local_id().size_t() > sub_group.get_local_range().size_t()/2 - 1`
 |`id<1>`
 |`sub_group_mask.find_low()`
 |`id(sub_group.get_local_range().size()/2)`
 
 |`find_low() const`
-|1
 |`false`
 |`id<1>`
 |`sub_group_mask.find_low()`
 |`id(sub_group.get_local_range().size())`
 
 |`find_high() const`
-|1
 |`sub_group.get_local_id().size_t() < sub_group.get_local_range().size_t()/2`
 |`id<1>`
 |`sub_group_mask.find_high()`
 |`id(sub_group.get_local_range().size_t()/2 - 1)`
 
 |`find_high() const`
-|1
 |`false`
 |`id<1>`
 |`sub_group_mask.find_high()`

--- a/test_plans/sub_group_mask.asciidoc
+++ b/test_plans/sub_group_mask.asciidoc
@@ -60,36 +60,45 @@ extension.
 
 ==== sub_group_mask(unsigned long long val) [[ull_ctor]]
 
-* Construct `sub_group_mask` instance `s` with `sub_group_mask(unsigned long long val)` ctor
-  and `size_t val`. Where `val` is `item.get_local_linear_id()` and  `0b1010...`.
-* Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`.
+Run the following test with `VALUE` = `item.get_local_linear_id()` and with `VALUE` = `0b1010...`:
+[source,c++]
+----
+size_t val = VALUE;
+sub_group_mask mask{val};
+for ( size_t i = 0; i < mask.size(); ++i ) {
+  if (mask[id(i)] != ((val >> i) & 1)) {
+    /* test fails */
+  }
+}
+----
 
 ==== template <typename T, std::size_t K> sub_group_mask(const sycl::marray<T, K>& val) [[marray_ctor]]
 
-For `marray<T, dim>` where `T` equals to integral types below:
+Run the following test with all combinations of:
 
-* `char`
-* `signed char`
-* `unsigned char`
-* `short int`
-* `unsigned short int`
-* `int`
-* `unsigned int`
-* `long int`
-* `unsigned long int`
-* `long long int`
-* `unsigned long long int`
+* TYPE: `char`, `signed char`, `unsigned char`, `short int`, `unsigned short int`, `int`, `unsigned int`, `long int`,
+`unsigned long int`, `long long int`, `unsigned long long int`
+* DIM: `2`, `5`, `10`
+* VALUE: `item.get_local_linear_id()`, `0b101010...`
 
-and `dim` is `2`, `5`, and `10`.
-
-* Construct `marray<T, dim>` instance `val` with default ctor.
-* Use initial variable `size_t value` with values `item.get_local_linear_id()` and `0b1010...`.
-* If `CHAR_BIT * sizeof(val) < CHAR_BIT * sizeof(value)`
-  for `N = CHAR_BIT * sizeof(val)` set first `N` bits of `val` to first `N` bits of `value`.
-* If `CHAR_BIT * sizeof(val) >= CHAR_BIT * sizeof(value)`
-  for `N = CHAR_BIT * sizeof(value)` set first `N` bits of `val` to first `N` bits of `value`.
-* Construct `sub_group_mask` instance `s` with `sub_group_mask(val)` ctor.
-* Check that for `N = 0...sub_group_mask.size() - 1` `s[id(N)]` == `((val >> N) & 1)`.
+[source,c++]
+----
+marray<TYPE, DIM> ma;
+size_t val = VALUE;
+if (sizeof(ma) < sizeof(val)) {
+  int N = CHAR_BIT * sizeof(ma);
+  /* set first N bits of "ma" to first N bits of "val" */
+} else {
+  int N = CHAR_BIT * sizeof(val);
+  /* set first N  bits of "ma" to first N bits of "val" */
+}
+sub_group_mask mask{ma};
+for (size_t i = 0;  i < mask.size();  ++i) {
+  if (mask[id(i)] != ((val >> i) & 1)) {
+    /* test fails */
+  }
+}
+----
 
 ==== sub_group_mask(const sub_group_mask& other)
 

--- a/test_plans/sub_group_mask.asciidoc
+++ b/test_plans/sub_group_mask.asciidoc
@@ -16,16 +16,22 @@ is selected on the CTS command line.
 
 === Feature test macro
 
-All of the tests should use `#ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK` so they can be skipped
-if feature is not supported.
+Part of the extension feature is available from revision 1 and tests for it should use
+`#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 1` and can be skipped if the feature is not supported.
+The other part of the feature is available from revision 2 and tests for it should use
+`#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2` and can be skipped if the feature is not supported.
 
 == Tests
 
 All of the following tests have these initial steps performed in defferent .cpp files :
 
 * Create a `queue` from the tested device and call `queue::submit()`.
-* Submit a kernel via `handler::parallel_for()` with parameters `sycl::nd_range<1>(range<1>(128), range<1>(32))`
+* Submit a kernel via `handler::parallel_for()` with parameters `sycl::nd_range<1>(range<1>(32), range<1>(32))`
   and lambda finction with parameter `sycl::nd_item<1>`.
+* Lambda function should be decorated with attribute `reqd_sub_group_size(N)` with `N` values = `[8,16,32]`.
+  If device does not support `sub_group` size `N`, test for size `N` can be skipped.
+  `device.get_info<sycl::info::device::sub_group_sizes>()` should be used
+  to check supported `sub_group` sizes.
 * In lambda function use `nd_item::get_sub_group()` to get `sycl::sub_group` instance.
 * Use `sub_group_ballot` to get `sub_group_mask` instance with predicate suitable for test.
 * Use accessor to buffer for type `bool` to save results.
@@ -35,6 +41,101 @@ All of the following tests have these initial steps performed in defferent .cpp 
 === Test for max_bits
 
 Check that member `size_t max_bits` exists.
+
+=== Tests for constructors and operator=
+
+==== sub_group_mask()
+
+Available from revision 2.
+
+* Construct `sub_group_mask` instance `s` `with sub_group_mask()` ctor.
+* Check that `s.none() == true`.
+* Check that `s.size() == sub_group.max_local_range().size()`.
+
+==== sub_group_mask(unsigned long long val)
+
+Available from revision 2.
+
+* Construct `sub_group_mask` instance `s` with `sub_group_mask(unsigned long long val)` ctor
+  and `val == item.get_global_linear_id()`.
+* Extract bits to `unsigned long long` `out` variable with function `s.extract_bits(out)`.
+* Check that `out == val`.
+
+==== template <typename T, std::size_t K> sub_group_mask(const sycl::marray<T, K>& val)
+
+For T equals to integral types below:
+
+* `char`
+* `signed char`
+* `unsigned char`
+* `short int`
+* `unsigned short int`
+* `int`
+* `unsigned int`
+* `long int`
+* `unsigned long int`
+* `long long int`
+* `unsigned long long int`
+
+And `marray<T, dim>` where T is the integral type above
+and `dim` == `sub_group.max_local_range().size()`.
+
+* Init `marray<T, dim> val` variable with `value = item.get_global_linear_id()%std::numeric_limits<T>::max()`.
+* Construct `sub_group_mask` instance `s` with `sub_group_mask(val)` ctor.
+* Extract bits to `marray<T, dim>` `out` variable with function `s.extract_bits(out)`.
+* Check that `out == val`.
+
+==== sub_group_mask(const sub_group_mask& other)
+
+For T equals to integral types below:
+
+* `char`
+* `signed char`
+* `unsigned char`
+* `short int`
+* `unsigned short int`
+* `int`
+* `unsigned int`
+* `long int`
+* `unsigned long int`
+* `long long int`
+* `unsigned long long int`
+
+And `marray<T, dim>` where T is the integral type above
+and `dim` == `sub_group.max_local_range().size()`.
+
+* Init `marray<T, dim> val` variable with `value = item.get_global_linear_id()%std::numeric_limits<T>::max()`.
+* Construct `sub_group_mask` instance `s` with `sub_group_mask(val)` ctor.
+* Construct `sub_group_mask` instance `copy` with `sub_group_mask(s)` copy ctor.
+* Extract bits to `marray<T, dim>` `out` variable with function `copy.extract_bits(out)`.
+* Check that `out == val`.
+
+==== sub_group_mask& operator=(const sub_group_mask& other)
+
+For T equals to integral types below:
+
+* `char`
+* `signed char`
+* `unsigned char`
+* `short int`
+* `unsigned short int`
+* `int`
+* `unsigned int`
+* `long int`
+* `unsigned long int`
+* `long long int`
+* `unsigned long long int`
+
+And `marray<T, dim>` where T is the integral type above
+and `dim` == `sub_group.max_local_range().size()`.
+
+* Init `marray<T, dim> expexted` variable with `value = expected_val`.
+* Init `marray<T, dim> changed` variable with `value = changed_val`.
+* Construct `sub_group_mask` instance `e_mask` with `sub_group_mask(expected)` ctor.
+* Construct `sub_group_mask` instance `ch_mask` with `sub_group_mask(changed)` copy ctor.
+* Use `ch_mask = e_mask` to assign ch_mask instance with copy of e_mask.
+* Extract bits to `marray<T, dim>` `out` variable with function `ch_mask.extract_bits(out)`.
+* Check that `out == expected`.
 
 === Tests for Member Functions
 
@@ -46,99 +147,113 @@ Member functions from Table are checked with following steps:
 * Check return type.
 * Check that Expression returns Exprected value.
 
-[%header,cols="2,2,1,2,2"]
+[%header,cols="2,2,1,1,2,2"]
 |===
 |Function
+|Revision
 |Predicate
 |Return type
 |Expression
 |Expected value
 
 |`operator[](id<1> id) const`
+|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask[id(N)]` for `N = 0...sub_group_mask.size - 1`
 |`N%2 == 0`
 
 |`test(id<1> id) const`
+|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask.test(id(N))` for `N = 0...sub_group_mask.size - 1`
 |`N%2 == 0`
 
 |`all() const`
+|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask.all()`
 |`false`
 
 |`all() const`
+|1
 |`true`
 |`bool`
 |`sub_group_mask.all()`
 |`true`
 
 |`any() const`
+|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask.any()`
 |`true`
 
 |`any() const`
+|1
 |`false`
 |`bool`
 |`sub_group_mask.any()`
 |`false`
 
 |`none() const`
+|1
 |`sub_group.get_local_id().size_t()%2 == 0`
 |`bool`
 |`sub_group_mask.none()`
 |`false`
 
 |`none() const`
+|1
 |`false`
 |`bool`
 |`sub_group_mask.none()`
 |`true`
 
 |`count() const`
+|1
 |`sub_group.get_local_id().size_t() < sub_group.get_local_range().size_t()/2`
 |`uint32_t`
 |`sub_group_mask.count()`
 |`sub_group.get_local_range().size()/2`
 
 |`size() const`
+|1
 |`true`
 |`uint32_t`
 |`sub_group_mask.size()`
 |`sub_group.get_local_range().size()`
 
 |`find_low() const`
+|1
 |`sub_group.get_local_id().size_t() > sub_group.get_local_range().size_t()/2 - 1`
 |`id<1>`
 |`sub_group_mask.find_low()`
 |`id(sub_group.get_local_range().size()/2)`
 
 |`find_low() const`
+|1
 |`false`
 |`id<1>`
 |`sub_group_mask.find_low()`
 |`id(sub_group.get_local_range().size())`
 
 |`find_high() const`
+|1
 |`sub_group.get_local_id().size_t() < sub_group.get_local_range().size_t()/2`
 |`id<1>`
 |`sub_group_mask.find_high()`
 |`id(sub_group.get_local_range().size_t()/2 - 1)`
 
 |`find_high() const`
+|1
 |`false`
 |`id<1>`
 |`sub_group_mask.find_high()`
 |`id(sub_group.get_local_range().size_t())`
 |===
-
 
 ==== operator[](id<1> id)
 


### PR DESCRIPTION
Cover gaps in sub_group_mask extension test plan according to updated version of specification [sycl_ext_oneapi_sub_group_mask](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_sub_group_mask.asciidoc).