### PR TITLE
get_specialization_constant() return type check

### DIFF
--- a/tests/kernel_bundle/kernel_bundle_spec_const.cpp
+++ b/tests/kernel_bundle/kernel_bundle_spec_const.cpp
@@ -49,7 +49,7 @@ TEST_CASE(
 
   using KernelName = class simple_kernel;
 
-  queue.submit([&](sycl::handler &cgh) {
+  queue.submit([&](sycl::handler& cgh) {
     cgh.single_task<KernelName>([=](sycl::kernel_handler h) {
       // just to establish `kernel_handler::get_specialization_constant()` call
       // usage of spec constants is checked in spec_constants tests

--- a/tests/kernel_bundle/kernel_bundle_spec_const.cpp
+++ b/tests/kernel_bundle/kernel_bundle_spec_const.cpp
@@ -74,6 +74,16 @@ TEST_CASE(
   CHECK(inputBundle.has_specialization_constant<SpecName>());
   CHECK(!inputBundle.has_specialization_constant<OtherSpecName>());
 
+  {
+    INFO("Check get_specialization_constant() return type");
+    CHECK(std::is_same_v<
+          std::remove_reference_t<decltype(SpecName)>::value_type,
+          decltype(inputBundle.get_specialization_constant<SpecName>())>);
+    CHECK(std::is_same_v<
+          std::remove_reference_t<decltype(OtherSpecName)>::value_type,
+          decltype(inputBundle.get_specialization_constant<OtherSpecName>())>);
+  }
+
   CHECK(inputBundle.get_specialization_constant<SpecName>() == new_value);
 
   auto objectBundle = sycl::compile(inputBundle);

--- a/tests/kernel_bundle/use_kernel_bundle_verify_that_kernel_was_invoked.cpp
+++ b/tests/kernel_bundle/use_kernel_bundle_verify_that_kernel_was_invoked.cpp
@@ -35,14 +35,14 @@ struct kernel;
  *  @param log sycl_cts::util::logger class object
  *  @param ctx Context that will used for sycl::queue
  */
-void invoke_kernel_and_verify_invocation(util::logger &log,
-                                         const sycl::context &ctx) {
+void invoke_kernel_and_verify_invocation(util::logger& log,
+                                         const sycl::context& ctx) {
   sycl::queue queue(ctx, ctx.get_devices()[0]);
   bool flags[] = {false, false};
 
   {
     sycl::buffer<bool> flag_buffer{flags, sycl::range<1>{2}};
-    queue.submit([&](sycl::handler &cgh) {
+    queue.submit([&](sycl::handler& cgh) {
       auto kernel_bundle{
           sycl::get_kernel_bundle<kernel, sycl::bundle_state::input>(ctx)};
 
@@ -84,13 +84,13 @@ class TEST_NAME : public sycl_cts::util::test_base {
  public:
   /** return information about this test
    */
-  void get_info(test_base::info &out) const override {
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
    */
-  void run(util::logger &log) override {
+  void run(util::logger& log) override {
     sycl::device dev = util::get_cts_object::device();
     sycl::context ctx(dev.get_platform().get_devices());
 


### PR DESCRIPTION
Tests for `kernel_bundle` and `kernel_handler` `get_specialization_constant()` member function return type.