### PR TITLE
math_builtin: change remquo reference

### DIFF
--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -24,8 +24,8 @@
 
 #include <sycl/sycl.hpp>
 
-#include "./math_helper.h"
 #include "./../oclmath/reference_math.h"
+#include "./math_helper.h"
 #include <cmath>
 
 // FIXME: hipSYCL does not support marray
@@ -1361,7 +1361,7 @@ using std::remainder;
 MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(remainder)
 
 template <typename T>
-T remquo(T x, T y, int* quo) {
+T remquo(T x, T y, int *quo) {
   return reference_remquol(x, y, quo);
 }
 

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -25,7 +25,7 @@
 #include <sycl/sycl.hpp>
 
 #include "./math_helper.h"
-
+#include "./../oclmath/reference_math.h"
 #include <cmath>
 
 // FIXME: hipSYCL does not support marray
@@ -1360,7 +1360,11 @@ sycl_cts::resultRef<sycl::marray<T, N>> powr(sycl::marray<T, N> a,
 using std::remainder;
 MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(remainder)
 
-using std::remquo;
+template <typename T>
+T remquo(T x, T y, int* quo) {
+  return reference_remquol(x, y, quo);
+}
+
 template <typename T, int N>
 sycl::vec<T, N> remquo(sycl::vec<T, N> a, sycl::vec<T, N> b,
                        sycl::vec<int, N> *c) {


### PR DESCRIPTION
`remquo` reference was changed from `std::remquo` to `reference_remquol` from `oclmath/reference_math.h` because different behavior of `std` and `sycl` spec.