### PR TITLE
Use left shift on unsigned 1

### DIFF
--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_flip_id.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_flip_id.cpp
@@ -23,7 +23,7 @@ struct check_result_flip_id {
     sub_group_mask.extract_bits(before_flip);
     sub_group_mask.flip(local_id);
     sub_group_mask.extract_bits(after_flip);
-    return after_flip == (before_flip ^ (1 << local_id.get(0)));
+    return after_flip == (before_flip ^ (1U << local_id.get(0)));
   }
 };
 


### PR DESCRIPTION
In `before_flip ^ (1 << local_id.get(0))`, usual arithmetic conversions say that the is converted RHS to `unsigned long`. When `local_id.get(0) == 31`, `(1 << local_id.get(0)) == (1 << 31)` is negative, so when converted to unsigned long, due to sign extension, it gets the byte pattern `ff ff ff ff 80 00 00 00`. Change `1` to `1U` so that zero extension happens and the RHS gets the byte pattern `00 00 00 00 80 00 00 00`.