### PR TITLE
Enable function_objects tests for DPCPP

### DIFF
--- a/tests/function_objects/function_objects_core.cpp
+++ b/tests/function_objects/function_objects_core.cpp
@@ -33,8 +33,7 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   for_all_combinations<check_scalar_return_type>(get_op_types(), types, types);
 });
 
-// Issue link https://github.com/intel/llvm/issues/8331
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp, hipSYCL)
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("function objects void specializations vector core", "[function_objects]")({
   const auto types_vector =
       named_type_pack<TYPES_VECTOR>::generate(TYPE_NAMES_VECTOR);

--- a/tests/function_objects/function_objects_fp64.cpp
+++ b/tests/function_objects/function_objects_fp64.cpp
@@ -50,8 +50,7 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
       get_op_types(), types_only_double, types_only_double);
 });
 
-// Issue link https://github.com/intel/llvm/issues/8331
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp, hipSYCL)
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("function objects void specializations vector fp64",
  "[function_objects][fp64]")({
   auto queue = sycl_cts::util::get_cts_object::queue();


### PR DESCRIPTION
Enable tests for function objects for marray and vector for DPCPP because blocking issue was resolved.