### PR TITLE
Cover gaps for marray

### DIFF
--- a/tests/marray/marray_members.h
+++ b/tests/marray/marray_members.h
@@ -137,9 +137,11 @@ class run_marray_members_test {
     {
       STATIC_CHECK(std::is_same_v<typename marray_t::value_type, DataT>);
       STATIC_CHECK(std::is_same_v<typename marray_t::reference, DataT&>);
-      STATIC_CHECK(std::is_same_v<typename marray_t::const_reference, const DataT&>);
+      STATIC_CHECK(
+          std::is_same_v<typename marray_t::const_reference, const DataT&>);
       STATIC_CHECK(std::is_same_v<typename marray_t::iterator, DataT*>);
-      STATIC_CHECK(std::is_same_v<typename marray_t::const_iterator , const DataT*>);
+      STATIC_CHECK(
+          std::is_same_v<typename marray_t::const_iterator, const DataT*>);
     }
   }
 };

--- a/tests/marray/marray_members.h
+++ b/tests/marray/marray_members.h
@@ -132,6 +132,15 @@ class run_marray_members_test {
       CHECK((*it_ma == DataT(1)));
       CHECK((it_ma == it_ma_tmp));
     }
+
+    // member types
+    {
+      STATIC_CHECK(std::is_same_v<typename marray_t::value_type, DataT>);
+      STATIC_CHECK(std::is_same_v<typename marray_t::reference, DataT&>);
+      STATIC_CHECK(std::is_same_v<typename marray_t::const_reference, const DataT&>);
+      STATIC_CHECK(std::is_same_v<typename marray_t::iterator, DataT*>);
+      STATIC_CHECK(std::is_same_v<typename marray_t::const_iterator , const DataT*>);
+    }
   }
 };
 

--- a/tests/marray/marray_operator_helper.h
+++ b/tests/marray/marray_operator_helper.h
@@ -108,6 +108,12 @@ OPERATOR_BINARY(sr, >>);
 
 OPERATOR_BINARY_RELATIONAL(land, &&);
 OPERATOR_BINARY_RELATIONAL(lor, ||);
+OPERATOR_BINARY_RELATIONAL(eq, ==);
+OPERATOR_BINARY_RELATIONAL(not_eq, !=);
+OPERATOR_BINARY_RELATIONAL(less, <);
+OPERATOR_BINARY_RELATIONAL(grater, >);
+OPERATOR_BINARY_RELATIONAL(less_eq, <=);
+OPERATOR_BINARY_RELATIONAL(grater_eq, >=);
 
 #define OPERATOR_BINARY_ASSIGN(id, op)                                  \
   struct op_assign_##id {                                               \

