### PR TITLE
Add atomic_ref stress tests

### DIFF
--- a/tests/atomic_ref_stress/CMakeLists.txt
+++ b/tests/atomic_ref_stress/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB test_cases_list *.cpp)
+
+add_cts_test(${test_cases_list})

--- a/tests/atomic_ref_stress/atomic_ref_stress_atomic64.cpp
+++ b/tests/atomic_ref_stress/atomic_ref_stress_atomic64.cpp
@@ -1,0 +1,130 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "atomic_ref_stress_common.h"
+#include <catch2/catch_test_macros.hpp>
+
+namespace atomic_ref_stress_test_atomic64 {
+
+TEST_CASE("sycl::atomic_ref atomicity for device scope test. long long type",
+          "[atomic_ref_stress]") {
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_atomicity_device_scope<long long>{}("long long");
+}
+
+TEST_CASE("sycl::atomic_ref atomicity for device scope test. double type",
+          "[atomic_ref_stress]") {
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  if (!queue.get_device().has(sycl::aspect::fp64))
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_atomicity_device_scope<double>{}("double");
+}
+
+TEST_CASE(
+    "sycl::atomic_ref atomicity for work_group scope test. long long type",
+    "[atomic_ref_stress]") {
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_atomicity_work_group_scope<long long>{}(
+      "long long");
+}
+
+TEST_CASE("sycl::atomic_ref atomicity for work_group scope test. double type",
+          "[atomic_ref_stress]") {
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  if (!queue.get_device().has(sycl::aspect::fp64))
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_atomicity_work_group_scope<double>{}("double");
+}
+
+TEST_CASE("sycl::atomic_ref aquire and release. long long type",
+          "[atomic_ref_stress]") {
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_aquire_release<long long>{}("long long");
+}
+
+TEST_CASE("sycl::atomic_ref aquire and release. double types",
+          "[atomic_ref_stress]") {
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  if (!queue.get_device().has(sycl::aspect::fp64))
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_aquire_release<double>{}("double");
+}
+
+TEST_CASE("sycl::atomic_ref ordering. long long type", "[atomic_ref_stress]") {
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_ordering<long long>{}("long long");
+}
+
+TEST_CASE("sycl::atomic_ref ordering. double type", "[atomic_ref_stress]") {
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  if (!queue.get_device().has(sycl::aspect::fp64))
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_ordering<double>{}("double");
+}
+
+}  // namespace atomic_ref_stress_test_atomic64

--- a/tests/atomic_ref_stress/atomic_ref_stress_atomic64.cpp
+++ b/tests/atomic_ref_stress/atomic_ref_stress_atomic64.cpp
@@ -18,13 +18,21 @@
 //
 *******************************************************************************/
 
