### PR TITLE
Improve group reduce function object coverage and add result verification

### DIFF
--- a/tests/group_functions/group_broadcast.cpp
+++ b/tests/group_functions/group_broadcast.cpp
@@ -23,7 +23,8 @@
 // FIXME: ComputeCpp does not implement group_broadcast for sycl::vec,
 //        sycl::marray, unsigned long long int, and long long int
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
+
 using BroadcastTypes =
     std::tuple<size_t, float, char, signed char, unsigned char, short int,
                unsigned short int, int, unsigned int, long int,

--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -23,7 +23,7 @@
 // FIXME: ComputeCpp does not implement reduce for unsigned long long int and
 //        long long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
 using ReduceTypes =
     unnamed_type_pack<size_t, float, char, signed char, unsigned char,
                       short int, unsigned short int, int, unsigned int,
@@ -68,10 +68,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
-  // check all work group dimensions
-  joint_reduce_group<1, TestType>(queue);
-  joint_reduce_group<2, TestType>(queue);
-  joint_reduce_group<3, TestType>(queue);
+  // Get binary operators from TestType
+  const auto Operators = get_op_types<TestType>();
+  const auto Type = unnamed_type_pack<TestType>();
+  for_all_combinations<invoke_joint_reduce_group>(Dims, Type, Operators, queue);
 #endif
 }
 
@@ -122,10 +122,13 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
   if constexpr (std::is_same_v<T, U>)
 #endif
   {
+    // Get binary operators from T
+    const auto Operators = get_op_types<T>();
+    const auto RetType = unnamed_type_pack<T>();
+    const auto ReducedType = unnamed_type_pack<U>();
     // check all work group dimensions
-    init_joint_reduce_group<1, T, U>(queue);
-    init_joint_reduce_group<2, T, U>(queue);
-    init_joint_reduce_group<3, T, U>(queue);
+    for_all_combinations<invoke_init_joint_reduce_group>(
+        Dims, RetType, ReducedType, Operators, queue);
   }
 #endif
 }
@@ -152,10 +155,10 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
-  // check all work group dimensions
-  reduce_over_group<1, TestType>(queue);
-  reduce_over_group<2, TestType>(queue);
-  reduce_over_group<3, TestType>(queue);
+  // Get binary operators from TestType
+  const auto Operators = get_op_types<TestType>();
+  const auto Type = unnamed_type_pack<TestType>();
+  for_all_combinations<invoke_reduce_over_group>(Dims, Type, Operators, queue);
 #endif
 }
 
@@ -199,10 +202,13 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
   if constexpr (std::is_same_v<T, U>)
 #endif
   {
+    // Get binary operators from T
+    const auto Operators = get_op_types<T>();
+    const auto RetType = unnamed_type_pack<T>();
+    const auto ReducedType = unnamed_type_pack<U>();
     // check all work group dimensions
-    init_reduce_over_group<1, T, U>(queue);
-    init_reduce_over_group<2, T, U>(queue);
-    init_reduce_over_group<3, T, U>(queue);
+    for_all_combinations<invoke_init_reduce_over_group>(
+        Dims, RetType, ReducedType, Operators, queue);
   }
 #endif
 }

--- a/tests/group_functions/group_reduce.h
+++ b/tests/group_functions/group_reduce.h
@@ -21,17 +21,95 @@
 #include "../common/disabled_for_test_case.h"
 
 #include "group_functions_common.h"
+#include <optional>
 
-template <int D, typename T>
+constexpr size_t init = 1412;
+static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
+
+template <typename T>
+inline auto get_op_types() {
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  static const auto types =
+      named_type_pack<sycl::plus<T>, sycl::multiplies<T>, sycl::bit_and<T>,
+                      sycl::bit_or<T>, sycl::bit_xor<T>, sycl::logical_and<T>,
+                      sycl::logical_or<T>, sycl::minimum<T>,
+                      sycl::maximum<T>>::generate("plus", "multiplies",
+                                                  "bit_and", "bit_or",
+                                                  "bit_xor", "logical_and",
+                                                  "logical_or", "minimum",
+                                                  "maximum");
+#else
+  static const auto types =
+      named_type_pack<sycl::plus<T>, sycl::maximum<T>>::generate("plus",
+                                                                 "maximum");
+#endif
+  return types;
+}
+
+template <bool with_init, typename OpT, typename IteratorT>
+size_t get_reduce_reference(IteratorT first, IteratorT end) {
+  // Cast `init` to size_t so that guards are introduced in verification
+  if constexpr (with_init)
+    return std::accumulate(first, end, size_t(init), OpT());
+  else
+    return std::accumulate(first + 1, end, size_t(*first), OpT());
+}
+
+template <bool with_init, typename OpT, typename InputT, typename OutputT>
+bool reduce_over_group_verify_helper(std::vector<InputT> &v_input, std::vector<OutputT> &v_output,
+                                     size_t global_size, size_t local_size, size_t offset = 0) {
+  bool res = false;
+  const size_t count = (global_size + local_size - 1) / local_size;
+  size_t beg = 0;
+  for (size_t i = 0; i < count; ++i) {
+    size_t cur_local_size = (i == count - 1 && global_size % local_size)
+                                ? global_size % local_size
+                                : local_size;
+    auto v_input_begin = v_input.begin() + beg + offset;
+    auto v_output_begin = v_output.begin() + beg + offset;
+    const size_t group_reduced =
+        get_reduce_reference<with_init, OpT>(v_input_begin, v_input_begin + cur_local_size);
+
+    beg += cur_local_size;
+    res = (group_reduced > util::exact_max<OutputT>) ||
+          std::all_of(v_output_begin, v_output_begin + cur_local_size,
+                      [=](OutputT i) { return i == group_reduced; });
+    if (!res) break;
+  }
+  return res;
+}
+
+template <bool with_init, typename OpT, typename InputT, typename OutputT>
+bool reduce_over_group_verifier(std::vector<InputT> &v_input, std::vector<OutputT> &v_output,
+                                size_t global_size, size_t local_size) {
+  return reduce_over_group_verify_helper<with_init, OpT>(
+      v_input, v_output, global_size, local_size);
+}
+
+template <bool with_init, typename OpT, typename InputT, typename OutputT>
+bool reduce_over_group_sg_verifier(std::vector<InputT> &v_input, std::vector<OutputT> &v_output, size_t global_size,
+                                   size_t local_size, size_t sg_size) {
+  bool res = false;
+  const size_t count = (global_size + local_size - 1) / local_size;
+  for (size_t i = 0; i < count; ++i) {
+    res = reduce_over_group_verify_helper<with_init, OpT>(
+        v_input, v_output, local_size, sg_size, local_size * i);
+    if (!res) break;
+  }
+  return res;
+}
+
+template <int D, typename T, typename OpT>
 class joint_reduce_group_kernel;
 
 /**
  * @brief Provides test for joint reduce by group
  * @tparam D Dimension to use for group instance
  * @tparam T Type for reduced values
+ * @tparam OpT Type for binary operator
  */
