### PR TITLE
Enable tests with sycl::aspect::emulated

### DIFF
--- a/tests/common/string_makers.h
+++ b/tests/common/string_makers.h
@@ -62,9 +62,7 @@ struct StringMaker<sycl::target> {
       case type::device:
         return "target::device";
 // FIXME: re-enable when target::host_task is implemented
-// Issue link for DPCPP https://github.com/intel/llvm/issues/8298
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP && \
-    !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
       case type::host_task:
         return "target::host_task";
 #endif
@@ -94,12 +92,8 @@ struct StringMaker<sycl::aspect> {
         return "aspect::accelerator";
       case type::custom:
         return "aspect::custom";
-// FIXME: re-enable when aspect::emulated is implemented
-// Issue link https://github.com/intel/llvm/issues/8324
-#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
       case type::emulated:
         return "aspect::emulated";
-#endif  // SYCL_CTS_COMPILING_WITH_DPCPP
       case type::host_debuggable:
         return "aspect::host_debuggable";
       case type::fp16:

--- a/tests/device_selector/device_selector_aspect.cpp
+++ b/tests/device_selector/device_selector_aspect.cpp
@@ -30,12 +30,6 @@ using namespace sycl_cts;
 
 /** Return a named value pack of all defined aspects. */
 static auto get_aspect_pack() {
-// FIXME: remove when https://github.com/intel/llvm/issues/8324 is fixed
-#ifdef SYCL_CTS_COMPILING_WITH_DPCPP
-  WARN(
-      "DPCPP does not define sycl::aspect::emulated."
-      "Skipping test cases for this aspect.");
-#endif
   static const auto types =
       value_pack<sycl::aspect, sycl::aspect::cpu, sycl::aspect::gpu,
                  sycl::aspect::accelerator, sycl::aspect::custom,
@@ -48,12 +42,8 @@ static auto get_aspect_pack() {
                  sycl::aspect::usm_atomic_host_allocations,
                  sycl::aspect::usm_shared_allocations,
                  sycl::aspect::usm_atomic_shared_allocations,
-                 sycl::aspect::usm_system_allocations
-#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
-                 ,
-                 sycl::aspect::emulated
-#endif
-                 >::generate_named();
+                 sycl::aspect::usm_system_allocations,
+                 sycl::aspect::emulated>::generate_named();
   return types;
 }
 


### PR DESCRIPTION
Enable tests with sycl::aspect::emulated for DPCPP because issue https://github.com/intel/llvm/issues/8324 were resolved.

Also enable usage of target::host_task  for DPCPP in the same file.