### PR TITLE
Enabled group_functions tests

### DIFF
--- a/tests/group_functions/group_reduce.cpp
+++ b/tests/group_functions/group_reduce.cpp
@@ -90,11 +90,6 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
         "hipSYCL has no implementation of T joint_reduce(sub_group g, Ptr "
         "first, Ptr last, T init, "
         "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8341
-    WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
@@ -115,10 +110,8 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
-  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   if constexpr (std::is_same_v<T, U>)
 #endif
   {
@@ -167,12 +160,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 
   // check types to only print warning once
   if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8341
-    WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
         "long long int. Skipping the test cases.");
@@ -192,10 +180,8 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
-  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   if constexpr (std::is_same_v<T, U>)
 #endif
   {

--- a/tests/group_functions/group_reduce_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp16.cpp
@@ -91,11 +91,6 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
         "ComputeCpp cannot handle cases of different types. "
         "Skipping such test cases.");
     WARN("ComputeCpp cannot handle half type. Skipping the test.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8341
-    WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
 #endif
   }
 
@@ -103,10 +98,8 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
-  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   if constexpr (std::is_same_v<T, U>)
 #endif
   {
@@ -151,12 +144,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 
   // check types to only print warning once
   if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8341
-    WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
         "long long int. Skipping the test cases.");
@@ -172,10 +160,8 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
   return;
 #else
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-    // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    // FIXME:ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     if constexpr (std::is_same_v<T, U>)
 #endif
     {

--- a/tests/group_functions/group_reduce_fp64.cpp
+++ b/tests/group_functions/group_reduce_fp64.cpp
@@ -89,11 +89,6 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
         "hipSYCL has no implementation of T joint_reduce(sub_group g, Ptr "
         "first, Ptr last, T init, "
         "BinaryOperation binary_op) over sub-groups. Skipping the test case.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8341
-    WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
@@ -114,10 +109,8 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group joint reduce functions with init",
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
-  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   if constexpr (std::is_same_v<T, U>)
 #endif
   {
@@ -172,12 +165,7 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
 
   // check types to only print warning once
   if constexpr (std::is_same_v<T, char> && std::is_same_v<U, char>) {
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8341
-    WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp does not implement reduce for unsigned long long int and "
         "long long int. Skipping the test cases.");
@@ -198,10 +186,8 @@ TEMPLATE_LIST_TEST_CASE("Group and sub-group reduce functions with init",
   return;
 #else
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-    // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    // FIXME: ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     if constexpr (std::is_same_v<T, U>)
 #endif
     {

--- a/tests/group_functions/group_reduce_fp64_fp16.cpp
+++ b/tests/group_functions/group_reduce_fp64_fp16.cpp
@@ -39,21 +39,14 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group joint reduce functions with init",
         "ComputeCpp cannot handle cases of different types. "
         "Skipping such test cases.");
     WARN("ComputeCpp cannot handle half type. Skipping the test.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8341
-    WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
 #endif
   }
 
   // FIXME: ComputeCpp has no half
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
-  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   if (queue.get_device().has(sycl::aspect::fp16) &&
@@ -73,12 +66,7 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
   auto queue = sycl_cts::util::get_cts_object::queue();
   // check dimensions to only print warning once
   if constexpr (D == 1) {
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-    // Link to issue https://github.com/intel/llvm/issues/8341
-    WARN(
-        "DPCPP cannot handle cases of different types. "
-        "Skipping such test cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "ComputeCpp cannot handle cases of different types. "
         "Skipping such test cases.");
@@ -89,10 +77,8 @@ TEMPLATE_TEST_CASE_SIG("Group and sub-group reduce functions with init",
   // FIXME: ComputeCpp has no half
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
-  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   if (queue.get_device().has(sycl::aspect::fp16) &&

--- a/tests/group_functions/group_scan.cpp
+++ b/tests/group_functions/group_scan.cpp
@@ -50,11 +50,6 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "hipSYCL joint_exclusive_scan and joint_inclusive_scan cannot process "
       "over several sub-groups simultaneously. Using one sub-group only.");
   WARN("hipSYCL does not support sycl::known_identity_v yet.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
-      "Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
 #endif
@@ -63,10 +58,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   // FIXME: ComputeCpp does not implement joint scan
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
-  // FIXME: hipSYCL and DPCPP cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#elif defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // FIXME: hipSYCL cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   for_all_combinations<invoke_joint_scan_group_same_type>(Dims, ScanTypes{},
                                                           queue);
 #else
@@ -87,11 +80,6 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "hipSYCL joint_exclusive_scan and joint_inclusive_scan with init values "
       "cannot process over several sub-groups simultaneously. Using one "
       "sub-group only.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for T, *InPtr and "
-      "*OutPtr. Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
 #endif
@@ -100,10 +88,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   // FIXME: ComputeCpp does not implement joint scan
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
-  // FIXME: hipSYCL and DPCPP cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#elif defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+  // FIXME: hipSYCL cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
   for_all_combinations<invoke_init_joint_scan_group_same_type>(
       Dims, ScanTypes{}, queue);
 #else
@@ -141,12 +127,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][type_list][dim]")({
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for T and V. Skipping such "
-      "test cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN(
       "ComputeCpp does not implement scan for unsigned long long int and "
       "long long int. Skipping the test cases.");
@@ -165,10 +146,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   //        clang-8: error: spirv-ll-tool command failed due to signal
 #if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
-  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp cannot handle cases of different types
+#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   for_all_combinations<invoke_init_scan_over_group_same_type>(Dims, ScanTypes{},
                                                               queue);
 #else

--- a/tests/group_functions/group_scan_fp16.cpp
+++ b/tests/group_functions/group_scan_fp16.cpp
@@ -56,11 +56,6 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "hipSYCL joint_exclusive_scan and joint_inclusive_scan cannot process "
       "over several sub-groups simultaneously. Using one sub-group only.");
   WARN("hipSYCL does not support sycl::known_identity_v yet.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
-      "Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
   WARN("ComputeCpp cannot handle half type. Skipping the test.");
@@ -72,10 +67,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    // FIXME: hipSYCL and DPCPP cannot handle cases of different types
-    // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // FIXME: hipSYCL cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
     for_all_combinations<invoke_joint_scan_group_same_type>(Dims, HalfType{},
                                                             queue);
 #else
@@ -100,11 +93,6 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "hipSYCL joint_exclusive_scan and joint_inclusive_scan with init values "
       "cannot process over several sub-groups simultaneously. Using one "
       "sub-group only.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for T, *InPtr and "
-      "*OutPtr. Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
   WARN("ComputeCpp cannot handle half type. Skipping the test.");
@@ -116,10 +104,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    // FIXME: hipSYCL and DPCPP cannot handle cases of different types
-    // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // FIXME: hipSYCL cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
     for_all_combinations<invoke_init_joint_scan_group_same_type>(
         Dims, HalfType{}, queue);
 #else
@@ -154,12 +140,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][type_list][fp16][dim]")({
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for T and V. Skipping such "
-      "test cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN(
       "ComputeCpp does not implement scan for unsigned long long int and "
       "long long int. Skipping the test cases.");
@@ -175,10 +156,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-    // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    // FIXME: ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     for_all_combinations<invoke_init_scan_over_group_same_type>(
         Dims, HalfType{}, queue);
 #else

