### PR TITLE
Reduce number of iterations in reduction tests

### DIFF
--- a/tests/reduction/reduction_common.h
+++ b/tests/reduction/reduction_common.h
@@ -33,7 +33,13 @@ namespace reduction_common {
 constexpr bool with_property{true};
 constexpr bool without_property{false};
 
-constexpr size_t number_iterations{7};
+// The buffer prepared from get_buffer will be the sequence 0, 1, ...,
+// number_iterations-1. This number should be small enough to prevent
+// overflow issues. (e.g. in a half multiplication reduction, for
+// number_iterations >= 10, then a left-to-right reduction results in
+// 0, while a right-to-left reduction results in nan because 9! * 0 =
+// inf * 0 = nan.)
+constexpr size_t number_iterations{4};
 
 constexpr int identity_value{0};
 

--- a/tests/reduction/reduction_common.h
+++ b/tests/reduction/reduction_common.h
@@ -33,7 +33,7 @@ namespace reduction_common {
 constexpr bool with_property{true};
 constexpr bool without_property{false};
 
-constexpr size_t number_iterations{10};
+constexpr size_t number_iterations{7};
 
 constexpr int identity_value{0};
 


### PR DESCRIPTION
In a case of `reduction_without_identity_param_fp16`, a reduction with a half multiplication functor using the "each_work_item_twice" kernel is invoked. The result should be the product of the list `0, 0, 1, 1, 2, 2, ..., 8, 8, 9, 9`. Depending on how the product is computed, the result can either be `0` (e.g. left to right multiplication) or `nan` (e.g. right to left will overflow for half and then compute `inf*0=nan`). Both of these should be allowed as the SYCL spec does specify the order the the reduction must be computed. However, the assertion checks the reduction result against result from `std::accumulate` (a left to right reduction), so there is a potential for a discrepancy (as is the case for DPC++). The `number_iterations` variable determines the input range used in the reduction tests, so this PR reduces it to `7` to remove the possibility of this discrepancy. 