### PR TITLE
Update local accessor usage in legacy tests

### DIFF
--- a/tests/accessor_legacy/accessor_api_local_common.h
+++ b/tests/accessor_legacy/accessor_api_local_common.h
@@ -133,7 +133,9 @@ class check_local_accessor_api_methods {
             buffer_accessor_get_pointer_kernel<
                 kernelName, dims, mode, target, acc_placeholder::local>;
 
-        h.parallel_for<kernel_name>(kernelRange, verifier);
+        h.parallel_for<kernel_name>(
+            sycl::nd_range<data_dim<dims>::value>(kernelRange, kernelRange),
+            verifier);
       });
     }
 
@@ -205,10 +207,10 @@ class check_local_accessor_api_reads_and_writes {
               kernelName, dims, mode, target, acc_placeholder::local>;
 
         handler.parallel_for<kernel_name>(
-            range,
-            buffer_accessor_api_rw<
-                T, dims, mode, target, errorTarget, acc_placeholder::local>(
-                    size, accIdSyntax, accMultiDimSyntax, errorAccessor, range));
+            sycl::nd_range<data_dim<dims>::value>(range, range),
+            buffer_accessor_api_rw<T, dims, mode, target, errorTarget,
+                                   acc_placeholder::local>(
+                size, accIdSyntax, accMultiDimSyntax, errorAccessor, range));
       });
     }
 

--- a/tests/address_space/address_space_common.h
+++ b/tests/address_space/address_space_common.h
@@ -175,7 +175,7 @@ class check_types {
             constantBuff, cgh);
         sycl::accessor<T, 1, read_write, sycl::target::local> localAcc(r, cgh);
 