+#include "../common/disabled_for_test_case.h"
 #include "atomic_ref_stress_common.h"
 #include <catch2/catch_test_macros.hpp>
 
 namespace atomic_ref_stress_test_atomic64 {
 
-TEST_CASE("sycl::atomic_ref atomicity for device scope test. long long type",
-          "[atomic_ref_stress]") {
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity for device scope test. long long type",
+ "[atomic_ref_stress]")({
   auto queue = once_per_unit::get_queue();
   if (!queue.get_device().has(sycl::aspect::atomic64))
     SKIP(
@@ -32,10 +40,11 @@ TEST_CASE("sycl::atomic_ref atomicity for device scope test. long long type",
         "Skipping the test case.");
 
   atomic_ref_stress_test::run_atomicity_device_scope<long long>{}("long long");
-}
+});
 
-TEST_CASE("sycl::atomic_ref atomicity for device scope test. double type",
-          "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity for device scope test. double type",
+ "[atomic_ref_stress]")({
   auto queue = once_per_unit::get_queue();
   if (!queue.get_device().has(sycl::aspect::atomic64))
     SKIP(
@@ -47,11 +56,11 @@ TEST_CASE("sycl::atomic_ref atomicity for device scope test. double type",
         "Skipping the test case.");
 
   atomic_ref_stress_test::run_atomicity_device_scope<double>{}("double");
-}
+});
 
-TEST_CASE(
-    "sycl::atomic_ref atomicity for work_group scope test. long long type",
-    "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity for work_group scope test. long long type",
+ "[atomic_ref_stress]")({
   auto queue = once_per_unit::get_queue();
   if (!queue.get_device().has(sycl::aspect::atomic64))
     SKIP(
@@ -60,10 +69,11 @@ TEST_CASE(
 
   atomic_ref_stress_test::run_atomicity_work_group_scope<long long>{}(
       "long long");
-}
+});
 
-TEST_CASE("sycl::atomic_ref atomicity for work_group scope test. double type",
-          "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity for work_group scope test. double type",
+ "[atomic_ref_stress]")({
   auto queue = once_per_unit::get_queue();
   if (!queue.get_device().has(sycl::aspect::atomic64))
     SKIP(
@@ -75,10 +85,10 @@ TEST_CASE("sycl::atomic_ref atomicity for work_group scope test. double type",
         "Skipping the test case.");
 
   atomic_ref_stress_test::run_atomicity_work_group_scope<double>{}("double");
-}
+});
 
-TEST_CASE("sycl::atomic_ref aquire and release. long long type",
-          "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref aquire and release. long long type", "[atomic_ref_stress]")({
   auto queue = once_per_unit::get_queue();
   if (!queue.get_device().has(sycl::aspect::atomic64))
     SKIP(
@@ -86,10 +96,10 @@ TEST_CASE("sycl::atomic_ref aquire and release. long long type",
         "Skipping the test case.");
 
   atomic_ref_stress_test::run_aquire_release<long long>{}("long long");
-}
+});
 
-TEST_CASE("sycl::atomic_ref aquire and release. double types",
-          "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref aquire and release. double types", "[atomic_ref_stress]")({
   auto queue = once_per_unit::get_queue();
   if (!queue.get_device().has(sycl::aspect::atomic64))
     SKIP(
@@ -101,9 +111,10 @@ TEST_CASE("sycl::atomic_ref aquire and release. double types",
         "Skipping the test case.");
 
   atomic_ref_stress_test::run_aquire_release<double>{}("double");
-}
+});
 
-TEST_CASE("sycl::atomic_ref ordering. long long type", "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref ordering. long long type", "[atomic_ref_stress]")({
   auto queue = once_per_unit::get_queue();
   if (!queue.get_device().has(sycl::aspect::atomic64))
     SKIP(
@@ -111,9 +122,10 @@ TEST_CASE("sycl::atomic_ref ordering. long long type", "[atomic_ref_stress]") {
         "Skipping the test case.");
 
   atomic_ref_stress_test::run_ordering<long long>{}("long long");
-}
+});
 
-TEST_CASE("sycl::atomic_ref ordering. double type", "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref ordering. double type", "[atomic_ref_stress]")({
   auto queue = once_per_unit::get_queue();
   if (!queue.get_device().has(sycl::aspect::atomic64))
     SKIP(
@@ -125,6 +137,6 @@ TEST_CASE("sycl::atomic_ref ordering. double type", "[atomic_ref_stress]") {
         "Skipping the test case.");
 
   atomic_ref_stress_test::run_ordering<double>{}("double");
-}
+});
 
 }  // namespace atomic_ref_stress_test_atomic64

--- a/tests/atomic_ref_stress/atomic_ref_stress_atomic64.cpp
+++ b/tests/atomic_ref_stress/atomic_ref_stress_atomic64.cpp
@@ -19,7 +19,10 @@
 *******************************************************************************/
 
 #include "../common/disabled_for_test_case.h"
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "atomic_ref_stress_common.h"
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include <catch2/catch_test_macros.hpp>
 
 namespace atomic_ref_stress_test_atomic64 {

--- a/tests/atomic_ref_stress/atomic_ref_stress_common.h
+++ b/tests/atomic_ref_stress/atomic_ref_stress_common.h
@@ -1,0 +1,313 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//
+*******************************************************************************/
+#ifndef SYCL_CTS_ATOMIC_REF_STRESS_TEST_H
+#define SYCL_CTS_ATOMIC_REF_STRESS_TEST_H
+
+#include "../atomic_ref/atomic_ref_common.h"
+#include "../common/once_per_unit.h"
+#include "../common/section_name_builder.h"
+#include "../common/type_coverage.h"
+
+#include <atomic>
+
+namespace atomic_ref_stress_test {
+using namespace sycl_cts;
+
+template <typename T, typename MemoryOrderT, typename MemoryScopeT,
+          typename AddressSpaceT>
+class atomicity_device_scope {
+  static constexpr sycl::memory_order MemoryOrder = MemoryOrderT::value;
+  static constexpr sycl::memory_scope MemoryScope = MemoryScopeT::value;
+  static constexpr sycl::access::address_space AddressSpace =
+      AddressSpaceT::value;
+
+ public:
+  void operator()(const std::string &type_name,
+                  const std::string &memory_order_name,
+                  const std::string &memory_scope_name,
+                  const std::string &address_space_name) {
+    INFO(atomic_ref::tests::common::get_section_name(
+        type_name, memory_order_name, memory_scope_name, address_space_name,
+        "atomicity_device_scope"));
+    auto queue = once_per_unit::get_queue();
+    if (!atomic_ref::tests::common::memory_order_and_scope_are_supported(
+            queue, MemoryOrder, MemoryScope))
+      return;
+    T val{};
+    const size_t size =
+        queue.get_device().get_info<sycl::info::device::max_work_group_size>();
+    {
+      sycl::buffer buf{&val, {1}};
+      queue.submit([&](sycl::handler &cgh) {
+        sycl::accessor acc{buf, cgh};
+        cgh.parallel_for({size}, [=](auto i) {
+          sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace> a_r{
+              acc[0]};
+          a_r.fetch_add(2);
+        });
+      });
+    }
+    CHECK(val == size * 2);
+  }
+};
+
+template <typename T, typename MemoryOrderT, typename MemoryScopeT,
+          typename AddressSpaceT>
+class atomicity_work_group_scope {
+  static constexpr sycl::memory_order MemoryOrder = MemoryOrderT::value;
+  static constexpr sycl::memory_scope MemoryScope = MemoryScopeT::value;
+  static constexpr sycl::access::address_space AddressSpace =
+      AddressSpaceT::value;
+
+ public:
+  void operator()(const std::string &type_name,
+                  const std::string &memory_order_name,
+                  const std::string &memory_scope_name,
+                  const std::string &address_space_name) {
+    INFO(atomic_ref::tests::common::get_section_name(
+        type_name, memory_order_name, memory_scope_name, address_space_name,
+        "atomicity_work_group_scope"));
+    auto queue = once_per_unit::get_queue();
+    if (!atomic_ref::tests::common::memory_order_and_scope_are_supported(
+            queue, MemoryOrder, MemoryScope))
+      return;
+    constexpr size_t group_range = 4;
+    const size_t local_range =
+        queue.get_device().get_info<sycl::info::device::max_work_group_size>();
+    std::array<T, group_range> vals;
+    vals.fill(0);
+    {
+      sycl::buffer buf{vals.data(), {group_range}};
+      queue
+          .submit([&](sycl::handler &cgh) {
+            sycl::accessor acc{buf, cgh};
+            sycl::local_accessor<T> lacc{{1}, cgh};
+            cgh.parallel_for(
+                sycl::nd_range<1>(group_range * local_range, local_range),
+                [=](auto item) {
+                  sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace>
+                      a_r{lacc[0]};
+                  a_r.store(0);
+                  sycl::group_barrier(item.get_group());
+                  if (a_r.fetch_sub(T(2)) - T(2) == -T(local_range * 2)) {
+                    acc[item.get_group_linear_id()] = a_r.load();
+                  }
+                });
+          })
+          .wait_and_throw();
+    }
+    CHECK(std::all_of(vals.cbegin(), vals.cend(),
+                      [=](T i) { return i == -T(local_range * 2); }));
+  }
+};
+
+template <typename T, typename MemoryOrderT, typename MemoryScopeT,
+          typename AddressSpaceT>
+class aquire_release {
+  static constexpr sycl::memory_order MemoryOrder = MemoryOrderT::value;
+  static constexpr sycl::memory_scope MemoryScope = MemoryScopeT::value;
+  static constexpr sycl::access::address_space AddressSpace =
+      AddressSpaceT::value;
+
+ public:
+  void operator()(const std::string &type_name,
+                  const std::string &memory_order_name,
+                  const std::string &memory_scope_name,
+                  const std::string &address_space_name) {
+    INFO(atomic_ref::tests::common::get_section_name(
+        type_name, memory_order_name, memory_scope_name, address_space_name,
+        "aquire_release"));
+    auto queue = once_per_unit::get_queue();
+    if (!atomic_ref::tests::common::memory_order_and_scope_are_supported(
+            queue, MemoryOrder, MemoryScope))
+      return;
+    constexpr size_t global_range = 64;
+    constexpr size_t local_range = 2;
+    sycl::nd_range<1> nd_range(global_range, local_range);
+    std::array<bool, global_range / local_range> res;
+    res.fill(false);
+    {
+      sycl::buffer buf{res.data(), {global_range / local_range}};
+      queue.submit([&](sycl::handler &cgh) {
+        sycl::accessor res_acc{buf, cgh};
+        sycl::local_accessor<T, 0> x{cgh};
+        sycl::local_accessor<T, 0> y{cgh};
+        sycl::local_accessor<T, 0> A{cgh};
+        sycl::local_accessor<T, 0> B{cgh};
+        cgh.parallel_for(nd_range, [=](auto item) {
+          sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace> refA{A};
+          sycl::atomic_ref<T, MemoryOrder, MemoryScope, AddressSpace> refB{B};
+          refA.store(0);
+          refB.store(0);
+          sycl::group_barrier(item.get_group());
+          if (item.get_local_id() == 0) {
+            x = refA.load();
+            refB.store(1);
+          } else {
+            y = refB.load();
+            refA.store(1);
+          }
+          sycl::group_barrier(item.get_group());
+          if (item.get_local_id() == 0)
+            res_acc[item.get_group_linear_id()] = !(x == 1 && y == 1);
+        });
+      });
+    }
+    CHECK(std::all_of(res.cbegin(), res.cend(), [=](T i) { return i; }));
+  }
+};
+
+template <typename T, typename MemoryOrderT, typename MemoryScopeT,
+          typename AddressSpaceT>
+class ordering {
+  static constexpr sycl::memory_order MemoryOrder1 = MemoryOrderT::value;
+  static constexpr sycl::memory_order MemoryOrder2 =
+      (MemoryOrder1 == sycl::memory_order::release)
+          ? sycl::memory_order::acquire
+          : sycl::memory_order::seq_cst;
+  static constexpr sycl::memory_scope MemoryScope = MemoryScopeT::value;
+  static constexpr sycl::access::address_space AddressSpace =
+      AddressSpaceT::value;
+
+ public:
+  void operator()(const std::string &type_name,
+                  const std::string &memory_order_name,
+                  const std::string &memory_scope_name,
+                  const std::string &address_space_name) {
+    INFO(atomic_ref::tests::common::get_section_name(
+        type_name, memory_order_name, memory_scope_name, address_space_name,
+        "ordering"));
+    auto queue = once_per_unit::get_queue();
+    if (!atomic_ref::tests::common::memory_order_and_scope_are_supported(
+            queue, MemoryOrder1, MemoryScope))
+      return;
+    if (!atomic_ref::tests::common::memory_order_is_supported(queue,
+                                                              MemoryOrder2))
+      return;
+    size_t local_range =
+        queue.get_device().get_info<sycl::info::device::max_work_group_size>();
+    constexpr size_t global_range = 32768;
+    if (local_range > global_range) local_range = global_range;
+    sycl::nd_range<1> nd_range(global_range, local_range);
+    std::array<bool, global_range> res;
+    res.fill(false);
+    {
+      sycl::buffer buf{res.data(), {global_range}};
+      queue.submit([&](sycl::handler &cgh) {
+        sycl::accessor res_acc{buf, cgh};
+        sycl::local_accessor<T, 0> local_acc{cgh};
+        sycl::local_accessor<bool> arr_acc{{local_range}, cgh};
+        cgh.parallel_for(nd_range, [=](auto item) {
+          arr_acc[item.get_local_id()] = false;
+          sycl::group_barrier(item.get_group());
+          sycl::atomic_ref<T, sycl::memory_order::relaxed, MemoryScope,
+                           AddressSpace>
+              a_r{local_acc};
+          arr_acc[item.get_local_id()] = true;
+          a_r.store(item.get_local_id(), MemoryOrder1);
+          res_acc[item.get_global_id()] =
+              (arr_acc[a_r.load(MemoryOrder2)] == true);
+        });
+      });
+    }
+    CHECK(std::all_of(res.cbegin(), res.cend(), [=](T i) { return i; }));
+  }
+};
+
+template <typename T>
+struct run_atomicity_device_scope {
+  void operator()(const std::string &type_name) {
+    const auto memory_orders =
+        value_pack<sycl::memory_order, sycl::memory_order::relaxed,
+                   sycl::memory_order::acq_rel,
+                   sycl::memory_order::seq_cst>::generate_named();
+    const auto memory_scopes =
+        value_pack<sycl::memory_scope, sycl::memory_scope::device,
+                   sycl::memory_scope::system>::generate_named();
+    const auto address_spaces = value_pack<
+        sycl::access::address_space, sycl::access::address_space::global_space,
+        sycl::access::address_space::generic_space>::generate_named();
+
+    for_all_combinations<atomicity_device_scope, T>(
+        memory_orders, memory_scopes, address_spaces, type_name);
+  }
+};
+
+template <typename T>
+struct run_atomicity_work_group_scope {
+  void operator()(const std::string &type_name) {
+    const auto memory_orders =
+        value_pack<sycl::memory_order, sycl::memory_order::relaxed,
+                   sycl::memory_order::acq_rel,
+                   sycl::memory_order::seq_cst>::generate_named();
+    const auto memory_scopes =
+        value_pack<sycl::memory_scope, sycl::memory_scope::device,
+                   sycl::memory_scope::system,
+                   sycl::memory_scope::work_group>::generate_named();
+    const auto address_spaces = value_pack<
+        sycl::access::address_space, sycl::access::address_space::local_space,
+        sycl::access::address_space::generic_space>::generate_named();
+
+    for_all_combinations<atomicity_work_group_scope, T>(
+        memory_orders, memory_scopes, address_spaces, type_name);
+  }
+};
+
+template <typename T>
+struct run_aquire_release {
+  void operator()(const std::string &type_name) {
+    const auto memory_orders =
+        value_pack<sycl::memory_order, sycl::memory_order::acq_rel,
+                   sycl::memory_order::seq_cst>::generate_named();
+    const auto memory_scopes =
+        value_pack<sycl::memory_scope, sycl::memory_scope::device,
+                   sycl::memory_scope::system,
+                   sycl::memory_scope::work_group>::generate_named();
+    const auto address_spaces = value_pack<
+        sycl::access::address_space, sycl::access::address_space::local_space,
+        sycl::access::address_space::generic_space>::generate_named();
+
+    for_all_combinations<aquire_release, T>(memory_orders, memory_scopes,
+                                            address_spaces, type_name);
+  }
+};
+
+template <typename T>
+struct run_ordering {
+  void operator()(const std::string &type_name) {
+    const auto memory_orders =
+        value_pack<sycl::memory_order, sycl::memory_order::release,
+                   sycl::memory_order::seq_cst>::generate_named();
+    const auto memory_scopes =
+        value_pack<sycl::memory_scope, sycl::memory_scope::device,
+                   sycl::memory_scope::system,
+                   sycl::memory_scope::work_group>::generate_named();
+    const auto address_spaces = value_pack<
+        sycl::access::address_space, sycl::access::address_space::local_space,
+        sycl::access::address_space::generic_space>::generate_named();
+
+    for_all_combinations<ordering, T>(memory_orders, memory_scopes,
+                                      address_spaces, type_name);
+  }
+};
+
+}  // namespace atomic_ref_stress_test
+#endif  // SYCL_CTS_ATOMIC_REF_STRESS_TEST_H

--- a/tests/atomic_ref_stress/atomic_ref_stress_core.cpp
+++ b/tests/atomic_ref_stress/atomic_ref_stress_core.cpp
@@ -19,7 +19,10 @@
 *******************************************************************************/
 
 #include "../common/disabled_for_test_case.h"
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "atomic_ref_stress_common.h"
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&
+        // !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include <catch2/catch_test_macros.hpp>
 
 namespace atomic_ref_stress_test_core {

--- a/tests/atomic_ref_stress/atomic_ref_stress_core.cpp
+++ b/tests/atomic_ref_stress/atomic_ref_stress_core.cpp
@@ -18,33 +18,43 @@
 //
 *******************************************************************************/
 
+#include "../common/disabled_for_test_case.h"
 #include "atomic_ref_stress_common.h"
 #include <catch2/catch_test_macros.hpp>
 
 namespace atomic_ref_stress_test_core {
 
-TEST_CASE("sycl::atomic_ref atomicity for device scope. core types",
-          "[atomic_ref_stress]") {
+// FIXME: re-enable for computecpp when
+// sycl::access::address_space::generic_space and possibility of a SYCL kernel
+// with an unnamed type are implemented in computecpp, re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity for device scope. core types",
+ "[atomic_ref_stress]")({
   const auto type_pack = named_type_pack<int, float>::generate("int", "float");
   for_all_types<atomic_ref_stress_test::run_atomicity_device_scope>(type_pack);
-}
+});
 
-TEST_CASE("sycl::atomic_ref atomicity for work_group scope. core types",
-          "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity for work_group scope. core types",
+ "[atomic_ref_stress]")({
   const auto type_pack = named_type_pack<int, float>::generate("int", "float");
   for_all_types<atomic_ref_stress_test::run_atomicity_work_group_scope>(
       type_pack);
-}
+});
 
-TEST_CASE("sycl::atomic_ref aquire and release. core types",
-          "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref aquire and release. core types", "[atomic_ref_stress]")({
   const auto type_pack = named_type_pack<int, float>::generate("int", "float");
   for_all_types<atomic_ref_stress_test::run_aquire_release>(type_pack);
-}
+});
 
-TEST_CASE("sycl::atomic_ref ordering. core types", "[atomic_ref_stress]") {
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref ordering. core types", "[atomic_ref_stress]")({
   const auto type_pack = named_type_pack<int, float>::generate("int", "float");
   for_all_types<atomic_ref_stress_test::run_ordering>(type_pack);
-}
+});
 
 }  // namespace atomic_ref_stress_test_core