--- a/tests/marray/marray_operators.h
+++ b/tests/marray/marray_operators.h
@@ -516,13 +516,12 @@ class check_marray_operators_for_type {
 
     static const auto binary_operators =
         named_type_pack<op_add, op_sub, op_mul, op_div, op_mod, op_bor, op_band,
-                        op_bxor, op_sl, op_sr, op_eq, op_not_eq, op_less,
-                        op_grater
-    // <= and >= are not being compiled in computecpp for double type
-    // <= and >= are ambiguous for 'const double' and
+                        op_bxor, op_sl, op_sr, op_eq, op_not_eq
+    // <=, >=, <, > are not being compiled in computecpp for double type
+    // <=, >=, <, > are ambiguous for 'const double' and
     // 'const sycl::marray<double, 1>'
 #if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
-                        ,
+                        , op_less, op_grater,
                         op_less_eq, op_grater_eq
 #endif
     // && and || are not defined for floating-point types
@@ -535,9 +534,9 @@ class check_marray_operators_for_type {
                         op_land, op_lor
 #endif
                         >::generate("+", "-", "*", "/", "%", "|", "&", "^",
-                                    "<<", ">>", "==", "!=", "<", ">"
+                                    "<<", ">>", "==", "!="
 #if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
-                                    ,
+                                    , "<", ">",
                                     "<=", ">=", "&&", "||"
 #endif
         );

--- a/tests/marray/marray_operators.h
+++ b/tests/marray/marray_operators.h
@@ -521,8 +521,8 @@ class check_marray_operators_for_type {
     // <=, >=, <, > are ambiguous for 'const double' and
     // 'const sycl::marray<double, 1>'
 #if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
-                        , op_less, op_grater,
-                        op_less_eq, op_grater_eq
+                        ,
+                        op_less, op_grater, op_less_eq, op_grater_eq
 #endif
     // && and || are not defined for floating-point types
     // && and || are ambiguous for 'const bool' and
@@ -536,8 +536,8 @@ class check_marray_operators_for_type {
                         >::generate("+", "-", "*", "/", "%", "|", "&", "^",
                                     "<<", ">>", "==", "!="
 #if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
-                                    , "<", ">",
-                                    "<=", ">=", "&&", "||"
+                                    ,
+                                    "<", ">", "<=", ">=", "&&", "||"
 #endif
         );
 

--- a/tests/marray/marray_operators.h
+++ b/tests/marray/marray_operators.h
@@ -516,7 +516,7 @@ class check_marray_operators_for_type {
 
     static const auto binary_operators =
         named_type_pack<op_add, op_sub, op_mul, op_div, op_mod, op_bor, op_band,
-                        op_bxor, op_sl, op_sr
+                        op_bxor, op_sl, op_sr, op_eq, op_not_eq, op_less, op_grater, op_less_eq, op_grater_eq
     // && and || are not defined for floating-point types
     // && and || are ambiguous for 'const bool' and
     //  'const cl::sycl::marray<bool, 1>'
@@ -527,7 +527,7 @@ class check_marray_operators_for_type {
                         op_land, op_lor
 #endif
                         >::generate("+", "-", "*", "/", "%", "|", "&", "^",
-                                    "<<", ">>"
+                                    "<<", ">>", "==", "!=", "<", ">", "<=", ">="
 #if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
                                     ,
                                     "&&", "||"

--- a/tests/marray/marray_operators.h
+++ b/tests/marray/marray_operators.h
@@ -516,13 +516,14 @@ class check_marray_operators_for_type {
 
     static const auto binary_operators =
         named_type_pack<op_add, op_sub, op_mul, op_div, op_mod, op_bor, op_band,
-                        op_bxor, op_sl, op_sr, op_eq, op_not_eq
+                        op_bxor, op_sl, op_sr
     // <=, >=, <, > are not being compiled in computecpp for double type
     // <=, >=, <, > are ambiguous for 'const double' and
     // 'const sycl::marray<double, 1>'
 #if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
                         ,
-                        op_less, op_grater, op_less_eq, op_grater_eq
+                        op_eq, op_not_eq, op_less, op_grater, op_less_eq,
+                        op_grater_eq
 #endif
     // && and || are not defined for floating-point types
     // && and || are ambiguous for 'const bool' and
@@ -534,10 +535,10 @@ class check_marray_operators_for_type {
                         op_land, op_lor
 #endif
                         >::generate("+", "-", "*", "/", "%", "|", "&", "^",
-                                    "<<", ">>", "==", "!="
+                                    "<<", ">>"
 #if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
                                     ,
-                                    "<", ">", "<=", ">=", "&&", "||"
+                                    "==", "!=", "<", ">", "<=", ">=", "&&", "||"
 #endif
         );
 

--- a/tests/marray/marray_operators.h
+++ b/tests/marray/marray_operators.h
@@ -516,7 +516,8 @@ class check_marray_operators_for_type {
 
     static const auto binary_operators =
         named_type_pack<op_add, op_sub, op_mul, op_div, op_mod, op_bor, op_band,
-                        op_bxor, op_sl, op_sr, op_eq, op_not_eq, op_less, op_grater, op_less_eq, op_grater_eq
+                        op_bxor, op_sl, op_sr, op_eq, op_not_eq, op_less,
+                        op_grater, op_less_eq, op_grater_eq
     // && and || are not defined for floating-point types
     // && and || are ambiguous for 'const bool' and
     //  'const cl::sycl::marray<bool, 1>'

--- a/tests/marray/marray_operators.h
+++ b/tests/marray/marray_operators.h
@@ -517,7 +517,14 @@ class check_marray_operators_for_type {
     static const auto binary_operators =
         named_type_pack<op_add, op_sub, op_mul, op_div, op_mod, op_bor, op_band,
                         op_bxor, op_sl, op_sr, op_eq, op_not_eq, op_less,
-                        op_grater, op_less_eq, op_grater_eq
+                        op_grater
+    // <= and >= are not being compiled in computecpp for double type
+    // <= and >= are ambiguous for 'const double' and
+    // 'const sycl::marray<double, 1>'
+#if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+                        ,
+                        op_less_eq, op_grater_eq
+#endif
     // && and || are not defined for floating-point types
     // && and || are ambiguous for 'const bool' and
     //  'const cl::sycl::marray<bool, 1>'
@@ -528,10 +535,10 @@ class check_marray_operators_for_type {
                         op_land, op_lor
 #endif
                         >::generate("+", "-", "*", "/", "%", "|", "&", "^",
-                                    "<<", ">>", "==", "!=", "<", ">", "<=", ">="
+                                    "<<", ">>", "==", "!=", "<", ">"
 #if !defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
                                     ,
-                                    "&&", "||"
+                                    "<=", ">=", "&&", "||"
 #endif
         );
 


### PR DESCRIPTION
Add checking of ==, !=, <, >, <=, >= operators and member types of marray