-template <int D, typename T>
-void joint_reduce_group(sycl::queue& queue) {
+template <int D, typename T, typename OpT>
+void joint_reduce_group(sycl::queue& queue, const std::string& op_name) {
   // 2 functions * 2 function objects
   constexpr int test_matrix = 2;
   const std::string test_names[test_matrix] = {
@@ -39,8 +117,6 @@ void joint_reduce_group(sycl::queue& queue) {
       "Ptr last, BinaryOperation binary_op)",
       "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, Ptr "
       "first, Ptr last, BinaryOperation binary_op)"};
-  constexpr int test_cases = 2;
-  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
   sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
@@ -50,12 +126,16 @@ void joint_reduce_group(sycl::queue& queue) {
     std::vector<T> v(size);
     std::iota(v.begin(), v.end(), 1);
 
+    // checks are plagued by UB for too short types
+    // so that the guards are introduced as the second parts in
+    // res_acc calculations
+    const size_t reduced = get_reduce_reference<false, OpT>(v.begin(), v.end());
+
     // array to return results
-    bool res[test_matrix * test_cases] = {false};
+    bool res[test_matrix] = {false};
     {
       sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
-      sycl::buffer<bool, 1> res_sycl(res,
-                                     sycl::range<1>(test_matrix * test_cases));
+      sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(test_matrix));
 
       queue.submit([&](sycl::handler& cgh) {
         auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
@@ -63,79 +143,64 @@ void joint_reduce_group(sycl::queue& queue) {
 
         sycl::nd_range<D> executionRange(work_group_range, work_group_range);
 
-        cgh.parallel_for<joint_reduce_group_kernel<D, T>>(
+        cgh.parallel_for<joint_reduce_group_kernel<D, T, OpT>>(
             executionRange, [=](sycl::nd_item<D> item) {
               T* v_begin = v_acc.get_pointer();
               T* v_end = v_begin + v_acc.size();
-              // checks are plagued by UB for too short types
-              // so that the guards are introduced as the second parts in
-              // res_acc calculations
-              size_t reduced;
 
               sycl::group<D> group = item.get_group();
-
-              ASSERT_RETURN_TYPE(
-                  T, sycl::joint_reduce(group, v_begin, v_end, sycl::plus<T>()),
-                  "Return type of joint_reduce(group g, Ptr first, Ptr last, "
-                  "BinaryOperation binary_op) is wrong\n");
-
-              reduced = size * (size + 1) / 2;
-              res_acc[0] = (reduced == sycl::joint_reduce(group, v_begin, v_end,
-                                                          sycl::plus<T>())) ||
-                           (reduced > util::exact_max<T>);
-
-              reduced = size;
-              res_acc[1] =
-                  (reduced == sycl::joint_reduce(group, v_begin, v_end,
-                                                 sycl::maximum<T>())) ||
-                  (reduced > util::exact_max<T>);
-
               sycl::sub_group sub_group = item.get_sub_group();
 
               ASSERT_RETURN_TYPE(
-                  T,
-                  sycl::joint_reduce(sub_group, v_begin, v_end,
-                                     sycl::maximum<T>()),
+                  T, sycl::joint_reduce(group, v_begin, v_end, OpT()),
+                  "Return type of joint_reduce(group g, Ptr first, Ptr last, "
+                  "BinaryOperation binary_op) is wrong\n");
+
+              res_acc[0] = (reduced ==
+                            sycl::joint_reduce(group, v_begin, v_end, OpT())) ||
+                           (reduced > util::exact_max<T>);
+
+              ASSERT_RETURN_TYPE(
+                  T, sycl::joint_reduce(sub_group, v_begin, v_end, OpT()),
                   "Return type of joint_reduce(sub_group g, Ptr first, Ptr "
                   "last, BinaryOperation binary_op) is wrong\n");
 
-              reduced = size * (size + 1) / 2;
           // FIXME: hipSYCL has no implementation over sub-groups
 #ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
-              res_acc[2] = true;
+              res_acc[1] = true;
 #else
-            res_acc[2] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, sycl::plus<T>()))
-              || (reduced > util::exact_max<T>);
-#endif
-
-              reduced = size;
-          // FIXME: hipSYCL has no implementation over sub-groups
-#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
-              res_acc[3] = true;
-#else
-            res_acc[3] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, sycl::maximum<T>()))
-              || (reduced > util::exact_max<T>);
+              res_acc[1] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, OpT()))
+                || (reduced > util::exact_max<T>);
 #endif
             });
       });
     }
     int index = 0;
