### PR TITLE
Enable tests with atomic_fence_scope_capabilities and atomic_fence_order_capabilities

### DIFF
--- a/tests/atomic_fence/atomic_fence.cpp
+++ b/tests/atomic_fence/atomic_fence.cpp
@@ -50,8 +50,6 @@ enum class test_type {
 bool check_atomic_fence_order_capability(sycl::queue& queue,
                                          sycl::memory_order order,
                                          const std::string& order_name) {
-// FIXME: re-enable when https://github.com/intel/llvm/issues/8293 is fixed
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
   auto orders =
       queue.get_device()
           .get_info<sycl::info::device::atomic_fence_order_capabilities>();
@@ -60,7 +58,6 @@ bool check_atomic_fence_order_capability(sycl::queue& queue,
          order_name);
     return false;
   }
-#endif
   return true;
 }
 
@@ -74,17 +71,14 @@ bool check_atomic_fence_order_capability(sycl::queue& queue,
 bool check_atomic_fence_scope_capability(sycl::queue& queue,
                                          sycl::memory_scope scope,
                                          const std::string& scope_name) {
-// FIXME: re-enable when https://github.com/intel/llvm/issues/8293 is fixed
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
   auto scopes =
       queue.get_device()
           .get_info<sycl::info::device::atomic_fence_scope_capabilities>();
-  if (std::find(scopes.begin(), scopes.end(), scope) == orders.end()) {
+  if (std::find(scopes.begin(), scopes.end(), scope) == scopes.end()) {
     WARN(std::string("Device does not support atomic_fence with scope = ") +
          scope_name);
     return false;
   }
-#endif
   return true;
 }
 

--- a/tests/context/context_info.cpp
+++ b/tests/context/context_info.cpp
@@ -38,8 +38,6 @@ TEST_CASE("context info", "[context]") {
         ctx.get_info<sycl::info::context::atomic_memory_order_capabilities>();
     CHECK(check_contains(capabilities, sycl::memory_order::relaxed));
   }
-// Issue link https://github.com/intel/llvm/issues/8323
-#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
   {  // check get_info for info::context::atomic_fence_order_capabilities
     check_get_info_param<sycl::info::context::atomic_fence_order_capabilities,
                          std::vector<sycl::memory_order>>(ctx);
@@ -50,12 +48,6 @@ TEST_CASE("context info", "[context]") {
     CHECK(check_contains(capabilities, sycl::memory_order::release));
     CHECK(check_contains(capabilities, sycl::memory_order::acq_rel));
   }
-#else
-  WARN(
-      "Implementation does not support "
-      "sycl::info::context::atomic_fence_order_capabilities "
-      "Skipping the test case.");
-#endif
   {  // check get_info for info::context::atomic_memory_scope_capabilities
     check_get_info_param<sycl::info::context::atomic_memory_scope_capabilities,
                          std::vector<sycl::memory_scope>>(ctx);
@@ -63,8 +55,6 @@ TEST_CASE("context info", "[context]") {
         ctx.get_info<sycl::info::context::atomic_memory_scope_capabilities>();
     CHECK(check_contains(capabilities, sycl::memory_scope::work_group));
   }
-// Issue link https://github.com/intel/llvm/issues/8323
-#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
   {  // check get_info for info::context::atomic_fence_scope_capabilities
     check_get_info_param<sycl::info::context::atomic_fence_scope_capabilities,
                          std::vector<sycl::memory_scope>>(ctx);
@@ -72,10 +62,4 @@ TEST_CASE("context info", "[context]") {
         ctx.get_info<sycl::info::context::atomic_fence_scope_capabilities>();
     CHECK(check_contains(capabilities, sycl::memory_scope::work_group));
   }
-#else
-  WARN(
-      "Implementation does not support "
-      "sycl::info::context::atomic_fence_scope_capabilities "
-      "Skipping the test case.");
-#endif
 }

--- a/tests/device/device_info.cpp
+++ b/tests/device/device_info.cpp
@@ -185,9 +185,6 @@ TEST_CASE("device info", "[device]") {
           dev.get_info<sycl::info::device::atomic_memory_order_capabilities>();
       CHECK(check_contains(capabilities, sycl::memory_order::relaxed));
     }
-// FIXME: re-enable when issue is fixed
-// https://github.com/intel/llvm/issues/8293
-#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
     {
       check_get_info_param<sycl::info::device::atomic_fence_order_capabilities,
                            std::vector<sycl::memory_order>>(dev);
@@ -198,12 +195,6 @@ TEST_CASE("device info", "[device]") {
       CHECK(check_contains(capabilities, sycl::memory_order::release));
       CHECK(check_contains(capabilities, sycl::memory_order::acq_rel));
     }
-#else
-    WARN(
-        "Implementation does not support "
-        "sycl::info::device::atomic_fence_order_capabilities "
-        "Skipping the test case.");
-#endif
     {
       check_get_info_param<sycl::info::device::atomic_memory_scope_capabilities,
                            std::vector<sycl::memory_scope>>(dev);
@@ -211,9 +202,6 @@ TEST_CASE("device info", "[device]") {
           dev.get_info<sycl::info::device::atomic_memory_scope_capabilities>();
       CHECK(check_contains(capabilities, sycl::memory_scope::work_group));
     }
-// FIXME: re-enable when issue is fixed
-// https://github.com/intel/llvm/issues/8293
-#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
     {
       check_get_info_param<sycl::info::device::atomic_fence_scope_capabilities,
                            std::vector<sycl::memory_scope>>(dev);
@@ -221,12 +209,6 @@ TEST_CASE("device info", "[device]") {
           dev.get_info<sycl::info::device::atomic_fence_scope_capabilities>();
       CHECK(check_contains(capabilities, sycl::memory_scope::work_group));
     }
-#else
-    WARN(
-        "Implementation does not support "
-        "sycl::info::device::atomic_fence_scope_capabilities "
-        "Skipping the test case.");
-#endif
     check_get_info_param<sycl::info::device::profiling_timer_resolution,
                          size_t>(dev);
     check_get_info_param<sycl::info::device::is_endian_little, bool>(dev);

--- a/tests/group_functions/group_barrier.cpp
+++ b/tests/group_functions/group_barrier.cpp
@@ -30,11 +30,9 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
                        2, 3) {
   auto queue = sycl_cts::util::get_cts_object::queue();
 
-  // FIXME: hipSYCL and DPCPP have no implemented
+  // FIXME: hipSYCL have no implemented
   //  atomic_fence_scope_capabilities query
-  //  Issue to link https://github.com/intel/llvm/issues/8323
-#if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-      defined(SYCL_CTS_COMPILING_WITH_DPCPP))
+#if !defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   std::vector<sycl::memory_scope> supported_barriers =
       queue.get_context()
           .get_info<sycl::info::context::atomic_fence_scope_capabilities>();
@@ -44,7 +42,7 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
       sycl::memory_scope::sub_group, sycl::memory_scope::work_group,
       sycl::memory_scope::device, sycl::memory_scope::system};
   WARN(
-      "hipSYCL and DPCPP have no implementation of "
+      "hipSYCL have no implementation of "
       "atomic_fence_scope_capabilities query, suppose all barrier types as "
       "valid.");
 #endif

--- a/tests/group_functions/group_barrier.cpp
+++ b/tests/group_functions/group_barrier.cpp
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
                        2, 3) {
   auto queue = sycl_cts::util::get_cts_object::queue();
 
-  // FIXME: hipSYCL have no implemented
+  // FIXME: hipSYCL has not implemented
   //  atomic_fence_scope_capabilities query
 #if !defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   std::vector<sycl::memory_scope> supported_barriers =
@@ -42,7 +42,7 @@ TEMPLATE_TEST_CASE_SIG("Group barriers", "[group_func][dim]", ((int D), D), 1,
       sycl::memory_scope::sub_group, sycl::memory_scope::work_group,
       sycl::memory_scope::device, sycl::memory_scope::system};
   WARN(
-      "hipSYCL have no implementation of "
+      "hipSYCL has no implementation of "
       "atomic_fence_scope_capabilities query, suppose all barrier types as "
       "valid.");
 #endif


### PR DESCRIPTION
Enable tests with sycl::info::device::atomic_fence_scope_capabilities and sycl::info::device::atomic_fence_order_capabilities for DPCPP because issue https://github.com/intel/llvm/issues/8293 is resolved.