### PR TITLE
Fix type pack creation for atomic_ref tests

### DIFF
--- a/tests/atomic_ref/atomic_ref_common.h
+++ b/tests/atomic_ref/atomic_ref_common.h
@@ -97,25 +97,41 @@ inline std::string get_section_name(const std::string& type_name,
  * @brief Factory function for getting type_pack with fp64 type
  */
 inline auto get_atomic64_types() {
-  static const auto types =
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-      named_type_pack<long long, unsigned long long>::generate(
-          "long long", "unsigned long long");
+  if constexpr (sizeof(long) == 32) {
+    static const auto types =
+        named_type_pack<long long, unsigned long long>::generate(
+            "long long", "unsigned long long");
+    return types;
+  } else {
+    static const auto types =
+        named_type_pack<long, unsigned long, long long,
+                        unsigned long long>::generate("long", "unsigned long",
+                                                      "long long",
+                                                      "unsigned long long");
+    return types;
+  }
 #else
-      named_type_pack<long long>::generate("long long");
+  return named_type_pack<long long>::generate("long long");
 #endif
-  return types;
 }
 
 /**
  * @brief Factory function for getting type_pack with all generic types
  */
 inline auto get_full_conformance_type_pack() {
-  static const auto types =
-      named_type_pack<int, unsigned int, long int, unsigned long int,
-                      float>::generate("int", "unsigned int", "long int",
-                                       "unsigned long int", "float");
-  return types;
+  if constexpr (sizeof(long) > 32) {
+    static const auto types =
+        named_type_pack<int, unsigned int, float>::generate(
+            "int", "unsigned int", "float");
+    return types;
+  } else {
+    static const auto types =
+        named_type_pack<int, unsigned int, long int, unsigned long int,
+                        float>::generate("int", "unsigned int", "long int",
+                                         "unsigned long int", "float");
+    return types;
+  }
 }
 
 /**

--- a/tests/atomic_ref/atomic_ref_common.h
+++ b/tests/atomic_ref/atomic_ref_common.h
@@ -98,7 +98,10 @@ inline std::string get_section_name(const std::string& type_name,
  */
 inline auto get_atomic64_types() {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  if constexpr (sizeof(long) == 32) {
+  // according to C++ standard the long type might to be at least 32 bits or
+  // wider so if the long type is greater than 4 bytes it should be included
+  // into the atomic 64 type pack
+  if constexpr (sizeof(long) == 4) {
     static const auto types =
         named_type_pack<long long, unsigned long long>::generate(
             "long long", "unsigned long long");
@@ -120,7 +123,8 @@ inline auto get_atomic64_types() {
  * @brief Factory function for getting type_pack with all generic types
  */
 inline auto get_full_conformance_type_pack() {
-  if constexpr (sizeof(long) > 32) {
+  // add the long type into the standard type pack if its size is 4 bytes
+  if constexpr (sizeof(long) > 4) {
     static const auto types =
         named_type_pack<int, unsigned int, float>::generate(
             "int", "unsigned int", "float");


### PR DESCRIPTION
Because of type long can have size greater than 32 bits added checking of its size. Now this type is included in `atomic64` type pack if its size greater than 4 bytes.