### PR TITLE
Fix optional kernel features test case

### DIFF
--- a/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
+++ b/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
@@ -198,12 +198,6 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(ComputeCpp, hipSYCL)
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
 
   {
-    run_separate_lambda_with_accessor<kname, FeatureTypeT, FeatureAspectT,
-                                      call_attribute_type::dummy_non_decorated>(
-        is_exception_expected, expected_errc, queue);
-  }
-
-  {
     using FunctorT = decorated_call_non_decorated_dummy<FeatureAspectT>;
 
     run_functor_with_accessor<FunctorT>(is_exception_expected, expected_errc,


### PR DESCRIPTION
The test case description is "Kernel does not use the tested feature but is decorated with the corresponding attribute
`[[sycl::device_has()]]`", but this call of `run_separate_lambda_with_accessor` tests lambda's that are not decorated with `[[sycl::device_has()]]` and that do not use any optional features, which makes it incorrectly assert that a exception with `kernel_not_supported` error code must be thrown.