### PR TITLE
Fix atomic ref tests

### DIFF
--- a/tests/atomic_ref/atomic_ref_T_op_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_T_op_test_atomic64.cpp
@@ -47,10 +47,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_T_op_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref::operator T() test. double type", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_T_op_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_T_op_test_atomic64.cpp
@@ -47,6 +47,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_T_op_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_T_op_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_atomic64.cpp
@@ -49,10 +49,16 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_add_sub_op_all_types_test>(
       type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref operator+=()/operator-=() test. double type",
+ "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_atomic64.cpp
@@ -49,6 +49,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_add_sub_op_all_types_test>(
       type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_add_sub_op_all_types_test>(
+      type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_assign_op_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_atomic64.cpp
@@ -47,10 +47,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_assign_op_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref::operator=() test. double type", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_assign_op_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_atomic64.cpp
@@ -36,8 +36,8 @@ namespace atomic_ref::tests::api::core::atomic64 {
 // with an unnamed type are implemented in computecpp, re-enable for hipsycl
 // when sycl::info::device::atomic_memory_order_capabilities and
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
-// hipsycl, re-enable for dpcpp when atomic_ref<T*>::operator=() is implemented
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp, hipSYCL)
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("sycl::atomic_ref::operator=() test. atomic64 types", "[atomic_ref]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::atomic64)) {
@@ -47,6 +47,14 @@ DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_assign_op_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_assign_op_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_assign_op_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_core.cpp
@@ -36,8 +36,8 @@ namespace atomic_ref::tests::api::core {
 // with an unnamed type are implemented in computecpp, re-enable for hipsycl
 // when sycl::info::device::atomic_memory_order_capabilities and
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
-// hipsycl, re-enable for dpcpp when atomic_ref<T*>::operator=() is implemented
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp, hipSYCL)
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("sycl::atomic_rer::operator=() test. core types", "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_assign_op_test>(type_pack);

--- a/tests/atomic_ref/atomic_ref_assign_op_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_pointers.cpp
@@ -36,8 +36,8 @@ namespace atomic_ref::tests::api::core {
 // with an unnamed type are implemented in computecpp, re-enable for hipsycl
 // when sycl::info::device::atomic_memory_order_capabilities and
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
-// hipsycl, re-enable for dpcpp when atomic_ref<T*>::operator=() is implemented
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp, hipSYCL)
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
 ("sycl::atomic_rer::operator=() test. pointers types", "[atomic_ref]")({
   const auto type_pack =
       atomic_ref::tests::common::get_conformance_pointers_type_pack();

--- a/tests/atomic_ref/atomic_ref_bitwise_op_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_bitwise_op_test_atomic64.cpp
@@ -49,10 +49,16 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_bitwise_op_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref operator^=()/operator|=()/operator&=() test. double type",
+ "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_bitwise_op_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_bitwise_op_test_atomic64.cpp
@@ -49,6 +49,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_bitwise_op_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_bitwise_op_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_common.h
+++ b/tests/atomic_ref/atomic_ref_common.h
@@ -27,6 +27,7 @@
 #include "../common/common.h"
 #include "../common/section_name_builder.h"
 #include "../common/type_coverage.h"
+#include "../common/type_list.h"
 
 namespace atomic_ref::tests::common {
 using namespace sycl_cts;
@@ -98,10 +99,10 @@ inline std::string get_section_name(const std::string& type_name,
 inline auto get_atomic64_types() {
   static const auto types =
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-      named_type_pack<long long, unsigned long long, double>::generate(
-          "long long", "unsigned long long", "double");
+      named_type_pack<long long, unsigned long long>::generate(
+          "long long", "unsigned long long");
 #else
-      named_type_pack<long long, double>::generate("long long", "double");
+      named_type_pack<long long>::generate("long long");
 #endif
   return types;
 }

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test.h
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test.h
@@ -325,7 +325,7 @@ void atomic_ref_compare_exchange_test<ExchangeType, T, MemoryOrderT,
   }
   {
     INFO(test_description +
-         "\nError, \"expected\" argument value is not upadted after "
+         "\nError, \"expected\" argument value is not updated after "
          "compare_exchange call with uneq values");
     CHECK(result[1]);
   }
@@ -337,7 +337,7 @@ void atomic_ref_compare_exchange_test<ExchangeType, T, MemoryOrderT,
   }
   {
     INFO(test_description +
-         "\nError, \"expected\" argument value is not upadted after "
+         "\nError, \"expected\" argument value is not updated after "
          "compare_exchange_overloaded call with uneq values");
     CHECK(result[3]);
   }

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test_atomic64.cpp
@@ -50,6 +50,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_compare_exchange_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_compare_exchange_test>(
+      type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test_atomic64.cpp
@@ -50,10 +50,17 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_compare_exchange_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref compare_exchange_strong()/compare_exchange_weak() test. "
+ "double type",
+ "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_constructors.h
+++ b/tests/atomic_ref/atomic_ref_constructors.h
@@ -63,7 +63,7 @@ class run_constructor_tests {
       if constexpr (AddressSpace != sycl::access::address_space::global_space) {
         std::array res{false, false, false};
         {
-          sycl::buffer result_buf(res.data(), sycl::range(2));
+          sycl::buffer result_buf(res.data(), sycl::range(res.size()));
 
           queue
               .submit([&](sycl::handler &cgh) {
@@ -106,7 +106,7 @@ class run_constructor_tests {
         std::array res{false, false, false};
         {
           sycl::buffer data_buf(&value, sycl::range(1));
-          sycl::buffer result_buf(res.data(), sycl::range(2));
+          sycl::buffer result_buf(res.data(), sycl::range(res.size()));
 
           queue
               .submit([&](sycl::handler &cgh) {

--- a/tests/atomic_ref/atomic_ref_constructors_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_atomic64.cpp
@@ -47,10 +47,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::constructors::run_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref constructors. double type", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_constructors_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_atomic64.cpp
@@ -47,6 +47,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::constructors::run_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::constructors::run_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::constructors::core::atomic64

--- a/tests/atomic_ref/atomic_ref_exchange_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_exchange_test_atomic64.cpp
@@ -47,10 +47,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_exchange_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref::exchange() test. double type", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_exchange_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_exchange_test_atomic64.cpp
@@ -47,6 +47,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_exchange_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_exchange_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_atomic64.cpp
@@ -49,6 +49,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_fetch_add_sub_all_types_test>(
       type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_fetch_add_sub_all_types_test>(
+      type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_atomic64.cpp
@@ -49,10 +49,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_fetch_add_sub_all_types_test>(
       type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref fetch_add()/fetch_sub() test. double type", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_fetch_bitwise_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_bitwise_test_atomic64.cpp
@@ -49,10 +49,16 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_fetch_bitwise_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref fetch_xor()/fetch_or()/fetch_and() test. double type",
+ "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_fetch_bitwise_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_bitwise_test_atomic64.cpp
@@ -49,6 +49,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_fetch_bitwise_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_fetch_bitwise_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_fetch_min_max_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_min_max_test_atomic64.cpp
@@ -48,10 +48,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_fetch_min_max_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref fetch_min()/fetch_max() test. double type", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_fetch_min_max_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_min_max_test_atomic64.cpp
@@ -48,6 +48,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_fetch_min_max_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_fetch_min_max_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test_atomic64.cpp
@@ -50,6 +50,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_incr_decr_op_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_incr_decr_op_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test_atomic64.cpp
@@ -50,10 +50,16 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_incr_decr_op_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref increment/decrement operators test. double type",
+ "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_is_lock_free_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_is_lock_free_test_atomic64.cpp
@@ -47,10 +47,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_is_lock_free_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref::is_lock_free() test. double type", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();

--- a/tests/atomic_ref/atomic_ref_is_lock_free_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_is_lock_free_test_atomic64.cpp
@@ -47,6 +47,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_is_lock_free_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_is_lock_free_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_static_members_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_static_members_atomic64.cpp
@@ -34,14 +34,11 @@ namespace atomic_ref::tests::static_members::core::atomic64 {
 // implemented in computecpp
 DISABLED_FOR_TEST_CASE(ComputeCpp)
 ("sycl::atomic_ref static members. atomic64 types", "[atomic_ref]")({
-  auto queue = sycl_cts::util::get_cts_object::queue();
-  if (!queue.get_device().has(sycl::aspect::atomic64)) {
-    SKIP(
-        "Device does not support atomic64 operations. "
-        "Skipping the test case.");
-  }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::static_members::run_test>(type_pack);
+
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::static_members::run_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::static_members::core::atomic64

--- a/tests/atomic_ref/atomic_ref_store_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_store_test_atomic64.cpp
@@ -47,6 +47,14 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_store_test>(type_pack);
+
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case for double type.");
+  }
+  const auto type_pack_fp64 = get_cts_types::get_fp64_type();
+  for_all_types<atomic_ref::tests::api::run_store_test>(type_pack_fp64);
 });
 
 }  // namespace atomic_ref::tests::api::core::atomic64

--- a/tests/atomic_ref/atomic_ref_store_test_atomic64.cpp
+++ b/tests/atomic_ref/atomic_ref_store_test_atomic64.cpp
@@ -47,10 +47,15 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   }
   const auto type_pack = atomic_ref::tests::common::get_atomic64_types();
   for_all_types<atomic_ref::tests::api::run_store_test>(type_pack);
+});
 
-  if (!queue.get_device().has(sycl::aspect::fp64)) {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref::store() test. double type", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64) or
+      !queue.get_device().has(sycl::aspect::atomic64)) {
     SKIP(
-        "Device does not support fp64 operations. "
+        "Device does not support fp64 or atomic64 operations. "
         "Skipping the test case for double type.");
   }
   const auto type_pack_fp64 = get_cts_types::get_fp64_type();


### PR DESCRIPTION
Added additional checking for fp64 support before running tests for type `double` and enabled tests for `operator=()` for dpcpp. Fixed a mistake in `atomic_ref` constructors tests, fixed a typo in `compare_exchange()` test.