### PR TITLE
Add missed test cases for sycl::vec

### DIFF
--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -380,7 +380,7 @@ template <typename vecType, int N>
 bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   // size()
   size_t count = inputVec.size();
-  if (count != N) {
+  if (count != N || !noexcept(inputVec.size())) {
     return false;
   }
   count = vector_swizzle_check<vecType, N>::get_swizzle(inputVec).size();
@@ -389,7 +389,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   }
 
   // get_count()
-  // TODO: mark this check as testing deprecated functionality
+#if SYCL_CTS_TEST_DEPRECATED_FEATURES
   size_t count_depr = inputVec.get_count();
   if (count_depr != N) {
     return false;
@@ -399,11 +399,11 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (count_depr != N) {
     return false;
   }
-
+#endif
   // byte_size()
   size_t size = inputVec.byte_size();
   size_t M = (N == 3) ? 4 : N;
-  if (size != sizeof(vecType) * M) {
+  if (size != sizeof(vecType) * M || !noexcept(inputVec.byte_size())) {
     return false;
   }
   size = vector_swizzle_check<vecType, N>::get_swizzle(inputVec).byte_size();
@@ -412,7 +412,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   }
 
   // get_size()
-  // TODO: mark this check as testing deprecated functionality
+#if SYCL_CTS_TEST_DEPRECATED_FEATURES
   size_t size_depr = inputVec.get_size();
   if (size_depr != sizeof(vecType) * M) {
     return false;
@@ -422,6 +422,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (size_depr != sizeof(vecType) * M) {
     return false;
   }
+#endif
   return true;
 }
 

--- a/tests/vector_api/generate_vector_api.py
+++ b/tests/vector_api/generate_vector_api.py
@@ -107,7 +107,7 @@ def gen_checks(type_str, size):
         type_str, kernel_name,
         'API test for sycl::vec<' + type_str + ', ' + str(size) + '>',
         test_string)