-    for (int i = 0; i < test_matrix; ++i)
-      for (int j = 0; j < test_cases; ++j) {
-        std::string work_group =
-            sycl_cts::util::work_group_print(work_group_range);
-        CAPTURE(D, work_group, size);
-        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                         << " operation"
-                            " and Ptr = "
-                         << type_name<T>() << "* is "
-                         << (res[index] ? "right" : "wrong"));
-        CHECK(res[index++]);
-      }
+    for (int i = 0; i < test_matrix; ++i) {
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
+      CAPTURE(D, work_group, size);
+      INFO("Value of " << test_names[i] << " with " << op_name
+                       << " operation"
+                          " and Ptr = "
+                       << type_name<T>() << "* is "
+                       << (res[index] ? "right" : "wrong"));
+      CHECK(res[index++]);
+    }
   }
 }
 
-template <int D, typename T, typename U>
+template <typename DimensionT, typename T, typename OperatorT>
+class invoke_joint_reduce_group {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue, const std::string& op_name) {
+    joint_reduce_group<D, T, OperatorT>(queue, op_name);
+  }
+};
+
+template <int D, typename T, typename U, typename OpT>
 class init_joint_reduce_group_kernel;
 
 /**
@@ -143,9 +208,10 @@ class init_joint_reduce_group_kernel;
  * @tparam D Dimension to use for group instance
  * @tparam T Type for init and result values
  * @tparam U Type for reduced values
+ * @tparam OpT Type for binary operator
  */
