### PR TITLE
Fix type of operator passed to scan

### DIFF
--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -240,26 +240,26 @@ void init_joint_scan_group(sycl::queue& queue) {
     SECTION("Check joint scan for group with sycl::plus and input size " +
             std::to_string(size)) {
       check_scan<D, T, U, sycl::group<D>, true, I>(queue, size, executionRange,
-                                                   sycl::plus<U>());
+                                                   sycl::plus<I>());
     }
 
     SECTION("Check joint scan for group with sycl::maximum and input size " +
             std::to_string(size)) {
       check_scan<D, T, U, sycl::group<D>, true, I>(queue, size, executionRange,
-                                                   sycl::maximum<U>());
+                                                   sycl::maximum<I>());
     }
 
     SECTION("Check joint scan for sub_group with sycl::plus and input size " +
             std::to_string(size)) {
       check_scan<D, T, U, sycl::sub_group, true, I>(queue, size, executionRange,
-                                                    sycl::plus<U>());
+                                                    sycl::plus<I>());
     }
 
     SECTION(
         "Check joint scan for sub_group with sycl::maximum and input size " +
         std::to_string(size)) {
       check_scan<D, T, U, sycl::sub_group, true, I>(queue, size, executionRange,
-                                                    sycl::maximum<U>());
+                                                    sycl::maximum<I>());
     }
   }
 }


### PR DESCRIPTION
For the `joint_exclusive_scan` and `join_inclusive_scan` overloads with an `init` param of type `T`, the `binary_op(init, *first)` should have type `T`.

[4.17.4.6. `exclusive_scan` and `inclusive_scan`](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_exclusive_scan_and_inclusive_scan)