### PR TITLE
Reduce accessor build and run time

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -197,6 +197,18 @@ inline auto get_conformance_type_pack() {
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 }
 
+template <template <typename, typename...> class action,
+          typename... actionArgsT>
+void common_run_tests() {
+  const auto types = get_conformance_type_pack();
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  for_all_types_vectors_marray<action, actionArgsT...>(types);
+#else
+  for_all_types<action, actionArgsT...>(types);
+  for_type_vectors_marray<action, int, actionArgsT...>("int");
+#endif
+}
+
 /**
  * @brief Factory function for getting type_pack with access modes values
  */

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -197,6 +197,12 @@ inline auto get_conformance_type_pack() {
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 }
 
+/**
+ * @brief Function helps run every test for all types in full conformabce mode
+ *        or for reduce types in regular mode
+ * @tparam action Functor template for test to run
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ */
 template <template <typename, typename...> class action,
           typename... actionArgsT>
 void common_run_tests() {

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -205,7 +205,7 @@ void common_run_tests() {
   for_all_types_vectors_marray<action, actionArgsT...>(types);
 #else
   for_all_types<action, actionArgsT...>(types);
-  for_type_vectors_marray<action, int, actionArgsT...>("int");
+  for_type_vectors_marray_reduced<action, int, actionArgsT...>("int");
 #endif
 }
 

--- a/tests/accessor/accessor_default_values_core.cpp
+++ b/tests/accessor/accessor_default_values_core.cpp
@@ -26,9 +26,7 @@ namespace accessor_default_values_test_core {
 using namespace sycl_cts;
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Accessors constructor default values test core types.", "[accessor]")({
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_tests>(types);
-});
+("Accessors constructor default values test core types.",
+ "[accessor]")({ common_run_tests<run_tests>(); });
 
 }  // namespace accessor_default_values_test_core

--- a/tests/accessor/accessor_exceptions_core.cpp
+++ b/tests/accessor/accessor_exceptions_core.cpp
@@ -28,22 +28,14 @@ using namespace sycl_cts;
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("Generic sycl::accessor constructor exceptions test. Core types.",
- "[accessor]")({
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_tests_with_types, generic_accessor>(types);
-});
+ "[accessor]")({ common_run_tests<run_tests, generic_accessor>(); });
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::local_accessor constructor exceptions test. Core types.",
- "[accessor]")({
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_tests_with_types, local_accessor>(types);
-});
+ "[accessor]")({ common_run_tests<run_tests, local_accessor>(); });
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
-("sycl::host_accessor constructor exceptions test. Core types.", "[accessor]")({
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_tests_with_types, host_accessor>(types);
-});
+("sycl::host_accessor constructor exceptions test. Core types.",
+ "[accessor]")({ common_run_tests<run_tests, host_accessor>(); });
 
 }  // namespace accessor_exceptions_test_core

--- a/tests/accessor/accessor_implicit_conversions_core.cpp
+++ b/tests/accessor/accessor_implicit_conversions_core.cpp
@@ -28,22 +28,19 @@ namespace accessor_implicit_conversions_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor implicit conversion. core types",
  "[accessor][generic_accessor][conversion][core]")({
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_test_generic>(types);
+  common_run_tests<run_test_generic>();
 });
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("The sycl::local_accessor implicit conversion. core types",
  "[accessor][local_accessor][conversion][core]")({
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_test_local>(types);
+  common_run_tests<run_test_local>();
 });
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("The sycl::host_accessor implicit conversion. core types",
  "[accessor][host_accessor][conversion][core]")({
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_test_host>(types);
+  common_run_tests<run_test_host>();
 });
 
 }  // namespace accessor_implicit_conversions_core

--- a/tests/accessor/generic_accessor_api_core.cpp
+++ b/tests/accessor/generic_accessor_api_core.cpp
@@ -24,8 +24,7 @@ namespace generic_accessor_api_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("Generic sycl::accessor api. core types", "[accessor]")({
   using namespace generic_accessor_api_common;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_generic_api_for_type>(types);
+  common_run_tests<run_generic_api_for_type>();
 });
 
 }  // namespace generic_accessor_api_core

--- a/tests/accessor/generic_accessor_common_buffer_constructors_core.cpp
+++ b/tests/accessor/generic_accessor_common_buffer_constructors_core.cpp
@@ -38,9 +38,7 @@ namespace generic_accessor_common_buffer_constructors_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("Generic sycl::accessor buffer constructors. core types", "[accessor]")({
   using namespace generic_accessor_common_buffer_constructors;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_generic_common_buffer_constructors_test>(
-      types);
+  common_run_tests<run_generic_common_buffer_constructors_test>();
 });
 
 }  // namespace generic_accessor_common_buffer_constructors_core

--- a/tests/accessor/generic_accessor_def_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_def_constructor_core.cpp
@@ -35,8 +35,7 @@ namespace generic_accessor_def_constructor_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor def constructors. core types", "[accessor]")({
   using namespace generic_accessor_def_constructor;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_generic_def_constructor_test>(types);
