### PR TITLE
sycl::half test for numeric limits specialization 

### DIFF
--- a/tests/scalars/scalars_sycl_types.cpp
+++ b/tests/scalars/scalars_sycl_types.cpp
@@ -284,6 +284,12 @@ class TEST_NAME : public util::test_base {
 
       myQueue.wait_and_throw();
     }
+
+    // Check sycl::half limits specialization
+    {
+      INFO("Check that std::numeric_limits is specialized for sycl::half type");
+      CHECK(std::numeric_limits<sycl::half>::is_specialized);
+    }
   }
 };
 


### PR DESCRIPTION
Due to [SYCL spec](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_scalar_data_types), `std::numeric_limits` must be specialized for `sycl::half` type.