### PR TITLE
Fix optional_kernel_features tests

### DIFF
--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -165,7 +165,7 @@ class non_decorated_call_non_decorated_function {
 };
 
 /**
- * @brief Not decorated functor that invokes not decorated function that use
+ * @brief Non-decorated functor that invokes non-decorated function that uses
  * feature defined in FeatureTypeT
  */
 template <typename FeatureTypeT>
@@ -338,32 +338,32 @@ const auto get_lambda_with_no_arg(const sycl::accessor<bool, 1> &acc) {
   static constexpr sycl::aspect AnotherFeatureAspect =
       get_another_aspect<FeatureAspectT>();
   if constexpr (CallType == call_attribute_type::external_decorated) {
-    return [=]() {
+    return [=] {
       use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
           acc);
     };
   } else if constexpr (CallType ==
                        call_attribute_type::external_decorated_with_attr) {
-    return [acc]() [[sycl::device_has(AnotherFeatureAspect)]] {
+    return [acc] [[sycl::device_has(AnotherFeatureAspect)]] {
       use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
           acc);
     };
   } else if constexpr (CallType == call_attribute_type::non_decorated) {
-    return [=]() {
+    return [=] {
       use_feature_function_non_decorated_with_accessor<FeatureTypeT>(acc);
     };
   } else if constexpr (CallType == call_attribute_type::decorated) {
-    return [=]() {
+    return [=] {
       use_feature_function_decorated<FeatureTypeT, FeatureAspectT>(acc);
     };
   } else if constexpr (CallType == call_attribute_type::dummy_decorated) {
     return [=] { dummy_function_decorated<FeatureAspectT>(acc); };
   } else if constexpr (CallType == call_attribute_type::dummy_non_decorated) {
-    return [=]() { dummy_function_non_decorated(acc); };
+    return [=] { dummy_function_non_decorated(acc); };
   } else if constexpr (CallType == call_attribute_type::type_used) {
-    return [acc]() { USE_FEATURE(FeatureTypeT); };
+    return [acc] { USE_FEATURE(FeatureTypeT); };
   } else if constexpr (CallType == call_attribute_type::type_used_with_attr) {
-    return [=]() [[sycl::device_has(AnotherFeatureAspect)]] {
+    return [=] [[sycl::device_has(AnotherFeatureAspect)]] {
       USE_FEATURE(FeatureTypeT);
     };
   }

--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -29,6 +29,17 @@ namespace kernel_features_common {
 // FIXME: re-enable compilation with hipSYCL or computecpp when `sycl::errc` is supported
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 
+enum class call_attribute_type {
+  external_decorated,
+  external_decorated_with_attr,
+  non_decorated,
+  decorated,
+  dummy_decorated,
+  dummy_non_decorated,
+  type_used,
+  type_used_with_attr
+};
+
 #ifdef SYCL_EXTERNAL
 /**
  * @brief The external function that use T and decorated with attribute
@@ -38,7 +49,7 @@ namespace kernel_features_common {
  */
 template <typename T, sycl::aspect aspect>
 [[sycl::device_has(aspect)]] SYCL_EXTERNAL void
-use_feature_function_external_decorated();
+use_feature_function_external_decorated(const sycl::accessor<bool, 1> &acc);
 #endif
 
 /**
@@ -54,16 +65,34 @@ inline void use_feature_function_non_decorated() {
 }
 
 /**
+ * @brief The function that use T
+ *
+ * @tparam T The type of variable that will use inside the function
+ */
+template <typename T>
+inline void use_feature_function_non_decorated_with_accessor(
+    const sycl::accessor<bool, 1> &acc) {
+  unsigned long long temp = 42;
+  T feature1(temp);
+  T feature2(temp);
+  feature1 += 42;
+  acc[0] = (feature1 == feature2);
+}
+
+/**
  * @brief The function that use T and decorated with attribute
  *
  * @tparam T The type of variable that will use inside the function
  * @tparam aspect Instance of sycl::aspect that will be used in attribute
  */
 template <typename T, sycl::aspect aspect>
-[[sycl::device_has(aspect)]] void use_feature_function_decorated() {
+[[sycl::device_has(aspect)]] void use_feature_function_decorated(
+    const sycl::accessor<bool, 1> &acc) {
   unsigned long long temp = 42;
-  T feature(temp);
-  feature += 42;
+  T feature1(temp);
+  T feature2(temp);
+  feature1 += 42;
+  acc[0] = (feature1 == feature2);
 }
 
 /**
@@ -73,9 +102,12 @@ template <typename T, sycl::aspect aspect>
  * @tparam aspect Instance of sycl::aspect that will be used in attribute
  */
 template <sycl::aspect aspect>
-[[sycl::device_has(aspect)]] void dummy_function_decorated() {
-  int var = 0;
-  var += 42;
+[[sycl::device_has(aspect)]] void dummy_function_decorated(
+    const sycl::accessor<bool, 1> &acc) {
+  int var1 = 0;
+  int var2 = 0;
+  var1 += 42;
+  acc[0] = (var1 == var2);
 }
 
 /**
@@ -84,9 +116,11 @@ template <sycl::aspect aspect>
  * @tparam T The type of variable that will use inside the function
  * @tparam aspect Instance of sycl::aspect that will be used in attribute
  */
-inline void dummy_function_non_decorated() {
-  int var = 0;
-  var += 42;
+inline void dummy_function_non_decorated(const sycl::accessor<bool, 1> &acc) {
+  int var1 = 0;
+  int var2 = 0;
+  var1 += 42;
+  acc[0] = (var1 == var2);
 }
 
 /**
@@ -94,8 +128,10 @@ inline void dummy_function_non_decorated() {
  */
 #define USE_FEATURE(TYPE)       \
   unsigned long long temp = 42; \
-  TYPE feature(temp);           \
-  feature += 42;
+  TYPE feature1(temp);          \
+  TYPE feature2(temp);          \
+  feature1 += 42;               \
+  acc[0] = (feature1 == feature2);
 
 /**
  * @brief Not decorated functor that use feature defined in FeatureTypeT
@@ -103,6 +139,8 @@ inline void dummy_function_non_decorated() {
 template <typename FeatureTypeT>
 class non_decorated_call_use_feature {
  public:
+  sycl::accessor<bool, 1> acc;
+  non_decorated_call_use_feature(sycl::accessor<bool, 1> _acc) : acc(_acc) {}
   void operator()() const { USE_FEATURE(FeatureTypeT); }
   void operator()(sycl::item<1>) const { USE_FEATURE(FeatureTypeT); }
   void operator()(sycl::group<1>) const { USE_FEATURE(FeatureTypeT); }
@@ -127,20 +165,45 @@ class non_decorated_call_non_decorated_function {
 };
 
 /**
+ * @brief Not decorated functor that invokes not decorated function that use
+ * feature defined in FeatureTypeT
+ */
+template <typename FeatureTypeT>
+class non_decorated_call_non_decorated_function_with_accessor {
+ public:
+  sycl::accessor<bool, 1> acc;
+  non_decorated_call_non_decorated_function_with_accessor(
+      sycl::accessor<bool, 1> _acc)
+      : acc(_acc) {}
+  void operator()() const {
+    use_feature_function_non_decorated_with_accessor<FeatureTypeT>(acc);
+  }
+  void operator()(sycl::item<1>) const {
+    use_feature_function_non_decorated_with_accessor<FeatureTypeT>(acc);
+  }
+  void operator()(sycl::group<1>) const {
+    use_feature_function_non_decorated_with_accessor<FeatureTypeT>(acc);
+  }
+};
+
+/**
  * @brief Not decorated functor that invokes decorated with FeatureAspectT
  * function that use feature defined in FeatureTypeT
  */
 template <typename FeatureTypeT, sycl::aspect FeatureAspectT>
 class non_decorated_call_decorated_function {
  public:
+  sycl::accessor<bool, 1> acc;
+  non_decorated_call_decorated_function(sycl::accessor<bool, 1> _acc)
+      : acc(_acc) {}
   void operator()() const {
-    use_feature_function_decorated<FeatureTypeT, FeatureAspectT>();
+    use_feature_function_decorated<FeatureTypeT, FeatureAspectT>(acc);
   }
   void operator()(sycl::item<1>) const {
-    use_feature_function_decorated<FeatureTypeT, FeatureAspectT>();
+    use_feature_function_decorated<FeatureTypeT, FeatureAspectT>(acc);
   }
   void operator()(sycl::group<1>) const {
-    use_feature_function_decorated<FeatureTypeT, FeatureAspectT>();
+    use_feature_function_decorated<FeatureTypeT, FeatureAspectT>(acc);
   }
 };
 
@@ -152,14 +215,17 @@ class non_decorated_call_decorated_function {
 template <typename FeatureTypeT, sycl::aspect FeatureAspectT>
 class non_decorated_call_decorated_external_function {
  public:
+  sycl::accessor<bool, 1> acc;
+  non_decorated_call_decorated_external_function(sycl::accessor<bool, 1> _acc)
+      : acc(_acc) {}
   void operator()() const {
-    use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>();
+    use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(acc);
   }
   void operator()(sycl::item<1>) const {
-    use_feature_function_decorated<FeatureTypeT, FeatureAspectT>();
+    use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(acc);
   }
   void operator()(sycl::group<1>) const {
-    use_feature_function_decorated<FeatureTypeT, FeatureAspectT>();
+    use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(acc);
   }
 };
 #endif
@@ -171,12 +237,15 @@ class non_decorated_call_decorated_external_function {
 template <sycl::aspect FeatureAspectT>
 class non_decorated_call_decorated_dummy {
  public:
-  void operator()() const { dummy_function_decorated<FeatureAspectT>(); }
+  sycl::accessor<bool, 1> acc;
+  non_decorated_call_decorated_dummy(sycl::accessor<bool, 1> _acc)
+      : acc(_acc) {}
+  void operator()() const { dummy_function_decorated<FeatureAspectT>(acc); }
   void operator()(sycl::item<1>) const {
-    dummy_function_decorated<FeatureAspectT>();
+    dummy_function_decorated<FeatureAspectT>(acc);
   }
   void operator()(sycl::group<1>) const {
-    dummy_function_decorated<FeatureAspectT>();
+    dummy_function_decorated<FeatureAspectT>(acc);
   }
 };
 
@@ -187,6 +256,8 @@ class non_decorated_call_decorated_dummy {
 template <typename FeatureTypeT, sycl::aspect FeatureAspectT>
 class decorated_call_use_feature {
  public:
+  sycl::accessor<bool, 1> acc;
+  decorated_call_use_feature(sycl::accessor<bool, 1> _acc) : acc(_acc) {}
   [[sycl::device_has(FeatureAspectT)]] void operator()() const {
     USE_FEATURE(FeatureTypeT);
   }
@@ -207,14 +278,17 @@ template <typename FeatureTypeT, sycl::aspect KernelAspectT,
           sycl::aspect FunctionAspectT = KernelAspectT>
 class decorated_call_decorated_external_function {
  public:
+  sycl::accessor<bool, 1> acc;
+  decorated_call_decorated_external_function(sycl::accessor<bool, 1> _acc)
+      : acc(_acc) {}
   [[sycl::device_has(KernelAspectT)]] void operator()() const {
-    use_feature_function_external_decorated<FeatureTypeT, FunctionAspectT>();
+    use_feature_function_external_decorated<FeatureTypeT, FunctionAspectT>(acc);
   }
   [[sycl::device_has(KernelAspectT)]] void operator()(sycl::item<1>) const {
-    use_feature_function_external_decorated<FeatureTypeT, FunctionAspectT>();
+    use_feature_function_external_decorated<FeatureTypeT, FunctionAspectT>(acc);
   }
   [[sycl::device_has(KernelAspectT)]] void operator()(sycl::group<1>) const {
-    use_feature_function_external_decorated<FeatureTypeT, FunctionAspectT>();
+    use_feature_function_external_decorated<FeatureTypeT, FunctionAspectT>(acc);
   }
 };
 #endif
@@ -226,14 +300,17 @@ class decorated_call_decorated_external_function {
 template <sycl::aspect FeatureAspectT>
 class decorated_call_non_decorated_dummy {
  public:
+  sycl::accessor<bool, 1> acc;
+  decorated_call_non_decorated_dummy(sycl::accessor<bool, 1> _acc)
+      : acc(_acc) {}
   [[sycl::device_has(FeatureAspectT)]] void operator()() const {
-    dummy_function_non_decorated();
+    dummy_function_non_decorated(acc);
   }
   [[sycl::device_has(FeatureAspectT)]] void operator()(sycl::item<1>) const {
-    dummy_function_non_decorated();
+    dummy_function_non_decorated(acc);
   }
   [[sycl::device_has(FeatureAspectT)]] void operator()(sycl::group<1>) const {
-    dummy_function_non_decorated();
+    dummy_function_non_decorated(acc);
   }
 };
 
@@ -252,6 +329,118 @@ constexpr sycl::aspect get_another_aspect() {
     return sycl::aspect::atomic64;
   } else {
     return sycl::aspect::fp16;
+  }
+}
+
+template <typename FeatureTypeT, sycl::aspect FeatureAspectT,
+          call_attribute_type CallType>
+const auto get_lambda_with_no_arg(const sycl::accessor<bool, 1> &acc) {
+  static constexpr sycl::aspect AnotherFeatureAspect =
+      get_another_aspect<FeatureAspectT>();
+  if constexpr (CallType == call_attribute_type::external_decorated) {
+    return [=]() {
+      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
+          acc);
+    };
+  } else if constexpr (CallType ==
+                       call_attribute_type::external_decorated_with_attr) {
+    return [acc]() [[sycl::device_has(AnotherFeatureAspect)]] {
+      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
+          acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::non_decorated) {
+    return [=]() {
+      use_feature_function_non_decorated_with_accessor<FeatureTypeT>(acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::decorated) {
+    return [=]() {
+      use_feature_function_decorated<FeatureTypeT, FeatureAspectT>(acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::dummy_decorated) {
+    return [=] { dummy_function_decorated<FeatureAspectT>(acc); };
+  } else if constexpr (CallType == call_attribute_type::dummy_non_decorated) {
+    return [=]() { dummy_function_non_decorated(acc); };
+  } else if constexpr (CallType == call_attribute_type::type_used) {
+    return [acc]() { USE_FEATURE(FeatureTypeT); };
+  } else if constexpr (CallType == call_attribute_type::type_used_with_attr) {
+    return [=]() [[sycl::device_has(AnotherFeatureAspect)]] {
+      USE_FEATURE(FeatureTypeT);
+    };
+  }
+}
+
+template <typename FeatureTypeT, sycl::aspect FeatureAspectT,
+          call_attribute_type CallType>
+const auto get_lambda_with_item_arg(const sycl::accessor<bool, 1> &acc) {
+  static constexpr sycl::aspect AnotherFeatureAspect =
+      get_another_aspect<FeatureAspectT>();
+  if constexpr (CallType == call_attribute_type::external_decorated) {
+    return [=](sycl::item<1>) {
+      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
+          acc);
+    };
+  } else if constexpr (CallType ==
+                       call_attribute_type::external_decorated_with_attr) {
+    return [acc](sycl::item<1>) [[sycl::device_has(AnotherFeatureAspect)]] {
+      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
+          acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::non_decorated) {
+    return [=](sycl::item<1>) {
+      use_feature_function_non_decorated_with_accessor<FeatureTypeT>(acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::decorated) {
+    return [=](sycl::item<1>) {
+      use_feature_function_decorated<FeatureTypeT, FeatureAspectT>(acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::dummy_decorated) {
+    return
+        [=](sycl::item<1>) { dummy_function_decorated<FeatureAspectT>(acc); };
+  } else if constexpr (CallType == call_attribute_type::dummy_non_decorated) {
+    return [=](sycl::item<1>) { dummy_function_non_decorated(acc); };
+  } else if constexpr (CallType == call_attribute_type::type_used) {
+    return [=](sycl::item<1>) { USE_FEATURE(FeatureTypeT); };
+  } else if constexpr (CallType == call_attribute_type::type_used_with_attr) {
+    return [acc](sycl::item<1>) [[sycl::device_has(AnotherFeatureAspect)]] {
+      USE_FEATURE(FeatureTypeT);
+    };
+  }
+}
+template <typename FeatureTypeT, sycl::aspect FeatureAspectT,
+          call_attribute_type CallType>
+const auto get_lambda_with_group_arg(const sycl::accessor<bool, 1> &acc) {
+  static constexpr sycl::aspect AnotherFeatureAspect =
+      get_another_aspect<FeatureAspectT>();
+  if constexpr (CallType == call_attribute_type::external_decorated) {
+    return [=](sycl::group<1>) {
+      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
+          acc);
+    };
+  } else if constexpr (CallType ==
+                       call_attribute_type::external_decorated_with_attr) {
+    return [acc](sycl::group<1>) [[sycl::device_has(AnotherFeatureAspect)]] {
+      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
+          acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::non_decorated) {
+    return [=](sycl::group<1>) {
+      use_feature_function_non_decorated_with_accessor<FeatureTypeT>(acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::decorated) {
+    return [=](sycl::group<1>) {
+      use_feature_function_decorated<FeatureTypeT, FeatureAspectT>(acc);
+    };
+  } else if constexpr (CallType == call_attribute_type::dummy_decorated) {
+    return
+        [=](sycl::group<1>) { dummy_function_decorated<FeatureAspectT>(acc); };
+  } else if constexpr (CallType == call_attribute_type::dummy_non_decorated) {
+    return [=](sycl::group<1>) { dummy_function_non_decorated(acc); };
+  } else if constexpr (CallType == call_attribute_type::type_used) {
+    return [=](sycl::group<1>) { USE_FEATURE(FeatureTypeT); };
+  } else if constexpr (CallType == call_attribute_type::type_used_with_attr) {
+    return [acc](sycl::group<1>) [[sycl::device_has(AnotherFeatureAspect)]] {
+      USE_FEATURE(FeatureTypeT);
+    };
   }
 }
 
@@ -297,6 +486,7 @@ inline void check_async_exception(sycl::queue &queue,
  * @param parallel_for_action Task for parallel_for invocation
  * @param parallel_for_wg_action Task for parallel_for_work_group invocation
  */
+
 template <typename SingleTaskActionT, typename ParallelForActionT,
           typename ParallelForWgActionT>
 void execute_tasks_and_check_exception(
@@ -337,6 +527,44 @@ void execute_tasks_and_check_exception(
       CHECK_NOTHROW(single_task_action);
       check_async_exception(queue, false);
     }
+    {
+      INFO(parallel_for_desc);
+      CHECK_NOTHROW(parallel_for_action);
+      check_async_exception(queue, false);
+    }
+    {
+      INFO(parallel_for_wg_desc);
+      CHECK_NOTHROW(parallel_for_wg_action);
+      check_async_exception(queue, false);
+    }
+  }
+}
+
+template <typename ParallelForActionT, typename ParallelForWgActionT>
+void execute_tasks_and_check_exception(
+    const bool is_exception_expected, const sycl::errc errc_expected,
+    sycl::queue &queue, const std::string &description,
+    ParallelForActionT parallel_for_action,
+    ParallelForWgActionT parallel_for_wg_action) {
+  const std::string parallel_for_desc =
+      "Execution of " + description + " in parallel_for";
+  const std::string parallel_for_wg_desc =
+      "Execution of " + description + " in parallel_for_work_group";
+
+  if (is_exception_expected) {
+    {
+      INFO(parallel_for_desc);
+      CHECK_THROWS_MATCHES(parallel_for_action(), sycl::exception,
+                           sycl_cts::util::equals_exception(errc_expected));
+      check_async_exception(queue, false);
+    }
+    {
+      INFO(errc_expected);
+      CHECK_THROWS_MATCHES(parallel_for_wg_action(), sycl::exception,
+                           sycl_cts::util::equals_exception(errc_expected));
+      check_async_exception(queue, false);
+    }
+  } else {
     {
       INFO(parallel_for_desc);
       CHECK_NOTHROW(parallel_for_action);
@@ -411,6 +639,110 @@ void run_separate_lambda(const bool is_exception_expected,
         .wait();
   };
 
+  execute_tasks_and_check_exception(
+      is_exception_expected, errc_expected, queue, "separate lambda",
+      single_task_action, parallel_for_action, parallel_for_wg_action);
+}
+
+template <typename KernelName, typename LambdaItemArg, typename LambdaGroupArg>
+void run_separate_lambda_nd_range(const bool is_exception_expected,
+                                  const sycl::errc errc_expected,
+                                  sycl::queue &queue,
+                                  LambdaItemArg separate_lambda_nd_item_arg,
+                                  LambdaGroupArg separate_lambda_group_arg) {
+  auto parallel_for_action = [&queue, separate_lambda_nd_item_arg] {
+    queue
+        .submit([&](sycl::handler &cgh) {
+          cgh.parallel_for<
+              kernel_separate_lambda<KernelName, call_type::item_arg>>(
+              sycl::nd_range{sycl::range{1}, sycl::range{1}},
+              separate_lambda_nd_item_arg);
+        })
+        .wait();
+  };
+
+  auto parallel_for_wg_action = [&queue, separate_lambda_group_arg] {
+    queue
+        .submit([&](sycl::handler &cgh) {
+          cgh.parallel_for_work_group<
+              kernel_separate_lambda<KernelName, call_type::group_arg>>(
+              sycl::range{1}, sycl::range{1}, separate_lambda_group_arg);
+        })
+        .wait();
+  };
+
+  execute_tasks_and_check_exception(is_exception_expected, errc_expected, queue,
+                                    "separate lambda", parallel_for_action,
+                                    parallel_for_wg_action);
+}
+
+/**
+ * @brief The function helps to run separate lambdas in the kernel by
+ * executing them in single_task, parallel_for and parallel_for_work_group.
+ * The function also expects exception depending on is_exception_expected
+ * flag.
+ *
+ * @tparam KernelName The name of the kernel. All \p run_separate_lambda calls
+ *         should have a unique name.
+ * @tparam FeatureTypeT feature type
+ * @tparam FeatureAspectT aspect type
+ * @tparam CallType type of call_attribute_type used to get right lambda
+ * invocation
+ * @param is_exception_expected The flag shows if exception expected from
+ * the kernel
+ * @param errc_expected The error code that expected from sycl::exception
+ * @param queue The sycl::queue instance for device
+ * invocation
+ */
+template <typename KernelName, typename FeatureTypeT,
+          sycl::aspect Aspect = sycl::aspect::cpu,
+          call_attribute_type CallType = call_attribute_type::type_used>
+void run_separate_lambda_with_accessor(const bool is_exception_expected,
+                                       const sycl::errc errc_expected,
+                                       sycl::queue &queue) {
+  auto single_task_action = [&queue] {
+    bool value = false;
+    sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));
+    queue
+        .submit([&](sycl::handler &cgh) {
+          auto acc = buffer.get_access(cgh);
+          const auto lambda_no_arg =
+              get_lambda_with_no_arg<FeatureTypeT, Aspect, CallType>(acc);
+          cgh.single_task<
+              kernel_separate_lambda<KernelName, call_type::no_arg>>(
+              lambda_no_arg);
+        })
+        .wait();
+  };
+  auto parallel_for_action = [&queue] {
+    bool value = false;
+    sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));
+    queue
+        .submit([&](sycl::handler &cgh) {
+          auto acc = buffer.get_access(cgh);
+          const auto lambda_item_arg =
+              get_lambda_with_item_arg<FeatureTypeT, Aspect, CallType>(acc);
+          cgh.parallel_for<
+              kernel_separate_lambda<KernelName, call_type::item_arg>>(
+              sycl::range{1}, lambda_item_arg);
+        })
+        .wait();
+  };
+  auto parallel_for_wg_action = [&queue] {
+    bool value = false;
+    sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));
+    queue
+        .submit([&](sycl::handler &cgh) {
+          auto acc = buffer.get_access(cgh);
+          const auto lambda_group_arg =
+              get_lambda_with_group_arg<FeatureTypeT, Aspect, CallType>(acc);
+          cgh.parallel_for_work_group<
+              kernel_separate_lambda<KernelName, call_type::group_arg>>(
+              sycl::range{1}, sycl::range{1}, lambda_group_arg);
+        })
+        .wait();
+  };
+
   execute_tasks_and_check_exception(is_exception_expected, errc_expected, queue,
                                     "separate lambda", single_task_action,
                                     parallel_for_action, parallel_for_action);
@@ -462,6 +794,85 @@ void run_functor(const bool is_exception_expected,
         .wait();
   };
 
+  execute_tasks_and_check_exception(
+      is_exception_expected, errc_expected, queue, "functor",
+      single_task_action, parallel_for_action, parallel_for_wg_action);
+}
+
+template <typename Functor>
+void run_functor_nd_range(const bool is_exception_expected,
+                          const sycl::errc errc_expected, sycl::queue &queue) {
+  auto parallel_for_action = [&queue] {
+    queue
+        .submit([&](sycl::handler &cgh) {
+          cgh.parallel_for<kernel_parallel_for<Functor>>(
+              sycl::nd_range{sycl::range{1}, sycl::range{1}}, Functor{});
+        })
+        .wait();
+  };
+  auto parallel_for_wg_action = [&queue] {
+    queue
+        .submit([&](sycl::handler &cgh) {
+          cgh.parallel_for_work_group<kernel_parallel_for_wg<Functor>>(
+              sycl::range{1}, sycl::range{1}, Functor{});
+        })
+        .wait();
+  };
+
+  execute_tasks_and_check_exception(is_exception_expected, errc_expected, queue,
+                                    "functor", parallel_for_action,
+                                    parallel_for_wg_action);
+}
+
+/**
+ * @brief The function helps to run functors in the kernel by executing
+ * them in single_task, parallel_for and parallel_for_work_group. The function
+ * also expects exception depending on is_exception_expected flag.
+ *
+ * @tparam Functor The type of functor for single_task,parallel_for, and
+ * parallel_for_work_group invocations
+ * @param is_exception_expected The flag shows if exception expected from the
+ * @param errc_expected The error code that expected from sycl::exception
+ * @param queue The sycl::queue instance for device
+ * kernel
+ */
+template <typename Functor>
+void run_functor_with_accessor(const bool is_exception_expected,
+                               const sycl::errc errc_expected,
+                               sycl::queue &queue) {
+  auto single_task_action = [&queue] {
+    bool value = false;
+    sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));
+    queue
+        .submit([&](sycl::handler &cgh) {
+          auto acc = buffer.get_access(cgh);
+          cgh.single_task<kernel_single_task<Functor>>(Functor{acc});
+        })
+        .wait();
+  };
+  auto parallel_for_action = [&queue] {
+    bool value = false;
+    sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));
+    queue
+        .submit([&](sycl::handler &cgh) {
+          auto acc = buffer.get_access(cgh);
+          cgh.parallel_for<kernel_parallel_for<Functor>>(sycl::range{1},
+                                                         Functor{acc});
+        })
+        .wait();
+  };
+  auto parallel_for_wg_action = [&queue] {
+    bool value = false;
+    sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));
+    queue
+        .submit([&](sycl::handler &cgh) {
+          auto acc = buffer.get_access(cgh);
+          cgh.parallel_for_work_group<kernel_parallel_for_wg<Functor>>(
+              sycl::range{1}, sycl::range{1}, Functor{acc});
+        })
+        .wait();
+  };
+
   execute_tasks_and_check_exception(is_exception_expected, errc_expected, queue,
                                     "functor", single_task_action,
                                     parallel_for_action, parallel_for_action);
@@ -494,8 +905,11 @@ class kernel_submission_call;
                                                                             \
   {                                                                         \
     auto single_task_action = [&QUEUE] {                                    \
+      bool value = false;                                                   \
+      sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));              \
       QUEUE                                                                 \
           .submit([&](sycl::handler &cgh) {                                 \
+            auto acc = buffer.get_access(cgh);                              \
             cgh.single_task<                                                \
                 kernel_submission_call<KERNEL_NAME, call_type::no_arg>>(    \
                 [=]() ATTRIBUTE { __VA_ARGS__; });                          \
@@ -503,8 +917,11 @@ class kernel_submission_call;
           .wait();                                                          \
     };                                                                      \
     auto parallel_for_action = [&QUEUE] {                                   \
+      bool value = false;                                                   \
+      sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));              \
       QUEUE                                                                 \
           .submit([&](sycl::handler &cgh) {                                 \
+            auto acc = buffer.get_access(cgh);                              \
             cgh.parallel_for<                                               \
                 kernel_submission_call<KERNEL_NAME, call_type::item_arg>>(  \
                 sycl::range{1},                                             \
@@ -513,8 +930,11 @@ class kernel_submission_call;
           .wait();                                                          \
     };                                                                      \
     auto parallel_for_wg_action = [&QUEUE] {                                \
+      bool value = false;                                                   \
+      sycl::buffer<bool, 1> buffer(&value, sycl::range<1>(1));              \
       QUEUE                                                                 \
           .submit([&](sycl::handler &cgh) {                                 \
+            auto acc = buffer.get_access(cgh);                              \
             cgh.parallel_for_work_group<                                    \
                 kernel_submission_call<KERNEL_NAME, call_type::group_arg>>( \
                 sycl::range{1}, sycl::range{1},                             \
@@ -525,7 +945,37 @@ class kernel_submission_call;
                                                                             \
     execute_tasks_and_check_exception(                                      \
         IS_EXCEPTION_EXPECTED, ERRC, QUEUE, "submission call",              \
-        single_task_action, parallel_for_action, parallel_for_action);      \
+        single_task_action, parallel_for_action, parallel_for_wg_action);   \
+  }
+
+#define RUN_SUBMISSION_CALL_ND_RANGE(IS_EXCEPTION_EXPECTED, ERRC, QUEUE,      \
+                                     ATTRIBUTE, KERNEL_NAME, ...)             \
+                                                                              \
+  {                                                                           \
+    auto parallel_for_action = [&QUEUE] {                                     \
+      QUEUE                                                                   \
+          .submit([&](sycl::handler &cgh) {                                   \
+            cgh.parallel_for<                                                 \
+                kernel_submission_call<KERNEL_NAME, call_type::item_arg>>(    \
+                sycl::nd_range{sycl::range{1}, sycl::range{1}},               \
+                [=](sycl::nd_item<1>) ATTRIBUTE { __VA_ARGS__; });            \
+          })                                                                  \
+          .wait();                                                            \
+    };                                                                        \
+    auto parallel_for_wg_action = [&QUEUE] {                                  \
+      QUEUE                                                                   \
+          .submit([&](sycl::handler &cgh) {                                   \
+            cgh.parallel_for_work_group<                                      \
+                kernel_submission_call<KERNEL_NAME, call_type::group_arg>>(   \
+                sycl::range{1}, sycl::range{1},                               \
+                [=](sycl::group<1>) ATTRIBUTE { __VA_ARGS__; });              \
+          })                                                                  \
+          .wait();                                                            \
+    };                                                                        \
+                                                                              \
+    execute_tasks_and_check_exception(IS_EXCEPTION_EXPECTED, ERRC, QUEUE,     \
+                                      "submission call", parallel_for_action, \
+                                      parallel_for_wg_action);                \
   }
 
 #endif  // #if !SYCL_CTS_COMPILING_WITH_HIPSYCL &&

--- a/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
+++ b/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
@@ -57,23 +57,16 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
   {
-    const auto lambda_no_arg = []() { USE_FEATURE(FeatureTypeT); };
-    const auto lambda_item_arg = [](sycl::item<1>) {
-      USE_FEATURE(FeatureTypeT);
-    };
-    const auto lambda_group_arg = [](sycl::group<1>) {
-      USE_FEATURE(FeatureTypeT);
-    };
-
-    run_separate_lambda<kname>(is_exception_expected, expected_errc, queue,
-                               lambda_no_arg, lambda_item_arg,
-                               lambda_group_arg);
+    run_separate_lambda_with_accessor<kname, FeatureTypeT, FeatureAspectT,
+                                      call_attribute_type::type_used>(
+        is_exception_expected, expected_errc, queue);
   }
 
   {
     using FunctorT = non_decorated_call_use_feature<FeatureTypeT>;
 
-    run_functor<FunctorT>(is_exception_expected, expected_errc, queue);
+    run_functor_with_accessor<FunctorT>(is_exception_expected, expected_errc,
+                                        queue);
   }
 
   {
@@ -107,31 +100,23 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
   {
-    const auto lambda_no_arg = []() {
-      use_feature_function_non_decorated<FeatureTypeT>();
-    };
-    const auto lambda_item_arg = [](sycl::item<1>) {
-      use_feature_function_non_decorated<FeatureTypeT>();
-    };
-    const auto lambda_group_arg = [](sycl::group<1>) {
-      use_feature_function_non_decorated<FeatureTypeT>();
-    };
-
-    run_separate_lambda<kname>(is_exception_expected, expected_errc, queue,
-                               lambda_no_arg, lambda_item_arg,
-                               lambda_group_arg);
+    run_separate_lambda_with_accessor<kname, FeatureTypeT, FeatureAspectT,
+                                      call_attribute_type::non_decorated>(
+        is_exception_expected, expected_errc, queue);
   }
 
   {
-    using FunctorT = non_decorated_call_non_decorated_function<FeatureTypeT>;
+    using FunctorT =
+        non_decorated_call_non_decorated_function_with_accessor<FeatureTypeT>;
 
-    run_functor<FunctorT>(is_exception_expected, expected_errc, queue);
+    run_functor_with_accessor<FunctorT>(is_exception_expected, expected_errc,
+                                        queue);
   }
 
   {
-    RUN_SUBMISSION_CALL(is_exception_expected, expected_errc, queue,
-                        NO_ATTRIBUTE, kname,
-                        use_feature_function_non_decorated<FeatureTypeT>());
+    RUN_SUBMISSION_CALL(
+        is_exception_expected, expected_errc, queue, NO_ATTRIBUTE, kname,
+        use_feature_function_non_decorated_with_accessor<FeatureTypeT>(acc));
   }
 });
 
@@ -165,19 +150,9 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
   {
-    const auto lambda_no_arg = []() {
-      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-    const auto lambda_item_arg = [](sycl::item<1>) {
-      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-    const auto lambda_group_arg = [](sycl::group<1>) {
-      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-
-    run_separate_lambda<kname>(is_exception_expected, expected_errc, queue,
-                               lambda_no_arg, lambda_item_arg,
-                               lambda_group_arg);
+    run_separate_lambda_with_accessor<kname, FeatureTypeT, FeatureAspectT,
+                                      call_attribute_type::external_decorated>(
+        is_exception_expected, expected_errc, queue);
   }
 
   {
@@ -185,14 +160,15 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
         non_decorated_call_decorated_external_function<FeatureTypeT,
                                                        FeatureAspectT>;
 
-    run_functor<FunctorT>(is_exception_expected, expected_errc, queue);
+    run_functor_with_accessor<FunctorT>(is_exception_expected, expected_errc,
+                                        queue);
   }
 
   {
     RUN_SUBMISSION_CALL(
         is_exception_expected, expected_errc, queue, NO_ATTRIBUTE, kname,
-        use_feature_function_external_decorated<FeatureTypeT,
-                                                FeatureAspectT>());
+        use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
+            acc));
   }
 });
 #endif
@@ -222,33 +198,22 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
   {
-    const auto lambda_no_arg = []() [[sycl::device_has(FeatureAspectT)]] {
-      dummy_function_non_decorated();
-    };
-    const auto lambda_item_arg = [](sycl::item<1>)
-                                     [[sycl::device_has(FeatureAspectT)]] {
-                                       dummy_function_non_decorated();
-                                     };
-    const auto lambda_group_arg = [](sycl::group<1>)
-                                      [[sycl::device_has(FeatureAspectT)]] {
-                                        dummy_function_non_decorated();
-                                      };
-
-    run_separate_lambda<kname>(is_exception_expected, expected_errc, queue,
-                               lambda_no_arg, lambda_item_arg,
-                               lambda_group_arg);
+    run_separate_lambda_with_accessor<kname, FeatureTypeT, FeatureAspectT,
+                                      call_attribute_type::dummy_non_decorated>(
+        is_exception_expected, expected_errc, queue);
   }
 
   {
     using FunctorT = decorated_call_non_decorated_dummy<FeatureAspectT>;
 
-    run_functor<FunctorT>(is_exception_expected, expected_errc, queue);
+    run_functor_with_accessor<FunctorT>(is_exception_expected, expected_errc,
+                                        queue);
   }
 
   {
     RUN_SUBMISSION_CALL(is_exception_expected, expected_errc, queue,
                         [[sycl::device_has(FeatureAspectT)]], kname,
-                        dummy_function_non_decorated());
+                        dummy_function_non_decorated(acc));
   }
 });
 
@@ -277,31 +242,22 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
   {
-    const auto lambda_no_arg = []() {
-      dummy_function_decorated<FeatureAspectT>();
-    };
-    const auto lambda_item_arg = [](sycl::item<1>) {
-      dummy_function_decorated<FeatureAspectT>();
-    };
-    const auto lambda_group_arg = [](sycl::group<1>) {
-      dummy_function_decorated<FeatureAspectT>();
-    };
-
-    run_separate_lambda<kname>(is_exception_expected, expected_errc, queue,
-                               lambda_no_arg, lambda_item_arg,
-                               lambda_group_arg);
+    run_separate_lambda_with_accessor<kname, FeatureTypeT, FeatureAspectT,
+                                      call_attribute_type::dummy_decorated>(
+        is_exception_expected, expected_errc, queue);
   }
 
   {
     using FunctorT = non_decorated_call_decorated_dummy<FeatureAspectT>;
 
-    run_functor<FunctorT>(is_exception_expected, expected_errc, queue);
+    run_functor_with_accessor<FunctorT>(is_exception_expected, expected_errc,
+                                        queue);
   }
 
   {
     RUN_SUBMISSION_CALL(is_exception_expected, expected_errc, queue,
                         NO_ATTRIBUTE, kname,
-                        dummy_function_decorated<FeatureAspectT>());
+                        dummy_function_decorated<FeatureAspectT>(acc));
   }
 });
 
@@ -331,32 +287,23 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
   {
-    const auto lambda_no_arg = []() {
-      use_feature_function_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-    const auto lambda_item_arg = [](sycl::item<1>) {
-      use_feature_function_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-    const auto lambda_group_arg = [](sycl::group<1>) {
-      use_feature_function_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-
-    run_separate_lambda<kname>(is_exception_expected, expected_errc, queue,
-                               lambda_no_arg, lambda_item_arg,
-                               lambda_group_arg);
+    run_separate_lambda_with_accessor<kname, FeatureTypeT, FeatureAspectT,
+                                      call_attribute_type::decorated>(
+        is_exception_expected, expected_errc, queue);
   }
 
   {
     using FunctorT =
         non_decorated_call_decorated_function<FeatureTypeT, FeatureAspectT>;
 
-    run_functor<FunctorT>(is_exception_expected, expected_errc, queue);
+    run_functor_with_accessor<FunctorT>(is_exception_expected, expected_errc,
+                                        queue);
   }
 
   {
     RUN_SUBMISSION_CALL(
         is_exception_expected, expected_errc, queue, NO_ATTRIBUTE, kname,
-        use_feature_function_decorated<FeatureTypeT, FeatureAspectT>());
+        use_feature_function_decorated<FeatureTypeT, FeatureAspectT>(acc));
   }
 });
 
@@ -386,28 +333,17 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   }
 
   {
-    const auto lambda_no_arg = []() [[sycl::device_has(AnotherFeatureAspect)]] {
-      USE_FEATURE(FeatureTypeT);
-    };
-    const auto lambda_item_arg =
-        [](sycl::item<1>) [[sycl::device_has(AnotherFeatureAspect)]] {
-          USE_FEATURE(FeatureTypeT);
-        };
-    const auto lambda_group_arg =
-        [](sycl::group<1>) [[sycl::device_has(AnotherFeatureAspect)]] {
-          USE_FEATURE(FeatureTypeT);
-        };
-
-    run_separate_lambda<kname>(other_feature_exception_expect, expected_errc,
-                               queue, lambda_no_arg, lambda_item_arg,
-                               lambda_group_arg);
+    run_separate_lambda_with_accessor<kname, FeatureTypeT, FeatureAspectT,
+                                      call_attribute_type::type_used_with_attr>(
+        other_feature_exception_expect, expected_errc, queue);
   }
 
   {
     using FunctorT =
         decorated_call_use_feature<FeatureTypeT, AnotherFeatureAspect>;
 
-    run_functor<FunctorT>(other_feature_exception_expect, expected_errc, queue);
+    run_functor_with_accessor<FunctorT>(other_feature_exception_expect,
+                                        expected_errc, queue);
   }
 
   {
@@ -450,36 +386,26 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   }
 
   {
-    const auto lambda_no_arg = []() [[sycl::device_has(AnotherFeatureAspect)]] {
-      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-    const auto lambda_item_arg = [](sycl::item<1>) [[sycl::device_has(
-                                     AnotherFeatureAspect)]] {
-      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-    const auto lambda_group_arg = [](sycl::group<1>) [[sycl::device_has(
-                                      AnotherFeatureAspect)]] {
-      use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>();
-    };
-
-    run_separate_lambda<kname>(other_feature_exception_expect, expected_errc,
-                               queue, lambda_no_arg, lambda_item_arg,
-                               lambda_group_arg);
+    run_separate_lambda_with_accessor<
+        kname, FeatureTypeT, FeatureAspectT,
+        call_attribute_type::external_decorated_with_attr>(
+        other_feature_exception_expect, expected_errc, queue);
   }
 
   {
     using FunctorT = decorated_call_decorated_external_function<
         FeatureTypeT, AnotherFeatureAspect, FeatureAspectT>;
 
-    run_functor<FunctorT>(other_feature_exception_expect, expected_errc, queue);
+    run_functor_with_accessor<FunctorT>(other_feature_exception_expect,
+                                        expected_errc, queue);
   }
 
   {
     RUN_SUBMISSION_CALL(
         other_feature_exception_expect, expected_errc, queue,
         [[sycl::device_has(AnotherFeatureAspect)]], kname,
-        use_feature_function_external_decorated<FeatureTypeT,
-                                                FeatureAspectT>());
+        use_feature_function_external_decorated<FeatureTypeT, FeatureAspectT>(
+            acc));
   }
 });
 #endif

--- a/tests/optional_kernel_features/kernel_features_separate_unit.cpp
+++ b/tests/optional_kernel_features/kernel_features_separate_unit.cpp
@@ -13,22 +13,28 @@
 namespace kernel_features_common {
 template <typename T, sycl::aspect aspect>
 [[sycl::device_has(aspect)]] SYCL_EXTERNAL void
-use_feature_function_external_decorated();
+use_feature_function_external_decorated(const sycl::accessor<bool, 1>& acc);
 
 template <>
 SYCL_EXTERNAL void
-use_feature_function_external_decorated<sycl::half, sycl::aspect::fp16>() {
+use_feature_function_external_decorated<sycl::half, sycl::aspect::fp16>(
+    const sycl::accessor<bool, 1>& acc) {
   float temp = 42.25f;
-  sycl::half feature(temp);
-  feature += 42;
+  sycl::half feature1(temp);
+  sycl::half feature2(temp);
+  feature1 += 42;
+  acc[0] = (feature1 == feature2);
 }
 
 template <>
 SYCL_EXTERNAL void
-use_feature_function_external_decorated<double, sycl::aspect::fp64>() {
+use_feature_function_external_decorated<double, sycl::aspect::fp64>(
+    const sycl::accessor<bool, 1>& acc) {
   float temp = 42.25f;
-  double feature(temp);
-  feature += 42;
+  double feature1(temp);
+  double feature2(temp);
+  feature1 += 42;
+  acc[0] = (feature1 == feature2);
 }
 
 using AtomicRefT =
@@ -36,10 +42,13 @@ using AtomicRefT =
                      sycl::memory_scope::device>;
 template <>
 SYCL_EXTERNAL void
-use_feature_function_external_decorated<AtomicRefT, sycl::aspect::atomic64>() {
+use_feature_function_external_decorated<AtomicRefT, sycl::aspect::atomic64>(
+    const sycl::accessor<bool, 1>& acc) {
   unsigned long long temp = 42;
-  AtomicRefT feature(temp);
-  feature += 42;
+  AtomicRefT feature1(temp);
+  AtomicRefT feature2(temp);
+  feature1 += 42;
+  acc[0] = (feature1 == feature2);
 }
 }  // namespace kernel_features_common
 #endif

--- a/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
+++ b/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
@@ -25,16 +25,14 @@ class empty_functor {
 template <size_t N>
 class sub_group_decorated_functor {
  public:
-  [[sycl::reqd_sub_group_size(N)]] void operator()() const {}
-  [[sycl::reqd_sub_group_size(N)]] void operator()(sycl::item<1>) const {}
+  [[sycl::reqd_sub_group_size(N)]] void operator()(sycl::nd_item<1>) const {}
   [[sycl::reqd_sub_group_size(N)]] void operator()(sycl::group<1>) const {}
 };
 
 template <size_t N>
 class work_group_decorated_functor {
  public:
-  [[sycl::reqd_work_group_size(N)]] void operator()() const {}
-  [[sycl::reqd_work_group_size(N)]] void operator()(sycl::item<1>) const {}
+  [[sycl::reqd_work_group_size(N)]] void operator()(sycl::nd_item<1>) const {}
   [[sycl::reqd_work_group_size(N)]] void operator()(sycl::group<1>) const {}
 };
 
@@ -167,53 +165,53 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 
   if (max_wg_size >= testing_wg_size[0]) {
     {
-      const auto separate_lambda_no_arg =
-          []() [[sycl::reqd_work_group_size(testing_wg_size[0])]]{};
       const auto separate_lambda_item_arg = [](sycl::item<1>)
           [[sycl::reqd_work_group_size(testing_wg_size[0])]]{};
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_work_group_size(testing_wg_size[0])]]{};
 
-      run_separate_lambda<kernel_speculative<5>>(
-          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
-          separate_lambda_item_arg, separate_lambda_group_arg);
+      run_separate_lambda_nd_range<kernel_speculative<5>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_item_arg,
+          separate_lambda_group_arg);
     }
 
     {
       using FunctorT = work_group_decorated_functor<testing_wg_size[0]>;
-      run_functor<FunctorT>(is_exception_expected, errc_expected, queue);
+      run_functor_nd_range<FunctorT>(is_exception_expected, errc_expected,
+                                     queue);
     }
 
     {
-      RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_work_group_size(testing_wg_size[0])]],
-                          kernel_speculative<5>, NO_KERNEL_BODY);
+      RUN_SUBMISSION_CALL_ND_RANGE(
+          is_exception_expected, errc_expected, queue,
+          [[sycl::reqd_work_group_size(testing_wg_size[0])]],
+          kernel_speculative<5>, NO_KERNEL_BODY);
     }
   }
 
   if (max_wg_size >= testing_wg_size[1]) {
     {
-      const auto separate_lambda_no_arg =
-          []() [[sycl::reqd_work_group_size(testing_wg_size[1])]]{};
       const auto separate_lambda_item_arg = [](sycl::item<1>)
           [[sycl::reqd_work_group_size(testing_wg_size[1])]]{};
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_work_group_size(testing_wg_size[1])]]{};
 
-      run_separate_lambda<kernel_speculative<6>>(
-          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
-          separate_lambda_item_arg, separate_lambda_group_arg);
+      run_separate_lambda_nd_range<kernel_speculative<6>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_item_arg,
+          separate_lambda_group_arg);
     }
 
     {
       using FunctorT = work_group_decorated_functor<testing_wg_size[1]>;
-      run_functor<FunctorT>(is_exception_expected, errc_expected, queue);
+      run_functor_nd_range<FunctorT>(is_exception_expected, errc_expected,
+                                     queue);
     }
 
     {
-      RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_work_group_size(testing_wg_size[1])]],
-                          kernel_speculative<6>, NO_KERNEL_BODY);
+      RUN_SUBMISSION_CALL_ND_RANGE(
+          is_exception_expected, errc_expected, queue,
+          [[sycl::reqd_work_group_size(testing_wg_size[1])]],
+          kernel_speculative<6>, NO_KERNEL_BODY);
     }
   }
 