-template <int D, typename T, typename U>
-void init_joint_reduce_group(sycl::queue& queue) {
+template <int D, typename T, typename U, typename OpT>
+void init_joint_reduce_group(sycl::queue& queue, const std::string& op_name) {
   // 2 functions * 2 function objects
   constexpr int test_matrix = 2;
   const std::string test_names[test_matrix] = {
@@ -153,8 +219,6 @@ void init_joint_reduce_group(sycl::queue& queue) {
       "binary_op)",
       "T joint_reduce(sub_group g, Ptr first, Ptr last, T init, "
       "BinaryOperation binary_op)"};
-  constexpr int test_cases = 2;
-  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
   sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
   size_t work_group_size = work_group_range.size();
@@ -164,12 +228,16 @@ void init_joint_reduce_group(sycl::queue& queue) {
     std::vector<U> v(size);
     std::iota(v.begin(), v.end(), 1);
 
+    // checks are plagued by UB for too short types
+    // so that the guards are introduced as the second parts in
+    // res_acc calculations
+    const size_t reduced = get_reduce_reference<true, OpT>(v.begin(), v.end());
+
     // array to return results
-    bool res[test_matrix * test_cases] = {false};
+    bool res[test_matrix] = {false};
     {
       sycl::buffer<U, 1> v_sycl(v.data(), sycl::range<1>(size));
-      sycl::buffer<bool, 1> res_sycl(res,
-                                     sycl::range<1>(test_matrix * test_cases));
+      sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(test_matrix));
 
       queue.submit([&](sycl::handler& cgh) {
         auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
@@ -177,180 +245,179 @@ void init_joint_reduce_group(sycl::queue& queue) {
 
         sycl::nd_range<D> executionRange(work_group_range, work_group_range);
 
-        cgh.parallel_for<init_joint_reduce_group_kernel<D, T, U>>(
+        cgh.parallel_for<init_joint_reduce_group_kernel<D, T, U, OpT>>(
             executionRange, [=](sycl::nd_item<D> item) {
               sycl::group<D> group = item.get_group();
               sycl::sub_group sub_group = item.get_sub_group();
 
               U* v_begin = v_acc.get_pointer();
               U* v_end = v_begin + v_acc.size();
-              // checks are plagued by UB for too short types
-              // so that the guards are introduced as the second parts in
-              // res_acc calculations
-              size_t reduced;
 
               ASSERT_RETURN_TYPE(
-                  T,
-                  sycl::joint_reduce(group, v_begin, v_end, T(1412),
-                                     sycl::plus<T>()),
+                  T, sycl::joint_reduce(group, v_begin, v_end, T(init), OpT()),
                   "Return type of joint_reduce(group g, Ptr first, Ptr last, T "
                   "init, BinaryOperation binary_op) is wrong\n");
 
-              reduced = size * (size + 1) / 2 + T(1412);
-              res_acc[0] =
-                  (reduced == sycl::joint_reduce(group, v_begin, v_end, T(1412),
-                                                 sycl::plus<T>())) ||
-                  (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
-
-              reduced = 2 * size;
-              res_acc[1] =
-                  (reduced == sycl::joint_reduce(group, v_begin, v_end,
-                                                 T(2 * size),
-                                                 sycl::maximum<T>())) ||
-                  (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
+              res_acc[0] = (reduced == sycl::joint_reduce(group, v_begin, v_end,
+                                                          T(init), OpT())) ||
+                           (reduced > util::exact_max<T>) ||
+                           (size > util::exact_max<U>);
 
               ASSERT_RETURN_TYPE(
                   T,
-                  sycl::joint_reduce(sub_group, v_begin, v_end, T(1412),
-                                     sycl::maximum<T>()),
+                  sycl::joint_reduce(sub_group, v_begin, v_end, T(init), OpT()),
                   "Return type of joint_reduce(sub_group g, Ptr first, Ptr "
                   "last, T init, BinaryOperation binary_op) is wrong\n");
 
-              reduced = size * (size + 1) / 2 + T(1412);
           // FIXME: hipSYCL has no implementation over sub-groups
 #ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
-              res_acc[2] = true;
+              res_acc[1] = true;
 #else
-            res_acc[2] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, T(1412), sycl::plus<T>()))
-              || (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
-#endif
-
-              reduced = 2 * size;
-          // FIXME: hipSYCL has no implementation over sub-groups
-#ifdef SYCL_CTS_COMPILING_WITH_HIPSYCL
-              res_acc[3] = true;
-#else
-            res_acc[3] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, T(2 * size), sycl::maximum<T>()))
-              || (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
+              res_acc[1] = (reduced == sycl::joint_reduce(sub_group, v_begin, v_end, T(init), OpT()))
+                || (reduced > util::exact_max<T>) || (size > util::exact_max<U>);
 #endif
             });
       });
     }
     int index = 0;
-    for (int i = 0; i < test_matrix; ++i)
-      for (int j = 0; j < test_cases; ++j) {
-        std::string work_group =
-            sycl_cts::util::work_group_print(work_group_range);
-        CAPTURE(D, work_group, size);
-        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                         << " operation"
-                            " and Ptr = "
-                         << type_name<U>() << "*, T = " << type_name<T>()
-                         << " is " << (res[index] ? "right" : "wrong"));
-        CHECK(res[index++]);
-      }
+    for (int i = 0; i < test_matrix; ++i) {
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
+      CAPTURE(D, work_group, size);
+      INFO("Value of " << test_names[i] << " with " << op_name
+                       << " operation"
+                          " and Ptr = "
+                       << type_name<U>() << "*, T = " << type_name<T>()
+                       << " is " << (res[index] ? "right" : "wrong"));
+      CHECK(res[index++]);
+    }
   }
 }
 
-template <int D, typename T>
+template <typename DimensionT, typename RetT, typename ReducedT,
+          typename OperatorT>
+class invoke_init_joint_reduce_group {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue, const std::string& op_name) {
+    init_joint_reduce_group<D, RetT, ReducedT, OperatorT>(queue, op_name);
+  }
+};
+
+template <int D, typename T, typename OpT>
 class reduce_over_group_kernel;
 
 /**
  * @brief Provides test for reduce over group values
  * @tparam D Dimension to use for group instance
  * @tparam T Type for reduced values
+ * @tparam OpT Type for binary operator
  */
-template <int D, typename T>
-void reduce_over_group(sycl::queue& queue) {
+template <int D, typename T, typename OpT>
+void reduce_over_group(sycl::queue& queue, const std::string& op_name) {
   // 2 function * 2 function objects
   constexpr int test_matrix = 2;
   const std::string test_names[test_matrix] = {
       "T reduce_over_group(group g, T x, BinaryOperation binary_op)",
       "T reduce_over_group(sub_group g, T x, BinaryOperation binary_op)"};
-  constexpr int test_cases = 2;
-  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
   sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
 
-  // array to return results
-  bool res[test_matrix * test_cases] = {false};
+  bool res = false;
+  // array to input data
+  std::vector<T> v(work_group_size);
+  std::iota(v.begin(), v.end(), 1);
+  // array to reduce results
+  std::vector<T> group_output(work_group_size, 0);
+  std::vector<T> sg_output(work_group_size, 0);
+
+  // Store subgroup size
+  size_t sg_size = 0;
   {
-    sycl::buffer<bool, 1> res_sycl(res,
-                                   sycl::range<1>(test_matrix * test_cases));
+    sycl::buffer<T, 1> v_sycl(
+        v.data(), sycl::range<1>(work_group_size));
+    sycl::buffer<T, 1> g_output_sycl(
+        group_output.data(), sycl::range<1>(work_group_size));
+    sycl::buffer<T, 1> sg_output_sycl(
+        sg_output.data(), sycl::range<1>(work_group_size));
+    sycl::buffer<size_t> sgs_sycl(&sg_size, sycl::range<1>(1));
 
     queue.submit([&](sycl::handler& cgh) {
-      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
+      auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+      auto g_output_acc =
+          g_output_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+      auto sg_output_acc =
+          sg_output_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+      auto sgs_acc = sgs_sycl.get_access<sycl::access::mode::read_write>(cgh);
       sycl::nd_range<D> executionRange(work_group_range, work_group_range);
 
-      cgh.parallel_for<reduce_over_group_kernel<D, T>>(
+      cgh.parallel_for<reduce_over_group_kernel<D, T, OpT>>(
           executionRange, [=](sycl::nd_item<D> item) {
             sycl::group<D> group = item.get_group();
             size_t group_size = group.get_local_linear_range();
-
-            T local_var = item.get_local_linear_id() + 1;
-            // checks are plagued by UB for too short types
-            // so that the guards are introduced as the second parts in res_acc
-            // calculations
-            size_t reduced;
-
-            ASSERT_RETURN_TYPE(
-                T, sycl::reduce_over_group(group, local_var, sycl::plus<T>()),
-                "Return type of reduce_over_group(group g, T x, "
-                "BinaryOperation binary_op) is wrong\n");
-
-            reduced = group_size * (group_size + 1) / 2;
-            res_acc[0] = (reduced == sycl::reduce_over_group(
-                                         group, local_var, sycl::plus<T>())) ||
-                         (reduced > util::exact_max<T>);
-
-            reduced = group_size;
-            res_acc[1] =
-                (reduced == sycl::reduce_over_group(group, local_var,
-                                                    sycl::maximum<T>())) ||
-                (reduced > util::exact_max<T>);
-
-            sycl::sub_group sub_group = item.get_sub_group();
-            size_t sub_group_size = sub_group.get_local_linear_range();
-
-            local_var = sub_group.get_local_linear_id() + 1;
+            size_t index = item.get_global_linear_id();
 
             ASSERT_RETURN_TYPE(T,
-                               sycl::reduce_over_group(sub_group, local_var,
-                                                       sycl::maximum<T>()),
-                               "Return type of reduce_over_group(sub_group g, "
-                               "T x, BinaryOperation binary_op) is wrong\n");
+                               sycl::reduce_over_group(group, v_acc[index], OpT()),
+                               "Return type of reduce_over_group(group g, T x, "
+                               "BinaryOperation binary_op) is wrong\n");
 
-            reduced = sub_group_size * (sub_group_size + 1) / 2;
-            res_acc[2] =
-                (reduced == sycl::reduce_over_group(sub_group, local_var,
-                                                    sycl::plus<T>())) ||
-                (reduced > util::exact_max<T>);
+            g_output_acc[index] =
+                sycl::reduce_over_group(group, v_acc[index], OpT());
 
-            reduced = sub_group_size;
-            res_acc[3] =
-                (reduced == sycl::reduce_over_group(sub_group, local_var,
-                                                    sycl::maximum<T>())) ||
-                (reduced > util::exact_max<T>);
+            sycl::sub_group sub_group = item.get_sub_group();
+            sgs_acc[0] = sub_group.get_local_linear_range();
+
+            ASSERT_RETURN_TYPE(
+                T, sycl::reduce_over_group(sub_group, v_acc[index], OpT()),
+                "Return type of reduce_over_group(sub_group g, "
+                "T x, BinaryOperation binary_op) is wrong\n");
+            sg_output_acc[index] =
+                sycl::reduce_over_group(sub_group, v_acc[index], OpT());
           });
     });
   }
-  int index = 0;
-  for (int i = 0; i < test_matrix; ++i)
-    for (int j = 0; j < test_cases; ++j) {
-      std::string work_group =
-          sycl_cts::util::work_group_print(work_group_range);
-      CAPTURE(D, work_group);
-      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                       << " operation"
-                          " and T = "
-                       << type_name<T>() << " is "
-                       << (res[index] ? "right" : "wrong"));
-      CHECK(res[index++]);
-    }
+
+  // // Verify return value for reduce_over_group on group
+  {
+    res = reduce_over_group_verifier<false, OpT>(
+        v, group_output, work_group_size, work_group_size);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Value of " << test_names[0] << " with " << op_name
+                     << " operation and T = " << type_name<T>() << " over group"
+                     << " is " << (res ? "right" : "wrong"));
+    CHECK(res);
+  }
+
+  // Verify return value for reduce_over_group on sub_group
+  {
+    res = reduce_over_group_sg_verifier<false, OpT>(
+        v, sg_output, work_group_size, work_group_size,
+        sg_size);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Value of " << test_names[0] << " with " << op_name
+                     << " operation and T = " << type_name<T>()
+                     << " over sub_group"
+                     << " is " << (res ? "right" : "wrong"));
+    CHECK(res);
+  }
 }
 
