### PR TITLE
sycl::vec operator[] const and operator vector_t() tests 

### DIFF
--- a/tests/vector_constructors/generate_vector_constructors.py
+++ b/tests/vector_constructors/generate_vector_constructors.py
@@ -192,6 +192,7 @@ def generate_constructor_tests(type_str, input_file, output_file):
         test_str += generate_explicit(type_str, size)
         test_str += generate_vec(type_str, size)
         test_str += generate_mixed(type_str, size)
+        test_str += generate_opencl(type_str, size)
         test_func_str += wrap_with_test_func(TEST_NAME, type_str,
                                              test_str, str(size))
         test_str = ''

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -1257,7 +1257,7 @@ subscript_operator_test_template = Template("""
       if (subscriptVec1[i] != data[i] || subscriptVec2[i] != data[i]
 // FIXME: re-enable when subscript operator for swizzle vec is implemented
 // link to issue: https://github.com/intel/llvm/issues/8880
-#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#if !SYCL_CTS_COMPILING_WITH_DPCPP
         || subscriptVec1.${swizzle}[i] != data[i]
         || subscriptVec2.${swizzle}[i] != data[i]
 #endif
@@ -1267,6 +1267,7 @@ subscript_operator_test_template = Template("""
       }
     }
   }
+#endif
 """)
 
 vector_t_operator_test_template = Template("""
@@ -1277,11 +1278,14 @@ vector_t_operator_test_template = Template("""
     const sycl::vec<${type}, 1> testVec(val);
     sycl::vec<${type}, ${size}>::vector_t data = testVec;
 
+// FIXME: re-enable when vec(vector_t) constructor is implemented
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
     const sycl::vec<${type}, 1> testVec2(data);
 
     if (!(testVec == testVec2)) {
       resAcc[0] = false;
     }
+#endif
   }
 #endif  // __SYCL_DEVICE_ONLY__
 """)

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -1257,7 +1257,7 @@ subscript_operator_test_template = Template("""
       if (subscriptVec1[i] != data[i] || subscriptVec2[i] != data[i]
 // FIXME: re-enable when subscript operator for swizzle vec is implemented
 // link to issue: https://github.com/intel/llvm/issues/8880
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
         || subscriptVec1.${swizzle}[i] != data[i]
         || subscriptVec2.${swizzle}[i] != data[i]
 #endif
@@ -1267,7 +1267,6 @@ subscript_operator_test_template = Template("""
       }
     }
   }
-#endif
 """)
 
 vector_t_operator_test_template = Template("""

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -1243,12 +1243,12 @@ subscript_operator_test_template = Template("""
     }
 
     // operator[] type check
-    if(!std::is_same_v<decltype(subscriptVec2[0]), ${type}&>) {
+    if constexpr (!std::is_same_v<decltype(subscriptVec2[0]), ${type}&>) {
       resAcc[0] = false;
     }
 
     // const operator[] type check
-    if(!std::is_same_v<decltype(subscriptVec1[0]), const ${type}&>) {
+    if constexpr (!std::is_same_v<decltype(subscriptVec1[0]), const ${type}&>) {
       resAcc[0] = false;
     }
 

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -1232,7 +1232,6 @@ non_fp_arithmetic_test_template = Template("""
 """)
 
 subscript_operator_test_template = Template("""
-  // subscript operator value
   {
     ${type} data[] = { ${data} };
     const sycl::vec<${type}, ${size}> subscriptVec1(${data});
@@ -1243,6 +1242,17 @@ subscript_operator_test_template = Template("""
       subscriptVec2[i] = data[i];
     }
 
+    // operator[] type check
+    if(!std::is_same_v<decltype(subscriptVec2[0]), ${type}&>) {
+      resAcc[0] = false;
+    }
+
+    // const operator[] type check
+    if(!std::is_same_v<decltype(subscriptVec1[0]), const ${type}&>) {
+      resAcc[0] = false;
+    }
+
+    // check subscript operator value
     for (int i = 0; i < ${size}; ++i) {
       if (subscriptVec1[i] != data[i] || subscriptVec2[i] != data[i]
 // FIXME: re-enable when subscript operator for swizzle vec is implemented
@@ -1257,6 +1267,23 @@ subscript_operator_test_template = Template("""
       }
     }
   }
+""")
+
+vector_t_operator_test_template = Template("""
+#ifdef __SYCL_DEVICE_ONLY__
+  // check operator vector_t() const
+  {
+    ${type} val = ${val};
+    const sycl::vec<${type}, 1> testVec(val);
+    sycl::vec<${type}, ${size}>::vector_t data = testVec;
+
+    const sycl::vec<${type}, 1> testVec2(data);
+
+    if (!(testVec == testVec2)) {
+      resAcc[0] = false;
+    }
+  }
+#endif  // __SYCL_DEVICE_ONLY__
 """)
 
 dataT_operator_test_template = Template("""
@@ -1315,6 +1342,11 @@ def generate_all_type_test(type_str, size):
     if size == 1:
         test_string += dataT_operator_test_template.substitute(
           type=type_str,
+          swizzle=get_swizzle(size),
+          val=Data.value_default_dict[type_str])
+        test_string += vector_t_operator_test_template.substitute(
+          type=type_str,
+          size=str(size),
           swizzle=get_swizzle(size),
           val=Data.value_default_dict[type_str])
     test_string += assign_dataT_operator_test_template.substitute(


### PR DESCRIPTION
Added tests for const version of subscript operator type check and operator `vector_t()`