### PR TITLE
Fixed deprecated accessor with target = local inside handler.single_task in math_builtin tests

### DIFF
--- a/tests/math_builtin_api/math_builtin.h
+++ b/tests/math_builtin_api/math_builtin.h
@@ -292,11 +292,10 @@ void check_function_multi_ptr_local(sycl_cts::util::logger& log, funT fun,
       auto resultPtr = buffer.template get_access<sycl::access_mode::write>(h);
       auto resultPtrArg =
           bufferArg.template get_access<sycl::access_mode::write>(h);
-      sycl::accessor<argT, 1, sycl::access_mode::read_write,
-                     sycl::target::local>
-          localAccessor(1, h);
-      h.single_task<kernel<N>>(
-          [arg, localAccessor, resultPtr, resultPtrArg, fun]() {
+      sycl::local_accessor<argT, 1> localAccessor(1, h);
+      h.parallel_for<kernel<N>>(
+          sycl::nd_range<1>{ndRng, ndRng},
+          [arg, localAccessor, resultPtr, resultPtrArg, fun](sycl::nd_item<1>) {
             localAccessor[0] = arg;
             resultPtr[0] = fun(localAccessor);
             resultPtrArg[0] = localAccessor[0];

--- a/tests/math_builtin_api/modules/test_generator.py
+++ b/tests/math_builtin_api/modules/test_generator.py
@@ -250,7 +250,7 @@ def generate_test_case(test_id, types, sig, memory, check, decorated = ""):
         testCaseSource = testCaseSource.replace("$DATA", sourcePtrDataName)
         accessorType = ""
         if memory == "local":
-            accessorType = "sycl::accessor<" + pointerType.name + ", 1, sycl::access_mode::read_write, sycl::target::local>"
+            accessorType = "sycl::local_accessor<" + pointerType.name + ", 1>"
         if memory == "global":
             accessorType = "sycl::accessor<" + pointerType.name + ", 1, sycl::access_mode::read_write, sycl::target::device>"
         testCaseSource = testCaseSource.replace("$ACCESSOR", accessorType)


### PR DESCRIPTION
In math_builtin tests, in check_function_multi_ptr_local changed single_task to parallel_for due to restriction of using accessor with target = local inside single_task.
Also changed deprecated accessor with target = local to local_accessor.