### PR TITLE
get_property() exception tests for buffer and queue

### DIFF
--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -81,12 +81,10 @@ inline void precalculate<3>(sycl::range<3>& rangeIn, sycl::range<3>& rangeOut,
 template <typename prop, typename buffer_t>
 void check_throw_matches(buffer_t& buf, const char* prop_name) {
 #if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
-  auto action = [&] {
-    auto no_prop = buf.template get_property<prop>();
-  };
+  auto action = [&] { auto no_prop = buf.template get_property<prop>(); };
   INFO("Check that get_property() throws errc::invalid " << prop_name);
   CHECK_THROWS_MATCHES(action(), sycl::exception,
-      sycl_cts::util::equals_exception(sycl::errc::invalid));
+                       sycl_cts::util::equals_exception(sycl::errc::invalid));
 #endif
 }
 

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -22,10 +22,10 @@
 #ifndef __SYCLCTS_TESTS_BUFFER_API_COMMON_H
 #define __SYCLCTS_TESTS_BUFFER_API_COMMON_H
 
+#include "../../../util/sycl_exceptions.h"
 #include "../common/common.h"
 #include "../common/get_group_range.h"
 #include "../common/once_per_unit.h"
-#include "../../../util/sycl_exceptions.h"
 
 namespace buffer_api_common {
 using namespace sycl_cts;
@@ -46,32 +46,32 @@ class empty_kernel {
 @brief used to calculate the ranges based on the dimensionality of the buffer
 */
 template <size_t dims>
-inline void precalculate(sycl::range<dims> &rangeIn,
-                         sycl::range<dims> &rangeOut, size_t &elementsCount,
+inline void precalculate(sycl::range<dims>& rangeIn,
+                         sycl::range<dims>& rangeOut, size_t& elementsCount,
                          size_t elementsIn, size_t elementsOut);
 
 template <>
-inline void precalculate<1>(sycl::range<1> &rangeIn,
-                            sycl::range<1> &rangeOut, size_t &elementsCount,
-                            size_t elementsIn, size_t elementsOut) {
+inline void precalculate<1>(sycl::range<1>& rangeIn, sycl::range<1>& rangeOut,
+                            size_t& elementsCount, size_t elementsIn,
+                            size_t elementsOut) {
   rangeIn = sycl::range<1>(elementsIn);
   rangeOut = sycl::range<1>(elementsOut);
   elementsCount = elementsOut;
 }
 
 template <>
-inline void precalculate<2>(sycl::range<2> &rangeIn,
-                            sycl::range<2> &rangeOut, size_t &elementsCount,
-                            size_t elementsIn, size_t elementsOut) {
+inline void precalculate<2>(sycl::range<2>& rangeIn, sycl::range<2>& rangeOut,
+                            size_t& elementsCount, size_t elementsIn,
+                            size_t elementsOut) {
   rangeIn = sycl::range<2>(elementsIn, elementsIn);
   rangeOut = sycl::range<2>(elementsOut, elementsIn);
   elementsCount = (elementsOut * elementsIn);
 }
 
 template <>
-inline void precalculate<3>(sycl::range<3> &rangeIn,
-                            sycl::range<3> &rangeOut, size_t &elementsCount,
-                            size_t elementsIn, size_t elementsOut) {
+inline void precalculate<3>(sycl::range<3>& rangeIn, sycl::range<3>& rangeOut,
+                            size_t& elementsCount, size_t elementsIn,
+                            size_t elementsOut) {
   rangeIn = sycl::range<3>(elementsIn, elementsIn, elementsIn);
   rangeOut = sycl::range<3>(elementsOut, elementsIn, elementsIn);
   elementsCount = (elementsOut * elementsIn * elementsIn);
@@ -79,38 +79,45 @@ inline void precalculate<3>(sycl::range<3> &rangeIn,
 
 template <typename prop, typename buffer_t>
 void check_throw_matches(buffer_t& buf, const char* prop_name) {
-  auto action = [&] {
-    auto no_prop = buf.template get_property<prop>();
-  };
+  auto action = [&] { auto no_prop = buf.template get_property<prop>(); };
   INFO("Check that get_property() throws errc::invalid " << prop_name);
   CHECK_THROWS_MATCHES(action(), sycl::exception,
-      sycl_cts::util::equals_exception(sycl::errc::invalid));
+                       sycl_cts::util::equals_exception(sycl::errc::invalid));
 }
 
 template <typename buffer_t>
 void check_get_prop_throws(buffer_t& buf) {
-  const bool use_host_ptr = buf.template has_property<sycl::property::buffer::use_host_ptr>();
-  const bool use_mutex = buf.template has_property<sycl::property::buffer::use_mutex>();
-  const bool context_bound = buf.template has_property<sycl::property::buffer::context_bound>();
+  const bool use_host_ptr =
+      buf.template has_property<sycl::property::buffer::use_host_ptr>();
+  const bool use_mutex =
+      buf.template has_property<sycl::property::buffer::use_mutex>();
+  const bool context_bound =
+      buf.template has_property<sycl::property::buffer::context_bound>();
 
   if (use_host_ptr) {
     if (use_mutex) {
-      check_throw_matches<sycl::property::buffer::context_bound>(buf, "context_bound");
+      check_throw_matches<sycl::property::buffer::context_bound>(
+          buf, "context_bound");
     } else if (context_bound) {
       check_throw_matches<sycl::property::buffer::use_mutex>(buf, "use_mutex");
     } else {
       check_throw_matches<sycl::property::buffer::use_mutex>(buf, "use_mutex");
-      check_throw_matches<sycl::property::buffer::context_bound>(buf, "context_bound");
+      check_throw_matches<sycl::property::buffer::context_bound>(
+          buf, "context_bound");
     }
   } else if (use_mutex) {
     if (context_bound) {
-      check_throw_matches<sycl::property::buffer::use_host_ptr>(buf, "use_host_ptr");
+      check_throw_matches<sycl::property::buffer::use_host_ptr>(buf,
+                                                                "use_host_ptr");
     } else {
-      check_throw_matches<sycl::property::buffer::use_host_ptr>(buf, "use_host_ptr");
-      check_throw_matches<sycl::property::buffer::context_bound>(buf, "context_bound");
+      check_throw_matches<sycl::property::buffer::use_host_ptr>(buf,
+                                                                "use_host_ptr");
+      check_throw_matches<sycl::property::buffer::context_bound>(
+          buf, "context_bound");
     }
   } else if (context_bound) {
-    check_throw_matches<sycl::property::buffer::use_host_ptr>(buf, "use_host_ptr");
+    check_throw_matches<sycl::property::buffer::use_host_ptr>(buf,
+                                                              "use_host_ptr");
     check_throw_matches<sycl::property::buffer::use_mutex>(buf, "use_mutex");
   }
 }
@@ -244,8 +251,7 @@ class kernel_buffer_accessor_type;
  * Generic buffer API test function
  */
 template <typename T, int size, int dims, typename alloc>
-void test_buffer(util::logger &log, sycl::range<dims> &r,
-                 sycl::id<dims> &i) {
+void test_buffer(util::logger& log, sycl::range<dims>& r, sycl::id<dims>& i) {
   {
     std::unique_ptr<T[]> data(new T[size]);
     std::fill(data.get(), (data.get() + size), 0);
@@ -259,19 +265,14 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     /* check the buffer returns a range */
     auto ret_range = buf.get_range();
     check_return_type<sycl::range<dims>>(log, ret_range,
-                                             "sycl::buffer::get_range()");
+                                         "sycl::buffer::get_range()");
 
     /* Check alias types */
     {
+      { check_type_existence<typename sycl::buffer<T, dims>::value_type>(); }
+      { check_type_existence<typename sycl::buffer<T, dims>::reference>(); }
       {
-        check_type_existence<typename sycl::buffer<T, dims>::value_type>();
-      }
-      {
-        check_type_existence<typename sycl::buffer<T, dims>::reference>();
-      }
-      {
-        check_type_existence<
-            typename sycl::buffer<T, dims>::const_reference>();
+        check_type_existence<typename sycl::buffer<T, dims>::const_reference>();
       }
       {
         check_type_existence<typename sycl::buffer<
@@ -317,7 +318,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     auto q = once_per_unit::get_queue();
 
     /* check the buffer returns the correct type of accessor */
-    q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler& cgh) {
       using kname = kernel_buffer_accessor_type<T, size, dims, alloc,
                                                 sycl::access_mode::read_write,
                                                 sycl::target::device>;
@@ -329,7 +330,7 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     });
 
     /* check the buffer returns the correct type of accessor */
-    q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler& cgh) {
       using kname = kernel_buffer_accessor_type<T, size, dims, alloc,
                                                 sycl::access_mode::read,
                                                 sycl::target::constant_buffer>;
@@ -346,15 +347,14 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
 #if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     {
       auto acc = buf.template get_access<sycl::access_mode::read_write>();
-      check_return_type<
-          sycl::accessor<T, dims, sycl::access_mode::read_write,
-                             sycl::target::host_buffer>>(
+      check_return_type<sycl::accessor<T, dims, sycl::access_mode::read_write,
+                                       sycl::target::host_buffer>>(
           log, acc, "sycl::buffer::get_access<read_write, host_buffer>()");
     }
 #endif
 
     /* check the buffer returns the correct type of accessor */
-    q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler& cgh) {
       using kname = kernel_buffer_accessor_type<T, size, dims, alloc,
                                                 sycl::access_mode::read_write,
                                                 sycl::target::device>;
@@ -371,11 +371,10 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
     /* check the buffer returns the correct type of accessor */
 #if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     {
-      auto acc = buf.template get_access<sycl::access_mode::read_write>(
-          r, offset);
-      check_return_type<
-          sycl::accessor<T, dims, sycl::access_mode::read_write,
-                             sycl::target::host_buffer>>(
+      auto acc =
+          buf.template get_access<sycl::access_mode::read_write>(r, offset);
+      check_return_type<sycl::accessor<T, dims, sycl::access_mode::read_write,
+                                       sycl::target::host_buffer>>(
           log, acc,
           "sycl::buffer::get_access<read_write, host_buffer>(range<>, "
           "id<>)");
@@ -426,8 +425,8 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
                               "has_property<use_mutex>()");
       CHECK(hasUseMutexProperty);
 
-      auto hasContentBoundProperty = buf.template has_property<
-          sycl::property::buffer::context_bound>();
+      auto hasContentBoundProperty =
+          buf.template has_property<sycl::property::buffer::context_bound>();
       check_return_type<bool>(log, hasContentBoundProperty,
                               "has_property<context_bound>()");
       CHECK(hasContentBoundProperty);
@@ -442,8 +441,8 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
           log, useMutexProperty.get_mutex_ptr(),
           "sycl::property::buffer::use_mutex::get_mutex_ptr()");
 
-      auto contentBoundProperty = buf.template get_property<
-          sycl::property::buffer::context_bound>();
+      auto contentBoundProperty =
+          buf.template get_property<sycl::property::buffer::context_bound>();
       check_return_type<sycl::property::buffer::context_bound>(
           log, contentBoundProperty, "get_property<context_bound>()");
       check_return_type<sycl::context>(
@@ -454,16 +453,25 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
        * error code if buffer was not constructed with use_host_ptr property
        */
       {
-        sycl::buffer<T, dims> buf_host_ptr(data.get(), r, {sycl::property::buffer::use_host_ptr()});
-        sycl::buffer<T, dims> buf_mutex(data.get(), r, {sycl::property::buffer::use_mutex(mutex)});
-        sycl::buffer<T, dims> buf_context(data.get(), r, {sycl::property::buffer::context_bound(context)});
+        sycl::buffer<T, dims> buf_host_ptr(
+            data.get(), r, {sycl::property::buffer::use_host_ptr()});
+        sycl::buffer<T, dims> buf_mutex(
+            data.get(), r, {sycl::property::buffer::use_mutex(mutex)});
+        sycl::buffer<T, dims> buf_context(
+            data.get(), r, {sycl::property::buffer::context_bound(context)});
 
-        sycl::buffer<T, dims> buf_host_ptr_mutex(data.get(), r, {sycl::property::buffer::use_host_ptr(),
-            sycl::property::buffer::use_mutex(mutex)});
-        sycl::buffer<T, dims> buf_host_ptr_context(data.get(), r, {sycl::property::buffer::use_host_ptr(),
-            sycl::property::buffer::context_bound(context)});
-        sycl::buffer<T, dims> buf_mutex_context(data.get(), r, {sycl::property::buffer::use_mutex(mutex),
-            sycl::property::buffer::context_bound(context)});
+        sycl::buffer<T, dims> buf_host_ptr_mutex(
+            data.get(), r,
+            {sycl::property::buffer::use_host_ptr(),
+             sycl::property::buffer::use_mutex(mutex)});
+        sycl::buffer<T, dims> buf_host_ptr_context(
+            data.get(), r,
+            {sycl::property::buffer::use_host_ptr(),
+             sycl::property::buffer::context_bound(context)});
+        sycl::buffer<T, dims> buf_mutex_context(
+            data.get(), r,
+            {sycl::property::buffer::use_mutex(mutex),
+             sycl::property::buffer::context_bound(context)});
 
         check_get_prop_throws(buf_host_ptr);
         check_get_prop_throws(buf_mutex);
@@ -479,13 +487,13 @@ void test_buffer(util::logger &log, sycl::range<dims> &r,
 }
 
 /**
-* @brief Tests reinterpreting a buffer
-* @tparam T Underlying data type of the input buffer
-* @tparam numDims Number of input dimensions
-* @param log Logger object
-*/
+ * @brief Tests reinterpreting a buffer
+ * @tparam T Underlying data type of the input buffer
+ * @tparam numDims Number of input dimensions
+ * @param log Logger object
+ */
 template <typename T, int numDims>
-void test_type_reinterpret(util::logger &log) {
+void test_type_reinterpret(util::logger& log) {
   static constexpr size_t inputElemsPerDim = 4;
   static constexpr size_t numElems = [](size_t elemsPerDim) {
     for (int i = 1; i < numDims; ++i) elemsPerDim *= elemsPerDim;
@@ -504,12 +512,13 @@ void test_type_reinterpret(util::logger &log) {
 
   // Check reinterpreting without a range to the same dimension
   test_buffer_reinterpret_no_range<T, ReinterpretT, numDims, numDims>::check(
-      reinterpret_cast<T *>(reinterpretInputData), inputElemsPerDim,
-      log);
+      reinterpret_cast<T*>(reinterpretInputData), inputElemsPerDim, log);
 }
 
-template <typename T> class check_buffer_api_for_type {
-  template <typename alloc> void check_with_alloc(util::logger &log) {
+template <typename T>
+class check_buffer_api_for_type {
+  template <typename alloc>
+  void check_with_alloc(util::logger& log) {
     const int size = 8;
     sycl::range<1> range1d(size);
     sycl::range<2> range2d(size, size);
@@ -529,8 +538,8 @@ template <typename T> class check_buffer_api_for_type {
     test_type_reinterpret<T, 3>(log);
   }
 
-public:
-  void operator()(util::logger &log, const std::string &typeName) {
+ public:
+  void operator()(util::logger& log, const std::string& typeName) {
     INFO("testing: " + type_name_string<T>::get(typeName));
     check_with_alloc<sycl::buffer_allocator<T>>(log);
     check_with_alloc<std::allocator<T>>(log);
@@ -542,7 +551,7 @@ public:
  */
 class check_buffer_linearization {
  public:
-  void operator()(util::logger &log) {
+  void operator()(util::logger& log) {
     constexpr int g_size = 4;  // global range size
     constexpr int l_size = 2;  // local range size
     auto q = once_per_unit::get_queue();
@@ -584,14 +593,14 @@ class check_buffer_linearization {
    * Buffer linearization test
    */
   template <int dims, typename alloc>
-  void test_buffer_linearization(util::logger &log, sycl::nd_range<dims> &r) {
+  void test_buffer_linearization(util::logger& log, sycl::nd_range<dims>& r) {
     static_assert(dims >= 1 && dims < 4,
                   "Linearization test requires dims to be one of {1;2;3}.");
     INFO("testing: linearization in " + std::to_string(dims) + " dimensions.");
     auto q = once_per_unit::get_queue();
 
     sycl::buffer<size_t, dims, alloc> buf(r.get_global_range());
-    q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler& cgh) {
       auto acc = buf.get_access(cgh, sycl::write_only, sycl::no_init);
       cgh.parallel_for<write_id<dims, alloc>>(r, [=](sycl::nd_item<dims> i) {
         // clang-format off

--- a/tests/buffer/buffer_api_common.h
+++ b/tests/buffer/buffer_api_common.h
@@ -77,12 +77,17 @@ inline void precalculate<3>(sycl::range<3>& rangeIn, sycl::range<3>& rangeOut,
   elementsCount = (elementsOut * elementsIn * elementsIn);
 }
 
+// Enable when SYCL_CTS_SUPPORT_HAS_ERRC_ENUM is defined for ComputeCPP
 template <typename prop, typename buffer_t>
 void check_throw_matches(buffer_t& buf, const char* prop_name) {
-  auto action = [&] { auto no_prop = buf.template get_property<prop>(); };
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+  auto action = [&] {
+    auto no_prop = buf.template get_property<prop>();
+  };
   INFO("Check that get_property() throws errc::invalid " << prop_name);
   CHECK_THROWS_MATCHES(action(), sycl::exception,
-                       sycl_cts::util::equals_exception(sycl::errc::invalid));
+      sycl_cts::util::equals_exception(sycl::errc::invalid));
+#endif
 }
 
 template <typename buffer_t>

--- a/tests/queue/queue_properties.cpp
+++ b/tests/queue/queue_properties.cpp
@@ -104,30 +104,33 @@ void check_enable_profiling_prop(sycl::queue& queue) {
       "enable_profiling>()");
 }
 
-// Enable when SYCL_CTS_SUPPORT_HAS_ERRC_ENUM is defined for ComputeCPP
-void check_props(sycl::queue &queue) {
-#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+void check_props(sycl::queue& queue) {
   check_enable_profiling_prop(queue);
   check_in_order_prop(queue);
-#endif
 }
 
 void check_in_order_throws(sycl::queue& queue) {
+// Enable when SYCL_CTS_SUPPORT_HAS_ERRC_ENUM is defined for ComputeCPP
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
   auto action = [&] {
     auto get_prop =
         queue.template get_property<sycl::property::queue::enable_profiling>();
   };
   CHECK_THROWS_MATCHES(action(), sycl::exception,
                        sycl_cts::util::equals_exception(sycl::errc::invalid));
+#endif
 }
 
 void check_enable_profiling_throws(sycl::queue& queue) {
+// Enable when SYCL_CTS_SUPPORT_HAS_ERRC_ENUM is defined for ComputeCPP
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
   auto action = [&] {
     auto get_prop =
         queue.template get_property<sycl::property::queue::in_order>();
   };
   CHECK_THROWS_MATCHES(action(), sycl::exception,
                        sycl_cts::util::equals_exception(sycl::errc::invalid));
+#endif
 }
 
 TEST_CASE("check property::queue::enable_profiling", "[queue]") {

--- a/tests/queue/queue_properties.cpp
+++ b/tests/queue/queue_properties.cpp
@@ -21,6 +21,7 @@
 
 #include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
+#include "../../../util/sycl_exceptions.h"
 
 #define TEST_NAME queue_properties
 
@@ -108,6 +109,20 @@ void check_props(sycl::queue &queue) {
   check_in_order_prop(queue);
 }
 
+void check_in_order_throws(sycl::queue &queue) {
+  auto action = [&] {
+    auto get_prop = queue.template get_property<sycl::property::queue::enable_profiling>();
+  };
+  CHECK_THROWS_MATCHES(action(), sycl::exception, sycl_cts::util::equals_exception(sycl::errc::invalid));
+}
+
+void check_enable_profiling_throws(sycl::queue &queue) {
+  auto action = [&] {
+    auto get_prop = queue.template get_property<sycl::property::queue::in_order>();
+  };
+  CHECK_THROWS_MATCHES(action(), sycl::exception, sycl_cts::util::equals_exception(sycl::errc::invalid));
+}
+
 TEST_CASE("check property::queue::enable_profiling", "[queue]") {
   auto device = util::get_cts_object::device();
   if (!device.has(sycl::aspect::queue_profiling))
@@ -116,6 +131,7 @@ TEST_CASE("check property::queue::enable_profiling", "[queue]") {
   sycl::queue queue(
       device, sycl::property_list{sycl::property::queue::enable_profiling()});
   check_enable_profiling_prop(queue);
+  check_enable_profiling_throws(queue);
 }
 
 TEST_CASE("check property::queue::in_order", "[queue]") {
@@ -126,36 +142,43 @@ TEST_CASE("check property::queue::in_order", "[queue]") {
   SECTION("with constructor (propList)") {
     sycl::queue queue(sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION("with constructor (asyncHandler, propList)") {
     sycl::queue queue(asyncHandler,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION("with constructor (deviceSelector, propList)") {
     sycl::queue queue(cts_selector,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION("with constructor (deviceSelector, asyncHandler, propList)") {
     sycl::queue queue(cts_selector, asyncHandler,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION("with constructor (syclDevice, propList)") {
     sycl::queue queue(device,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION("with constructor (syclDevice, asyncHandler, propList)") {
     sycl::queue queue(device, asyncHandler,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION("with constructor (syclContext, deviceSelector, propList)") {
     sycl::queue queue(context, cts_selector,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION(
       "with constructor (syclContext, deviceSelector, asyncHandler, "
@@ -163,17 +186,20 @@ TEST_CASE("check property::queue::in_order", "[queue]") {
     sycl::queue queue(context, cts_selector, asyncHandler,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION("with constructor (syclContext, syclDevice, propList)") {
     sycl::queue queue(context, device,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
   SECTION(
       "with constructor (syclContext, syclDevice, asyncHandler, propList)") {
     sycl::queue queue(context, device, asyncHandler,
                       sycl::property_list{sycl::property::queue::in_order()});
     check_in_order(queue);
+    check_in_order_throws(queue);
   }
 }
 

--- a/tests/queue/queue_properties.cpp
+++ b/tests/queue/queue_properties.cpp
@@ -19,9 +19,9 @@
 //
 *******************************************************************************/
 
+#include "../../../util/sycl_exceptions.h"
 #include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
-#include "../../../util/sycl_exceptions.h"
 
 #define TEST_NAME queue_properties
 
@@ -33,7 +33,7 @@ class kernel3;
 
 using namespace sycl_cts;
 
-void check_in_order_prop(const sycl::queue &queue) {
+void check_in_order_prop(const sycl::queue& queue) {
   CHECK(queue.is_in_order());
 
   REQUIRE(queue.has_property<sycl::property::queue::in_order>());
@@ -45,13 +45,13 @@ void check_in_order_prop(const sycl::queue &queue) {
       "in_order>()");
 }
 
-void check_in_order_functionality(sycl::queue &queue) {
+void check_in_order_functionality(sycl::queue& queue) {
   if (!queue.get_device().has(sycl::aspect::usm_device_allocations))
     SKIP(
         "test for in_order functionality is skipped because device doesn't "
         "support usm_device_allocations");
 
-  bool *data_changed = sycl::malloc_device<bool>(1, queue);
+  bool* data_changed = sycl::malloc_device<bool>(1, queue);
   constexpr size_t buffer_size = 10;
   int loop_array[buffer_size];
   bool result = false;
@@ -61,12 +61,12 @@ void check_in_order_functionality(sycl::queue &queue) {
     // to garantee that data_changed initialized as false before two tested
     // commands are submitted
     queue
-        .submit([&](sycl::handler &cgh) {
+        .submit([&](sycl::handler& cgh) {
           cgh.single_task<kernel1>([=] { *data_changed = false; });
         })
         .wait_and_throw();
 
-    queue.submit([&](sycl::handler &cgh) {
+    queue.submit([&](sycl::handler& cgh) {
       auto res_acc = res_buf.get_access<sycl::access_mode::write>(cgh);
       auto loop_acc = loop_buf.get_access<sycl::access_mode::read_write>(cgh);
 
@@ -80,7 +80,7 @@ void check_in_order_functionality(sycl::queue &queue) {
       });
     });
 
-    queue.submit([&](sycl::handler &cgh) {
+    queue.submit([&](sycl::handler& cgh) {
       cgh.single_task<kernel3>([=] { *data_changed = true; });
     });
     queue.wait_and_throw();
@@ -88,13 +88,13 @@ void check_in_order_functionality(sycl::queue &queue) {
   CHECK(result);
 }
 
-void check_in_order(sycl::queue &queue) {
+void check_in_order(sycl::queue& queue) {
   check_in_order_prop(queue);
 
   check_in_order_functionality(queue);
 }
 
-void check_enable_profiling_prop(sycl::queue &queue) {
+void check_enable_profiling_prop(sycl::queue& queue) {
   CHECK(queue.has_property<sycl::property::queue::enable_profiling>());
 
   auto prop = queue.get_property<sycl::property::queue::enable_profiling>();
@@ -104,23 +104,27 @@ void check_enable_profiling_prop(sycl::queue &queue) {
       "enable_profiling>()");
 }
 
-void check_props(sycl::queue &queue) {
+void check_props(sycl::queue& queue) {
   check_enable_profiling_prop(queue);
   check_in_order_prop(queue);
 }
 
-void check_in_order_throws(sycl::queue &queue) {
+void check_in_order_throws(sycl::queue& queue) {
   auto action = [&] {
-    auto get_prop = queue.template get_property<sycl::property::queue::enable_profiling>();
+    auto get_prop =
+        queue.template get_property<sycl::property::queue::enable_profiling>();
   };
-  CHECK_THROWS_MATCHES(action(), sycl::exception, sycl_cts::util::equals_exception(sycl::errc::invalid));
+  CHECK_THROWS_MATCHES(action(), sycl::exception,
+                       sycl_cts::util::equals_exception(sycl::errc::invalid));
 }
 
-void check_enable_profiling_throws(sycl::queue &queue) {
+void check_enable_profiling_throws(sycl::queue& queue) {
   auto action = [&] {
-    auto get_prop = queue.template get_property<sycl::property::queue::in_order>();
+    auto get_prop =
+        queue.template get_property<sycl::property::queue::in_order>();
   };
-  CHECK_THROWS_MATCHES(action(), sycl::exception, sycl_cts::util::equals_exception(sycl::errc::invalid));
+  CHECK_THROWS_MATCHES(action(), sycl::exception,
+                       sycl_cts::util::equals_exception(sycl::errc::invalid));
 }
 
 TEST_CASE("check property::queue::enable_profiling", "[queue]") {

--- a/tests/queue/queue_properties.cpp
+++ b/tests/queue/queue_properties.cpp
@@ -104,9 +104,12 @@ void check_enable_profiling_prop(sycl::queue& queue) {
       "enable_profiling>()");
 }
 
-void check_props(sycl::queue& queue) {
+// Enable when SYCL_CTS_SUPPORT_HAS_ERRC_ENUM is defined for ComputeCPP
+void check_props(sycl::queue &queue) {
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
   check_enable_profiling_prop(queue);
   check_in_order_prop(queue);
+#endif
 }
 
 void check_in_order_throws(sycl::queue& queue) {


### PR DESCRIPTION
Added checks for `sycl::buffer` and `sycl::queue` `get_property()` member function `errc::invalid` exception when trying to get a property which object does not have.