### PR TITLE
sycl::buffer use_host_ptr() property tests 

### DIFF
--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -44,32 +44,32 @@ class empty_kernel {
 @brief used to calculate the ranges based on the dimensionality of the buffer
 */
 template <size_t dims>
-inline void precalculate(sycl::range<dims> &rangeIn,
-                         sycl::range<dims> &rangeOut, size_t &elementsCount,
+inline void precalculate(sycl::range<dims>& rangeIn,
+                         sycl::range<dims>& rangeOut, size_t& elementsCount,
                          size_t elementsIn, size_t elementsOut);
 
 template <>
-inline void precalculate<1>(sycl::range<1> &rangeIn,
-                            sycl::range<1> &rangeOut, size_t &elementsCount,
-                            size_t elementsIn, size_t elementsOut) {
+inline void precalculate<1>(sycl::range<1>& rangeIn, sycl::range<1>& rangeOut,
+                            size_t& elementsCount, size_t elementsIn,
+                            size_t elementsOut) {
   rangeIn = sycl::range<1>(elementsIn);
   rangeOut = sycl::range<1>(elementsOut);
   elementsCount = elementsOut;
 }
 
 template <>
-inline void precalculate<2>(sycl::range<2> &rangeIn,
-                            sycl::range<2> &rangeOut, size_t &elementsCount,
-                            size_t elementsIn, size_t elementsOut) {
+inline void precalculate<2>(sycl::range<2>& rangeIn, sycl::range<2>& rangeOut,
+                            size_t& elementsCount, size_t elementsIn,
+                            size_t elementsOut) {
   rangeIn = sycl::range<2>(elementsIn, elementsIn);
   rangeOut = sycl::range<2>(elementsOut, elementsIn);
   elementsCount = (elementsOut * elementsIn);
 }
 
 template <>
-inline void precalculate<3>(sycl::range<3> &rangeIn,
-                            sycl::range<3> &rangeOut, size_t &elementsCount,
-                            size_t elementsIn, size_t elementsOut) {
+inline void precalculate<3>(sycl::range<3>& rangeIn, sycl::range<3>& rangeOut,
+                            size_t& elementsCount, size_t elementsIn,
+                            size_t elementsOut) {
   rangeIn = sycl::range<3>(elementsIn, elementsIn, elementsIn);
   rangeOut = sycl::range<3>(elementsOut, elementsIn, elementsIn);
   elementsCount = (elementsOut * elementsIn * elementsIn);
@@ -204,8 +204,7 @@ class kernel_buffer_accessor_type;
  * Generic buffer API test function
  */
 template <typename T, int size, int dims, typename alloc>
-void test_buffer(util::logger &log, sycl::range<dims> &r,
-                 sycl::id<dims> &i) {
+void test_buffer(util::logger& log, sycl::range<dims>& r, sycl::id<dims>& i) {
   {
     std::unique_ptr<T[]> data(new T[size]);
     std::fill(data.get(), (data.get() + size), 0);
@@ -219,19 +218,14 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     /* check the buffer returns a range */
     auto ret_range = buf.get_range();
     check_return_type<sycl::range<dims>>(log, ret_range,
-                                             "sycl::buffer::get_range()");
+                                         "sycl::buffer::get_range()");
 
     /* Check alias types */
     {
+      { check_type_existence<typename sycl::buffer<T, dims>::value_type>(); }
+      { check_type_existence<typename sycl::buffer<T, dims>::reference>(); }
       {
-        check_type_existence<typename sycl::buffer<T, dims>::value_type>();
-      }
-      {
-        check_type_existence<typename sycl::buffer<T, dims>::reference>();
-      }
-      {
-        check_type_existence<
-            typename sycl::buffer<T, dims>::const_reference>();
+        check_type_existence<typename sycl::buffer<T, dims>::const_reference>();
       }
       {
         check_type_existence<typename sycl::buffer<
@@ -277,7 +271,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     auto q = util::get_cts_object::queue();
 
     /* check the buffer returns the correct type of accessor */
-    q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler& cgh) {
       using kname = kernel_buffer_accessor_type<T, size, dims, alloc,
                                                 sycl::access_mode::read_write,
                                                 sycl::target::device>;
@@ -289,7 +283,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     });
 
     /* check the buffer returns the correct type of accessor */
-    q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler& cgh) {
       using kname = kernel_buffer_accessor_type<T, size, dims, alloc,
                                                 sycl::access_mode::read,
                                                 sycl::target::constant_buffer>;
@@ -306,15 +300,14 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
 #if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     {
       auto acc = buf.template get_access<sycl::access_mode::read_write>();
-      check_return_type<
-          sycl::accessor<T, dims, sycl::access_mode::read_write,
-                             sycl::target::host_buffer>>(
+      check_return_type<sycl::accessor<T, dims, sycl::access_mode::read_write,
+                                       sycl::target::host_buffer>>(
           log, acc, "sycl::buffer::get_access<read_write, host_buffer>()");
     }
 #endif
 
     /* check the buffer returns the correct type of accessor */
-    q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler& cgh) {
       using kname = kernel_buffer_accessor_type<T, size, dims, alloc,
                                                 sycl::access_mode::read_write,
                                                 sycl::target::device>;
@@ -331,11 +324,10 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     /* check the buffer returns the correct type of accessor */
 #if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     {
-      auto acc = buf.template get_access<sycl::access_mode::read_write>(
-          r, offset);
-      check_return_type<
-          sycl::accessor<T, dims, sycl::access_mode::read_write,
-                             sycl::target::host_buffer>>(
+      auto acc =
+          buf.template get_access<sycl::access_mode::read_write>(r, offset);
+      check_return_type<sycl::accessor<T, dims, sycl::access_mode::read_write,
+                                       sycl::target::host_buffer>>(
           log, acc,
           "sycl::buffer::get_access<read_write, host_buffer>(range<>, "
           "id<>)");
@@ -386,15 +378,17 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
                               "has_property<use_mutex>()");
       CHECK(hasUseMutexProperty);
 
-      auto hasContentBoundProperty = buf.template has_property<
-          sycl::property::buffer::context_bound>();
+      auto hasContentBoundProperty =
+          buf.template has_property<sycl::property::buffer::context_bound>();
       check_return_type<bool>(log, hasContentBoundProperty,
                               "has_property<context_bound>()");
       CHECK(hasContentBoundProperty);
 
-      sycl::buffer<T, dims> buf_host_ptr(data.get(), r, {sycl::property::buffer::use_host_ptr()});
+      sycl::buffer<T, dims> buf_host_ptr(
+          data.get(), r, {sycl::property::buffer::use_host_ptr()});
       auto hasUseHostPtrProperty =
-          buf_host_ptr.template has_property<sycl::property::buffer::use_host_ptr>();
+          buf_host_ptr
+              .template has_property<sycl::property::buffer::use_host_ptr>();
       check_return_type<bool>(log, hasUseHostPtrProperty,
                               "has_property<use_host_ptr>()");
       CHECK(hasUseHostPtrProperty);
@@ -409,21 +403,24 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
           log, useMutexProperty.get_mutex_ptr(),
           "sycl::property::buffer::use_mutex::get_mutex_ptr()");
 
-      auto contentBoundProperty = buf.template get_property<
-          sycl::property::buffer::context_bound>();
+      auto contentBoundProperty =
+          buf.template get_property<sycl::property::buffer::context_bound>();
       check_return_type<sycl::property::buffer::context_bound>(
           log, contentBoundProperty, "get_property<context_bound>()");
       check_return_type<sycl::context>(
           log, contentBoundProperty.get_context(),
           "sycl::property::buffer::context_bound::get_context()");
 
-      sycl::host_accessor<T, dims, sycl::access_mode::read_write> acc_host_ptr(buf_host_ptr);
+      sycl::host_accessor<T, dims, sycl::access_mode::read_write> acc_host_ptr(
+          buf_host_ptr);
       auto useHostPtrProperty =
-          buf_host_ptr.template get_property<sycl::property::buffer::use_host_ptr>();
+          buf_host_ptr
+              .template get_property<sycl::property::buffer::use_host_ptr>();
       check_return_type<sycl::property::buffer::use_host_ptr>(
           log, useHostPtrProperty, "get_property<use_host_ptr>()");
-      INFO("Check that address of reference type returned from host accessor "
-           "is the same as corresponding host data address");
+      INFO(
+          "Check that address of reference type returned from host accessor "
+          "is the same as corresponding host data address");
       CHECK(data.get() == &acc_host_ptr[sycl::id<dims>{}]);
     }
 
@@ -432,13 +429,13 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
 }
 
 /**
-* @brief Tests reinterpreting a buffer
-* @tparam T Underlying data type of the input buffer
-* @tparam numDims Number of input dimensions
-* @param log Logger object
-*/
+ * @brief Tests reinterpreting a buffer
+ * @tparam T Underlying data type of the input buffer
+ * @tparam numDims Number of input dimensions
+ * @param log Logger object
+ */
 template <typename T, int numDims>
-void test_type_reinterpret(util::logger &log) {
+void test_type_reinterpret(util::logger& log) {
   static constexpr size_t inputElemsPerDim = 4;
   static constexpr size_t numElems = [](size_t elemsPerDim) {
     for (int i = 1; i < numDims; ++i) elemsPerDim *= elemsPerDim;
@@ -457,12 +454,13 @@ void test_type_reinterpret(util::logger &log) {
 
   // Check reinterpreting without a range to the same dimension
   test_buffer_reinterpret_no_range<T, ReinterpretT, numDims, numDims>::check(
-      reinterpret_cast<T *>(reinterpretInputData), inputElemsPerDim,
-      log);
+      reinterpret_cast<T*>(reinterpretInputData), inputElemsPerDim, log);
 }
 
-template <typename T> class check_buffer_api_for_type {
-  template <typename alloc> void check_with_alloc(util::logger &log) {
+template <typename T>
+class check_buffer_api_for_type {
+  template <typename alloc>
+  void check_with_alloc(util::logger& log) {
     const int size = 8;
     sycl::range<1> range1d(size);
     sycl::range<2> range2d(size, size);
@@ -482,8 +480,8 @@ template <typename T> class check_buffer_api_for_type {
     test_type_reinterpret<T, 3>(log);
   }
 
-public:
-  void operator()(util::logger &log, const std::string &typeName) {
+ public:
+  void operator()(util::logger& log, const std::string& typeName) {
     INFO("testing: " + type_name_string<T>::get(typeName));
     check_with_alloc<sycl::buffer_allocator<T>>(log);
     check_with_alloc<std::allocator<T>>(log);
@@ -495,7 +493,7 @@ public:
  */
 class check_buffer_linearization {
  public:
-  void operator()(util::logger &log) {
+  void operator()(util::logger& log) {
     constexpr int g_size = 4;  // global range size
     constexpr int l_size = 2;  // local range size
     auto q = util::get_cts_object::queue();
@@ -537,14 +535,14 @@ class check_buffer_linearization {
    * Buffer linearization test
    */
   template <int dims, typename alloc>
-  void test_buffer_linearization(util::logger &log, sycl::nd_range<dims> &r) {
+  void test_buffer_linearization(util::logger& log, sycl::nd_range<dims>& r) {
     static_assert(dims >= 1 && dims < 4,
                   "Linearization test requires dims to be one of {1;2;3}.");
     INFO("testing: linearization in " + std::to_string(dims) + " dimensions.");
     auto q = util::get_cts_object::queue();
 
     sycl::buffer<size_t, dims, alloc> buf(r.get_global_range());
-    q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler& cgh) {
       auto acc = buf.get_access(cgh, sycl::write_only, sycl::no_init);
       cgh.parallel_for<write_id<dims, alloc>>(r, [=](sycl::nd_item<dims> i) {
         // clang-format off


### PR DESCRIPTION
Added checks for `sycl::buffer` `has_property()/get_property()` member functions with `use_host_ptr` property and basic functionality test with `host_accessor`. Additionally, applied new clang format.