### PR TITLE
Add checks for exception for placeholder accessor for different memory operations

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -526,6 +526,7 @@ void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor,
           sycl::accessor res_acc(res_buf);
 
           auto acc = get_accessor_functor(data_buf, cgh);
+
           if constexpr (Target == sycl::target::host_task) {
             cgh.host_task([=] {
               // We are free either to create new accessor instance or to
@@ -699,39 +700,151 @@ void check_common_constructor(const sycl::range<Dimension>& r,
  * @param r Range for accessors buffer
  * @param get_accessor_functor Functor for accessor creation
  */
-template <accessor_type AccType, typename DataT, int Dimension,
-          sycl::access_mode AccessMode, sycl::target Target,
-          typename GetAccFunctorT>
-void check_placeholder_accessor_exception(const sycl::range<Dimension>& r,
-                                          GetAccFunctorT get_accessor_functor) {
+template <typename DataT, int Dimension, typename GetAccFunctorT, typename OpT>
+void run_placeholder_accessor_exception(const sycl::range<Dimension>& r,
+                                        GetAccFunctorT get_accessor_functor,
+                                        OpT memory_operation,
+                                        std::string op_name) {
   auto queue = util::get_cts_object::queue();
   DataT some_data = value_operations::init<DataT>(expected_val);
-  bool is_placeholder = false;
+  using T = std::remove_const_t<DataT>;
+  T other_data = value_operations::init<T>(changed_val);
   {
     sycl::buffer<DataT, Dimension> data_buf(&some_data, r);
+    sycl::buffer<T, Dimension> other_buf(&other_data, r);
 
     auto action = [&] {
       queue
           .submit([&](sycl::handler& cgh) {
             auto acc = get_accessor_functor(data_buf);
-            is_placeholder = acc.is_placeholder();
-            if constexpr (Target == sycl::target::host_task) {
-              cgh.host_task([=] {});
-            } else if constexpr (Target == sycl::target::device) {
-              cgh.parallel_for_work_group(sycl::range(1),
-                                          [=](sycl::group<1>) {});
-            }
+            sycl::accessor<T, Dimension> other_acc(other_buf, cgh);
+            memory_operation(acc, cgh, other_acc);
           })
           .wait_and_throw();
     };
-    CHECK(is_placeholder);
     INFO(
         "Implementation has to throw a sycl::exception with "
         "sycl::errc::kernel_argument when a placeholder accessor is passed to "
-        "the command");
+        "the command. Check for " +
+        op_name);
     CHECK_THROWS_MATCHES(
         action(), sycl::exception,
         sycl_cts::util::equals_exception(sycl::errc::kernel_argument));
+  }
+}
+
+/**
+ * @brief Function helps to check if passing of a placeholder accessor triggers
+ * the exception
+ *
+ * @tparam DataT Type of underlying data
+ * @tparam Dimension Dimensions of the accessor
+ * @tparam AccessMode Access mode of the accessor
+ * @tparam Target Target of accessor
+ * @param r Range for accessors buffer
+ * @param get_accessor_functor Functor for accessor creation
+ */
+template <typename DataT, int Dimension, sycl::access_mode AccessMode,
+          sycl::target Target, typename GetAccFunctorT>
+void check_placeholder_accessor_exception(const sycl::range<Dimension>& r,
+                                          GetAccFunctorT get_accessor_functor) {
+  if constexpr (Target == sycl::target::host_task) {
+    auto host_task = [&](auto& acc, auto& cgh, auto& acc2) {
+      cgh.host_task([=] { auto copy_acc = acc; });
+    };
+    run_placeholder_accessor_exception<DataT>(r, get_accessor_functor,
+                                              host_task, "host_task");
+  } else {
+    auto single_task = [&](auto& acc, auto& cgh, auto& acc2) {
+      cgh.single_task([=] { auto copy_acc = acc; });
+    };
+    run_placeholder_accessor_exception<DataT>(r, get_accessor_functor,
+                                              single_task, "single_task");
+
+    auto parallel_for_range = [&](auto& acc, auto& cgh, auto& acc2) {
+      cgh.parallel_for(r, [=](auto item) { auto copy_acc = acc; });
+    };
+    run_placeholder_accessor_exception<DataT>(
+        r, get_accessor_functor, parallel_for_range, "parallel_for with range");
+
+    auto parallel_for_nd_range = [&](auto& acc, auto& cgh, auto& acc2) {
+      cgh.parallel_for(sycl::nd_range<Dimension>(r, r),
+                       [=](auto nd_item) { auto copy_acc = acc; });
+    };
+    run_placeholder_accessor_exception<DataT>(r, get_accessor_functor,
+                                              parallel_for_nd_range,
+                                              "parallel_for with nd_range");
+
+    auto parallel_for_work_group = [&](auto& acc, auto& cgh, auto& acc2) {
+      cgh.parallel_for_work_group(r, [=](auto group) { auto copy_acc = acc; });
+    };
+    run_placeholder_accessor_exception<DataT>(r, get_accessor_functor,
+                                              parallel_for_work_group,
+                                              "parallel_for_work_group");
+
+    auto update_host = [&](auto& acc, auto& cgh, auto& acc2) {
+      cgh.update_host(acc);
+    };
+    run_placeholder_accessor_exception<DataT>(r, get_accessor_functor,
+                                              update_host, "update_host");
+
+    if constexpr (AccessMode != sycl::access_mode::write) {
+      auto copy_to_shared = [&](auto& acc, auto& cgh, auto& acc2) {
+        using T = std::remove_const_t<DataT>;
+        std::shared_ptr<T> dest(new T);
+        cgh.copy(acc, dest);
+      };
+      run_placeholder_accessor_exception<DataT>(
+          r, get_accessor_functor, copy_to_shared, "copy to std::shared_ptr");
+
+      auto copy_to_pointer = [&](auto& acc, auto& cgh, auto& acc2) {
+        using T = std::remove_const_t<DataT>;
+        T val;
+        T* dest = &val;
+        cgh.copy(acc, dest);
+      };
+      run_placeholder_accessor_exception<DataT>(
+          r, get_accessor_functor, copy_to_pointer, "copy to pointer");
+
+      auto copy_to_acc = [&](auto& acc, auto& cgh, auto& acc2) {
+        cgh.copy(acc, acc2);
+      };
+      run_placeholder_accessor_exception<DataT>(
+          r, get_accessor_functor, copy_to_acc, "copy to new accessor");
+    }
+
+    if constexpr (AccessMode != sycl::access_mode::read) {
+      auto copy_shared = [&](auto& acc, auto& cgh, auto& acc2) {
+        using T = std::remove_const_t<DataT>;
+        std::shared_ptr<T> src(new T);
+        cgh.copy(src, acc);
+      };
+      run_placeholder_accessor_exception<DataT>(
+          r, get_accessor_functor, copy_shared, "copy std::shared_ptr");
+
+      auto copy_pointer = [&](auto& acc, auto& cgh, auto& acc2) {
+        using T = std::remove_const_t<DataT>;
+        T val;
+        T* src = &val;
+        cgh.copy(src, acc);
+      };
+      run_placeholder_accessor_exception<DataT>(r, get_accessor_functor,
+                                                copy_shared, "copy pointer");
+
+      auto copy_acc = [&](auto& acc, auto& cgh, auto& acc2) {
+        cgh.copy(acc2, acc);
+      };
+      run_placeholder_accessor_exception<DataT>(r, get_accessor_functor,
+                                                copy_acc, "copy new accessor");
+
+      auto fill = [&](auto& acc, auto& cgh, auto& acc2) {
+        using T = std::remove_const_t<DataT>;
+        T val = T(changed_val);
+        cgh.fill(acc, val);
+      };
+      run_placeholder_accessor_exception<DataT>(r, get_accessor_functor, fill,
+                                                "fill");
+    }
   }
 }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&

--- a/tests/accessor/generic_accessor_placeholder_constructors.h
+++ b/tests/accessor/generic_accessor_placeholder_constructors.h
@@ -139,8 +139,8 @@ void test_placeholder_accessors_exception(const std::string& type_name,
     auto get_acc_functor = [](sycl::buffer<DataT, Dimension>& data_buf) {
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf);
     };
-    check_placeholder_accessor_exception<AccType, DataT, Dimension, AccessMode,
-                                         Target>(r, get_acc_functor);
+    check_placeholder_accessor_exception<DataT, Dimension, AccessMode, Target>(
+        r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -151,8 +151,8 @@ void test_placeholder_accessors_exception(const std::string& type_name,
     auto get_acc_functor = [r](sycl::buffer<DataT, Dimension>& data_buf) {
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, r);
     };
-    check_placeholder_accessor_exception<AccType, DataT, Dimension, AccessMode,
-                                         Target>(r, get_acc_functor);
+    check_placeholder_accessor_exception<DataT, Dimension, AccessMode, Target>(
+        r, get_acc_functor);
   }
 
   section_name = get_section_name<Dimension>(
@@ -165,8 +165,8 @@ void test_placeholder_accessors_exception(const std::string& type_name,
       return sycl::accessor<DataT, Dimension, AccessMode, Target>(data_buf, r,
                                                                   offset);
     };
-    check_placeholder_accessor_exception<AccType, DataT, Dimension, AccessMode,
-                                         Target>(r, get_acc_functor);
+    check_placeholder_accessor_exception<DataT, Dimension, AccessMode, Target>(
+        r, get_acc_functor);
   }
 }
 

--- a/tests/accessor/generic_accessor_placeholder_constructors_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_constructors_core.cpp
@@ -24,8 +24,7 @@
 #include "../common/common.h"
 
 // FIXME: re-enable when sycl::accessor is implemented
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP && \
-    !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_constructors.h"
 #endif


### PR DESCRIPTION
Cover gaps that only parallel_for_work_group was checked on exception when placeholder accessor is passed as an argument to a command.