### PR TITLE
Fix host_task tests

### DIFF
--- a/tests/host_task/host_task_interop_api.cpp
+++ b/tests/host_task/host_task_interop_api.cpp
@@ -55,7 +55,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
         cl_command_queue cl_native_queue{nullptr};
         q.submit([&](sycl::handler& cgh) {
           cgh.host_task([=, &cl_native_queue](sycl::interop_handle ih) {
-            cl_native_queue = ih.get_native_queue();
+            cl_native_queue = ih.get_native_queue<sycl::backend::opencl>();
           });
         });
         q.wait_and_throw();
@@ -69,7 +69,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
         cl_device_id cl_native_device_id{nullptr};
         q.submit([&](sycl::handler& cgh) {
           cgh.host_task([=, &cl_native_device_id](sycl::interop_handle ih) {
-            cl_native_device_id = ih.get_native_device();
+            cl_native_device_id = ih.get_native_device<sycl::backend::opencl>();
           });
         });
         q.wait_and_throw();
@@ -84,7 +84,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
         cl_context cl_native_context{nullptr};
         q.submit([&](sycl::handler& cgh) {
           cgh.host_task([=, &cl_native_context](sycl::interop_handle ih) {
-            cl_native_context = ih.get_native_context();
+            cl_native_context = ih.get_native_context<sycl::backend::opencl>();
           });
         });
         q.wait_and_throw();
@@ -102,8 +102,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
         q.submit([&](sycl::handler& cgh) {
           auto buf_acc_dev{buf.get_access<sycl::access_mode::read_write>(cgh)};
           cgh.host_task([=](sycl::interop_handle ih) {
-            cl_command_queue native_queue = ih.get_native_queue();
-            std::vector<cl_mem> native_mems = ih.get_native_mem(buf_acc_dev);
+            cl_command_queue native_queue =
+                ih.get_native_queue<sycl::backend::opencl>();
+            std::vector<cl_mem> native_mems =
+                ih.get_native_mem<sycl::backend::opencl>(buf_acc_dev);
             for (auto native_mem : native_mems)
               call_opencl(native_queue, native_mem, size, pattern);
           });

--- a/tests/host_task/host_task_invoke_api.cpp
+++ b/tests/host_task/host_task_invoke_api.cpp
@@ -48,10 +48,9 @@ struct host_task_command_group {
   void operator()(sycl::handler& cgh) {
     int a = m_add;
     int container_size = m_bufRef.get().size();
-    auto acc_host =
-        m_bufRef.get()
-            .template get_access<sycl::access_mode::read_write,
-                                 sycl::target::host_buffer>(cgh);
+    auto acc_host = m_bufRef.get()
+                        .template get_access<sycl::access_mode::read_write,
+                                             sycl::target::host_task>(cgh);
     cgh.host_task([=]() {
       for (int i = 0; i < container_size; ++i) {
         acc_host[i] += a;
@@ -159,8 +158,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
       q.submit([&](sycl::handler& cgh) {
         auto acc_host{
-            buffer.get_access<sycl::access_mode::read,
-                              sycl::target::host_buffer>(cgh)};
+            buffer.get_access<sycl::access_mode::read, sycl::target::host_task>(
+                cgh)};
         auto acc_dev = buffer.get_access<sycl::access_mode::write>(cgh);
         cgh.host_task([=]() {
           for (int i = 0; i < container_size; ++i) {


### PR DESCRIPTION
Add expected template parameter for interop functions.
Replace `target::host_buffer` with `sycl::target::host_task`.