-    string+= vector_element_type_template.substitute(
+    string += vector_element_type_template.substitute(
         type=type_str,
         size=size,
         swizIndexes=', '.join(Data.swizzle_elem_list_dict[size][::-1]))

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -183,6 +183,8 @@ all_type_test_template = Template("""
   if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
+// FIXME: re-enable when unary opeartor+ is implemented
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
   for (int i = 0; i < ${size}; ++i) {
     resArr[i] = static_cast<${type}>(${test_value_1});
   }
@@ -194,6 +196,7 @@ all_type_test_template = Template("""
   if (!check_vector_values(resVec, resArr)) {
     resAcc[0] = false;
   }
+#endif
   for (int i = 0; i < ${size}; ++i) {
     resArr[i] = -(static_cast<${type}>(${test_value_1}));
   }
@@ -1244,7 +1247,7 @@ subscript_operator_test_template = Template("""
       if (subscriptVec1[i] != data[i] || subscriptVec2[i] != data[i]
 // FIXME: re-enable when subscript operator for swizzle vec is implemented
 // link to issue: https://github.com/intel/llvm/issues/8880
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
         || subscriptVec1.${swizzle}[i] != data[i]
         || subscriptVec2.${swizzle}[i] != data[i]
 #endif
@@ -1261,7 +1264,8 @@ dataT_operator_test_template = Template("""
   {
     ${type} val = ${val};
     const sycl::vec<${type}, 1> testVec(${val});
-
+// FIXME: re-enable when subscript operator DataT() is implemented
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
     ${type} data = testVec;
     if (data != val) {
       resAcc[0] = false;
@@ -1271,6 +1275,7 @@ dataT_operator_test_template = Template("""
     if (data != val) {
       resAcc[0] = false;
     }
+#endif
   }
 """)
 

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -183,6 +183,28 @@ all_type_test_template = Template("""
   if (!check_vector_values_div(resVec, resArr)) {
     resAcc[0] = false;
   }
+  for (int i = 0; i < ${size}; ++i) {
+    resArr[i] = static_cast<${type}>(${test_value_1});
+  }
+  resVec = +testVec1;
+  if (!check_vector_values(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  resVec = +testVec1.${swizzle};
+  if (!check_vector_values(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  for (int i = 0; i < ${size}; ++i) {
+    resArr[i] = -(static_cast<${type}>(${test_value_1}));
+  }
+  resVec = -testVec1;
+  if (!check_vector_values(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  resVec = -testVec1.${swizzle};
+  if (!check_vector_values(resVec, resArr)) {
+    resAcc[0] = false;
+  }
 
   // Post and pre increment and decrement
   // C++17 does not allow ++ or -- (either prefix or postfix) for the bool type
@@ -1164,23 +1186,113 @@ non_fp_arithmetic_test_template = Template("""
   if (!check_vector_values(resVec, resArr)) {
     resAcc[0] = false;
   }
+  for (int i = 0; i < ${size}; ++i) {
+    resArr[i] = static_cast<${type}>(${test_value_1}) % static_cast<${type}>(${test_value_2});
+  }
+  resVec = testVec1 % testVec2;
+  if (!check_vector_values_div(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  resVec = testVec1 % testVec2.${swizzle};
+  if (!check_vector_values_div(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  resVec = testVec1 % static_cast<${type}>(${test_value_2});
+  if (!check_vector_values_div(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+// FIXME: re-enable when operator% for sycl::vec is fully implemented
+// link to issue: https://github.com/intel/llvm/issues/8881
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
+  resVec = testVec1.${swizzle} % testVec2;
+  if (!check_vector_values_div(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  resVec = testVec1.${swizzle} % testVec2.${swizzle};
+  if (!check_vector_values_div(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  resVec = testVec1.${swizzle} % static_cast<${type}>(${test_value_2});
+  if (!check_vector_values_div(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  resVec = static_cast<${type}>(${test_value_1}) % testVec2;
+  if (!check_vector_values_div(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+  resVec = static_cast<${type}>(${test_value_1}) % testVec2.${swizzle};
+  if (!check_vector_values_div(resVec, resArr)) {
+    resAcc[0] = false;
+  }
+#endif
+
 """)
 
 subscript_operator_test_template = Template("""
   // subscript operator value
-  ${type} data[] = { ${data} };
-  sycl::vec<${type}, ${size}> subscriptVec1(${data});
+  {
+    ${type} data[] = { ${data} };
+    const sycl::vec<${type}, ${size}> subscriptVec1(${data});
 
-  // subscript operator assignment
-  sycl::vec<${type}, ${size}> subscriptVec2;
-  for (int i = 0; i < ${size}; ++i) {
-    subscriptVec2[i] = data[i];
+    // subscript operator assignment
+    sycl::vec<${type}, ${size}> subscriptVec2;
+    for (int i = 0; i < ${size}; ++i) {
+      subscriptVec2[i] = data[i];
+    }
+
+    for (int i = 0; i < ${size}; ++i) {
+      if (subscriptVec1[i] != data[i] || subscriptVec2[i] != data[i]
+// FIXME: re-enable when subscript operator for swizzle vec is implemented
+// link to issue: https://github.com/intel/llvm/issues/8880
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
+        || subscriptVec1.${swizzle}[i] != data[i]
+        || subscriptVec2.${swizzle}[i] != data[i]
+#endif
+        )
+      {
+        resAcc[0] = false;
+      }
+    }
   }
+""")
 
-  for (int i = 0; i < ${size}; ++i) {
-    if (subscriptVec1[i] != data[i] || subscriptVec2[i] != data[i]) {
+dataT_operator_test_template = Template("""
+  // check operator DataT() const
+  {
+    ${type} val = ${val};
+    const sycl::vec<${type}, 1> testVec(${val});
+
+    ${type} data = testVec;
+    if (data != val) {
       resAcc[0] = false;
     }
+
+    data = testVec.${swizzle};
+    if (data != val) {
+      resAcc[0] = false;
+    }
+  }
+""")
+
+assign_dataT_operator_test_template = Template("""
+  // check operator=(const DataT&)
+  {
+    const ${type} val = ${val};
+    sycl::vec<${type}, ${size}> testVec;
+
+    testVec = val;
+    ${type} resArr[${size}];
+    for (int i = 0; i < ${size}; ++i) {
+      resArr[i] = val;
+    }
+    if (!check_vector_values(testVec, resArr)) {
+      resAcc[0] = false;
+    }
+// FIXME: re-enable when operator=(const DataT&) for swizzle_vec is implemented
+// link to issue: https://github.com/intel/llvm/issues/8877
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
+    testVec.${swizzle} = val;
+#endif
   }
 """)
 
@@ -1193,7 +1305,18 @@ def generate_all_type_test(type_str, size):
     test_string = subscript_operator_test_template.substitute(
         type=type_str,
         size=str(size),
+        swizzle=get_swizzle(size),
         data=', '.join(Data.vals_list_dict[size]))
+    if size == 1:
+        test_string += dataT_operator_test_template.substitute(
+          type=type_str,
+          swizzle=get_swizzle(size),
+          val=Data.value_default_dict[type_str])
+    test_string += assign_dataT_operator_test_template.substitute(
+        type=type_str,
+        size=str(size),
+        swizzle=get_swizzle(size),
+        val=Data.value_default_dict[type_str])
     test_string += all_type_test_template.substitute(
         type=type_str,
         size=str(size),


### PR DESCRIPTION
Added missed test cases for:

- unary operators -,+
- operator%
- operator DataT()
- noexcept check for size() and byte_size()
- check for swizzled vec for operator[]
- constructor vec(const ArgTN&... args)
- element_type