### PR TITLE
Fix read_write_zero_dim_acc

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -485,7 +485,7 @@ void read_write_zero_dim_acc(AccT testing_acc, ResultAccT res_acc) {
     res_acc[0] = value_operations::are_equal(acc_ref, other_data);
   }
   if constexpr (AccessMode != sycl::access_mode::read) {
-    DataT acc_ref(testing_acc);
+    DataT& acc_ref = testing_acc;
     value_operations::assign(acc_ref, changed_val);
   }
 }


### PR DESCRIPTION
Based on `read_write_acc`, it looks like `read_write_zero_dim_acc` should be assigning `changed_val` to element that is accessed by the given accessor `testing_acc`, and not assigning `changed_val` to a local variable. (Or, just using `testing_acc` as the LHS of the assignment.)