### PR TITLE
Add waiting on queue for memcpy2d queue shortcut exceptions tests

### DIFF
--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions.h
@@ -132,6 +132,7 @@ class run_queue_shortcut_exceptions_tests {
         CHECK_THROWS_MATCHES(
             action3(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
+        queue.wait();
       }
     }
     SECTION(sycl_cts::section_name(std::string("Check copy2d with T = ") +
@@ -192,6 +193,7 @@ class run_queue_shortcut_exceptions_tests {
       CHECK_THROWS_MATCHES(
           action3(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
+      queue.wait();
     }
     if constexpr (std::is_same_v<T, unsigned char>) {
       SECTION(sycl_cts::section_name(std::string("Check memset2d with T = ") +
@@ -235,6 +237,7 @@ class run_queue_shortcut_exceptions_tests {
         CHECK_THROWS_MATCHES(
             action3(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
+        queue.wait();
       }
     }
     SECTION(sycl_cts::section_name(std::string("Check fill2d with T = ") +
@@ -278,6 +281,7 @@ class run_queue_shortcut_exceptions_tests {
       CHECK_THROWS_MATCHES(
           action3(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
+      queue.wait();
     }
   }
 };


### PR DESCRIPTION
To make sure that all submitted commands finished before releasing SECTION resources.