@@ -225,27 +223,27 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
       std::find(sg_sizes_vec.begin(), sg_sizes_vec.end(), testing_sg_size[0]);
   if (find_res != sg_sizes_vec.end()) {
     {
-      const auto separate_lambda_no_arg =
-          []() [[sycl::reqd_sub_group_size(testing_sg_size[0])]]{};
       const auto separate_lambda_item_arg =
           [](sycl::item<1>) [[sycl::reqd_sub_group_size(testing_sg_size[0])]]{};
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_sub_group_size(testing_sg_size[0])]]{};
 
-      run_separate_lambda<kernel_speculative<7>>(
-          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
-          separate_lambda_item_arg, separate_lambda_group_arg);
+      run_separate_lambda_nd_range<kernel_speculative<7>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_item_arg,
+          separate_lambda_group_arg);
     }
 
     {
       using FunctorT = sub_group_decorated_functor<testing_sg_size[0]>;
-      run_functor<FunctorT>(is_exception_expected, errc_expected, queue);
+      run_functor_nd_range<FunctorT>(is_exception_expected, errc_expected,
+                                     queue);
     }
 
     {
-      RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_sub_group_size(testing_sg_size[0])]],
-                          kernel_speculative<7>, NO_KERNEL_BODY);
+      RUN_SUBMISSION_CALL_ND_RANGE(
+          is_exception_expected, errc_expected, queue,
+          [[sycl::reqd_sub_group_size(testing_sg_size[0])]],
+          kernel_speculative<7>, NO_KERNEL_BODY);
     }
   }
 
