### PR TITLE
Format pointer and reference declarations consistently

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,9 @@ BinPackParameters: true
 BinPackArguments: true
 ColumnLimit:     80
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
-DerivePointerAlignment: true
+# Do not adapt pointer and reference alignment to the current style.
+# Just use PointerAlignment parameter unconditionally for consistency.
+DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 IndentCaseLabels: true
 IndentWrappedFunctionNames: false
@@ -59,5 +61,3 @@ ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 SpaceBeforeParens: ControlStatements
 DisableFormat:   false
 SortIncludes:   true
-...
-


### PR DESCRIPTION
Do not adapt pointer and reference alignment to the current style.
 Just use PointerAlignment parameter unconditionally for consistency.