### PR TITLE
Update tests usage of accessor providing multi_ptr

### DIFF
--- a/tests/address_space/address_space_common.h
+++ b/tests/address_space/address_space_common.h
@@ -171,7 +171,7 @@ class check_types {
 
         auto resAcc = resBuff.get_access<read_write>(cgh);
         auto initAcc = initBuff.template get_access<read_only>(cgh);
-        auto globalAcc = globalBuff.template get_access<read_only>(cgh);
+        auto globalAcc = globalBuff.template get_access<read_write>(cgh);
         sycl::accessor<T, 1, read_only, sycl::target::constant_buffer> constAcc(
             constantBuff, cgh);
         sycl::accessor<T, 1, read_write, sycl::target::local> localAcc(r, cgh);
@@ -182,14 +182,20 @@ class check_types {
           T priv = initAcc[3];
 
           pass &= test_duplication(
-              globalAcc.get_pointer(), localAcc.get_pointer(),
-              constAcc.get_pointer(), sycl::private_ptr<T>(&priv));
+              globalAcc
+                  .template get_multi_ptr<sycl::access::decorated::legacy>(),
+              localAcc.get_pointer(), constAcc.get_pointer(),
+              sycl::private_ptr<T>(&priv));
           pass &= test_return_type_deduction(
-              globalAcc.get_pointer(), localAcc.get_pointer(),
-              constAcc.get_pointer(), sycl::private_ptr<T>(&priv));
+              globalAcc
+                  .template get_multi_ptr<sycl::access::decorated::legacy>(),
+              localAcc.get_pointer(), constAcc.get_pointer(),
+              sycl::private_ptr<T>(&priv));
           pass &= test_initialization(
-              globalAcc.get_pointer(), localAcc.get_pointer(),
-              constAcc.get_pointer(), sycl::private_ptr<T>(&priv));
+              globalAcc
+                  .template get_multi_ptr<sycl::access::decorated::legacy>(),
+              localAcc.get_pointer(), constAcc.get_pointer(),
+              sycl::private_ptr<T>(&priv));
           resAcc[0] = pass;
         });
       });

--- a/tests/address_space/address_space_common.h
+++ b/tests/address_space/address_space_common.h
@@ -180,7 +180,8 @@ class check_types {
           bool pass = true;
           localAcc[0] = initAcc[2];
           T priv = initAcc[3];
-
+// FIXME: re-enable when sycl::access::decorated is implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
           pass &= test_duplication(
               globalAcc
                   .template get_multi_ptr<sycl::access::decorated::legacy>(),
@@ -197,6 +198,7 @@ class check_types {
               localAcc.get_pointer(), constAcc.get_pointer(),
               sycl::private_ptr<T>(&priv));
           resAcc[0] = pass;
+#endif
         });
       });
     }