-template <int D, typename T, typename U>
+template <typename DimensionT, typename T, typename OperatorT>
+class invoke_reduce_over_group {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue, const std::string& op_name) {
+    reduce_over_group<D, T, OperatorT>(queue, op_name);
+  }
+};
+
+template <int D, typename T, typename U, typename OpT>
 class init_reduce_over_group_kernel;
 
 /**
@@ -358,102 +425,112 @@ class init_reduce_over_group_kernel;
  * @tparam D Dimension to use for group instance
  * @tparam T Type for group values
  * @tparam U Type for init and result values
+ * @tparam OpT Type for binary operator
  */
-template <int D, typename T, typename U>
-void init_reduce_over_group(sycl::queue& queue) {
+template <int D, typename T, typename U, typename OpT>
+void init_reduce_over_group(sycl::queue& queue, const std::string& op_name) {
   // 2 function * 2 function objects
   constexpr int test_matrix = 2;
   const std::string test_names[test_matrix] = {
       "T reduce_over_group(group g, V x, T init, BinaryOperation binary_op)",
       "T reduce_over_group(sub_group g, V x, T init, BinaryOperation "
       "binary_op)"};
-  constexpr int test_cases = 2;
-  const std::string test_cases_names[test_cases] = {"plus", "maximum"};
 
   sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
+  size_t work_group_size = work_group_range.size();
 
-  // array to return results
-  bool res[test_matrix * test_cases] = {false};
+  bool res = false;
+  // array to input data
+  std::vector<T> v(work_group_size);
+  std::iota(v.begin(), v.end(), 1);
+  // array to reduce results
+  std::vector<T> group_output(work_group_size, 0);
+  std::vector<T> sg_output(work_group_size, 0);
+
+  // Store subgroup size
+  size_t sg_size = 0;
   {
-    sycl::buffer<bool, 1> res_sycl(res,
-                                   sycl::range<1>(test_matrix * test_cases));
+    sycl::buffer<T, 1> v_sycl(
+        v.data(), sycl::range<1>(work_group_size));
+    sycl::buffer<T, 1> g_output_sycl(
+        group_output.data(), sycl::range<1>(work_group_size));
+    sycl::buffer<T, 1> sg_output_sycl(
+        sg_output.data(), sycl::range<1>(work_group_size));
+    sycl::buffer<size_t> sgs_sycl(&sg_size, sycl::range<1>(1));
 
     queue.submit([&](sycl::handler& cgh) {
-      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
+      auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+      auto g_output_acc =
+          g_output_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+      auto sg_output_acc =
+          sg_output_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+      auto sgs_acc = sgs_sycl.get_access<sycl::access::mode::read_write>(cgh);
       sycl::nd_range<D> executionRange(work_group_range, work_group_range);
 
-      cgh.parallel_for<init_reduce_over_group_kernel<D, T, U>>(
+      cgh.parallel_for<init_reduce_over_group_kernel<D, T, U, OpT>>(
           executionRange, [=](sycl::nd_item<D> item) {
             sycl::group<D> group = item.get_group();
             size_t group_size = group.get_local_linear_range();
-
-            U local_var = item.get_local_linear_id() + 1;
-            // checks are plagued by UB for too short types
-            // so that the guards are introduced as the second parts in res_acc
-            // calculations
-            size_t reduced;
+            size_t index = item.get_global_linear_id();
 
             ASSERT_RETURN_TYPE(T,
                                sycl::reduce_over_group(
-                                   group, local_var, T(1412), sycl::plus<T>()),
+                                   group, v_acc[index], T(init), OpT()),
                                "Return type of reduce_over_group(group g, V x, "
                                "T init, BinaryOperation binary_op) is wrong\n");
 
-            reduced = group_size * (group_size + 1) / 2 + T(1412);
-            res_acc[0] =
-                (reduced == sycl::reduce_over_group(group, local_var, T(1412),
-                                                    sycl::plus<T>())) ||
-                (group_size > util::exact_max<U>) ||
-                (reduced > util::exact_max<T>);
-
-            reduced = 2 * group_size;
-            res_acc[1] = (reduced == sycl::reduce_over_group(
-                                         group, local_var, T(2 * group_size),
-                                         sycl::maximum<T>())) ||
-                         (group_size > util::exact_max<U>) ||
-                         (reduced > util::exact_max<T>);
+            g_output_acc[index] =
+                sycl::reduce_over_group(group, v_acc[index], T(init), OpT());
 
             sycl::sub_group sub_group = item.get_sub_group();
-            size_t sub_group_size = sub_group.get_local_linear_range();
-
-            local_var = sub_group.get_local_linear_id() + 1;
+            sgs_acc[0] = sub_group.get_local_linear_range();
 
             ASSERT_RETURN_TYPE(
                 T,
-                sycl::reduce_over_group(sub_group, local_var, T(1412),
-                                        sycl::maximum<T>()),
+                sycl::reduce_over_group(sub_group, v_acc[index], T(init),
+                                        OpT()),
                 "Return type of reduce_over_group(sub_group g, V x, T init, "
                 "BinaryOperation binary_op) is wrong\n");
-
-            reduced = sub_group_size * (sub_group_size + 1) / 2 + T(1412);
-            res_acc[2] = (reduced ==
-                          sycl::reduce_over_group(sub_group, local_var, T(1412),
-                                                  sycl::plus<T>())) ||
-                         (sub_group_size > util::exact_max<U>) ||
-                         (reduced > util::exact_max<T>);
-
-            reduced = 2 * sub_group_size;
-            res_acc[3] =
-                (reduced == sycl::reduce_over_group(sub_group, local_var,
-                                                    T(2 * sub_group_size),
-                                                    sycl::maximum<T>())) ||
-                (sub_group_size > util::exact_max<U>) ||
-                (reduced > util::exact_max<T>);
+            sg_output_acc[index] =
+                sycl::reduce_over_group(sub_group, v_acc[index], T(init), OpT());
           });
     });
   }
-  int index = 0;
-  for (int i = 0; i < test_matrix; ++i)
-    for (int j = 0; j < test_cases; ++j) {
-      std::string work_group =
-          sycl_cts::util::work_group_print(work_group_range);
-      CAPTURE(D, work_group);
-      INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                       << " operation"
-                          " and T = "
-                       << type_name<U>() << ", V = " << type_name<T>() << " is "
-                       << (res[index] ? "right" : "wrong"));
-      CHECK(res[index++]);
-    }
+
+  // // Verify return value for reduce_over_group on group
+  {
+    res = reduce_over_group_verifier<true, OpT>(
+        v, group_output, work_group_size, work_group_size);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Value of " << test_names[0] << " with " << op_name
+                     << " operation and T = " << type_name<T>() << " over group"
+                     << " is " << (res ? "right" : "wrong"));
+    CHECK(res);
+  }
+
+  // Verify return value for reduce_over_group on sub_group
+  {
+    res = reduce_over_group_sg_verifier<true, OpT>(
+        v, sg_output, work_group_size, work_group_size,
+        sg_size);
+    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
+    CAPTURE(D, work_group);
+    INFO("Value of " << test_names[0] << " with " << op_name
+                     << " operation and T = " << type_name<T>()
+                     << " over sub_group"
+                     << " is " << (res ? "right" : "wrong"));
+    CHECK(res);
+  }
 }
+
+template <typename DimensionT, typename RetT, typename ReducedT,
+          typename OperatorT>
+class invoke_init_reduce_over_group {
+  static constexpr int D = DimensionT::value;
+
+ public:
+  void operator()(sycl::queue& queue, const std::string& op_name) {
+    init_reduce_over_group<D, RetT, ReducedT, OperatorT>(queue, op_name);
+  }
+};

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -23,7 +23,7 @@
 // FIXME: ComputeCpp does not implement reduce for unsigned long long int and
 //        long long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
 using ReduceTypes =
     unnamed_type_pack<size_t, float, char, signed char, unsigned char,
                       short int, unsigned short int, int, unsigned int,
@@ -41,24 +41,21 @@ using prod2 =
     product<std::tuple, DoubleExtendedTypes, DoubleExtendedTypes>::type;
 
 // hipSYCL has no implementation over sub-groups
-TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
-                       "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
+TEST_CASE("Group and sub-group joint reduce functions",
+          "[group_func][fp64][dim]") {
   auto queue = sycl_cts::util::get_cts_object::queue();
-  // check dimensions to only print warning once
-  if constexpr (D == 1) {
-    // FIXME: hipSYCL omission
+  // FIXME: hipSYCL omission
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
-    WARN(
-        "hipSYCL has no implementation of "
-        "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, "
-        "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
-        "Skipping the test case.");
+  WARN(
+      "hipSYCL has no implementation of "
+      "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, "
+      "Ptr first, Ptr last, BinaryOperation binary_op) over sub-groups. "
+      "Skipping the test case.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
-    WARN(
-        "ComputeCpp fails to compile with segfault in the compiler. "
-        "Skipping the test.");
+  WARN(
+      "ComputeCpp fails to compile with segfault in the compiler. "
+      "Skipping the test.");
 #endif
-  }
 
   // FIXME: Codeplay ComputeCpp - CE 2.11.0
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
@@ -68,7 +65,11 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions",
   return;
 #else
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    joint_reduce_group<D, double>(queue);
+    // Get binary operators from TestType
+    const auto Operators = get_op_types<double>();
+    const auto Type = unnamed_type_pack<double>();
+    for_all_combinations<invoke_joint_reduce_group>(Dims, Type, Operators,
+                                                    queue);
   } else {
     WARN("Device does not support double precision floating point operations.");
   }
@@ -123,10 +124,13 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
   {
     if (queue.get_device().has(sycl::aspect::fp64)) {
       if constexpr (std::is_same_v<T, double> || std::is_same_v<U, double>) {
+        // Get binary operators from T
+        const auto Operators = get_op_types<T>();
+        const auto RetType = unnamed_type_pack<T>();
+        const auto ReducedType = unnamed_type_pack<U>();
         // check all work group dimensions
-        init_joint_reduce_group<1, T, U>(queue);
-        init_joint_reduce_group<2, T, U>(queue);
-        init_joint_reduce_group<3, T, U>(queue);
+        for_all_combinations<invoke_init_joint_reduce_group>(
+            Dims, RetType, ReducedType, Operators, queue);
       }
     } else {
       WARN(
@@ -137,17 +141,13 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 #endif
 }
 
-TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
-                       "[group_func][fp64][dim]", ((int D), D), 1, 2, 3) {
+TEST_CASE("Group and sub-group reduce functions", "[group_func][fp64][dim]") {
   auto queue = sycl_cts::util::get_cts_object::queue();
-  // check dimension to only print warning once
-  if constexpr (D == 1) {
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
-    WARN(
-        "ComputeCpp fails to compile with segfault in the compiler. "
-        "Skipping the test.");
+  WARN(
+      "ComputeCpp fails to compile with segfault in the compiler. "
+      "Skipping the test.");
 #endif
-  }
 
   // FIXME: Codeplay ComputeCpp - CE 2.11.0
   //        Device Compiler - clang version 8.0.0  (based on LLVM 8.0.0svn)
@@ -157,7 +157,11 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions",
   return;
 #else
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    reduce_over_group<D, double>(queue);
+    // Get binary operators from TestType
+    const auto Operators = get_op_types<double>();
+    const auto Type = unnamed_type_pack<double>();
+    for_all_combinations<invoke_reduce_over_group>(Dims, Type, Operators,
+                                                   queue);
   } else {
     WARN("Device does not support double precision floating point operations.");
   }
@@ -206,10 +210,13 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 #endif
     {
       if constexpr (std::is_same_v<T, double> || std::is_same_v<U, double>) {
+        // Get binary operators from T
+        const auto Operators = get_op_types<T>();
+        const auto RetType = unnamed_type_pack<T>();
+        const auto ReducedType = unnamed_type_pack<U>();
         // check all work group dimensions
-        init_reduce_over_group<1, T, U>(queue);
-        init_reduce_over_group<2, T, U>(queue);
-        init_reduce_over_group<3, T, U>(queue);
+        for_all_combinations<invoke_init_reduce_over_group>(
+            Dims, RetType, ReducedType, Operators, queue);
       }
     }
   } else {

--- a/tests/group_functions/group_reduce_fp64_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp64_fp16.cpp
@@ -23,11 +23,24 @@
 
 #include "group_reduce.h"
 
-TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
-                       "[group_func][fp16][fp64][dim]", ((int D), D), 1, 2, 3) {
+// FIXME: ComputeCpp has no half
+#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
+using ReduceTypes = unnamed_type_pack<>;
+#else
+using ReduceTypes = unnamed_type_pack<double, sycl::half>;
+#endif
+
+// 2-dim Cartesian product of type lists
+using prod2 = product<std::tuple, ReduceTypes, ReduceTypes>::type;
+
+TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
+                        "[group_func][fp16][fp64][dim]", prod2) {
   auto queue = sycl_cts::util::get_cts_object::queue();
-  // check dimensions to only print warning once
-  if constexpr (D == 1) {
+  using T = std::tuple_element_t<0, TestType>;
+  using U = std::tuple_element_t<1, TestType>;
+
+  // check types to only print warning once
+  if constexpr (std::is_same_v<T, double> && std::is_same_v<U, double>) {
     // FIXME: hipSYCL omission
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
     WARN(
@@ -58,8 +71,13 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
 #else
   if (queue.get_device().has(sycl::aspect::fp16) &&
       queue.get_device().has(sycl::aspect::fp64)) {
-    init_joint_reduce_group<D, sycl::half, double>(queue);
-    init_joint_reduce_group<D, double, sycl::half>(queue);
+    // Get binary operators from T
+    const auto Operators = get_op_types<T>();
+    const auto RetType = unnamed_type_pack<T>();
+    const auto ReducedType = unnamed_type_pack<U>();
+    // check all work group dimensions
+    for_all_combinations<invoke_init_joint_reduce_group>(
+        Dims, RetType, ReducedType, Operators, queue);
   } else {
     WARN(
         "Device does not support half and double precision floating point "
@@ -68,11 +86,14 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
 #endif
 }
 
-TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
-                       "[group_func][fp16][fp64][dim]", ((int D), D), 1, 2, 3) {
+TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
+                        "[group_func][fp16][fp64][dim]", prod2) {
   auto queue = sycl_cts::util::get_cts_object::queue();
-  // check dimensions to only print warning once
-  if constexpr (D == 1) {
+  using T = std::tuple_element_t<0, TestType>;
+  using U = std::tuple_element_t<1, TestType>;
+
+  // check types to only print warning once
+  if constexpr (std::is_same_v<T, double> && std::is_same_v<U, double>) {
 #if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
     // Link to issue https://github.com/intel/llvm/issues/8341
     WARN(
@@ -97,8 +118,13 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
 #else
   if (queue.get_device().has(sycl::aspect::fp16) &&
       queue.get_device().has(sycl::aspect::fp64)) {
-    init_reduce_over_group<D, sycl::half, double>(queue);
-    init_reduce_over_group<D, double, sycl::half>(queue);
+    // Get binary operators from T
+    const auto Operators = get_op_types<T>();
+    const auto RetType = unnamed_type_pack<T>();
+    const auto ReducedType = unnamed_type_pack<U>();
+    // check all work group dimensions
+    for_all_combinations<invoke_init_reduce_over_group>(
+        Dims, RetType, ReducedType, Operators, queue);
   } else {
     WARN(
         "Device does not support half and double precision floating point "

--- a/tests/group_functions/group_reduce_fp64_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp64_fp16.cpp
@@ -23,12 +23,7 @@
 
 #include "group_reduce.h"
 
-// FIXME: ComputeCpp has no half
-#ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
-using ReduceTypes = unnamed_type_pack<>;
-#else
 using ReduceTypes = unnamed_type_pack<double, sycl::half>;
-#endif
 
 // 2-dim Cartesian product of type lists
 using prod2 = product<std::tuple, ReduceTypes, ReduceTypes>::type;

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -25,7 +25,7 @@
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
 using ScanTypes =
     unnamed_type_pack<size_t, float, char, signed char, unsigned char,
                       short int, unsigned short int, int, unsigned int,

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -27,7 +27,7 @@
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
 using ScanTypes =
     unnamed_type_pack<size_t, float, char, signed char, unsigned char,
                       short int, unsigned short int, int, unsigned int,

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -27,7 +27,7 @@
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
 using ScanTypes =
     unnamed_type_pack<size_t, float, char, signed char, unsigned char,
                       short int, unsigned short int, int, unsigned int,

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -30,7 +30,7 @@
 // FIXME: ComputeCpp does not implement scan for unsigned long long int and long
 // long int
 #ifdef SYCL_CTS_COMPILING_WITH_COMPUTECPP
-#ifdef SYCL_CTS_ENABLE_FULL_CONFORMANCE
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
 using ScanTypes =
     unnamed_type_pack<size_t, float, char, signed char, unsigned char,
                       short int, unsigned short int, int, unsigned int,


### PR DESCRIPTION
1. Test group reduce functions with all function objects in FULL CONFORMANCE
2. Verify results with std::accumulate
3. Update incorrect usage of `SYCL_CTS_ENABLE_FULL_CONFORMANCE` 