### PR TITLE
Update test plan for optional kernel features and add test plan for kernel attributes

### DIFF
--- a/test_plans/kernel_attributes.asciidoc
+++ b/test_plans/kernel_attributes.asciidoc
@@ -1,0 +1,53 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for behavior for optional kernel features
+
+This is a test plan for optional kernel features described in
+https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:kernel.attributes[5.8.1. Kernel attributes]
+and not checked in optional kernel features tests.
+
+
+== Testing scope
+
+=== Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line if not stated otherwise.
+
+== Tests
+
+All tests should use following methods of kernels submission unless stated otherwise:
+
+* parallel_for_work_group
+* parallel_for
+
+Kernel should be defined:
+
+* through lambda in submission call
+* through a separate functor
+* through a separate lambda
+
+=== Call for work_group_size_hint
+
+For `size = 4`:
+
+For following dimensions `D = 1, 2, 3`:
+
+For kernel invocation with `work_group_size = size, size/2, size * 2`:
+
+* Create kernel with attribute `[[sycl::work_group_size_hint(W...)]]` where `W...` is `size` repeated for each tested dimension.
+Kernel should write a value to acessor to a buffer<int, D>.
+* Submit kernel to device.
+* Check that kernel is executed without any exception and have expected result.
+
+=== Call for vec_type_hint
+
+In addition to parallel_for_work_group and parallel_for this test should use single_task for kernel invocation.
+
+This test case should use `#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS` to skip check id deprecated features are not tested.
+
+* Create kernel with attribute `[[sycl::vec_type_hint(<sycl::vec<T, N>>)]]` where `N = 1, 2, 3, 4, 8 or 16` and `T = int, float`.
+Kernel should write a value to acessor to a buffer<sycl::vec<T, N>, 1>.
+* Submit kernel to device.
+* Check that kernel is executed without any exception and have expected result.

--- a/test_plans/kernel_attributes.asciidoc
+++ b/test_plans/kernel_attributes.asciidoc
@@ -1,9 +1,9 @@
 :sectnums:
 :xrefstyle: short
 
-= Test plan for behavior for optional kernel features
+= Test plan for behavior of kernel attributes
 
-This is a test plan for optional kernel features described in
+This is a test plan for kernel attributes described in
 https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:kernel.attributes[5.8.1. Kernel attributes]
 and not checked in optional kernel features tests.
 

--- a/test_plans/optional_kernel_features.asciidoc
+++ b/test_plans/optional_kernel_features.asciidoc
@@ -124,21 +124,3 @@ The first kernel is submitted unconditionally to the device.
 Each of the remaining kernels is submitted to the device only if it supports the kernel's feature / work-group size / sub-group size.
 
 Check that no exception is thrown.
-
-=== Call for work_group_size_hint
-
-For following dimensions `D = 1, 2, 3`:
-
-* Create kernel with attribute `[[sycl::work_group_size_hint(W...)]]` where `W...` is `size = 16` repeated for each tested dimension.
-Kernel should write a value to acessor to a buffer<int, D>.
-* Submit kernel to device.
-* Check that kernel is executed without any exception and have expected result.
-
-=== Call for vec_type_hint
-
-This test case should use `#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS` to skip check id deprecated features are not tested.
-
-* Create kernel with attribute `[[sycl::vec_type_hint(<sycl::vec<T, N>>)]]` where `N = 1, 2, 3, 4, 8 or 16` and `T = int, float`.
-Kernel should write a value to acessor to a buffer<sycl::vec<T, N>, 1>.
-* Submit kernel to device.
-* Check that kernel is executed without any exception and have expected result.

--- a/test_plans/optional_kernel_features.asciidoc
+++ b/test_plans/optional_kernel_features.asciidoc
@@ -66,15 +66,21 @@ Submit kernel to the device and check the result:
 
 For following sizes:
 
-* 16
+* 4
 * 4294967295
+
+For following dimensions D:
+
+* 1
+* 2
+* 3
 
 Do the following:
 
-* Get device's max work group size using info::device::max_work_group_size.
-* Create kernel with attribute [[sycl::reqd_work_group_size(W)]] where W is tested size.
+* Get device's max work group size using info::device::max_work_group_size and info::device::max_work_item_sizes<D>.
+* Create kernel with attribute [[sycl::reqd_work_group_size(W...)]] where W... is tested size repeated for each tested dimension.
 * Submit kernels to device.
-* Check that, if W > max work group size, synchronous `errc::kernel_not_supported` is thrown,
+* Check that, if W*...*W > max_work_group_size or W > max_work_item_sizes<D> for any dimension, synchronous `errc::kernel_not_supported` is thrown,
   and that otherwise kernel is executed without any exception.
 
 === Runtime exception if kernel is decorated with [[sycl::reqd_work_group_size(W)]] and uses mismatched nd_range
@@ -118,3 +124,21 @@ The first kernel is submitted unconditionally to the device.
 Each of the remaining kernels is submitted to the device only if it supports the kernel's feature / work-group size / sub-group size.
 
 Check that no exception is thrown.
+
+=== Call for work_group_size_hint
+
+For following dimensions `D = 1, 2, 3`:
+
+* Create kernel with attribute `[[sycl::work_group_size_hint(W...)]]` where `W...` is `size = 16` repeated for each tested dimension.
+Kernel should write a value to acessor to a buffer<int, D>.
+* Submit kernel to device.
+* Check that kernel is executed without any exception and have expected result.
+
+=== Call for vec_type_hint
+
+This test case should use `#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS` to skip check id deprecated features are not tested.
+
+* Create kernel with attribute `[[sycl::vec_type_hint(<sycl::vec<T, N>>)]]` where `N = 1, 2, 3, 4, 8 or 16` and `T = int, float`.
+Kernel should write a value to acessor to a buffer<sycl::vec<T, N>, 1>.
+* Submit kernel to device.
+* Check that kernel is executed without any exception and have expected result.


### PR DESCRIPTION
Added test plan for checks for attributes `work_group_size_hint` and `vec_type_hint` whose effects, if any, are implementation-defined.
Added test cases for `reqd_work_group_size` for different dimensions in optional kernel features test plan.