+  common_run_tests<run_generic_def_constructor_test>();
 });
 
 }  // namespace generic_accessor_def_constructor_core

--- a/tests/accessor/generic_accessor_linearization_core.cpp
+++ b/tests/accessor/generic_accessor_linearization_core.cpp
@@ -37,8 +37,7 @@ namespace generic_accessor_linearization_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor linearization test. core types", "[accessor]")({
   using namespace generic_accessor_linearization;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_generic_linearization_for_type>(types);
+  common_run_tests<run_generic_linearization_for_type>();
 });
 
 }  // namespace generic_accessor_linearization_core

--- a/tests/accessor/generic_accessor_placeholder_buffer_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_constructor_core.cpp
@@ -37,9 +37,7 @@ namespace generic_accessor_placeholder_buffer_constructor_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder constructors. core types", "[accessor]")({
   using namespace generic_accessor_placeholder_buffer_constructor;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_generic_placeholder_buffer_constructor_test>(
-      types);
+  common_run_tests<run_generic_placeholder_buffer_constructor_test>();
 });
 
 }  // namespace generic_accessor_placeholder_buffer_constructor_core

--- a/tests/accessor/generic_accessor_placeholder_buffer_constructor_exceptions_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_constructor_exceptions_core.cpp
@@ -38,9 +38,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer constructor exceptions. core types",
  "[accessor]")({
   using namespace generic_accessor_placeholder_buffer_constructor_exceptions;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<
-      run_generic_placeholder_buffer_constructor_exceptions_test>(types);
+  common_run_tests<
+      run_generic_placeholder_buffer_constructor_exceptions_test>();
 });
 
 }  // namespace generic_accessor_placeholder_buffer_constructor_exceptions_core

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_core.cpp
@@ -38,9 +38,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer range constructor. core types",
  "[accessor]")({
   using namespace generic_accessor_placeholder_buffer_range_constructor;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<
-      run_generic_placeholder_buffer_range_constructor_test>(types);
+  common_run_tests<run_generic_placeholder_buffer_range_constructor_test>();
 });
 
 }  // namespace generic_accessor_placeholder_buffer_range_constructor_core

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_exceptions_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_exceptions_core.cpp
@@ -39,9 +39,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
  "types",
  "[accessor]")({
   using namespace generic_accessor_placeholder_buffer_range_constructor_exceptions;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<
-      run_generic_placeholder_buffer_range_constructor_exceptions_test>(types);
+  common_run_tests<
+      run_generic_placeholder_buffer_range_constructor_exceptions_test>();
 });
 
 }  // namespace

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_core.cpp
@@ -39,9 +39,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
  "types",
  "[accessor]")({
   using namespace generic_accessor_placeholder_buffer_range_offset_constructor;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<
-      run_generic_placeholder_buffer_range_offset_constructor_test>(types);
+  common_run_tests<
+      run_generic_placeholder_buffer_range_offset_constructor_test>();
 });
 
 }  // namespace

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_exceptions_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_exceptions_core.cpp
@@ -39,10 +39,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
  "exceptions. core types",
  "[accessor]")({
   using namespace generic_accessor_placeholder_buffer_range_offset_constructor_exceptions;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<
-      run_generic_placeholder_buffer_range_offset_constructor_exceptions_test>(
-      types);
+  common_run_tests<
+      run_generic_placeholder_buffer_range_offset_constructor_exceptions_test>();
 });
 
 }  // namespace

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor_core.cpp
@@ -39,9 +39,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
  "types",
  "[accessor]")({
   using namespace generic_accessor_placeholder_zero_length_buffer_constructor;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<
-      run_generic_placeholder_zero_length_buffer_constructor>(types);
+  common_run_tests<run_generic_placeholder_zero_length_buffer_constructor>();
 });
 
 }  // namespace generic_accessor_placeholder_zero_length_buffer_constructor_core

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor_core.cpp
@@ -39,9 +39,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
  "core types",
  "[accessor]")({
   using namespace generic_accessor_placeholder_zero_length_buffer_range_constructor;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<
-      run_generic_placeholder_zero_length_buffer_range_constructor_test>(types);
+  common_run_tests<
+      run_generic_placeholder_zero_length_buffer_range_constructor_test>();
 });
 
 }  // namespace

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_core.cpp
@@ -39,10 +39,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
  "constructor. core types",
  "[accessor]")({
   using namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<
-      run_generic_placeholder_zero_length_buffer_range_offset_constructor_test>(
-      types);
+  common_run_tests<
+      run_generic_placeholder_zero_length_buffer_range_offset_constructor_test>();
 });
 
 }  // namespace

--- a/tests/accessor/generic_accessor_properties_core.cpp
+++ b/tests/accessor/generic_accessor_properties_core.cpp
@@ -23,8 +23,7 @@ namespace generic_accessor_properties_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor properties test. core types", "[accessor]")({
   using namespace generic_accessor_properties;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_generic_properties_tests>(types);
+  common_run_tests<run_generic_properties_tests>();
 });
 
 }  // namespace generic_accessor_properties_core

--- a/tests/accessor/generic_accessor_zero_dim_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_zero_dim_constructor_core.cpp
@@ -37,8 +37,7 @@ namespace generic_accessor_zero_dim_constructor_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor zero-dim constructors. core types", "[accessor]")({
   using namespace generic_accessor_zero_dim_constructor;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_generic_zero_dim_constructor_test>(types);
+  common_run_tests<run_generic_zero_dim_constructor_test>();
 });
 
 }  // namespace generic_accessor_zero_dim_constructor_core

--- a/tests/accessor/host_accessor_api_core.cpp
+++ b/tests/accessor/host_accessor_api_core.cpp
@@ -21,8 +21,7 @@ namespace host_accessor_api_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::host_accessor api. core types", "[accessor]")({
   using namespace host_accessor_api_common;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_host_accessor_api_for_type>(types);
+  common_run_tests<run_host_accessor_api_for_type>();
 });
 
 }  // namespace host_accessor_api_core

--- a/tests/accessor/host_accessor_constructors_core.cpp
+++ b/tests/accessor/host_accessor_constructors_core.cpp
@@ -35,8 +35,7 @@ namespace host_accessor_constructors_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sycl::host_accessor constructors. core types", "[accessor]")({
   using namespace host_accessor_constructors;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_host_constructors_test>(types);
+  common_run_tests<run_host_constructors_test>();
 });
 
 }  // namespace host_accessor_constructors_core

--- a/tests/accessor/host_accessor_linearization_core.cpp
+++ b/tests/accessor/host_accessor_linearization_core.cpp
@@ -34,8 +34,7 @@ namespace host_accessor_liniarization_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sycl::host_accessor linearization. core types", "[accessor]")({
   using namespace host_accessor_linearization;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_host_linearization_for_type>(types);
+  common_run_tests<run_host_linearization_for_type>();
 });
 
 }  // namespace host_accessor_liniarization_core

--- a/tests/accessor/host_accessor_properties_core.cpp
+++ b/tests/accessor/host_accessor_properties_core.cpp
@@ -22,8 +22,7 @@ namespace host_accessor_properties_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sycl::host_accessor properties. core types", "[accessor]")({
   using namespace host_accessor_properties;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_host_properties_tests>(types);
+  common_run_tests<run_host_properties_tests>();
 });
 
 }  // namespace host_accessor_properties_core

--- a/tests/accessor/local_accessor_access_among_work_items_core.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_core.cpp
@@ -25,10 +25,7 @@ namespace local_accessor_access_among_work_items_core {
 
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sycl::local_accessor access among work items. core types", "[accessor]")({
-  const auto types = get_conformance_type_pack();
-
-  for_all_types_vectors_marray<
-      run_local_accessor_access_among_work_items_tests>(types);
+  common_run_tests<run_local_accessor_access_among_work_items_tests>();
 });
 
 }  // namespace local_accessor_access_among_work_items_core

--- a/tests/accessor/local_accessor_api_core.cpp
+++ b/tests/accessor/local_accessor_api_core.cpp
@@ -21,8 +21,7 @@ namespace local_accessor_api_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::local_accessor api. core types", "[accessor]")({
   using namespace local_accessor_api_common;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_local_api_for_type>(types);
+  common_run_tests<run_local_api_for_type>();
 });
 
 }  // namespace local_accessor_api_core

--- a/tests/accessor/local_accessor_constructors_core.cpp
+++ b/tests/accessor/local_accessor_constructors_core.cpp
@@ -24,7 +24,6 @@ namespace local_accessor_constructors_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 ("sycl::local_accessor constructors. core types", "[accessor]")({
   using namespace local_accessor_constructors;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_local_constructors_test>(types);
+  common_run_tests<run_local_constructors_test>();
 });
 }  // namespace local_accessor_constructors_core

--- a/tests/accessor/local_accessor_linearization_core.cpp
+++ b/tests/accessor/local_accessor_linearization_core.cpp
@@ -34,8 +34,7 @@ namespace local_accessor_liniarization_core {
 DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sycl::local_accessor linearization. core types", "[accessor]")({
   using namespace local_accessor_linearization;
-  const auto types = get_conformance_type_pack();
-  for_all_types_vectors_marray<run_local_linearization_for_type>(types);
+  common_run_tests<run_local_linearization_for_type>();
 });
 
 }  // namespace local_accessor_liniarization_core


### PR DESCRIPTION
Reduced the accessor test build and run time by moving checks for some types to FULL_CONFORMANCE mode.
In regular mode vec and marray type as accessor data type run only for int and for the reduced number of sizes.