--- a/tests/atomic_ref_stress/atomic_ref_stress_core.cpp
+++ b/tests/atomic_ref_stress/atomic_ref_stress_core.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "atomic_ref_stress_common.h"
+#include <catch2/catch_test_macros.hpp>
+
+namespace atomic_ref_stress_test_core {
+
+TEST_CASE("sycl::atomic_ref atomicity for device scope. core types",
+          "[atomic_ref_stress]") {
+  const auto type_pack = named_type_pack<int, float>::generate("int", "float");
+  for_all_types<atomic_ref_stress_test::run_atomicity_device_scope>(type_pack);
+}
+
+TEST_CASE("sycl::atomic_ref atomicity for work_group scope. core types",
+          "[atomic_ref_stress]") {
+  const auto type_pack = named_type_pack<int, float>::generate("int", "float");
+  for_all_types<atomic_ref_stress_test::run_atomicity_work_group_scope>(
+      type_pack);
+}
+
+TEST_CASE("sycl::atomic_ref aquire and release. core types",
+          "[atomic_ref_stress]") {
+  const auto type_pack = named_type_pack<int, float>::generate("int", "float");
+  for_all_types<atomic_ref_stress_test::run_aquire_release>(type_pack);
+}
+
+TEST_CASE("sycl::atomic_ref ordering. core types", "[atomic_ref_stress]") {
+  const auto type_pack = named_type_pack<int, float>::generate("int", "float");
+  for_all_types<atomic_ref_stress_test::run_ordering>(type_pack);
+}
+
+}  // namespace atomic_ref_stress_test_core


### PR DESCRIPTION
Add sycl::atomic_ref stress tests according to extension of atomic_ref test plan section [3.2 Stress tests](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/atomic_ref.asciidoc#32-stress-tests), except for section [3.2.5. Atomicity with respect to atomic operations in host code](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/atomic_ref.asciidoc#325-atomicity-with-respect-to-atomic-operations-in-host-code) because it's not clear if std::atomic_ref should be available in SYCL 2020 - https://github.com/KhronosGroup/SYCL-CTS/pull/590#discussion_r1182611654)