### PR TITLE
Add checks for ranges/id-like types member 'dimensions'

### DIFF
--- a/tests/common/range_index_space_id.h
+++ b/tests/common/range_index_space_id.h
@@ -78,7 +78,7 @@ void check_members_test(const std::string& type_name) {
             [=] { check_members<T, Dim>(res_acc); });
       });
     }
-    for (int i = 0; i < 2; /*check_count;*/ ++i) {
+    for (size_t i = 0; i < check_count; ++i) {
       INFO(get_error_string(i, type_name));
       CHECK(result[i]);
     }
@@ -87,7 +87,7 @@ void check_members_test(const std::string& type_name) {
                  "' and dim = " + std::to_string(Dim) + " on host";
   SECTION(section_name) {
     check_members<T, Dim>(result);
-    for (int i = 0; i < check_count; ++i) {
+    for (size_t i = 0; i < check_count; ++i) {
       INFO(get_error_string(i, type_name));
       CHECK(result[i]);
     }

--- a/tests/common/range_index_space_id.h
+++ b/tests/common/range_index_space_id.h
@@ -1,0 +1,97 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL
+#include "../common/type_coverage.h"
+#endif
+
+namespace range_index_space_id {
+
+enum class check_codes : size_t {
+  dimensions_type = 0,
+  dimensions_value = 1,
+  code_count = 2,
+};
+
+constexpr size_t check_count = to_integral(check_codes::code_count);
+
+static const std::array<std::string, check_count> error_strings{
+    "Wrong type of member T<Dim>::dimensions",
+    "Wrong value of member T<Dim>::dimensions",
+};
+
+template <check_codes Code, typename ResultArray>
+void set_success_operation(ResultArray& result) {
+  int index = to_integral(Code);
+  result[index] = true;
+}
+
+std::string get_error_string(int code, const std::string& type_name) {
+  return error_strings[code] + " for type T '" + type_name + "'";
+}
+
+template <typename T, int Dim, typename ResultArray>
+void check_members(ResultArray& result) {
+  if (std::is_same_v<const int, decltype(T::dimensions)>) {
+    set_success_operation<check_codes::dimensions_type>(result);
+  }
+  if (Dim == T::dimensions) {
+    set_success_operation<check_codes::dimensions_value>(result);
+  }
+}
+
+template <typename T, int Dim>
+class kernel_range_id;
+
+template <typename T, int Dim>
+void check_members_test(const std::string& type_name) {
+  auto queue = once_per_unit::get_queue();
+  std::string section_name = std::string("Checking for type '") + type_name +
+                             "' and dim = " + std::to_string(Dim) +
+                             " in kernel function";
+  bool result[check_count];
+  std::fill(result, result + check_count, false);
+  SECTION(section_name) {
+    {
+      sycl::buffer<bool, 1> res_buf(result, sycl::range(check_count));
+      queue.submit([&](sycl::handler& cgh) {
+        sycl::accessor res_acc(res_buf, cgh);
+        cgh.single_task<kernel_range_id<T, Dim>>(
+            [=] { check_members<T, Dim>(res_acc); });
+      });
+    }
+    for (int i = 0; i < 2; /*check_count;*/ ++i) {
+      INFO(get_error_string(i, type_name));
+      CHECK(result[i]);
+    }
+  }
+  section_name = std::string("Checking for type '") + type_name +
+                 "' and dim = " + std::to_string(Dim) + " on host";
+  SECTION(section_name) {
+    check_members<T, Dim>(result);
+    for (int i = 0; i < check_count; ++i) {
+      INFO(get_error_string(i, type_name));
+      CHECK(result[i]);
+    }
+  }
+}
+
+}  // namespace range_index_space_id

--- a/tests/common/range_index_space_id.h
+++ b/tests/common/range_index_space_id.h
@@ -44,7 +44,7 @@ void set_success_operation(ResultArray& result) {
   result[index] = true;
 }
 
-std::string get_error_string(int code, const std::string& type_name) {
+inline std::string get_error_string(int code, const std::string& type_name) {
   return error_strings[code] + " for type T '" + type_name + "'";
 }
 

--- a/tests/group/group_members.cpp
+++ b/tests/group/group_members.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "../common/range_index_space_id.h"
+
+namespace group_members {
+
+template <int Dim>
+void run_test() {
+  std::string type_name =
+      std::string("sycl::group<") + std::to_string(Dim) + ">";
+  range_index_space_id::check_members_test<sycl::group<Dim>, Dim>(type_name);
+}
+
+TEST_CASE("sycl::group members", "[group]") {
+  run_test<1>();
+  run_test<2>();
+  run_test<3>();
+}
+
+}  // namespace group_members

--- a/tests/h_item/h_item_members.cpp
+++ b/tests/h_item/h_item_members.cpp
@@ -34,6 +34,8 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::h_item<Dim>, Dim>(type_name);
 }
 
+// FIXME: re-enable when sycl::h_item<>::dimensions is implemented
+// Issue link https://github.com/intel/llvm/issues/9786
 DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
 ("sycl::h_item members", "[h_item]")({
   run_test<1>();

--- a/tests/h_item/h_item_members.cpp
+++ b/tests/h_item/h_item_members.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "../common/range_index_space_id.h"
+
+namespace h_item_members {
+
+template <int Dim>
+void run_test() {
+  std::string type_name =
+      std::string("sycl::h_item<") + std::to_string(Dim) + ">";
+  range_index_space_id::check_members_test<sycl::h_item<Dim>, Dim>(type_name);
+}
+
+DISABLED_FOR_TEST_CASE(DPCPP)
+("sycl::h_item members", "[h_item]")({
+  run_test<1>();
+  run_test<2>();
+  run_test<3>();
+});
+
+}  // namespace h_item_members

--- a/tests/h_item/h_item_members.cpp
+++ b/tests/h_item/h_item_members.cpp
@@ -34,7 +34,7 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::h_item<Dim>, Dim>(type_name);
 }
 
-DISABLED_FOR_TEST_CASE(DPCPP)
+DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
 ("sycl::h_item members", "[h_item]")({
   run_test<1>();
   run_test<2>();

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -284,6 +284,8 @@ TEMPLATE_TEST_CASE_SIG("id supports get() and operator[]", "[id]", ((int D), D),
   }
 }
 
+// FIXME: re-enable when sycl::id<>::dimensions is implemented
+// Issue link https://github.com/intel/llvm/issues/9786
 DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(DPCPP, hipSYCL)
 ("id provides static constexpr member 'dimensions'", "[id]", ((int D), D), 1, 2,
  3)({

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -287,8 +287,8 @@ TEMPLATE_TEST_CASE_SIG("id supports get() and operator[]", "[id]", ((int D), D),
 DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(DPCPP)
 ("id provides static constexpr member 'dimensions'", "[id]", ((int D), D), 1, 2,
  3)({
-  CHECK(std::is_same_v < decltype(sycl::id<D>::dimensions), const int);
-  KCHECK(EVAL((std::is_same_v < decltype(sycl::id<D>::dimensions), const int)));
+  CHECK(std::is_same_v<decltype(sycl::id<D>::dimensions), const int>);
+  KCHECK(EVAL((std::is_same_v<decltype(sycl::id<D>::dimensions), const int>)));
 
   CHECK(sycl::id<D>::dimensions == D);
   KCHECK(EVAL(sycl::id<D>::dimensions) == D);

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -284,6 +284,16 @@ TEMPLATE_TEST_CASE_SIG("id supports get() and operator[]", "[id]", ((int D), D),
   }
 }
 
+DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(DPCPP)
+("id provides static constexpr member 'dimensions'", "[id]", ((int D), D), 1, 2,
+ 3)({
+  CHECK(std::is_same_v < decltype(sycl::id<D>::dimensions), const int);
+  KCHECK(EVAL((std::is_same_v < decltype(sycl::id<D>::dimensions), const int)));
+
+  CHECK(sycl::id<D>::dimensions == D);
+  KCHECK(EVAL(sycl::id<D>::dimensions) == D);
+});
+
 TEST_CASE("id can be converted to size_t if Dimensions == 1", "[id]") {
   using sycl::id;
   const auto convert = [] {

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -284,7 +284,7 @@ TEMPLATE_TEST_CASE_SIG("id supports get() and operator[]", "[id]", ((int D), D),
   }
 }
 
-DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(DPCPP)
+DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(DPCPP, hipSYCL)
 ("id provides static constexpr member 'dimensions'", "[id]", ((int D), D), 1, 2,
  3)({
   CHECK(std::is_same_v<decltype(sycl::id<D>::dimensions), const int>);

--- a/tests/item/item_members.cpp
+++ b/tests/item/item_members.cpp
@@ -34,6 +34,8 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::item<Dim>, Dim>(type_name);
 }
 
+// FIXME: re-enable when sycl::item<>::dimensions is implemented
+// Issue link https://github.com/intel/llvm/issues/9786
 DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
 ("sycl::item members", "[item]")({
   run_test<1>();

--- a/tests/item/item_members.cpp
+++ b/tests/item/item_members.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "../common/range_index_space_id.h"
+
+namespace item_members {
+
+template <int Dim>
+void run_test() {
+  std::string type_name =
+      std::string("sycl::item<") + std::to_string(Dim) + ">";
+  range_index_space_id::check_members_test<sycl::item<Dim>, Dim>(type_name);
+}
+
+DISABLED_FOR_TEST_CASE(DPCPP)
+("sycl::item members", "[item]")({
+  run_test<1>();
+  run_test<2>();
+  run_test<3>();
+});
+
+}  // namespace item_members

--- a/tests/item/item_members.cpp
+++ b/tests/item/item_members.cpp
@@ -34,7 +34,7 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::item<Dim>, Dim>(type_name);
 }
 
-DISABLED_FOR_TEST_CASE(DPCPP)
+DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
 ("sycl::item members", "[item]")({
   run_test<1>();
   run_test<2>();

--- a/tests/nd_item/nd_item_members.cpp
+++ b/tests/nd_item/nd_item_members.cpp
@@ -34,6 +34,8 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::nd_item<Dim>, Dim>(type_name);
 }
 
+// FIXME: re-enable when sycl::nd_item<>::dimensions is implemented
+// Issue link https://github.com/intel/llvm/issues/9786
 DISABLED_FOR_TEST_CASE(DPCPP)
 ("sycl::nd_item members", "[nd_item]")({
   run_test<1>();

--- a/tests/nd_item/nd_item_members.cpp
+++ b/tests/nd_item/nd_item_members.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "../common/range_index_space_id.h"
+
+namespace nd_item_members {
+
+template <int Dim>
+void run_test() {
+  std::string type_name =
+      std::string("sycl::nd_item<") + std::to_string(Dim) + ">";
+  range_index_space_id::check_members_test<sycl::nd_item<Dim>, Dim>(type_name);
+}
+
+DISABLED_FOR_TEST_CASE(DPCPP)
+("sycl::nd_item members", "[nd_item]")({
+  run_test<1>();
+  run_test<2>();
+  run_test<3>();
+});
+
+}  // namespace nd_item_members

--- a/tests/nd_range/nd_range_members.cpp
+++ b/tests/nd_range/nd_range_members.cpp
@@ -34,6 +34,8 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::nd_range<Dim>, Dim>(type_name);
 }
 
+// FIXME: re-enable when sycl::nd_range<>::dimensions is implemented
+// Issue link https://github.com/intel/llvm/issues/9786
 DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
 ("sycl::nd_range members", "[nd_range]")({
   run_test<1>();

--- a/tests/nd_range/nd_range_members.cpp
+++ b/tests/nd_range/nd_range_members.cpp
@@ -34,7 +34,7 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::nd_range<Dim>, Dim>(type_name);
 }
 
-DISABLED_FOR_TEST_CASE(DPCPP)
+DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
 ("sycl::nd_range members", "[nd_range]")({
   run_test<1>();
   run_test<2>();

--- a/tests/nd_range/nd_range_members.cpp
+++ b/tests/nd_range/nd_range_members.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "../common/range_index_space_id.h"
+
+namespace nd_range_members {
+
+template <int Dim>
+void run_test() {
+  std::string type_name =
+      std::string("sycl::nd_range<") + std::to_string(Dim) + ">";
+  range_index_space_id::check_members_test<sycl::nd_range<Dim>, Dim>(type_name);
+}
+
+DISABLED_FOR_TEST_CASE(DPCPP)
+("sycl::nd_range members", "[nd_range]")({
+  run_test<1>();
+  run_test<2>();
+  run_test<3>();
+});
+
+}  // namespace nd_range_members

--- a/tests/range/range_members.cpp
+++ b/tests/range/range_members.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "../common/range_index_space_id.h"
+
+namespace range_members {
+
+template <int Dim>
+void run_test() {
+  std::string type_name =
+      std::string("sycl::range<") + std::to_string(Dim) + ">";
+  range_index_space_id::check_members_test<sycl::range<Dim>, Dim>(type_name);
+}
+
+DISABLED_FOR_TEST_CASE(DPCPP)
+("sycl::range members", "[range]")({
+  run_test<1>();
+  run_test<2>();
+  run_test<3>();
+});
+
+}  // namespace range_members

--- a/tests/range/range_members.cpp
+++ b/tests/range/range_members.cpp
@@ -34,7 +34,7 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::range<Dim>, Dim>(type_name);
 }
 
-DISABLED_FOR_TEST_CASE(DPCPP)
+DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
 ("sycl::range members", "[range]")({
   run_test<1>();
   run_test<2>();

--- a/tests/range/range_members.cpp
+++ b/tests/range/range_members.cpp
@@ -34,6 +34,8 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::range<Dim>, Dim>(type_name);
 }
 
+// FIXME: re-enable when sycl::range<>::dimensions is implemented
+// Issue link https://github.com/intel/llvm/issues/9786
 DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
 ("sycl::range members", "[range]")({
   run_test<1>();

--- a/tests/sub_group/sub_group_members.cpp
+++ b/tests/sub_group/sub_group_members.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2017-2022 Codeplay Software LTD. All Rights Reserved.
+//  Copyright (c) 2022-2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#include "../common/common.h"
+#include "../common/once_per_unit.h"
+#include "../common/range_index_space_id.h"
+
+namespace sub_group_members {
+
+void run_test() {
+  std::string type_name = std::string("sycl::sub_group");
+  range_index_space_id::check_members_test<sycl::sub_group, 1>(type_name);
+}
+
+TEST_CASE("sycl::sub_group members", "[sub_group]") { run_test(); }
+
+}  // namespace sub_group_members


### PR DESCRIPTION
Covered gap with checks for 'dimensions' member of ranges/id-like types according to [4.9.1. Ranges and index space identifiers](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#ranges-identifiers) and PR [#351](https://github.com/KhronosGroup/SYCL-Docs/pull/351).