### PR TITLE
Test plan for oneapi extension local memory

### DIFF
--- a/test_plans/oneapi_local_memory.asciidoc
+++ b/test_plans/oneapi_local_memory.asciidoc
@@ -65,39 +65,75 @@ We should check that the allocating memory is actually available for all
 work-items in the work-group and the allocated objects are being created
 correctly.
 
+To test correctly initialization of the custom type object after call of _(2)_ 
+the custom type should have default constructor which initializes custom type
+data members by predefined known values.
+Apart from the default constructor the custom type should provide constructors
+taking one, two and three arguments to provide better testing for the args
+parameter pack to _(1)_.
+
 === Test description
 
 ==== Check initial value of allocated object and the type of returned value
 
 Define and submit a work-group data parallel SYCL kernel with work group size
-1.
+`n`.
 
 For the `group_local_memory(Group g, Args&&... args)` in kernel scope do the
 following:
 
 * Allocate local memory for an object of type `T`
-* Pass the initial value to the allocated object constructor through the `args`
-  parameter pack
+* Pass the chosen set of initial values to the constructor of type `T` through
+  the `args` parameter pack
 * Check the type of allocating function return value
-* Check that returned value is equal to the predefined initial value
+* Check the allocated object of type `T` has the predefined initial value
+
+For the custom type test should be performed for sets of initial values
+containing one, two and three values.
 
 For the `group_local_memory_for_overwrite(Group g)` in kernel scope do the
 following:
 
 * Allocate local memory for an object of type `T`
 * Check the type of allocating function return value
+* If the `T` is the custom type, check that object default constructor
+  was called, by comparing the allocated object data members with expected
+  values
+
+==== Check correctly initialization with different set of initial values in each work-group
+
+Define and submit a work-group data parallel SYCL kernel with work group size
+`n` and total execution range `num_work_group x n`.
+
+In kernel scope do the following:
+
+* Allocate local memory for an object of type `T` using function _(1)_
+* Each work-group chooses a different set of initial values used to
+  construct `T`
+* All work-items in a group pass the same set of initial values through the
+  `args` parameter pack
+* Work-items in each group check that the object of type `T` has the expected
+  initial value
+
+For the custom type test should be performed for sets of initial values
+containing one, two and three values.
 
 ==== Check availability of local memory by all work-items in the work-group
 
 Define and submit a work-group data parallel SYCL kernel with work group size
-n.
+`n`.
 
 In kernel scope do the following:
 
 * Allocate local memory for an `array[n]` of objects of type `T`
-* Assign the value `val` which is defined as `nd_item.get_local_linear_id()`
-  to the `array[(n - 1) - val]` (where n is work group size)
+* Assign the value `nd_item.get_local_linear_id() & 1` to the 
+  `array[(n - 1) - nd_item.get_local_linear_id()]` (where `n` is work group size)
 * Use group barrier to synchronize all work-items
-* Check the value `array[val]` is equal to `(n - 1) - val` for each work-item
+* Check the value `array[nd_item.get_local_linear_id()]` is equal to
+  `(n - 1) - nd_item.get_local_linear_id()` for each work-item
 
 Perform that test for allocating function _(1)_ and _(2)_.
+
+To perform this test with an object of the custom type, the custom type must
+provide a conversion constructor from `size_t` and
+`operator==(const CustomType&)`.

--- a/test_plans/oneapi_local_memory.asciidoc
+++ b/test_plans/oneapi_local_memory.asciidoc
@@ -23,7 +23,7 @@ be skipped if feature is not supported.
 
 Let `T` is the type of an object to be allocated within local memory space.
 
-Test is performed using the following types as `T`:
+Tests are performed using the following types as `T`:
 
 In regular mode:
 
@@ -100,4 +100,4 @@ In kernel scope do the following:
 * Use group barrier to synchronize all work-items
 * Check the value `array[val]` is equal to `(n - 1) - val` for each work-item
 
-Perform that test for allocating function _(1)_ and _(2)_
+Perform that test for allocating function _(1)_ and _(2)_.

--- a/test_plans/oneapi_local_memory.asciidoc
+++ b/test_plans/oneapi_local_memory.asciidoc
@@ -1,0 +1,103 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for sycl extension oneapi local memory
+
+This is a test plan for the extension enabling the declaration of local memory
+objects at the kernel functor scope described in
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc[sycl_ext_oneapi_local_memory.asciidoc]
+
+== Testing scope
+
+=== Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line.
+
+=== Feature test macro
+
+All of the tests should use `#ifdef SYCL_EXT_ONEAPI_LOCAL_MEMORY` so they can
+be skipped if feature is not supported.
+
+=== Type coverage
+
+Let `T` is the type of an object to be allocated within local memory space.
+
+Test is performed using the following types as `T`:
+
+In regular mode:
+
+* `int`
+* `float`
+* custom trivially destructible type
+
+In full conformance mode:
+
+* `bool`
+* `char`
+* `signed char`
+* `unsigned char`
+* `short`
+* `unsigned short`
+* `int`
+* `unsigned int`
+* `long`
+* `unsigned long`
+* `long long`
+* `unsigned long long`
+* `float`
+* `double`
+* custom trivially destructible type
+
+== Tests
+
+Extension introduces the following functions:
+
+* `template <typename T, typename Group, typename... Args>
+   multi_ptr<T, Group::address_space>
+   group_local_memory(Group g, Args&&... args);` _(1)_
+
+* `template <typename T, typename Group>
+   multi_ptr<T, Group::address_space>
+   group_local_memory_for_overwrite(Group g);` _(2)_
+
+We should check that the allocating memory is actually available for all
+work-items in the work-group and the allocated objects are being created
+correctly.
+
+=== Test description
+
+==== Check initial value of allocated object and the type of returned value
+
+Define and submit a work-group data parallel SYCL kernel with work group size
+1.
+
+For the `group_local_memory(Group g, Args&&... args)` in kernel scope do the
+following:
+
+* Allocate local memory for an object of type `T`
+* Pass the initial value to the allocated object constructor through the `args`
+  parameter pack
+* Check the type of allocating function return value
+* Check that returned value is equal to the predefined initial value
+
+For the `group_local_memory_for_overwrite(Group g)` in kernel scope do the
+following:
+
+* Allocate local memory for an object of type `T`
+* Check the type of allocating function return value
+
+==== Check availability of local memory by all work-items in the work-group
+
+Define and submit a work-group data parallel SYCL kernel with work group size
+n.
+
+In kernel scope do the following:
+
+* Allocate local memory for an `array[n]` of objects of type `T`
+* Assign the value `val` which is defined as `nd_item.get_local_linear_id()`
+  to the `array[(n - 1) - val]` (where n is work group size)
+* Use group barrier to synchronize all work-items
+* Check the value `array[val]` is equal to `(n - 1) - val` for each work-item
+
+Perform that test for allocating function _(1)_ and _(2)_


### PR DESCRIPTION
Add test plan for `sycl_ext_oneapi_local_memory` extension according to the [extension specification](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc)