### PR TITLE
Fix more image-related tests

### DIFF
--- a/tests/image/image_semantics.cpp
+++ b/tests/image/image_semantics.cpp
@@ -23,7 +23,6 @@
 #include "../common/semantics_reference.h"
 #include "default_image.h"
 
-// Enable DPCPP when https://github.com/intel/llvm/issues/8304 been fixed
 #if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) ||    \
       defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP) || \
       defined(SYCL_CTS_COMPILING_WITH_DPCPP))
@@ -34,13 +33,13 @@ struct storage_sampled {
   std::size_t byte_size;
   std::size_t size;
 
-  explicit storage(const sycl::sampled_image<Dimensions>& sampled_image)
-      : range(sampled_image.range()),
+  explicit storage_sampled(const sycl::sampled_image<Dimensions>& sampled_image)
+      : range(sampled_image.get_range()),
         byte_size(sampled_image.byte_size()),
         size(sampled_image.size()) {}
 
   bool check(const sycl::sampled_image<Dimensions>& sampled_image) const {
-    return sampled_image.range() == range &&
+    return sampled_image.get_range() == range &&
            sampled_image.byte_size() == byte_size &&
            sampled_image.size() == size;
   }
@@ -52,14 +51,14 @@ struct storage_unsampled {
   std::size_t byte_size;
   std::size_t size;
 
-  void store(const sycl::unsampled_image<Dimensions>& unsampled_image) {
-    range = unsampled_image.range();
-    byte_size = unsampled_image.byte_size();
-    size = unsampled_image.size();
-  }
+  explicit storage_unsampled(
+      const sycl::unsampled_image<Dimensions>& unsampled_image)
+      : range(unsampled_image.get_range()),
+        byte_size(unsampled_image.byte_size()),
+        size(unsampled_image.size()) {}
 
   bool check(const sycl::unsampled_image<Dimensions>& unsampled_image) const {
-    return unsampled_image.range() == range &&
+    return unsampled_image.get_range() == range &&
            unsampled_image.byte_size() == byte_size &&
            unsampled_image.size() == size;
   }
@@ -72,7 +71,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   auto sampled_image_0 = default_sampled_image::get();
   auto sampled_image_1 = default_sampled_image::get();
 
-  common_reference_semantics::check_host<storage_sampled>(
+  common_reference_semantics::check_host<storage_sampled<1>>(
       sampled_image_0, sampled_image_1, "sampled_image");
 });
 
@@ -84,7 +83,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   auto unsampled_image_0 = default_unsampled_image::get();
   auto unsampled_image_1 = default_unsampled_image::get();
 
-  common_reference_semantics::check_host<storage_unsampled>(
+  common_reference_semantics::check_host<storage_unsampled<1>>(
       unsampled_image_0, unsampled_image_1, "unsampled_image");
 });
 
@@ -96,23 +95,18 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
   auto t0 = default_unsampled_image::get();
 
   SECTION("mutation to copy") {
-    t0.get_host_access().write(0, val);
+    t0.get_host_access<data_type>().write(0, val);
     sycl::unsampled_image<1> t1(t0);
-    t1.get_host_access().write(0, new_val);
-    CHECK(new_val == t0.get_host_access()[0].x);
+    t1.get_host_access<data_type>().write(0, new_val);
+    data_type read_val = t0.get_host_access<data_type>().read(0);
+    CHECK(value_operations::are_equal(new_val, read_val));
   }
 
   SECTION("mutation to original") {
-    t0.get_host_access().write(0, val);
+    t0.get_host_access<data_type>().write(0, val);
     sycl::unsampled_image<1> t1(t0);
-    t0.get_host_access().write(0, new_val);
-    CHECK(new_val == t1.get_host_access()[0].x);
-  }
-
-  SECTION("mutation to original, const copy") {
-    t0.get_host_access().write(0, val);
-    const sycl::unsampled_image<1> t1(t0);
-    t0.get_host_access().write(0, new_val);
-    CHECK(new_val == t1.get_host_access()[0].x);
+    t0.get_host_access<data_type>().write(0, new_val);
+    data_type read_val = t1.get_host_access<data_type>().read(0);
+    CHECK(value_operations::are_equal(new_val, read_val));
   }
 });

--- a/tests/image/image_semantics.cpp
+++ b/tests/image/image_semantics.cpp
@@ -23,6 +23,7 @@
 #include "../common/semantics_reference.h"
 #include "default_image.h"
 
+// Enable DPCPP when https://github.com/intel/llvm/issues/8304 been fixed
 #if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) ||    \
       defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP) || \
       defined(SYCL_CTS_COMPILING_WITH_DPCPP))

--- a/tests/image_accessor/generic_image_accessor_semantics.cpp
+++ b/tests/image_accessor/generic_image_accessor_semantics.cpp
@@ -71,7 +71,8 @@ TEST_CASE("sampled_image_accessor common reference semantics (kernel)",
       [&](sycl::handler& cgh) {
         return sampled_image.get_access<data_type>(cgh);
       },
-      "sampled_image_accessor<int4, 1, image_target::device>");
+      "sampled_image_accessor<int4, 1, image_target::device>",
+      {sycl::aspect::image});
 }
 
 struct storage_unsampled {
@@ -131,5 +132,6 @@ TEST_CASE("unsampled_image_accessor common reference semantics (kernel)",
             cgh);
       },
       "unsampled_image_accessor<int4, 1, access_mode::read, "
-      "image_target::device>");
+      "image_target::device>",
+      {sycl::aspect::image});
 }


### PR DESCRIPTION
This commit fixes the following in the image-related tests:
 - Adds the data type template argument to `get_host_access` calls.
 - Fixes storage classes for sampled and unsampled image checks.
 - Replace calls to non-existant `range` memeber function to existing `get_range`.
 - Replaces subscripting on host image accessors to approriate `read` calls.
 - Removes a test case trying to call non-const `get_host_access` on a constant copy of an image.
 - Adds optional requirements to `common_reference_semantics::check_kernel` to enforce skips for images when unsupported on the selected device.