### PR TITLE
Move queue initialization into test body

### DIFF
--- a/tests/group_functions/group_broadcast.cpp
+++ b/tests/group_functions/group_broadcast.cpp
@@ -42,10 +42,9 @@ using BroadcastTypes = std::tuple<float, char, int, bool, util::custom_type>;
 using BroadcastTypes = CustomTypes;
 #endif
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-
 TEMPLATE_LIST_TEST_CASE("Group broadcast", "[group_func][type_list][dim]",
                         BroadcastTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check type to only print warning once
   if constexpr (std::is_same_v<TestType, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
@@ -80,6 +79,7 @@ TEMPLATE_LIST_TEST_CASE("Group broadcast", "[group_func][type_list][dim]",
 
 TEMPLATE_LIST_TEST_CASE("Sub-group broadcast and select",
                         "[group_func][type_list][dim]", BroadcastTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check type to only print warning once
   if constexpr (std::is_same_v<TestType, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)

--- a/tests/group_functions/group_broadcast_fp16.cpp
+++ b/tests/group_functions/group_broadcast_fp16.cpp
@@ -20,10 +20,9 @@
 
 #include "group_broadcast.h"
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-
 TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp16][dim]",
                        ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimension to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -50,6 +49,7 @@ TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp16][dim]",
 
 TEMPLATE_TEST_CASE_SIG("Sub-group broadcast and select",
                        "[group_func][fp16][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimension to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)

--- a/tests/group_functions/group_broadcast_fp64.cpp
+++ b/tests/group_functions/group_broadcast_fp64.cpp
@@ -20,10 +20,9 @@
 
 #include "group_broadcast.h"
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-
 TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp64][dim]",
                        ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimension to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -50,6 +49,7 @@ TEMPLATE_TEST_CASE_SIG("Group broadcast", "[group_func][fp64][dim]",
 
 TEMPLATE_TEST_CASE_SIG("Sub-group broadcast and select",
                        "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimension to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)

--- a/tests/group_functions/group_of.cpp
+++ b/tests/group_functions/group_of.cpp
@@ -23,10 +23,9 @@
 // use wide types to exclude truncation of init values
 using WideTypes = std::tuple<int32_t, uint32_t, int64_t, uint64_t, float>;
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-
 TEMPLATE_LIST_TEST_CASE("Group and sub_group joint of bool functions",
                         "[group_func][type_list][dim]", WideTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check type to only print warning once
   if constexpr (std::is_same_v<TestType, float>) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -53,6 +52,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub_group joint of bool functions",
 TEMPLATE_LIST_TEST_CASE(
     "Group and sub_group of bool functions with predicate functions",
     "[group_func][type_list][dim]", WideTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check type to only print warning once
   if constexpr (std::is_same_v<TestType, float>) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -82,6 +82,7 @@ TEMPLATE_LIST_TEST_CASE(
 
 TEMPLATE_TEST_CASE_SIG("Group and sub_group of bool functions",
                        "[group_func][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimension to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)

--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -20,8 +20,6 @@
 
 #include "group_reduce.h"
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-
 // FIXME: ComputeCpp does not implement reduce for unsigned long long int and
 //        long long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
@@ -43,6 +41,7 @@ using prod2 = product<std::tuple, ReduceTypes, ReduceTypes>::type;
 // hipSYCL has no implementation over sub-groups
 TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
                         "[group_func][type_list][dim]", ReduceTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check types to only print warning once
   if constexpr (std::is_same_v<TestType, char>) {
     // FIXME: hipSYCL omission
@@ -79,6 +78,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
 // hipSYCL has problems with 16-bit types for Ptr
 TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
                         "[group_func][type_list][dim]", prod2) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   using T = std::tuple_element_t<0, TestType>;
   using U = std::tuple_element_t<1, TestType>;
 
@@ -132,6 +132,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 
 TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions",
                         "[group_func][type_list][dim]", ReduceTypes) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check types to only print warning once
   if constexpr (std::is_same_v<TestType, char>) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -160,6 +161,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions",
 
 TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
                         "[group_func][type_list][dim]", prod2) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   using T = std::tuple_element_t<0, TestType>;
   using U = std::tuple_element_t<1, TestType>;
 

--- a/tests/group_functions/group_reduce_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp16.cpp
@@ -20,8 +20,6 @@
 
 #include "group_reduce.h"
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-
 // FIXME: ComputeCpp does not implement reduce for unsigned long long int and
 //        long long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
@@ -44,6 +42,7 @@ using prod2 = product<std::tuple, HalfExtendedTypes, HalfExtendedTypes>::type;
 // hipSYCL has no implementation over sub-groups
 TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
                        "[group_func][fp16][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimensions to only print warning once
   if constexpr (D == 1) {
     // FIXME: hipSYCL omission
@@ -72,6 +71,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
 
 TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
                         "[group_func][type_list][fp16][dim]", prod2) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   using T = std::tuple_element_t<0, TestType>;
   using U = std::tuple_element_t<1, TestType>;
 
@@ -127,6 +127,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 
 TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
                        "[group_func][fp16][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // FIXME: ComputeCpp has no half
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
   // check dimensions to only print warning once
@@ -144,6 +145,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
 
 TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
                         "[group_func][type_list][fp16][dim]", prod2) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   using T = std::tuple_element_t<0, TestType>;
   using U = std::tuple_element_t<1, TestType>;
 

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -40,11 +40,10 @@ using DoubleExtendedTypes = concatenation<ReduceTypes, double>::type;
 using prod2 =
     product<std::tuple, DoubleExtendedTypes, DoubleExtendedTypes>::type;
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-
 // hipSYCL has no implementation over sub-groups
 TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
                        "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimensions to only print warning once
   if constexpr (D == 1) {
     // FIXME: hipSYCL omission
@@ -78,6 +77,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
 
 TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
                         "[group_func][type_list][fp64][dim]", prod2) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   using T = std::tuple_element_t<0, TestType>;
   using U = std::tuple_element_t<1, TestType>;
 
@@ -139,6 +139,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 
 TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
                        "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimension to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
@@ -165,6 +166,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
 
 TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
                         "[group_func][type_list][fp64][dim]", prod2) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   using T = std::tuple_element_t<0, TestType>;
   using U = std::tuple_element_t<1, TestType>;
 

--- a/tests/group_functions/group_reduce_fp64_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp64_fp16.cpp
@@ -23,10 +23,9 @@
 
 #include "group_reduce.h"
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
-
 TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
                        "[group_func][fp16][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimensions to only print warning once
   if constexpr (D == 1) {
     // FIXME: hipSYCL omission
@@ -71,6 +70,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
 
 TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
                        "[group_func][fp16][fp64][dim]", ((int D), D), 1, 2, 3) {
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimensions to only print warning once
   if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -37,7 +37,6 @@ using ScanTypes = unnamed_type_pack<float, char, int>;
 using ScanTypes = Types;
 #endif
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 // FIXME: known_identity is not impemented yet for hipSYCL.
@@ -60,6 +59,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
 #endif
 
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // FIXME: ComputeCpp does not implement joint scan
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
@@ -96,6 +96,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
 #endif
 
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // FIXME: ComputeCpp does not implement joint scan
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
@@ -123,6 +124,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "Skipping the test.");
 #endif
 
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // FIXME: Codeplay ComputeCpp - CE 2.11.0
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
   //        clang-8: error: unable to execute command: Segmentation fault
@@ -156,6 +158,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "Skipping the test.");
 #endif
 
+  auto queue = sycl_cts::util::get_cts_object::queue();
   // FIXME: Codeplay ComputeCpp - CE 2.11.0
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
   //        clang-8: error: unable to execute command: Segmentation fault

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -42,7 +42,6 @@ using ScanTypes = Types;
 using HalfType = unnamed_type_pack<sycl::half>;
 using HalfExtendedTypes = concatenation<ScanTypes, sycl::half>::type;
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 // FIXME: known_identity is not impemented yet for hipSYCL.
@@ -71,6 +70,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
     // FIXME: hipSYCL and DPCPP cannot handle cases of different types
     // Link to issue https://github.com/intel/llvm/issues/8341
@@ -114,6 +114,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
     // FIXME: hipSYCL and DPCPP cannot handle cases of different types
     // Link to issue https://github.com/intel/llvm/issues/8341
@@ -139,6 +140,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   WARN("ComputeCpp cannot handle half type. Skipping the test.");
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
     for_all_combinations<invoke_scan_over_group>(Dims, HalfType{}, queue);
   } else {
@@ -171,6 +173,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
     // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
     // Link to issue https://github.com/intel/llvm/issues/8341

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -42,7 +42,6 @@ using ScanTypes = Types;
 using DoubleType = unnamed_type_pack<double>;
 using DoubleExtendedTypes = concatenation<ScanTypes, double>::type;
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 // FIXME: known_identity is not impemented yet for hipSYCL.
@@ -70,6 +69,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
     // FIXME: hipSYCL and DPCPP cannot handle cases of different types
     // Link to issue https://github.com/intel/llvm/issues/8341
@@ -112,6 +112,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
     // FIXME: hipSYCL and DPCPP cannot handle cases of different types
     // Link to issue https://github.com/intel/llvm/issues/8341
@@ -146,6 +147,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
     for_all_combinations<invoke_scan_over_group>(Dims, DoubleType{}, queue);
   } else {
@@ -183,6 +185,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
     // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
     // Link to issue https://github.com/intel/llvm/issues/8341

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -45,7 +45,6 @@ using ScanTypes = Types;
 using DoubleHalfTypes = unnamed_type_pack<double, sycl::half>;
 using DoubleHalfExtendedTypes = concatenation<ScanTypes, DoubleHalfTypes>::type;
 
-static auto queue = sycl_cts::util::get_cts_object::queue();
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 // FIXME: known_identity is not impemented yet for hipSYCL.
@@ -77,6 +76,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16) &&
       queue.get_device().has(sycl::aspect::fp64)) {
     // here DoubleHalfTypes can be used as only half+double combinations are
@@ -121,6 +121,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16) &&
       queue.get_device().has(sycl::aspect::fp64)) {
     for_all_combinations_with_two<invoke_init_joint_scan_group, double,
@@ -159,6 +160,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
+  auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16) &&
       queue.get_device().has(sycl::aspect::fp64)) {
     // here DoubleHalfTypes can be used as only half+double combinations are


### PR DESCRIPTION
Global static variable will be initialized at the startup point. "--device" doesn't work in this situation.