### PR TITLE
Enable tests for sycl::joint_reduce

### DIFF
--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -52,11 +52,6 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
         "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, "
         "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
         "Skipping the test case.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8348
-    WARN(
-        "DPCPP does not implement joint_reduce without init. Skipping the test "
-        "case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
@@ -67,18 +62,11 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
 #endif
   }
 
-  // FIXME: DPCPP compile error:
-  //        error: call to function 'joint_reduce' that is neither visible
-  //        in the template definition nor found by argument-dependent lookup
-  //        note: 'joint_reduce' should be declared prior to the call site
-  //        or in namespace 'sycl::ext::oneapi'
   // FIXME: Codeplay ComputeCpp - CE 2.11.0
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
   //        clang-8: error: unable to execute command: Segmentation fault
   //        clang-8: error: spirv-ll-tool command failed due to signal
-  // Link to issue https://github.com/intel/llvm/issues/8348
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   // check all work group dimensions

--- a/tests/group_functions/group_reduce_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp16.cpp
@@ -55,23 +55,11 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
         "Skipping the test case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN("ComputeCpp cannot handle half type. Skipping the test.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8348
-    WARN(
-        "DPCPP does not implement joint_reduce without init. Skipping the test "
-        "case.");
 #endif
   }
 
   // FIXME: ComputeCpp has no half
-  // FIXME: DPCPP compile error:
-  //        error: call to function 'joint_reduce' that is neither visible
-  //        in the template definition nor found by argument-dependent lookup
-  //        note: 'joint_reduce' should be declared prior to the call site
-  //        or in namespace 'sycl::ext::oneapi'
-  // Link to issue https://github.com/intel/llvm/issues/8348
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   if (queue.get_device().has(sycl::aspect::fp16)) {

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -54,11 +54,6 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
         "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, "
         "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
         "Skipping the test case.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8348
-    WARN(
-        "DPCPP does not implement joint_reduce without init. Skipping the test "
-        "case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp fails to compile with segfault in the compiler. "
@@ -66,18 +61,11 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
 #endif
   }
 
-  // FIXME: DPCPP compile error:
-  //        error: call to function 'joint_reduce' that is neither visible
-  //        in the template definition nor found by argument-dependent lookup
-  //        note: 'joint_reduce' should be declared prior to the call site
-  //        or in namespace 'sycl::ext::oneapi'
   // FIXME: Codeplay ComputeCpp - CE 2.11.0
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
   //        clang-8: error: unable to execute command: Segmentation fault
   //        clang-8: error: spirv-ll-tool command failed due to signal
-  // Link to issue https://github.com/intel/llvm/issues/8348
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   if (queue.get_device().has(sycl::aspect::fp64)) {


### PR DESCRIPTION
Enable tests for sycl::joint_reduce for DPCPP because issue https://github.com/intel/llvm/issues/8348 is resolved.