@@ -253,27 +251,27 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
       std::find(sg_sizes_vec.begin(), sg_sizes_vec.end(), testing_sg_size[1]);
   if (find_res != sg_sizes_vec.end()) {
     {
-      const auto separate_lambda_no_arg =
-          []() [[sycl::reqd_sub_group_size(testing_sg_size[1])]]{};
       const auto separate_lambda_item_arg =
           [](sycl::item<1>) [[sycl::reqd_sub_group_size(testing_sg_size[1])]]{};
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_sub_group_size(testing_sg_size[1])]]{};
 
-      run_separate_lambda<kernel_speculative<8>>(
-          is_exception_expected, errc_expected, queue, separate_lambda_no_arg,
-          separate_lambda_item_arg, separate_lambda_group_arg);
+      run_separate_lambda_nd_range<kernel_speculative<8>>(
+          is_exception_expected, errc_expected, queue, separate_lambda_item_arg,
+          separate_lambda_group_arg);
     }
 
     {
       using FunctorT = sub_group_decorated_functor<testing_sg_size[1]>;
-      run_functor<FunctorT>(is_exception_expected, errc_expected, queue);
+      run_functor_nd_range<FunctorT>(is_exception_expected, errc_expected,
+                                     queue);
     }
 
     {
-      RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                          [[sycl::reqd_sub_group_size(testing_sg_size[1])]],
-                          kernel_speculative<8>, NO_KERNEL_BODY);
+      RUN_SUBMISSION_CALL_ND_RANGE(
+          is_exception_expected, errc_expected, queue,
+          [[sycl::reqd_sub_group_size(testing_sg_size[1])]],
+          kernel_speculative<8>, NO_KERNEL_BODY);
     }
   }
 });