--- a/tests/group_functions/group_scan_fp64.cpp
+++ b/tests/group_functions/group_scan_fp64.cpp
@@ -56,11 +56,6 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "hipSYCL joint_exclusive_scan and joint_inclusive_scan cannot process "
       "over several sub-groups simultaneously. Using one sub-group only.");
   WARN("hipSYCL does not support sycl::known_identity_v yet.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
-      "Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
 #endif
@@ -71,10 +66,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    // FIXME: hipSYCL and DPCPP cannot handle cases of different types
-    // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // FIXME: hipSYCL cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
     for_all_combinations<invoke_joint_scan_group_same_type>(Dims, DoubleType{},
                                                             queue);
 #else
@@ -99,11 +92,6 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "hipSYCL joint_exclusive_scan and joint_inclusive_scan with init values "
       "cannot process over several sub-groups simultaneously. Using one "
       "sub-group only.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for T, *InPtr and "
-      "*OutPtr. Skipping such test cases.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
 #endif
@@ -114,10 +102,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    // FIXME: hipSYCL and DPCPP cannot handle cases of different types
-    // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP)
+    // FIXME: hipSYCL cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL)
     for_all_combinations<invoke_init_joint_scan_group_same_type>(
         Dims, DoubleType{}, queue);
 #else
@@ -161,12 +147,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][type_list][fp64][dim]")({
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for T and V. Skipping such "
-      "test cases.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN(
       "ComputeCpp does not implement scan for unsigned long long int and "
       "long long int. Skipping the test cases.");
@@ -187,10 +168,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-    // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+    // FIXME: ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     for_all_combinations<invoke_init_scan_over_group_same_type>(
         Dims, DoubleType{}, queue);
 #else

--- a/tests/group_functions/group_scan_fp64_fp16.cpp
+++ b/tests/group_functions/group_scan_fp64_fp16.cpp
@@ -58,21 +58,14 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "hipSYCL joint_exclusive_scan and joint_inclusive_scan cannot process "
       "over several sub-groups simultaneously. Using one sub-group only.");
   WARN("hipSYCL does not support sycl::known_identity_v yet.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for InPtr and OutPtr. "
-      "Skipping the test.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
   WARN("ComputeCpp cannot handle half type. Skipping the test.");
 #endif
 
   // FIXME: ComputeCpp does not implement joint scan and half type
-  // FIXME: hipSYCL and DPCPP cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
+  // FIXME: hipSYCL cannot handle cases of different types
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP) ||   \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -103,21 +96,14 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
       "hipSYCL joint_exclusive_scan and joint_inclusive_scan with init values "
       "cannot process over several sub-groups simultaneously. Using one "
       "sub-group only.");
-#elif defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for T, *InPtr and "
-      "*OutPtr. Skipping the test.");
 #elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN("ComputeCpp does not implement joint scan. Skipping the test.");
   WARN("ComputeCpp cannot handle half type. Skipping the test.");
 #endif
 
   // FIXME: ComputeCpp does not implement joint scan and half type
-  // FIXME: hipSYCL and DPCPP cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
+  // FIXME: hipSYCL cannot handle cases of different types
 #if defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
-    defined(SYCL_CTS_COMPILING_WITH_DPCPP) ||   \
     defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
@@ -141,12 +127,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("Group and sub-group scan functions with init",
  "[group_func][fp16][fp64][dim]")({
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP)
-  // Link to issue https://github.com/intel/llvm/issues/8341
-  WARN(
-      "DPCPP cannot handle cases of different types for T and V. Skipping the "
-      "test.");
-#elif defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   WARN(
       "ComputeCpp cannot handle cases of different types for T and V. Skipping "
       "the test.");
@@ -154,10 +135,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 #endif
 
   // FIXME: ComputeCpp has no half
-  // FIXME: DPCPP and ComputeCpp cannot handle cases of different types
-  // Link to issue https://github.com/intel/llvm/issues/8341
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+  // FIXME: ComputeCpp cannot handle cases of different types
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
   return;
 #else
   auto queue = sycl_cts::util::get_cts_object::queue();


### PR DESCRIPTION
Enabled group_functions tests due to fixed product issue [#8341](https://github.com/intel/llvm/issues/8341).