### PR TITLE
Fix generic_accessor_placeholder_buffer_constructor

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -663,7 +663,7 @@ void check_common_constructor(const sycl::range<Dimension>& r,
 
     queue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor res_acc(res_buf);
+          sycl::accessor res_acc(res_buf, cgh);
           auto acc = get_accessor_functor(data_buf, cgh);
 
           if constexpr (AccType == accessor_type::generic_accessor) {


### PR DESCRIPTION
`res_acc` is accessed through subscript operator under certain conditions, so it should not be a placeholder. 