--- a/tests/optional_kernel_features/kernel_features_sub_group_size_exceptions.cpp
+++ b/tests/optional_kernel_features/kernel_features_sub_group_size_exceptions.cpp
@@ -33,8 +33,7 @@ using namespace kernel_features_common;
 template <size_t N>
 class functor_with_attribute {
  public:
-  [[sycl::reqd_sub_group_size(N)]] void operator()() const {}
-  [[sycl::reqd_sub_group_size(N)]] void operator()(sycl::item<1>) const {}
+  [[sycl::reqd_sub_group_size(N)]] void operator()(sycl::nd_item<1>) const {}
   [[sycl::reqd_sub_group_size(N)]] void operator()(sycl::group<1>) const {}
 };
 
@@ -59,26 +58,24 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(hipSYCL, ComputeCpp)
   }
 
   {
-    const auto separate_lambda_no_arg = []()
-                                            [[sycl::reqd_sub_group_size(N)]] {};
-    const auto separate_lambda_item_arg =
-        [](sycl::item<1>) [[sycl::reqd_sub_group_size(N)]] {};
+    const auto separate_lambda_nd_item_arg =
+        [](sycl::nd_item<1>) [[sycl::reqd_sub_group_size(N)]] {};
     const auto separate_lambda_group_arg =
         [](sycl::group<1>) [[sycl::reqd_sub_group_size(N)]] {};
 
-    run_separate_lambda<kname>(is_exception_expected, errc_expected, queue,
-                               separate_lambda_no_arg, separate_lambda_item_arg,
-                               separate_lambda_group_arg);
+    run_separate_lambda_nd_range<kname>(is_exception_expected, errc_expected,
+                                        queue, separate_lambda_nd_item_arg,
+                                        separate_lambda_group_arg);
   }
 
   {
     using FunctorT = functor_with_attribute<N>;
-    run_functor<FunctorT>(is_exception_expected, errc_expected, queue);
+    run_functor_nd_range<FunctorT>(is_exception_expected, errc_expected, queue);
   }
 
   {
-    RUN_SUBMISSION_CALL(is_exception_expected, errc_expected, queue,
-                        [[sycl::reqd_sub_group_size(N)]], kname, {});
+    RUN_SUBMISSION_CALL_ND_RANGE(is_exception_expected, errc_expected, queue,
+                                 [[sycl::reqd_sub_group_size(N)]], kname, {});
   }
 });
 }  // namespace kernel_features_sub_group_size


### PR DESCRIPTION
Added kernel functions with accessor to avoid compiler optimisation. Removed single_task call and change parallel_for to use nd_range instead of range for kernels with specicfied group size attributes.