### PR TITLE
Fix info::kernel::num_args usage in kernel tests

### DIFF
--- a/tests/kernel/kernel_info.cpp
+++ b/tests/kernel/kernel_info.cpp
@@ -109,6 +109,10 @@ TEST_CASE("Test kernel info", "[kernel]") {
         range3Ret,
         "sycl::kernel::get_info<sycl::info::kernel_device_specific::global_"
         "work_size>(dev) for built_in_kernel");
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+    check_get_info_param<sycl::info::kernel::num_args, uint32_t>(
+        built_in_kernel);
+#endif
   }
 
   if (dev.get_info<sycl::info::device::device_type>() ==
@@ -186,7 +190,6 @@ TEST_CASE("Test kernel info", "[kernel]") {
 
 // FIXME: Reenable when struct information descriptors are implemented
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
-  check_get_info_param<sycl::info::kernel::num_args, uint32_t>(kernel);
   check_get_info_param<sycl::info::kernel::attributes, std::string>(kernel);
 #endif
 

--- a/tests/kernel/kernel_semantics.cpp
+++ b/tests/kernel/kernel_semantics.cpp
@@ -23,30 +23,32 @@
 #include "../kernel_bundle/kernel_bundle.h"
 
 struct storage {
-  std::uint32_t num_args;
+  sycl::context context;
 
   explicit storage(const sycl::kernel& kernel)
-      : num_args(kernel.get_info<sycl::info::kernel::num_args>()) {}
+      : context(kernel.get_context()) {}
 
   bool check(const sycl::kernel& kernel) const {
-    return kernel.get_info<sycl::info::kernel::num_args>() == num_args;
+    return kernel.get_context() == context;
   }
 };
 
 TEST_CASE("kernel common reference semantics", "[kernel]") {
-  sycl::context context = sycl_cts::util::get_cts_object::context();
-  sycl::queue queue = sycl_cts::util::get_cts_object::queue();
+  sycl::context context_0 = sycl_cts::util::get_cts_object::context();
+  sycl::context context_1 = sycl_cts::util::get_cts_object::context();
+  sycl::queue queue_0 = sycl_cts::util::get_cts_object::queue();
+  sycl::queue queue_1 = sycl_cts::util::get_cts_object::queue();
 
   using k_name = class kernel_comm_ref_sem;
   using k_name_other = class kernel_other_comm_ref_sem;
 
   sycl::kernel kernel_0 =
-      sycl::get_kernel_bundle<sycl::bundle_state::executable>(context)
+      sycl::get_kernel_bundle<sycl::bundle_state::executable>(context_0)
           .template get_kernel(sycl::get_kernel_id<k_name>());
   sycl::kernel kernel_1 =
-      sycl::get_kernel_bundle<sycl::bundle_state::executable>(context)
+      sycl::get_kernel_bundle<sycl::bundle_state::executable>(context_1)
           .template get_kernel(sycl::get_kernel_id<k_name_other>());
   common_reference_semantics::check_host<storage>(kernel_0, kernel_1, "kernel");
-  sycl_cts::tests::kernel_bundle::define_kernel<k_name>(queue);
-  sycl_cts::tests::kernel_bundle::define_kernel<k_name_other>(queue);
+  sycl_cts::tests::kernel_bundle::define_kernel<k_name>(queue_0);
+  sycl_cts::tests::kernel_bundle::define_kernel<k_name_other>(queue_1);
 }


### PR DESCRIPTION
Moved check_get_info_param top section that uses built_in kernel because otherwise exception is thrown as expected.
Changed semantics tests to use get_context() instead of info::kernel::num_args because there are not built_in kernels.