### PR TITLE
Fix incorrect name of define for testing deprecated features

### DIFF
--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -41,7 +41,7 @@ void test_accessor_methods(const AccT &accessor,
     CHECK(acc_isPlaceholder == expected_isPlaceholder);
   }
 
-#if SYCL_CTS_TEST_DEPRECATED_FEATURES
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
   {
     INFO("check get_size() method");
     auto acc_get_size = accessor.get_size();

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -389,7 +389,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   }
 
   // get_count()
-#if SYCL_CTS_TEST_DEPRECATED_FEATURES
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
   size_t count_depr = inputVec.get_count();
   if (count_depr != N) {
     return false;
@@ -412,7 +412,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   }
 
   // get_size()
-#if SYCL_CTS_TEST_DEPRECATED_FEATURES
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
   size_t size_depr = inputVec.get_size();
   if (size_depr != sizeof(vecType) * M) {
     return false;


### PR DESCRIPTION
Changed incorrect define SYCL_CTS_TEST_DEPRECATED_FEATURES to SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS in vec and accessor common headers.