-        cgh.single_task<kernel_name>([=]() {
+        cgh.parallel_for<kernel_name>(sycl::nd_range<1>(r, r), [=](auto item) {
           bool pass = true;
           localAcc[0] = initAcc[2];
           T priv = initAcc[3];

--- a/tests/atomic/atomic_api_32.cpp
+++ b/tests/atomic/atomic_api_32.cpp
@@ -43,7 +43,7 @@ class check_atomics_32 {
       sycl::accessor<T, 1, sycl::access_mode::atomic, target> acc)
       : m_acc(acc) {}
 
-  void operator()() const {
+  void operator()(sycl::nd_item<1> item) const {
     static constexpr auto addressSpace = target_map<target>::addressSpace;
     sycl::memory_order order = sycl::memory_order::relaxed;
     sycl::atomic<T, addressSpace> a = m_acc[0];
@@ -121,7 +121,7 @@ class check_atomics_32<float, target> {
       sycl::accessor<float, 1, sycl::access_mode::atomic, target> acc)
       : m_acc(acc) {}
 
-  void operator()() const {
+  void operator()(sycl::nd_item<1> item) const {
     static constexpr auto addressSpace = target_map<target>::addressSpace;
     sycl::memory_order order = sycl::memory_order::relaxed;
     sycl::atomic<float, addressSpace> a = m_acc[0];

--- a/tests/atomic/atomic_api_64_base.cpp
+++ b/tests/atomic/atomic_api_64_base.cpp
@@ -43,7 +43,7 @@ class check_base_atomics {
       sycl::accessor<T, 1, sycl::access_mode::atomic, target> acc)
       : m_acc(acc) {}
 
-  void operator()() const {
+  void operator()(sycl::nd_item<1> item) const {
     static constexpr auto addressSpace = target_map<target>::addressSpace;
     sycl::memory_order order = sycl::memory_order::relaxed;
     sycl::atomic<T, addressSpace> a = m_acc[0];

--- a/tests/atomic/atomic_api_64_extended.cpp
+++ b/tests/atomic/atomic_api_64_extended.cpp
@@ -43,7 +43,7 @@ class check_extended_atomics {
       sycl::accessor<T, 1, sycl::access_mode::atomic, target> acc)
       : m_acc(acc) {}
 
-  void operator()() const {
+  void operator()(sycl::nd_item<1> item) const {
     static constexpr auto addressSpace = target_map<target>::addressSpace;
     sycl::memory_order order = sycl::memory_order::relaxed;
     sycl::atomic<T, addressSpace> a = m_acc[0];

--- a/tests/atomic/atomic_api_common.h
+++ b/tests/atomic/atomic_api_common.h
@@ -96,12 +96,12 @@ class check_atomics {
     std::memset(&data, 0xFF, sizeof(T));
 
     sycl::buffer<T, 1> buf(&data, sycl::range<1>(1));
-
+    sycl::nd_range<1> nd_range(sycl::range<1>(1), sycl::range<1>(1));
     testQueue.submit([&](sycl::handler &cgh) {
       using functor = check_atomics_functor<T, target>;
       auto acc = target_map<target>::get_accessor(buf, cgh);
       auto f = functor(acc);
-      cgh.single_task<functor>(f);
+      cgh.parallel_for<functor>(nd_range, f);
     });
   }
 };

--- a/tests/atomic/atomic_constructors_common.h
+++ b/tests/atomic/atomic_constructors_common.h
@@ -43,6 +43,11 @@ class check_atomic_constructors {
      */
     sycl::atomic<T, addressSpace> a(m_acc.get_pointer());
   }
+  void operator()(sycl::nd_item<1> item) const {
+    /** Check atomic constructor
+     */
+    sycl::atomic<T, addressSpace> a(m_acc.get_pointer());
+  }
 };
 
 /** Check atomic constructors
@@ -76,7 +81,7 @@ class check_atomics<T, sycl::target::local> {
  public:
   void operator()(sycl_cts::util::logger &log, sycl::queue &testQueue) {
     auto testDevice = testQueue.get_device();
-
+    sycl::nd_range<1> nd_range(sycl::range<1>(1), sycl::range<1>(1));
     /** Check atomic constructors
      */
     testQueue.submit([&](sycl::handler &cgh) {
@@ -85,7 +90,7 @@ class check_atomics<T, sycl::target::local> {
                                     sycl::access::address_space::local_space>;
       sycl::accessor<T, 1, sycl::access_mode::read_write, sycl::target::local>
           acc(sycl::range<1>(1), cgh);
-      cgh.single_task<functor>(functor(acc));
+      cgh.parallel_for<functor>(nd_range, functor(acc));
     });
   }
 };

--- a/tests/multi_ptr/multi_ptr_legacy_api_common.h
+++ b/tests/multi_ptr/multi_ptr_legacy_api_common.h
@@ -614,396 +614,395 @@ class pointer_apis {
             sycl::nd_range<1>(sycl::range<1>(1), sycl::range<1>(1)),
             [resAcc, globalAccessor, constantAccessor,
              localAccessor](auto item) {
-          check_helper<T, U> checker;
+              check_helper<T, U> checker;
 
-          data_t privateData[size];
-          data_t *localData = const_cast<data_t*>(&localAccessor[0]);
+              data_t privateData[size];
+              data_t *localData = const_cast<data_t *>(&localAccessor[0]);
 
-          for (int i = 0; i < size; ++i) {
-            privateData[i] = reference_t::value(i);
-            localData[i] = reference_t::value(i);
-          }
+              for (int i = 0; i < size; ++i) {
+                privateData[i] = reference_t::value(i);
+                localData[i] = reference_t::value(i);
+              }
 
-          // Reference pointer values to check against
-          const auto expectedConstantPtr =
-              const_cast<U *>(static_cast<const U *>(&constantAccessor[0]));
-          const auto expectedGlobalPtr = static_cast<U *>(&globalAccessor[0]);
-          const auto expectedLocalPtr = static_cast<U *>(&localAccessor[0]);
-          const auto expectedPrivatePtr = static_cast<U *>(privateData);
+              // Reference pointer values to check against
+              const auto expectedConstantPtr =
+                  const_cast<U *>(static_cast<const U *>(&constantAccessor[0]));
+              const auto expectedGlobalPtr =
+                  static_cast<U *>(&globalAccessor[0]);
+              const auto expectedLocalPtr = static_cast<U *>(&localAccessor[0]);
+              const auto expectedPrivatePtr = static_cast<U *>(privateData);
 
-          /** check multi_ptr aliases
-           */
-          {
-            static_assert(
-              std::is_same<multiPtrGlobal, global_ptr_legacy<U>>::value,
-              "Invalid global_ptr type");
-            static_assert(
-              std::is_same<multiPtrConstant, constant_ptr_legacy<U>>::value,
-              "Invalid constant_ptr type");
-            static_assert(
-              std::is_same<multiPtrLocal, local_ptr_legacy<U>>::value,
-              "Invalid local_ptr type");
-            static_assert(
-              std::is_same<multiPtrPrivate, private_ptr_legacy<U>>::value,
-              "Invalid private_ptr type");
-          }
+              /** check multi_ptr aliases
+               */
+              {
+                static_assert(
+                    std::is_same<multiPtrGlobal, global_ptr_legacy<U>>::value,
+                    "Invalid global_ptr type");
+                static_assert(std::is_same<multiPtrConstant,
+                                           constant_ptr_legacy<U>>::value,
+                              "Invalid constant_ptr type");
+                static_assert(
+                    std::is_same<multiPtrLocal, local_ptr_legacy<U>>::value,
+                    "Invalid local_ptr type");
+                static_assert(
+                    std::is_same<multiPtrPrivate, private_ptr_legacy<U>>::value,
+                    "Invalid private_ptr type");
+              }
 
-          /** check member types
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
+              /** check member types
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
 
-            checker.member_types(globalMultiPtr);
-            checker.member_types(constantMultiPtr);
-            checker.member_types(localMultiPtr);
-            checker.member_types(privateMultiPtr);
-          }
+                checker.member_types(globalMultiPtr);
+                checker.member_types(constantMultiPtr);
+                checker.member_types(localMultiPtr);
+                checker.member_types(privateMultiPtr);
+              }
 
-          /** check address_space member
-           */
-          {
-            // construct a set of multi_ptr
-            sycl::global_ptr<U> globalPtr(expectedGlobalPtr);
-            sycl::constant_ptr<U> constantPtr(expectedConstantPtr);
-            sycl::local_ptr<U> localPtr(expectedLocalPtr);
-            sycl::private_ptr<U> privatePtr(expectedPrivatePtr);
+              /** check address_space member
+               */
+              {
+                // construct a set of multi_ptr
+                sycl::global_ptr<U> globalPtr(expectedGlobalPtr);
+                sycl::constant_ptr<U> constantPtr(expectedConstantPtr);
+                sycl::local_ptr<U> localPtr(expectedLocalPtr);
+                sycl::private_ptr<U> privatePtr(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
 
-            checker.address_space_member(globalMultiPtr);
-            checker.address_space_member(constantMultiPtr);
-            checker.address_space_member(localMultiPtr);
-            checker.address_space_member(privateMultiPtr);
-          }
+                checker.address_space_member(globalMultiPtr);
+                checker.address_space_member(constantMultiPtr);
+                checker.address_space_member(localMultiPtr);
+                checker.address_space_member(privateMultiPtr);
+              }
 
-          /** check copy assignment operators
-           */
-          {
-            // construct two sets of multi_ptr
-            global_ptr_legacy<U> globalPtrA(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtrA(expectedConstantPtr);
-            local_ptr_legacy<U> localPtrA(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtrA(expectedPrivatePtr);
+              /** check copy assignment operators
+               */
+              {
+                // construct two sets of multi_ptr
+                global_ptr_legacy<U> globalPtrA(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtrA(expectedConstantPtr);
+                local_ptr_legacy<U> localPtrA(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtrA(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtrA(globalPtrA);
-            multiPtrConstant constantMultiPtrA(constantPtrA);
-            multiPtrLocal localMultiPtrA(localPtrA);
-            multiPtrPrivate privateMultiPtrA(privatePtrA);
+                multiPtrGlobal globalMultiPtrA(globalPtrA);
+                multiPtrConstant constantMultiPtrA(constantPtrA);
+                multiPtrLocal localMultiPtrA(localPtrA);
+                multiPtrPrivate privateMultiPtrA(privatePtrA);
 
-            multiPtrGlobal globalMultiPtrB;
-            multiPtrConstant constantMultiPtrB;
-            multiPtrLocal localMultiPtrB;
-            multiPtrPrivate privateMultiPtrB;
+                multiPtrGlobal globalMultiPtrB;
+                multiPtrConstant constantMultiPtrB;
+                multiPtrLocal localMultiPtrB;
+                multiPtrPrivate privateMultiPtrB;
 
-            // check copy assignment operators
-            globalMultiPtrB = globalMultiPtrA;
-            constantMultiPtrB = constantMultiPtrA;
-            localMultiPtrB = localMultiPtrA;
-            privateMultiPtrB = privateMultiPtrA;
+                // check copy assignment operators
+                globalMultiPtrB = globalMultiPtrA;
+                constantMultiPtrB = constantMultiPtrA;
+                localMultiPtrB = localMultiPtrA;
+                privateMultiPtrB = privateMultiPtrA;
 
-            bool result = true;
-            result &= globalMultiPtrB == expectedGlobalPtr;
-            result &= constantMultiPtrB == expectedConstantPtr;
-            result &= localMultiPtrB == expectedLocalPtr;
-            result &= privateMultiPtrB == expectedPrivatePtr;
+                bool result = true;
+                result &= globalMultiPtrB == expectedGlobalPtr;
+                result &= constantMultiPtrB == expectedConstantPtr;
+                result &= localMultiPtrB == expectedLocalPtr;
+                result &= privateMultiPtrB == expectedPrivatePtr;
 
-            result &= reference_t::is_data_equal(globalMultiPtrB);
-            result &= reference_t::is_data_equal(constantMultiPtrB);
-            result &= reference_t::is_data_equal(localMultiPtrB);
-            result &= reference_t::is_data_equal(privateMultiPtrB);
+                result &= reference_t::is_data_equal(globalMultiPtrB);
+                result &= reference_t::is_data_equal(constantMultiPtrB);
+                result &= reference_t::is_data_equal(localMultiPtrB);
+                result &= reference_t::is_data_equal(privateMultiPtrB);
 
-            resAcc[to_integral(check_id::copy_assignment)] = result;
-          }
+                resAcc[to_integral(check_id::copy_assignment)] = result;
+              }
 
-          /** check move assignment operators
-           */
-          {
-            // construct two sets of multi_ptr
-            global_ptr_legacy<U> globalPtrA(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtrA(expectedConstantPtr);
-            local_ptr_legacy<U> localPtrA(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtrA(expectedPrivatePtr);
+              /** check move assignment operators
+               */
+              {
+                // construct two sets of multi_ptr
+                global_ptr_legacy<U> globalPtrA(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtrA(expectedConstantPtr);
+                local_ptr_legacy<U> localPtrA(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtrA(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtrA(globalPtrA);
-            multiPtrConstant constantMultiPtrA(constantPtrA);
-            multiPtrLocal localMultiPtrA(localPtrA);
-            multiPtrPrivate privateMultiPtrA(privatePtrA);
+                multiPtrGlobal globalMultiPtrA(globalPtrA);
+                multiPtrConstant constantMultiPtrA(constantPtrA);
+                multiPtrLocal localMultiPtrA(localPtrA);
+                multiPtrPrivate privateMultiPtrA(privatePtrA);
 
-            multiPtrGlobal globalMultiPtrB;
-            multiPtrConstant constantMultiPtrB;
-            multiPtrLocal localMultiPtrB;
-            multiPtrPrivate privateMultiPtrB;
+                multiPtrGlobal globalMultiPtrB;
+                multiPtrConstant constantMultiPtrB;
+                multiPtrLocal localMultiPtrB;
+                multiPtrPrivate privateMultiPtrB;
 
-            // check move assignment operators
-            globalMultiPtrB = std::move(globalMultiPtrA);
-            constantMultiPtrB = std::move(constantMultiPtrA);
-            localMultiPtrB = std::move(localMultiPtrA);
-            privateMultiPtrB = std::move(privateMultiPtrA);
+                // check move assignment operators
+                globalMultiPtrB = std::move(globalMultiPtrA);
+                constantMultiPtrB = std::move(constantMultiPtrA);
+                localMultiPtrB = std::move(localMultiPtrA);
+                privateMultiPtrB = std::move(privateMultiPtrA);
 
-            bool result = true;
-            result &= globalMultiPtrB == expectedGlobalPtr;
-            result &= constantMultiPtrB == expectedConstantPtr;
-            result &= localMultiPtrB == expectedLocalPtr;
-            result &= privateMultiPtrB == expectedPrivatePtr;
+                bool result = true;
+                result &= globalMultiPtrB == expectedGlobalPtr;
+                result &= constantMultiPtrB == expectedConstantPtr;
+                result &= localMultiPtrB == expectedLocalPtr;
+                result &= privateMultiPtrB == expectedPrivatePtr;
 
-            result &= reference_t::is_data_equal(globalMultiPtrB);
-            result &= reference_t::is_data_equal(constantMultiPtrB);
-            result &= reference_t::is_data_equal(localMultiPtrB);
-            result &= reference_t::is_data_equal(privateMultiPtrB);
+                result &= reference_t::is_data_equal(globalMultiPtrB);
+                result &= reference_t::is_data_equal(constantMultiPtrB);
+                result &= reference_t::is_data_equal(localMultiPtrB);
+                result &= reference_t::is_data_equal(privateMultiPtrB);
 
-            resAcc[to_integral(check_id::move_assignment)] = result;
-          }
+                resAcc[to_integral(check_id::move_assignment)] = result;
+              }
 
-          /** check assigning to multi_ptr
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
+              /** check assigning to multi_ptr
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
 
-            bool result = true;
-            result &= globalMultiPtr == expectedGlobalPtr;
-            result &= constantMultiPtr == expectedConstantPtr;
-            result &= localMultiPtr == expectedLocalPtr;
-            result &= privateMultiPtr == expectedPrivatePtr;
+                bool result = true;
+                result &= globalMultiPtr == expectedGlobalPtr;
+                result &= constantMultiPtr == expectedConstantPtr;
+                result &= localMultiPtr == expectedLocalPtr;
+                result &= privateMultiPtr == expectedPrivatePtr;
 
-            result &= reference_t::is_data_equal(globalMultiPtr);
-            result &= reference_t::is_data_equal(constantMultiPtr);
-            result &= reference_t::is_data_equal(localMultiPtr);
-            result &= reference_t::is_data_equal(privateMultiPtr);
+                result &= reference_t::is_data_equal(globalMultiPtr);
+                result &= reference_t::is_data_equal(constantMultiPtr);
+                result &= reference_t::is_data_equal(localMultiPtr);
+                result &= reference_t::is_data_equal(privateMultiPtr);
 
-            resAcc[to_integral(check_id::pointer_assignment)] = result;
-          }
+                resAcc[to_integral(check_id::pointer_assignment)] = result;
+              }
 
-          /** check get() methods
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
+              /** check get() methods
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
 
-            auto gPtr = globalMultiPtr.get();
-            auto cPtr = constantMultiPtr.get();
-            auto lPtr = localMultiPtr.get();
-            auto pPtr = privateMultiPtr.get();
+                auto gPtr = globalMultiPtr.get();
+                auto cPtr = constantMultiPtr.get();
+                auto lPtr = localMultiPtr.get();
+                auto pPtr = privateMultiPtr.get();
 
-            ASSERT_RETURN_TYPE(typename global_ptr_legacy<U>::pointer_t,
-                               gPtr, "sycl::multi_ptr::get()");
-            ASSERT_RETURN_TYPE(typename constant_ptr_legacy<U>::pointer_t,
-                               cPtr, "sycl::multi_ptr::get()");
-            ASSERT_RETURN_TYPE(typename local_ptr_legacy<U>::pointer_t, lPtr,
-                               "sycl::multi_ptr::get()");
-            ASSERT_RETURN_TYPE(typename private_ptr_legacy<U>::pointer_t,
-                               pPtr, "sycl::multi_ptr::get()");
+                ASSERT_RETURN_TYPE(typename global_ptr_legacy<U>::pointer_t,
+                                   gPtr, "sycl::multi_ptr::get()");
+                ASSERT_RETURN_TYPE(typename constant_ptr_legacy<U>::pointer_t,
+                                   cPtr, "sycl::multi_ptr::get()");
+                ASSERT_RETURN_TYPE(typename local_ptr_legacy<U>::pointer_t,
+                                   lPtr, "sycl::multi_ptr::get()");
+                ASSERT_RETURN_TYPE(typename private_ptr_legacy<U>::pointer_t,
+                                   pPtr, "sycl::multi_ptr::get()");
 
-            bool result = true;
-            result &= gPtr == expectedGlobalPtr;
-            result &= cPtr == expectedConstantPtr;
-            result &= lPtr == expectedLocalPtr;
-            result &= pPtr == expectedPrivatePtr;
+                bool result = true;
+                result &= gPtr == expectedGlobalPtr;
+                result &= cPtr == expectedConstantPtr;
+                result &= lPtr == expectedLocalPtr;
+                result &= pPtr == expectedPrivatePtr;
 
-            result &= reference_t::is_data_equal(gPtr);
-            result &= reference_t::is_data_equal(cPtr);
-            result &= reference_t::is_data_equal(lPtr);
-            result &= reference_t::is_data_equal(pPtr);
+                result &= reference_t::is_data_equal(gPtr);
+                result &= reference_t::is_data_equal(cPtr);
+                result &= reference_t::is_data_equal(lPtr);
+                result &= reference_t::is_data_equal(pPtr);
 
-            resAcc[to_integral(check_id::get_method)] = result;
-          }
+                resAcc[to_integral(check_id::get_method)] = result;
+              }
 
-          /** check prefetch() method
-           */
-          {
-            // construct a global multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            multiPtrGlobal globalMultiPtr(globalPtr);
+              /** check prefetch() method
+               */
+              {
+                // construct a global multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                multiPtrGlobal globalMultiPtr(globalPtr);
 
-            resAcc[to_integral(check_id::prefetch_method)] =
-                checker.prefetch_operation(globalMultiPtr);
-          }
+                resAcc[to_integral(check_id::prefetch_method)] =
+                    checker.prefetch_operation(globalMultiPtr);
+              }
 
-          /** check implicit conversion to a raw pointer
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
+              /** check implicit conversion to a raw pointer
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
 
-            U *gPtr = globalMultiPtr;
-            U *cPtr = constantMultiPtr;
-            U *lPtr = localMultiPtr;
-            U *pPtr = privateMultiPtr;
+                U *gPtr = globalMultiPtr;
+                U *cPtr = constantMultiPtr;
+                U *lPtr = localMultiPtr;
+                U *pPtr = privateMultiPtr;
 
-            bool result = true;
-            result &= gPtr == expectedGlobalPtr;
-            result &= cPtr == expectedConstantPtr;
-            result &= lPtr == expectedLocalPtr;
-            result &= pPtr == expectedPrivatePtr;
+                bool result = true;
+                result &= gPtr == expectedGlobalPtr;
+                result &= cPtr == expectedConstantPtr;
+                result &= lPtr == expectedLocalPtr;
+                result &= pPtr == expectedPrivatePtr;
 
-            result &= reference_t::is_data_equal(gPtr);
-            result &= reference_t::is_data_equal(cPtr);
-            result &= reference_t::is_data_equal(lPtr);
-            result &= reference_t::is_data_equal(pPtr);
+                result &= reference_t::is_data_equal(gPtr);
+                result &= reference_t::is_data_equal(cPtr);
+                result &= reference_t::is_data_equal(lPtr);
+                result &= reference_t::is_data_equal(pPtr);
 
-            resAcc[to_integral(check_id::raw_pointer_conversion)] = result;
-          }
+                resAcc[to_integral(check_id::raw_pointer_conversion)] = result;
+              }
 
-          /** check multi_ptr conversion methods
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
+              /** check multi_ptr conversion methods
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
 
-            checker.conversion_operators(globalMultiPtr, constantMultiPtr,
-                                         localMultiPtr, privateMultiPtr);
-            checker.const_conversion_operators(globalMultiPtr, constantMultiPtr,
-                                               localMultiPtr, privateMultiPtr);
-          }
-
-          /** check operator[int]() methods
-           *  check operator*() methods
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
-
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
-
-            resAcc[to_integral(check_id::access_operators)] =
-                checker.access_operators(globalMultiPtr, constantMultiPtr,
-                                         localMultiPtr, privateMultiPtr);
-          }
-
-          /** check operator->() methods
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
-
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
-
-            checker.arrow_operators(globalMultiPtr, constantMultiPtr,
-                                    localMultiPtr, privateMultiPtr);
-          }
-
-          /** check arithmetic operators
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
-
-            multiPtrGlobal globalMultiPtr(globalPtr);
-            multiPtrConstant constantMultiPtr(constantPtr);
-            multiPtrLocal localMultiPtr(localPtr);
-            multiPtrPrivate privateMultiPtr(privatePtr);
-
-            resAcc[to_integral(check_id::arithmetic_operators)] =
-                checker.arithmetic_operators(globalMultiPtr, constantMultiPtr,
+                checker.conversion_operators(globalMultiPtr, constantMultiPtr,
                                              localMultiPtr, privateMultiPtr);
-          }
+                checker.const_conversion_operators(
+                    globalMultiPtr, constantMultiPtr, localMultiPtr,
+                    privateMultiPtr);
+              }
 
-          /** check make_ptr function
-           */
-          {
-            using namespace sycl::access;
+              /** check operator[int]() methods
+               *  check operator*() methods
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
 
-            multiPtrGlobal globalMultiPtr =
-                sycl::make_ptr<U, address_space::global_space,
-                               decorated::legacy>(
-                    expectedGlobalPtr);
-            multiPtrConstant constantMultiPtr =
-                sycl::make_ptr<U, address_space::constant_space,
-                               decorated::legacy>(
-                    expectedConstantPtr);
-            multiPtrLocal localMultiPtr =
-                sycl::make_ptr<U, address_space::local_space,
-                               decorated::legacy>(
-                    expectedLocalPtr);
-            multiPtrPrivate privateMultiPtr =
-                sycl::make_ptr<U, address_space::private_space,
-                               decorated::legacy>(
-                    expectedPrivatePtr);
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
 
-            bool result = true;
+                resAcc[to_integral(check_id::access_operators)] =
+                    checker.access_operators(globalMultiPtr, constantMultiPtr,
+                                             localMultiPtr, privateMultiPtr);
+              }
 
-            result &= reference_t::is_data_equal(globalMultiPtr);
-            result &= reference_t::is_data_equal(constantMultiPtr);
-            result &= reference_t::is_data_equal(localMultiPtr);
-            result &= reference_t::is_data_equal(privateMultiPtr);
+              /** check operator->() methods
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
 
-            resAcc[to_integral(check_id::make_ptr_method)] = result;
-          }
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
 
-          /** check relation functions
-           */
-          {
-            // construct a set of multi_ptr
-            global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
-            constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
-            local_ptr_legacy<U> localPtr(expectedLocalPtr);
-            private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
+                checker.arrow_operators(globalMultiPtr, constantMultiPtr,
+                                        localMultiPtr, privateMultiPtr);
+              }
 
-            checker.relational_operators(globalPtr);
-            checker.relational_operators(constantPtr);
-            checker.relational_operators(localPtr);
-            checker.relational_operators(privatePtr);
-          }
-        });
+              /** check arithmetic operators
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
+
+                multiPtrGlobal globalMultiPtr(globalPtr);
+                multiPtrConstant constantMultiPtr(constantPtr);
+                multiPtrLocal localMultiPtr(localPtr);
+                multiPtrPrivate privateMultiPtr(privatePtr);
+
+                resAcc[to_integral(check_id::arithmetic_operators)] =
+                    checker.arithmetic_operators(
+                        globalMultiPtr, constantMultiPtr, localMultiPtr,
+                        privateMultiPtr);
+              }
+
+              /** check make_ptr function
+               */
+              {
+                using namespace sycl::access;
+
+                multiPtrGlobal globalMultiPtr =
+                    sycl::make_ptr<U, address_space::global_space,
+                                   decorated::legacy>(expectedGlobalPtr);
+                multiPtrConstant constantMultiPtr =
+                    sycl::make_ptr<U, address_space::constant_space,
+                                   decorated::legacy>(expectedConstantPtr);
+                multiPtrLocal localMultiPtr =
+                    sycl::make_ptr<U, address_space::local_space,
+                                   decorated::legacy>(expectedLocalPtr);
+                multiPtrPrivate privateMultiPtr =
+                    sycl::make_ptr<U, address_space::private_space,
+                                   decorated::legacy>(expectedPrivatePtr);
+
+                bool result = true;
+
+                result &= reference_t::is_data_equal(globalMultiPtr);
+                result &= reference_t::is_data_equal(constantMultiPtr);
+                result &= reference_t::is_data_equal(localMultiPtr);
+                result &= reference_t::is_data_equal(privateMultiPtr);
+
+                resAcc[to_integral(check_id::make_ptr_method)] = result;
+              }
+
+              /** check relation functions
+               */
+              {
+                // construct a set of multi_ptr
+                global_ptr_legacy<U> globalPtr(expectedGlobalPtr);
+                constant_ptr_legacy<U> constantPtr(expectedConstantPtr);
+                local_ptr_legacy<U> localPtr(expectedLocalPtr);
+                private_ptr_legacy<U> privatePtr(expectedPrivatePtr);
+
+                checker.relational_operators(globalPtr);
+                checker.relational_operators(constantPtr);
+                checker.relational_operators(localPtr);
+                checker.relational_operators(privatePtr);
+              }
+            });
       });
     } //end of buffer scope
 

--- a/tests/multi_ptr/multi_ptr_legacy_api_common.h
+++ b/tests/multi_ptr/multi_ptr_legacy_api_common.h
@@ -610,8 +610,10 @@ class pointer_apis {
                        sycl::target::local>
             localAccessor(size, handler);
 
-        handler.single_task<class kernel0<T, U>>(
-              [resAcc, globalAccessor, constantAccessor, localAccessor]() {
+        handler.parallel_for<class kernel0<T, U>>(
+            sycl::nd_range<1>(sycl::range<1>(1), sycl::range<1>(1)),
+            [resAcc, globalAccessor, constantAccessor,
+             localAccessor](auto item) {
           check_helper<T, U> checker;
 
           data_t privateData[size];

--- a/tests/multi_ptr/multi_ptr_legacy_constructors_common.h
+++ b/tests/multi_ptr/multi_ptr_legacy_constructors_common.h
@@ -59,121 +59,130 @@ class pointer_ctors {
       handler.parallel_for<class kernel0<T, U>>(
           sycl::nd_range<1>(sycl::range<1>(1), sycl::range<1>(1)),
           [=](auto item) {
-        data_t privateData[1];
+            data_t privateData[1];
 
-        /** check default constructors
-         */
-        {
-          multiPtrGlobal globalMultiPtr;
-          multiPtrConstant constantMultiPtr;
-          multiPtrLocal localMultiPtr;
-          multiPtrPrivate privateMultiPtr;
+            /** check default constructors
+             */
+            {
+              multiPtrGlobal globalMultiPtr;
+              multiPtrConstant constantMultiPtr;
+              multiPtrLocal localMultiPtr;
+              multiPtrPrivate privateMultiPtr;
 
-          silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr,
-                           privateMultiPtr);
-        }
+              silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr,
+                               privateMultiPtr);
+            }
 
-        /** check (elementType *) constructors
-         */
-        {
-          global_ptr_legacy<U> globalPtr(static_cast<U *>(&globalAccessor[0]));
-          constant_ptr_legacy<U> constantPtr(constantAccessor.get_pointer());
-          local_ptr_legacy<U> localPtr(static_cast<U *>(&localAccessor[0]));
-          private_ptr_legacy<U> privatePtr(static_cast<U *>(privateData));
+            /** check (elementType *) constructors
+             */
+            {
+              global_ptr_legacy<U> globalPtr(
+                  static_cast<U *>(&globalAccessor[0]));
+              constant_ptr_legacy<U> constantPtr(
+                  constantAccessor.get_pointer());
+              local_ptr_legacy<U> localPtr(static_cast<U *>(&localAccessor[0]));
+              private_ptr_legacy<U> privatePtr(static_cast<U *>(privateData));
 
-          multiPtrGlobal globalMultiPtr(globalPtr);
-          multiPtrConstant constantMultiPtr(constantPtr);
-          multiPtrLocal localMultiPtr(localPtr);
-          multiPtrPrivate privateMultiPtr(privatePtr);
+              multiPtrGlobal globalMultiPtr(globalPtr);
+              multiPtrConstant constantMultiPtr(constantPtr);
+              multiPtrLocal localMultiPtr(localPtr);
+              multiPtrPrivate privateMultiPtr(privatePtr);
 
-          silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr,
-                           privateMultiPtr);
-        }
+              silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr,
+                               privateMultiPtr);
+            }
 
-        /** check (pointer) constructors
-         */
-        {
-          global_ptr_legacy<U> globalPtr(static_cast<U *>(&globalAccessor[0]));
-          constant_ptr_legacy<U> constantPtr(constantAccessor.get_pointer());
-          local_ptr_legacy<U> localPtr(static_cast<U *>(&localAccessor[0]));
-          private_ptr_legacy<U> privatePtr(static_cast<U *>(privateData));
+            /** check (pointer) constructors
+             */
+            {
+              global_ptr_legacy<U> globalPtr(
+                  static_cast<U *>(&globalAccessor[0]));
+              constant_ptr_legacy<U> constantPtr(
+                  constantAccessor.get_pointer());
+              local_ptr_legacy<U> localPtr(static_cast<U *>(&localAccessor[0]));
+              private_ptr_legacy<U> privatePtr(static_cast<U *>(privateData));
 
-          multiPtrGlobal globalMultiPtr(globalPtr.get());
-          multiPtrConstant constantMultiPtr(constantPtr.get());
-          multiPtrLocal localMultiPtr(localPtr.get());
-          multiPtrPrivate privateMultiPtr(privatePtr.get());
+              multiPtrGlobal globalMultiPtr(globalPtr.get());
+              multiPtrConstant constantMultiPtr(constantPtr.get());
+              multiPtrLocal localMultiPtr(localPtr.get());
+              multiPtrPrivate privateMultiPtr(privatePtr.get());
 
-          silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr,
-                           privateMultiPtr);
-        }
+              silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr,
+                               privateMultiPtr);
+            }
 
-        /** check (std::nullptr_t) constructors
-         */
-        {
-          multiPtrGlobal globalMultiPtr(nullptr);
-          multiPtrConstant constantMultiPtr(nullptr);
-          multiPtrLocal localMultiPtr(nullptr);
-          multiPtrPrivate privateMultiPtr(nullptr);
+            /** check (std::nullptr_t) constructors
+             */
+            {
+              multiPtrGlobal globalMultiPtr(nullptr);
+              multiPtrConstant constantMultiPtr(nullptr);
+              multiPtrLocal localMultiPtr(nullptr);
+              multiPtrPrivate privateMultiPtr(nullptr);
 
-          silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr,
-                           privateMultiPtr);
-        }
+              silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr,
+                               privateMultiPtr);
+            }
 
-        /** check (accessor) constructors
-         */
-        {
-          multiPtrGlobal globalMultiPtr(globalAccessor);
-          multiPtrConstant constantMultiPtr(constantAccessor);
-          multiPtrLocal localMultiPtr(localAccessor);
+            /** check (accessor) constructors
+             */
+            {
+              multiPtrGlobal globalMultiPtr(globalAccessor);
+              multiPtrConstant constantMultiPtr(constantAccessor);
+              multiPtrLocal localMultiPtr(localAccessor);
 
-          silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr);
-        }
+              silence_warnings(globalMultiPtr, constantMultiPtr, localMultiPtr);
+            }
 
-        /** check copy constructors
-         */
-        {
-          global_ptr_legacy<U> globalPtrA(static_cast<U *>(&globalAccessor[0]));
-          constant_ptr_legacy<U> constantPtrA(constantAccessor.get_pointer());
-          local_ptr_legacy<U> localPtrA(static_cast<U *>(&localAccessor[0]));
-          private_ptr_legacy<U> privatePtrA(static_cast<U *>(privateData));
+            /** check copy constructors
+             */
+            {
+              global_ptr_legacy<U> globalPtrA(
+                  static_cast<U *>(&globalAccessor[0]));
+              constant_ptr_legacy<U> constantPtrA(
+                  constantAccessor.get_pointer());
+              local_ptr_legacy<U> localPtrA(
+                  static_cast<U *>(&localAccessor[0]));
+              private_ptr_legacy<U> privatePtrA(static_cast<U *>(privateData));
 
-          multiPtrGlobal globalMultiPtrA(globalPtrA);
-          multiPtrConstant constantMultiPtrA(constantPtrA);
-          multiPtrLocal localMultiPtrA(localPtrA);
-          multiPtrPrivate privateMultiPtrA(privatePtrA);
+              multiPtrGlobal globalMultiPtrA(globalPtrA);
+              multiPtrConstant constantMultiPtrA(constantPtrA);
+              multiPtrLocal localMultiPtrA(localPtrA);
+              multiPtrPrivate privateMultiPtrA(privatePtrA);
 
-          multiPtrGlobal globalMultiPtrB(globalMultiPtrA);
-          multiPtrConstant constantMultiPtrB(constantMultiPtrA);
-          multiPtrLocal localMultiPtrB(localMultiPtrA);
-          multiPtrPrivate privateMultiPtrB(privateMultiPtrA);
+              multiPtrGlobal globalMultiPtrB(globalMultiPtrA);
+              multiPtrConstant constantMultiPtrB(constantMultiPtrA);
+              multiPtrLocal localMultiPtrB(localMultiPtrA);
+              multiPtrPrivate privateMultiPtrB(privateMultiPtrA);
 
-          silence_warnings(globalMultiPtrB, constantMultiPtrB, localMultiPtrB,
-                           privateMultiPtrB);
-        }
+              silence_warnings(globalMultiPtrB, constantMultiPtrB,
+                               localMultiPtrB, privateMultiPtrB);
+            }
 
-        /** check move constructors
-         */
-        {
-          global_ptr_legacy<U> globalPtrA(static_cast<U *>(&globalAccessor[0]));
-          constant_ptr_legacy<U> constantPtrA(constantAccessor.get_pointer());
-          local_ptr_legacy<U> localPtrA(static_cast<U *>(&localAccessor[0]));
-          private_ptr_legacy<U> privatePtrA(static_cast<U *>(privateData));
+            /** check move constructors
+             */
+            {
+              global_ptr_legacy<U> globalPtrA(
+                  static_cast<U *>(&globalAccessor[0]));
+              constant_ptr_legacy<U> constantPtrA(
+                  constantAccessor.get_pointer());
+              local_ptr_legacy<U> localPtrA(
+                  static_cast<U *>(&localAccessor[0]));
+              private_ptr_legacy<U> privatePtrA(static_cast<U *>(privateData));
 
-          multiPtrGlobal globalMultiPtrA(globalPtrA);
-          multiPtrConstant constantMultiPtrA(constantPtrA);
-          multiPtrLocal localMultiPtrA(localPtrA);
-          multiPtrPrivate privateMultiPtrA(privatePtrA);
+              multiPtrGlobal globalMultiPtrA(globalPtrA);
+              multiPtrConstant constantMultiPtrA(constantPtrA);
+              multiPtrLocal localMultiPtrA(localPtrA);
+              multiPtrPrivate privateMultiPtrA(privatePtrA);
 
-          multiPtrGlobal globalMultiPtrB = std::move(globalMultiPtrA);
-          multiPtrConstant constantMultiPtrB = std::move(constantMultiPtrA);
-          multiPtrLocal localMultiPtrB = std::move(localMultiPtrA);
-          multiPtrPrivate privateMultiPtrB = std::move(privateMultiPtrA);
+              multiPtrGlobal globalMultiPtrB = std::move(globalMultiPtrA);
+              multiPtrConstant constantMultiPtrB = std::move(constantMultiPtrA);
+              multiPtrLocal localMultiPtrB = std::move(localMultiPtrA);
+              multiPtrPrivate privateMultiPtrB = std::move(privateMultiPtrA);
 
-          silence_warnings(globalMultiPtrB, constantMultiPtrB, localMultiPtrB,
-                           privateMultiPtrB);
-        }
-
-      });
+              silence_warnings(globalMultiPtrB, constantMultiPtrB,
+                               localMultiPtrB, privateMultiPtrB);
+            }
+          });
     });
   }
 };

--- a/tests/multi_ptr/multi_ptr_legacy_constructors_common.h
+++ b/tests/multi_ptr/multi_ptr_legacy_constructors_common.h
@@ -56,7 +56,9 @@ class pointer_ctors {
                      sycl::target::local>
           localAccessor(size, handler);
 
-      handler.single_task<class kernel0<T, U>>([=] {
+      handler.parallel_for<class kernel0<T, U>>(
+          sycl::nd_range<1>(sycl::range<1>(1), sycl::range<1>(1)),
+          [=](auto item) {
         data_t privateData[1];
 
         /** check default constructors


### PR DESCRIPTION
In SYCL 2020 local accessor must not be used in a SYCL kernel function that is invoked via single_task or via the simple form of parallel_for that takes a range parameter.