### PR TITLE
Fix unexpected failures of sycl::join exception tests

### DIFF
--- a/tests/kernel_bundle/sycl_join_kernel_bundles_with_diff_ctx.cpp
+++ b/tests/kernel_bundle/sycl_join_kernel_bundles_with_diff_ctx.cpp
@@ -49,9 +49,8 @@ TEST_CASE("sycl::join kernel bundles with different contexts", "[sycl::join]") {
   using namespace sycl_cts::tests::kernel_bundle;
 
   const std::vector<sycl::device> devices{sycl::device::get_devices()};
-  {
-    INFO("Requires at least two devices");
-    REQUIRE(devices.size() > 1);
+  if (devices.size() < 2){
+    SKIP("Requires at least two devices");
   }
 
   sycl::context first_ctx(devices[0]);


### PR DESCRIPTION
The `REQUIRE` macro causes tests to fail if the number of devices is less than 2, when it should skip tests instead.