### PR TITLE
Enable SYCL 2020 image related tests for DPCPP

### DIFF
--- a/tests/image/default_image.h
+++ b/tests/image/default_image.h
@@ -21,10 +21,8 @@
 #ifndef SYCL_CTS_IMAGE_DEFAULT_IMAGE_H
 #define SYCL_CTS_IMAGE_DEFAULT_IMAGE_H
 
-// Enable DPCPP when https://github.com/intel/llvm/issues/8304 been fixed
-#if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) ||    \
-      defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP) || \
-      defined(SYCL_CTS_COMPILING_WITH_DPCPP))
+#if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+      defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP))
 
 /**
  * Provides functionality to construct a default sampled_image and associated

--- a/tests/image/image_semantics.cpp
+++ b/tests/image/image_semantics.cpp
@@ -23,10 +23,8 @@
 #include "../common/semantics_reference.h"
 #include "default_image.h"
 
-// Enable DPCPP when https://github.com/intel/llvm/issues/8304 been fixed
-#if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) ||    \
-      defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP) || \
-      defined(SYCL_CTS_COMPILING_WITH_DPCPP))
+#if !(defined(SYCL_CTS_COMPILING_WITH_HIPSYCL) || \
+      defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP))
 
 template <int Dimensions>
 struct storage_sampled {
@@ -66,8 +64,7 @@ struct storage_unsampled {
 };
 
 #endif
-// Enable all tests when fixed https://github.com/intel/llvm/issues/8304
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("sampled_image common reference semantics", "[sampled_image]")({
   auto sampled_image_0 = default_sampled_image::get();
   auto sampled_image_1 = default_sampled_image::get();
@@ -79,7 +76,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
 // sampled_image common reference semantics, mutation
 // Cannot be tested, since sampled_image is read-only.
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("unsampled_image common reference semantics", "[unsampled_image]")({
   auto unsampled_image_0 = default_unsampled_image::get();
   auto unsampled_image_1 = default_unsampled_image::get();
@@ -88,7 +85,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
       unsampled_image_0, unsampled_image_1, "unsampled_image");
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp, DPCPP)
+DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 ("unsampled_image common reference semantics, mutation", "[unsampled_image]")({
   using data_type = default_unsampled_image::data_type;
   constexpr data_type val{1};

--- a/tests/property/property_api.cpp
+++ b/tests/property/property_api.cpp
@@ -75,9 +75,7 @@ TEST_CASE("property api", "[property]") {
     const auto objects = named_type_pack<sycl::buffer<int>>::generate("buffer");
     for_all_combinations<check_property_object>(properties, objects);
   }
-// Enable DPCPP when https://github.com/intel/llvm/issues/8304 been fixed
-#if !(defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-      defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP))
+#if !(defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP))
   {
     const auto properties = named_type_pack<
         sycl::property::image::use_host_ptr, sycl::property::image::use_mutex,
@@ -85,8 +83,9 @@ TEST_CASE("property api", "[property]") {
                                                         "image::use_mutex",
                                                         "image::context_bound");
     const auto objects =
-        named_type_pack<sycl::sampled_image, sycl::unsampled_image>::generate(
-            "sampled_image", "unsampled_image");
+        named_type_pack<sycl::sampled_image<>,
+                        sycl::unsampled_image<>>::generate("sampled_image",
+                                                           "unsampled_image");
     for_all_combinations<check_property_object>(properties, objects);
   }
 #else
@@ -96,9 +95,7 @@ TEST_CASE("property api", "[property]") {
       "Skipping the test case.");
 #endif
   {
-// Enable DPCPP when https://github.com/intel/llvm/issues/8304 been fixed
-#if defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-    defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
+#if defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP)
     WARN(
         "Implementation does not define sycl::unsampled_image_accessor and "
         "sycl::host_unsampled_image_accessor "
@@ -110,17 +107,14 @@ TEST_CASE("property api", "[property]") {
     // provide any template argument for the types that require it
     const auto objects =
         named_type_pack<sycl::accessor<int>, sycl::host_accessor<int>
-// Enable DPCPP when https://github.com/intel/llvm/issues/8304 been fixed
-#if !(defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-      defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP))
+#if !(defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP))
                         ,
-                        sycl::unsampled_image_accessor,
-                        sycl::host_unsampled_image_accessor
+                        sycl::unsampled_image_accessor<
+                            sycl::int4, 1, sycl::access_mode::read_write>,
+                        sycl::host_unsampled_image_accessor<sycl::int4, 1>
 #endif
                         >::generate("accessor", "host_accessor"
-// Enable DPCPP when https://github.com/intel/llvm/issues/8304 been fixed
-#if !(defined(SYCL_CTS_COMPILING_WITH_DPCPP) || \
-      defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP))
+#if !(defined(SYCL_CTS_COMPILING_WITH_COMPUTECPP))
                                     ,
                                     "unsampled_image_accessor",
                                     "host_unsampled_image_accessor"


### PR DESCRIPTION
This commit compile-time enables image-related tests for DPCPP.