--- a/tests/atomic/atomic_constructors_common.h
+++ b/tests/atomic/atomic_constructors_common.h
@@ -33,6 +33,14 @@ template <typename T, sycl::target target,
 class check_atomic_constructors {
   sycl::accessor<T, 1, sycl::access_mode::read_write, target> m_acc;
 
+  sycl::multi_ptr<T, addressSpace, sycl::access::decorated::legacy>
+  get_pointer() const {
+    if constexpr (target == sycl::target::device)
+      return m_acc.template get_multi_ptr<sycl::access::decorated::legacy>();
+    else
+      return m_acc.get_pointer();
+  }
+
  public:
   check_atomic_constructors(
       sycl::accessor<T, 1, sycl::access_mode::read_write, target> acc)
@@ -41,12 +49,12 @@ class check_atomic_constructors {
   void operator()() const {
     /** Check atomic constructor
      */
-    sycl::atomic<T, addressSpace> a(m_acc.get_pointer());
+    sycl::atomic<T, addressSpace> a(get_pointer());
   }
   void operator()(sycl::nd_item<1> item) const {
     /** Check atomic constructor
      */
-    sycl::atomic<T, addressSpace> a(m_acc.get_pointer());
+    sycl::atomic<T, addressSpace> a(get_pointer());
   }
 };
 

--- a/tests/device_event/device_event_api.cpp
+++ b/tests/device_event/device_event_api.cpp
@@ -73,6 +73,9 @@ class TEST_NAME : public util::test_base {
           cgh.parallel_for<class device_event_wait>(
               sycl::nd_range<1>(range, range),
               [=](sycl::nd_item<1> ndItem) {
+// FIXME: re-enable when sycl::access::decorated and get_multi_ptr is
+// implemented
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
                 // Run asynchronous copy for full buffer
                 sycl::device_event deviceEvent = ndItem.async_work_group_copy(
                     localAcc
@@ -82,7 +85,7 @@ class TEST_NAME : public util::test_base {
                     bufferSize);
 
                 deviceEvent.wait();
-
+#endif
                 // Check sample was updated
                 if (localAcc[sampleIndex] != referenceValue) {
                   errorAcc[0] = true;

--- a/tests/device_event/device_event_api.cpp
+++ b/tests/device_event/device_event_api.cpp
@@ -68,18 +68,18 @@ class TEST_NAME : public util::test_base {
 
           auto globalAcc = buf.get_access<sycl::access_mode::read_write>(cgh);
           auto errorAcc = errBuf.get_access<sycl::access_mode::write>(cgh);
-          auto localAcc =
-              sycl::accessor<int, 1, sycl::access_mode::read_write,
-                  sycl::target::local>(dataRange, cgh);
+          auto localAcc = sycl::local_accessor<int, 1>(dataRange, cgh);
 
           cgh.parallel_for<class device_event_wait>(
               sycl::nd_range<1>(range, range),
               [=](sycl::nd_item<1> ndItem) {
                 // Run asynchronous copy for full buffer
-                sycl::device_event deviceEvent =
-                    ndItem.async_work_group_copy(localAcc.get_pointer(),
-                                                 globalAcc.get_pointer(),
-                                                 bufferSize);
+                sycl::device_event deviceEvent = ndItem.async_work_group_copy(
+                    localAcc
+                        .template get_multi_ptr<sycl::access::decorated::yes>(),
+                    globalAcc
+                        .template get_multi_ptr<sycl::access::decorated::yes>(),
+                    bufferSize);
 
                 deviceEvent.wait();
 

--- a/tests/group_functions/group_of.h
+++ b/tests/group_functions/group_of.h
@@ -61,7 +61,8 @@ void joint_of_group(sycl::queue& queue) {
                                      sycl::range<1>(test_matrix * test_cases));
 
       queue.submit([&](sycl::handler& cgh) {
-        auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+        auto v_acc =
+            v_sycl.template get_access<sycl::access::mode::read_write>(cgh);
         auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
 
         sycl::nd_range<D> executionRange(work_group_range, work_group_range);

--- a/tests/group_functions/group_reduce.h
+++ b/tests/group_functions/group_reduce.h
@@ -143,7 +143,8 @@ void joint_reduce_group(sycl::queue& queue, const std::string& op_name) {
       sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(test_matrix));
 
       queue.submit([&](sycl::handler& cgh) {
-        auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+        auto v_acc =
+            v_sycl.template get_access<sycl::access::mode::read_write>(cgh);
         auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
 
         sycl::nd_range<D> executionRange(work_group_range, work_group_range);
@@ -245,7 +246,8 @@ void init_joint_reduce_group(sycl::queue& queue, const std::string& op_name) {
       sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(test_matrix));
 
       queue.submit([&](sycl::handler& cgh) {
-        auto v_acc = v_sycl.template get_access<sycl::access::mode::read>(cgh);
+        auto v_acc =
+            v_sycl.template get_access<sycl::access::mode::read_write>(cgh);
         auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
 
         sycl::nd_range<D> executionRange(work_group_range, work_group_range);

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -83,7 +83,7 @@ void check_scan(sycl::queue& queue, size_t size,
     queue
         .submit([&](sycl::handler& cgh) {
           auto v_acc =
-              v_sycl.template get_access<sycl::access::mode::read>(cgh);
+              v_sycl.template get_access<sycl::access::mode::read_write>(cgh);
           auto res_e_acc =
               res_e_sycl.template get_access<sycl::access::mode::read_write>(
                   cgh);

--- a/tests/multi_ptr/multi_ptr_access_members.h
+++ b/tests/multi_ptr/multi_ptr_access_members.h
@@ -165,8 +165,7 @@ class run_access_members_tests {
             test_device_code(priv_val_mptr);
           });
         } else {
-          auto acc_for_multi_ptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto acc_for_multi_ptr = val_buffer.template get_access(cgh);
           cgh.single_task<kname>([=] { test_device_code(acc_for_multi_ptr); });
         }
       });

--- a/tests/multi_ptr/multi_ptr_accessor_constructor.h
+++ b/tests/multi_ptr/multi_ptr_accessor_constructor.h
@@ -63,7 +63,8 @@ void run_tests(sycl_cts::util::logger& log, const std::string& type_name) {
   bool same_value = false;
 
   // default value
-  T init_value = user_def_types::get_init_value_helper<T>(10);
+  T init_value =
+      user_def_types::get_init_value_helper<std::remove_const_t<T>>(10);
 
   auto queue = once_per_unit::get_queue();
 
@@ -113,7 +114,8 @@ void run_tests(sycl_cts::util::logger& log, const std::string& type_name) {
 template <typename T, sycl::access::address_space Space, int dimension>
 void run_tests_for_dimension(sycl_cts::util::logger& log,
                              const std::string& type_name) {
-  run_tests<T, Space, dimension, sycl::access::mode::read>(log, type_name);
+  run_tests<const T, Space, dimension, sycl::access::mode::read>(log,
+                                                                 type_name);
   run_tests<T, Space, dimension, sycl::access::mode::write>(log, type_name);
   run_tests<T, Space, dimension, sycl::access::mode::read_write>(log,
                                                                  type_name);

--- a/tests/multi_ptr/multi_ptr_arithmetic_op.h
+++ b/tests/multi_ptr/multi_ptr_arithmetic_op.h
@@ -94,8 +94,7 @@ class run_multi_ptr_arithmetic_op_test {
         auto test_result_acc =
             test_result_buffer.template get_access<sycl::access_mode::write>(
                 cgh);
-        auto arr_acc =
-            arr_buffer.template get_access<sycl::access_mode::read>(cgh);
+        auto arr_acc = arr_buffer.template get_access(cgh);
 
         if constexpr (space == sycl::access::address_space::local_space) {
           sycl::local_accessor<T, 1> acc_for_mptr{sycl::range(m_array_size),

--- a/tests/multi_ptr/multi_ptr_common_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_common_assignment_ops.h
@@ -71,8 +71,7 @@ class run_common_assign_tests {
         using kname = kernel_common_assignment_ops<T, AddrSpaceT, IsDecorated>;
         auto res_acc =
             res_buf.template get_access<sycl::access_mode::write>(cgh);
-        auto val_acc =
-            val_buffer.template get_access<sycl::access_mode::read>(cgh);
+        auto val_acc = val_buffer.template get_access(cgh);
         if constexpr (space == sycl::access::address_space::global_space ||
                       space == sycl::access::address_space::generic_space) {
           cgh.single_task<kname>([=] {

--- a/tests/multi_ptr/multi_ptr_common_constructors.h
+++ b/tests/multi_ptr/multi_ptr_common_constructors.h
@@ -82,7 +82,7 @@ void run_tests(sycl_cts::util::logger &log, const std::string &type_name) {
   T ref_value{user_def_types::get_init_value_helper<T>(0)};
   auto queue = once_per_unit::get_queue();
 
-  using GlobalAccType = sycl::accessor<T, 1, sycl::access_mode::read>;
+  using GlobalAccType = sycl::accessor<T, 1, sycl::access_mode::read_write>;
   using LocalAccType = sycl::local_accessor<T, 1>;
   using PrivateAccType =
       sycl::multi_ptr<T, sycl::access::address_space::private_space, Decorated>;
@@ -110,7 +110,7 @@ void run_tests(sycl_cts::util::logger &log, const std::string &type_name) {
 
     // Check multi_ptr(const multi_ptr&)
     {
-      m_ptr_t other(ref_acc);
+      const m_ptr_t other(ref_acc);
       m_ptr_t mptr(other);
 
       same_type_acc[type_i++] =
@@ -158,7 +158,7 @@ void run_tests(sycl_cts::util::logger &log, const std::string &type_name) {
 
     queue.submit([&](sycl::handler &cgh) {
       using kname = kernel_common_constructors<T, Space, Decorated>;
-      auto ref_acc = ref_buf.template get_access<sycl::access_mode::read>(cgh);
+      auto ref_acc = ref_buf.template get_access(cgh);
       auto same_type_acc =
           same_type_buf.template get_access<sycl::access_mode::write>(cgh);
       auto same_value_acc =

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -164,8 +164,7 @@ class run_multi_ptr_comparison_op_test {
       queue.submit([&](sycl::handler &cgh) {
         using kname =
             kernel_comparison_op<T, AddrSpaceT, IsDecoratedT, KernelName>;
-        auto array_acc =
-            array_buffer.template get_access<sycl::access_mode::read>(cgh);
+        auto array_acc = array_buffer.template get_access(cgh);
         auto test_result_acc =
             test_result_buffer.template get_access<sycl::access_mode::write>(
                 cgh);

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
@@ -80,13 +80,11 @@ class run_convert_assignment_operators_tests {
                                                 SrcIsDecorated, DstIsDecorated>;
           auto res_acc =
               res_buf.template get_access<sycl::access_mode::write>(cgh);
-          auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto acc_for_mptr = val_buffer.template get_access(cgh);
 
           if constexpr (src_space ==
                         sycl::access::address_space::global_space) {
-            auto val_acc =
-                val_buffer.template get_access<sycl::access_mode::read>(cgh);
+            auto val_acc = val_buffer.template get_access(cgh);
             cgh.single_task<kname>([=] {
               const src_multi_ptr_t mptr_in(acc_for_mptr);
               dst_multi_ptr_t mptr_out;
@@ -157,8 +155,7 @@ class run_convert_assignment_operators_tests {
 
           if constexpr (src_space ==
                         sycl::access::address_space::global_space) {
-            auto val_acc =
-                val_buffer.template get_access<sycl::access_mode::read>(cgh);
+            auto val_acc = val_buffer.template get_access(cgh);
             cgh.single_task<kname>([=] {
               const src_multi_ptr_t mptr_in(val_acc);
               dst_multi_ptr_t mptr_out;

--- a/tests/multi_ptr/multi_ptr_deduction_guides.cpp
+++ b/tests/multi_ptr/multi_ptr_deduction_guides.cpp
@@ -103,6 +103,8 @@ class check_multi_ptr_deduction {
   }
 };
 
+// FIXME: re-enable when deduction guide for read is implemented
+// Issue link https://github.com/intel/llvm/issues/9692
 DISABLED_FOR_TEST_CASE(DPCPP)
 ("multi_ptr deduction guides", "[test_multi_ptr]")({
   for_all_types<check_multi_ptr_deduction>(deduction::vector_types);

--- a/tests/multi_ptr/multi_ptr_deduction_guides.cpp
+++ b/tests/multi_ptr/multi_ptr_deduction_guides.cpp
@@ -21,6 +21,7 @@
 *******************************************************************************/
 
 #include "../common/common.h"
+#include "../common/disabled_for_test_case.h"
 #include "../common/get_cts_string.h"
 #include "multi_ptr_common.h"
 
@@ -47,8 +48,10 @@ class check_multi_ptr_deduction {
 
   template <access::address_space space>
   void check_for_space() {
-    check_for_mode<access::mode::read, space>();
-    check_for_mode<access::mode::write, space>();
+    if constexpr (space == global) {
+      check_for_mode<access::mode::read, space>();
+      check_for_mode<access::mode::write, space>();
+    }
     check_for_mode<access::mode::read_write, space>();
   }
 
@@ -61,27 +64,48 @@ class check_multi_ptr_deduction {
 
   template <int dims, access::mode Mode, access::address_space accessor_space>
   void check_for_dims() {
+    using ElementType = std::conditional_t<
+        Mode == access::mode::read && accessor_space == global, const T, T>;
     using acc_t = std::conditional_t<accessor_space == global,
                                      accessor<T, dims, Mode, target::device>,
                                      local_accessor<T, dims>>;
-
-    acc_t _accessor;
-    multi_ptr mptr(_accessor);
-
+    bool res = false;
+    T data{user_def_types::get_init_value_helper<T>(0)};
+    auto r = sycl_cts::util::get_cts_object::range<dims>::get(1, 1, 1);
+    {
+      sycl::buffer<bool, 1> buf_res(&res, {1});
+      sycl::buffer<T, dims> buf_data(&data, r);
+      auto queue = once_per_unit::get_queue();
+      queue
+          .submit([&](sycl::handler& cgh) {
+            acc_t _accessor;
+            if constexpr (accessor_space == global)
+              acc_t(buf_data, cgh);
+            else
+              acc_t(r, cgh);
+            auto acc_res = buf_res.get_access(cgh);
+            cgh.single_task([=] {
+              auto mptr = multi_ptr(_accessor);
+              acc_res[0] = std::is_same_v<decltype(mptr),
+                                          multi_ptr<ElementType, accessor_space,
+                                                    access::decorated::no>>;
+            });
+          })
+          .wait_and_throw();
+    }
     std::string mode_str{sycl_cts::get_cts_string::for_mode<Mode>()};
     std::string space_str{(accessor_space == global) ? "global" : "local"};
     std::string fail_str{"Incorrect deduction with type " + type_name + " in " +
                          std::to_string(dims) + " dimensions and " + mode_str +
                          " mode in " + space_str + " space "};
-
     INFO(fail_str);
-    CHECK(std::is_same_v<decltype(mptr),
-                         multi_ptr<T, accessor_space, access::decorated::no>>);
+    CHECK(res);
   }
 };
 
-TEST_CASE("multi_ptr deduction guides", "[test_multi_ptr]") {
+DISABLED_FOR_TEST_CASE(DPCPP)
+("multi_ptr deduction guides", "[test_multi_ptr]")({
   for_all_types<check_multi_ptr_deduction>(deduction::vector_types);
   for_all_types<check_multi_ptr_deduction>(deduction::scalar_types);
-}
+});
 }  // namespace multi_ptr_deduction_guides

--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -77,8 +77,7 @@ class run_explicit_convert_tests {
             res_buf.template get_access<sycl::access_mode::write>(cgh);
         if constexpr (target_space ==
                       sycl::access::address_space::global_space) {
-          auto val_acc =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto val_acc = val_buffer.template get_access(cgh);
           cgh.single_task<kname>([=] {
             input_multi_ptr_t<T> mptr_in(val_acc);
             auto mptr_out =

--- a/tests/multi_ptr/multi_ptr_implicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_implicit_conversions.h
@@ -155,9 +155,7 @@ class run_implicit_convert_tests {
             test_device_code(priv_val_mptr);
           });
         } else {
-          auto expected_val_acc =
-              expected_val_buffer.template get_access<sycl::access_mode::read>(
-                  cgh);
+          auto expected_val_acc = expected_val_buffer.template get_access(cgh);
           cgh.single_task<kname>([=] { test_device_code(expected_val_acc); });
         }
       });

--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -73,8 +73,7 @@ class run_prefetch_test {
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
               res_buf.template get_access<sycl::access_mode::write>(cgh);
-          auto acc_for_mptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto acc_for_mptr = val_buffer.template get_access(cgh);
           cgh.single_task<kernel_prefetch_member<T, IsDecoratedT>>([=] {
             const multi_ptr_t mptr(acc_for_mptr);
 

--- a/tests/multi_ptr/multi_ptr_subscript_op_common.h
+++ b/tests/multi_ptr/multi_ptr_subscript_op_common.h
@@ -98,7 +98,7 @@ class run_subscript_op_tests {
         if constexpr (space == sycl::access::address_space::local_space) {
           sycl::local_accessor<T> exp_arr_acc{{array_size}, cgh};
           sycl::local_accessor<T> exp_arr_neg_acc{{array_size}, cgh};
-          cgh.single_task([=] {
+          cgh.parallel_for(sycl::nd_range<1>({1}, {1}), [=](auto item) {
             value_operations::assign(exp_arr_acc, exp_arr);
             value_operations::assign(exp_arr_neg_acc, exp_arr);
 
@@ -121,10 +121,8 @@ class run_subscript_op_tests {
             test_device_code(priv_arr_mptr, multi_ptr_negative);
           });
         } else {
-          auto exp_arr_acc =
-              exp_arr_buffer.template get_access<sycl::access_mode::read>(cgh);
-          auto exp_arr_neg_acc =
-              exp_arr_buffer.template get_access<sycl::access_mode::read>(cgh);
+          auto exp_arr_acc = exp_arr_buffer.template get_access(cgh);
+          auto exp_arr_neg_acc = exp_arr_buffer.template get_access(cgh);
           cgh.single_task([=] {
             T *arr_end = const_cast<T *>(&exp_arr_neg_acc[array_size - 1]);
             multi_ptr_t multi_ptr_negative =

--- a/tests/stream/stream_api.cpp
+++ b/tests/stream/stream_api.cpp
@@ -159,7 +159,8 @@ class check_multi_ptr {
           });
         } else {
           auto acc_for_multi_ptr =
-              val_buffer.template get_access<sycl::access_mode::read>(cgh);
+              val_buffer.template get_access<sycl::access_mode::read_write>(
+                  cgh);
           cgh.single_task<kernel_name>([=] {
             const multi_ptr_t multi_ptr(acc_for_multi_ptr);
             check_type(os, multi_ptr);

--- a/tests/vector_load_store/generate_vector_load_store.py
+++ b/tests/vector_load_store/generate_vector_load_store.py
@@ -34,6 +34,8 @@ TEST_NAME = 'LOAD_STORE'
 
 load_store_test_template = Template(
     """
+// FIXME: re-enable when sycl::access::decorated is implemented
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
     {
         ${type} inputData${type_as_str}${size}[${size}] = {${in_order_vals}};
         ${type} outputData${type_as_str}${size}[${size}] = {${val}};
@@ -84,6 +86,7 @@ load_store_test_template = Template(
 
         testQueue.wait_and_throw();
     }
+#endif
       """)
 
 

--- a/tests/vector_load_store/generate_vector_load_store.py
+++ b/tests/vector_load_store/generate_vector_load_store.py
@@ -33,7 +33,9 @@ from common_python_vec import (Data, append_fp_postfix, make_func_call,
 TEST_NAME = 'LOAD_STORE'
 
 load_store_test_template = Template(
-    """        ${type} inputData${type_as_str}${size}[${size}] = {${in_order_vals}};
+    """
+    {
+        ${type} inputData${type_as_str}${size}[${size}] = {${in_order_vals}};
         ${type} outputData${type_as_str}${size}[${size}] = {${val}};
         ${type} swizzleInputData${type_as_str}${size}[${size}] = {${reverse_order_vals}};
         ${type} swizzleOutputData${type_as_str}${size}[${size}] = {${val}};
@@ -55,9 +57,9 @@ load_store_test_template = Template(
               testVec${type_as_str}${size}.load(0, inPtr${type_as_str}${size});
               testVec${type_as_str}${size}.store(0, outPtr${type_as_str}${size});
 
-              auto multiPtrIn${type_as_str}${size} = inPtr${type_as_str}${size}.get_pointer();
+              auto multiPtrIn${type_as_str}${size} = inPtr${type_as_str}${size}.get_multi_ptr<${decorated}>();
               sycl::global_ptr<const ${type}> constMultiPtrIn${type_as_str}${size} = multiPtrIn${type_as_str}${size};
-              auto multiPtrOut${type_as_str}${size} = outPtr${type_as_str}${size}.get_pointer();
+              auto multiPtrOut${type_as_str}${size} = outPtr${type_as_str}${size}.get_multi_ptr<${decorated}>();
               testVec${type_as_str}${size}.load(0, multiPtrIn${type_as_str}${size});
               testVec${type_as_str}${size}.load(0, constMultiPtrIn${type_as_str}${size});
               testVec${type_as_str}${size}.store(0, multiPtrOut${type_as_str}${size});
@@ -67,9 +69,9 @@ load_store_test_template = Template(
               swizzledVec.load(0, swizzleInPtr${type_as_str}${size});
               swizzledVec.store(0, swizzleOutPtr${type_as_str}${size});
 
-              auto multiPtrInSwizzle${type_as_str}${size} = swizzleInPtr${type_as_str}${size}.get_pointer();
+              auto multiPtrInSwizzle${type_as_str}${size} = swizzleInPtr${type_as_str}${size}.get_multi_ptr<${decorated}>();
               sycl::global_ptr<const ${type}> constMultiPtrInSwizzle${type_as_str}${size} = multiPtrInSwizzle${type_as_str}${size};
-              auto multiPtrOutSwizzle${type_as_str}${size} = swizzleOutPtr${type_as_str}${size}.get_pointer();
+              auto multiPtrOutSwizzle${type_as_str}${size} = swizzleOutPtr${type_as_str}${size}.get_multi_ptr<${decorated}>();
               swizzledVec.load(0, multiPtrInSwizzle${type_as_str}${size});
               swizzledVec.load(0, constMultiPtrInSwizzle${type_as_str}${size});
               swizzledVec.store(0, multiPtrOutSwizzle${type_as_str}${size});
@@ -81,11 +83,18 @@ load_store_test_template = Template(
         check_array_equality<${type}, ${size}>(log, swizzleInputData${type_as_str}${size}, swizzleOutputData${type_as_str}${size});
 
         testQueue.wait_and_throw();
+    }
       """)
 
 
-def gen_kernel_name(type_str, size):
-    return 'KERNEL_load_store_' + remove_namespaces_whitespaces(type_str) + str(size)
+def gen_kernel_name(type_str, size, decorated):
+    return 'KERNEL_load_store_' + remove_namespaces_whitespaces(type_str) + str(size) + decorated
+
+def wrap_with_deprecated(test_string):
+    string = '#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS \n'
+    string += test_string
+    string += '#endif \n'
+    return string
 
 
 def gen_load_store_test(type_str, size):
@@ -99,8 +108,33 @@ def gen_load_store_test(type_str, size):
             append_fp_postfix(type_str, Data.vals_list_dict[size])),
         reverse_order_vals=', '.join(
             append_fp_postfix(type_str, Data.vals_list_dict[size][::-1])),
-        kernelName=gen_kernel_name(type_str, size),
-        swizVals=', '.join(Data.swizzle_elem_list_dict[size]))
+        kernelName=gen_kernel_name(type_str, size, 'yes'),
+        swizVals=', '.join(Data.swizzle_elem_list_dict[size]),
+        decorated='sycl::access::decorated::yes')
+    test_string += load_store_test_template.substitute(
+        type=type_str,
+        type_as_str=no_whitespace_type_str,
+        size=size,
+        val=Data.value_default_dict[type_str],
+        in_order_vals=', '.join(
+            append_fp_postfix(type_str, Data.vals_list_dict[size])),
+        reverse_order_vals=', '.join(
+            append_fp_postfix(type_str, Data.vals_list_dict[size][::-1])),
+        kernelName=gen_kernel_name(type_str, size, 'no'),
+        swizVals=', '.join(Data.swizzle_elem_list_dict[size]),
+        decorated='sycl::access::decorated::no')
+    test_string += wrap_with_deprecated(load_store_test_template.substitute(
+        type=type_str,
+        type_as_str=no_whitespace_type_str,
+        size=size,
+        val=Data.value_default_dict[type_str],
+        in_order_vals=', '.join(
+            append_fp_postfix(type_str, Data.vals_list_dict[size])),
+        reverse_order_vals=', '.join(
+            append_fp_postfix(type_str, Data.vals_list_dict[size][::-1])),
+        kernelName=gen_kernel_name(type_str, size, 'legacy'),
+        swizVals=', '.join(Data.swizzle_elem_list_dict[size]),
+        decorated='sycl::access::decorated::legacy'))
     return wrap_with_test_func(TEST_NAME, type_str,
                                wrap_with_extension_checks(
                                    type_str, test_string), str(size))


### PR DESCRIPTION
Updated tests that are use accessor and multi_ptr - get_pointer returns T* for target::device and get_multi_ptr should be used instead.
Changed accessors that are used in multi_ptr to read_write instead of read to accommodate this Spec change https://github.com/KhronosGroup/SYCL-Docs/pull/405  
Changed async_work_group_copy to take decorated ptr as per Spec.