### PR TITLE
Enable sycl::vec tests

### DIFF
--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -152,14 +152,11 @@ sycl::vec<convertType, N> rte(sycl::vec<vecType, N> inputVec) {
   if constexpr (if_FP_to_non_FP_conv_v<vecType, convertType>) {
     const int size = 8;
     vecType floats[size] = {2.3f, 3.8f, 1.5f, 2.5f, -2.3f, -3.8f, -1.5f, -2.5f};
-    convertType vals[size] = {2,
-                              4,
-                              2,
-                              2,
-                              static_cast<convertType>(-2),
-                              static_cast<convertType>(-4),
-                              static_cast<convertType>(-2),
-                              static_cast<convertType>(-2)};
+    convertType vals[size] = {
+        static_cast<convertType>(2),  static_cast<convertType>(4),
+        static_cast<convertType>(2),  static_cast<convertType>(2),
+        static_cast<convertType>(-2), static_cast<convertType>(-4),
+        static_cast<convertType>(-2), static_cast<convertType>(-2)};
     sycl::vec<convertType, N> resVec;
     for (size_t i = 0; i < N; ++i) {
       vecType elem = getElement(inputVec, i);
@@ -177,14 +174,11 @@ sycl::vec<convertType, N> rtz(sycl::vec<vecType, N> inputVec) {
   if constexpr (if_FP_to_non_FP_conv_v<vecType, convertType>) {
     const int size = 8;
     vecType floats[size] = {2.3f, 3.8f, 1.5f, 2.5f, -2.3f, -3.8f, -1.5f, -2.5f};
-    convertType vals[size] = {2,
-                              3,
-                              1,
-                              2,
-                              static_cast<convertType>(-2),
-                              static_cast<convertType>(-3),
-                              static_cast<convertType>(-1),
-                              static_cast<convertType>(-2)};
+    convertType vals[size] = {
+        static_cast<convertType>(2),  static_cast<convertType>(3),
+        static_cast<convertType>(1),  static_cast<convertType>(2),
+        static_cast<convertType>(-2), static_cast<convertType>(-3),
+        static_cast<convertType>(-1), static_cast<convertType>(-2)};
     sycl::vec<convertType, N> resVec;
     for (size_t i = 0; i < N; ++i) {
       vecType elem = getElement(inputVec, i);
@@ -202,14 +196,11 @@ sycl::vec<convertType, N> rtp(sycl::vec<vecType, N> inputVec) {
   if constexpr (if_FP_to_non_FP_conv_v<vecType, convertType>) {
     const int size = 8;
     vecType floats[size] = {2.3f, 3.8f, 1.5f, 2.5f, -2.3f, -3.8f, -1.5f, -2.5f};
-    convertType vals[size] = {3,
-                              4,
-                              2,
-                              3,
-                              static_cast<convertType>(-2),
-                              static_cast<convertType>(-3),
-                              static_cast<convertType>(-1),
-                              static_cast<convertType>(-2)};
+    convertType vals[size] = {
+        static_cast<convertType>(3),  static_cast<convertType>(4),
+        static_cast<convertType>(2),  static_cast<convertType>(3),
+        static_cast<convertType>(-2), static_cast<convertType>(-3),
+        static_cast<convertType>(-1), static_cast<convertType>(-2)};
     sycl::vec<convertType, N> resVec;
     for (size_t i = 0; i < N; ++i) {
       vecType elem = getElement(inputVec, i);
@@ -227,14 +218,11 @@ sycl::vec<convertType, N> rtn(sycl::vec<vecType, N> inputVec) {
   if constexpr (if_FP_to_non_FP_conv_v<vecType, convertType>) {
     const int size = 8;
     vecType floats[size] = {2.3f, 3.8f, 1.5f, 2.5f, -2.3f, -3.8f, -1.5f, -2.5f};
-    convertType vals[size] = {2,
-                              3,
-                              1,
-                              2,
-                              static_cast<convertType>(-3),
-                              static_cast<convertType>(-4),
-                              static_cast<convertType>(-2),
-                              static_cast<convertType>(-3)};
+    convertType vals[size] = {
+        static_cast<convertType>(2),  static_cast<convertType>(3),
+        static_cast<convertType>(1),  static_cast<convertType>(2),
+        static_cast<convertType>(-3), static_cast<convertType>(-4),
+        static_cast<convertType>(-2), static_cast<convertType>(-3)};
     sycl::vec<convertType, N> resVec;
     for (size_t i = 0; i < N; ++i) {
       vecType elem = getElement(inputVec, i);
@@ -511,11 +499,7 @@ template <typename vecType, int N>
 bool check_convert_as_all_types(sycl::vec<vecType, N> inputVec) {
   bool result = true;
 
-// FIXME: re-enable when as() for bool is implemented
-// https://github.com/intel/llvm/issues/9251
-#ifndef SYCL_CTS_COMPILING_WITH_DPCPP
   result += check_convert_as_all_dims<vecType, N, bool>(inputVec);
-#endif
   result += check_convert_as_all_dims<vecType, N, char>(inputVec);
   result += check_convert_as_all_dims<vecType, N, signed char>(inputVec);
   result += check_convert_as_all_dims<vecType, N, unsigned char>(inputVec);

--- a/tests/vector_api/generate_vector_api.py
+++ b/tests/vector_api/generate_vector_api.py
@@ -33,13 +33,9 @@ TEST_NAME = 'API'
 
 vector_element_type_template = Template("""
     CHECK(std::is_same_v<typename sycl::vec<${type}, ${size}>::element_type, ${type}>);
-// FIXME: re-enable when element_type for swizzle_vec is implemented
-// link to issue: https://github.com/intel/llvm/issues/8879
-#if !SYCL_CTS_COMPILING_WITH_DPCPP
     sycl::vec<${type}, ${size}> vec;
     CHECK(std::is_same_v<typename decltype(
         vec.template swizzle<${swizIndexes}>())::element_type, ${type}>);
-#endif
 """)
 
 vector_api_template = Template("""

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -1252,8 +1252,7 @@ subscript_operator_test_template = Template("""
     for (int i = 0; i < ${size}; ++i) {
       if (subscriptVec1[i] != data[i] || subscriptVec2[i] != data[i]
 // FIXME: re-enable when subscript operator for swizzle vec is implemented
-// link to issue: https://github.com/intel/llvm/issues/8880
-#if !SYCL_CTS_COMPILING_WITH_DPCPP && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
+#if !SYCL_CTS_COMPILING_WITH_COMPUTECPP
         || subscriptVec1.${swizzle}[i] != data[i]
         || subscriptVec2.${swizzle}[i] != data[i]
 #endif


### PR DESCRIPTION
Enable sycl::vec tests because issues https://github.com/intel/llvm/issues/8880, https://github.com/intel/llvm/issues/8879, https://github.com/intel/llvm/issues/9251 were fixed.