### PR TITLE
Cover gaps for scan

### DIFF
--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -216,3 +216,23 @@ using ExtendedTypes = concatenation<
 #endif
 
 using CustomTypes = concatenation<ExtendedTypes, util::custom_type>::type;
+
+template <typename T>
+inline auto get_op_types() {
+#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
+  static const auto types =
+      named_type_pack<sycl::plus<T>, sycl::multiplies<T>, sycl::bit_and<T>,
+                      sycl::bit_or<T>, sycl::bit_xor<T>, sycl::logical_and<T>,
+                      sycl::logical_or<T>, sycl::minimum<T>,
+                      sycl::maximum<T>>::generate("plus", "multiplies",
+                                                  "bit_and", "bit_or",
+                                                  "bit_xor", "logical_and",
+                                                  "logical_or", "minimum",
+                                                  "maximum");
+#else
+  static const auto types =
+      named_type_pack<sycl::plus<T>, sycl::maximum<T>>::generate("plus",
+                                                                 "maximum");
+#endif
+  return types;
+}

--- a/tests/group_functions/group_reduce.h
+++ b/tests/group_functions/group_reduce.h
@@ -26,26 +26,6 @@
 constexpr size_t init = 1412;
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 
-template <typename T>
-inline auto get_op_types() {
-#if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  static const auto types =
-      named_type_pack<sycl::plus<T>, sycl::multiplies<T>, sycl::bit_and<T>,
-                      sycl::bit_or<T>, sycl::bit_xor<T>, sycl::logical_and<T>,
-                      sycl::logical_or<T>, sycl::minimum<T>,
-                      sycl::maximum<T>>::generate("plus", "multiplies",
-                                                  "bit_and", "bit_or",
-                                                  "bit_xor", "logical_and",
-                                                  "logical_or", "minimum",
-                                                  "maximum");
-#else
-  static const auto types =
-      named_type_pack<sycl::plus<T>, sycl::maximum<T>>::generate("plus",
-                                                                 "maximum");
-#endif
-  return types;
-}
-
 template <bool with_init, typename OpT, typename IteratorT>
 size_t get_reduce_reference(IteratorT first, IteratorT end) {
   // Cast `init` to size_t so that guards are introduced in verification
@@ -202,7 +182,10 @@ class invoke_joint_reduce_group {
 
  public:
   void operator()(sycl::queue& queue, const std::string& op_name) {
-    joint_reduce_group<D, T, OperatorT>(queue, op_name);
+    if constexpr (type_traits::group_algorithms::is_legal_operator_v<
+                      T, OperatorT>) {
+      joint_reduce_group<D, T, OperatorT>(queue, op_name);
+    }
   }
 };
 
@@ -308,7 +291,10 @@ class invoke_init_joint_reduce_group {
 
  public:
   void operator()(sycl::queue& queue, const std::string& op_name) {
-    init_joint_reduce_group<D, RetT, ReducedT, OperatorT>(queue, op_name);
+    if constexpr (type_traits::group_algorithms::is_legal_operator_v<
+                      RetT, OperatorT>) {
+      init_joint_reduce_group<D, RetT, ReducedT, OperatorT>(queue, op_name);
+    }
   }
 };
 
@@ -420,7 +406,10 @@ class invoke_reduce_over_group {
 
  public:
   void operator()(sycl::queue& queue, const std::string& op_name) {
-    reduce_over_group<D, T, OperatorT>(queue, op_name);
+    if constexpr (type_traits::group_algorithms::is_legal_operator_v<
+                      T, OperatorT>) {
+      reduce_over_group<D, T, OperatorT>(queue, op_name);
+    }
   }
 };
 
@@ -430,8 +419,8 @@ class init_reduce_over_group_kernel;
 /**
  * @brief Provides test for reduce over group values with init
  * @tparam D Dimension to use for group instance
- * @tparam T Type for group values
- * @tparam U Type for init and result values
+ * @tparam T Type for init and result values
+ * @tparam U Type for group values
  * @tparam OpT Type for binary operator
  */
 template <int D, typename T, typename U, typename OpT>
@@ -448,7 +437,7 @@ void init_reduce_over_group(sycl::queue& queue, const std::string& op_name) {
 
   bool res = false;
   // array to input data
-  std::vector<T> v(work_group_size);
+  std::vector<U> v(work_group_size);
   std::iota(v.begin(), v.end(), 1);
   // array to reduce results
   std::vector<T> group_output(work_group_size, 0);
@@ -457,7 +446,7 @@ void init_reduce_over_group(sycl::queue& queue, const std::string& op_name) {
   // Store subgroup size
   size_t sg_size = 0;
   {
-    sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(work_group_size));
+    sycl::buffer<U, 1> v_sycl(v.data(), sycl::range<1>(work_group_size));
     sycl::buffer<T, 1> g_output_sycl(group_output.data(),
                                      sycl::range<1>(work_group_size));
     sycl::buffer<T, 1> sg_output_sycl(sg_output.data(),
@@ -537,6 +526,9 @@ class invoke_init_reduce_over_group {
 
  public:
   void operator()(sycl::queue& queue, const std::string& op_name) {
-    init_reduce_over_group<D, RetT, ReducedT, OperatorT>(queue, op_name);
+    if constexpr (type_traits::group_algorithms::is_legal_operator_v<
+                      RetT, OperatorT>) {
+      init_reduce_over_group<D, RetT, ReducedT, OperatorT>(queue, op_name);
+    }
   }
 };

--- a/tests/reduction/identity_helper.h
+++ b/tests/reduction/identity_helper.h
@@ -24,40 +24,6 @@
 #include <limits>
 #include <type_traits>
 
-/**
- Checks whether \p AccumulatorT and \p OperatorT form a valid SYCL operator. */
-template <typename AccumulatorT, typename OperatorT>
-using is_legal_operator = std::bool_constant<
-    (std::is_same_v<OperatorT, sycl::plus<AccumulatorT>> &&
-     std::is_arithmetic_v<AccumulatorT>) ||
-    (std::is_same_v<OperatorT, sycl::multiplies<AccumulatorT>> &&
-     std::is_arithmetic_v<AccumulatorT>) ||
-    (std::is_same_v<OperatorT, sycl::bit_and<AccumulatorT>> &&
-     std::is_integral_v<AccumulatorT>) ||
-    (std::is_same_v<OperatorT, sycl::bit_or<AccumulatorT>> &&
-     std::is_integral_v<AccumulatorT>) ||
-    (std::is_same_v<OperatorT, sycl::bit_xor<AccumulatorT>> &&
-     std::is_integral_v<AccumulatorT>) ||
-    (std::is_same_v<OperatorT, sycl::logical_and<AccumulatorT>> &&
-     std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>) ||
-    (std::is_same_v<OperatorT, sycl::logical_or<AccumulatorT>> &&
-     std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>) ||
-    (std::is_same_v<OperatorT, sycl::minimum<AccumulatorT>> &&
-     std::is_integral_v<AccumulatorT>) ||
-    (std::is_same_v<OperatorT, sycl::minimum<AccumulatorT>> &&
-     (std::is_floating_point_v<AccumulatorT> ||
-      std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>)) ||
-    (std::is_same_v<OperatorT, sycl::maximum<AccumulatorT>> &&
-     std::is_integral_v<AccumulatorT>) ||
-    (std::is_same_v<OperatorT, sycl::maximum<AccumulatorT>> &&
-     (std::is_floating_point_v<AccumulatorT> ||
-      std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>))>;
-/**
- Checks whether \p AccumulatorT and \p OperatorT form a valid SYCL operator. */
-template <typename AccumulatorT, typename OperatorT>
-inline constexpr bool is_legal_operator_v{
-    is_legal_operator<AccumulatorT, OperatorT>::value};
-
 /** plus */
 template <
     typename AccumulatorT, typename OperatorT,

--- a/tests/reduction/reducer_api.h
+++ b/tests/reduction/reducer_api.h
@@ -226,7 +226,9 @@ struct check_reducer_identity_operator {
 template <typename OperatorT, typename AccumulatorT>
 struct check_reducer_identity_operator<
     OperatorT, AccumulatorT,
-    typename std::enable_if_t<is_legal_operator_v<AccumulatorT, OperatorT>>> {
+    typename std::enable_if_t<
+        type_traits::group_algorithms::is_legal_operator_v<AccumulatorT,
+                                                           OperatorT>>> {
   void operator()(sycl::queue& queue, const std::string& op_name) {
     INFO("operation type: " << op_name);
 

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -388,6 +388,37 @@ template <typename T>
 inline constexpr bool less_or_equal_v = less_or_equal<T>::value;
 
 }  // namespace has_comparison
+
+namespace group_algorithms {
+/**
+ Checks whether \p T and \p OperatorT form a valid SYCL operator. */
+template <typename T, typename OperatorT>
+using is_legal_operator = std::bool_constant<
+    (std::is_same_v<OperatorT, sycl::plus<T>> && std::is_arithmetic_v<T>) ||
+    (std::is_same_v<OperatorT, sycl::multiplies<T>> &&
+     std::is_arithmetic_v<T>) ||
+    (std::is_same_v<OperatorT, sycl::bit_and<T>> && std::is_integral_v<T>) ||
+    (std::is_same_v<OperatorT, sycl::bit_or<T>> && std::is_integral_v<T>) ||
+    (std::is_same_v<OperatorT, sycl::bit_xor<T>> && std::is_integral_v<T>) ||
+    (std::is_same_v<OperatorT, sycl::logical_and<T>> &&
+     std::is_same_v<std::remove_cv_t<T>, bool>) ||
+    (std::is_same_v<OperatorT, sycl::logical_or<T>> &&
+     std::is_same_v<std::remove_cv_t<T>, bool>) ||
+    (std::is_same_v<OperatorT, sycl::minimum<T>> && std::is_integral_v<T>) ||
+    (std::is_same_v<OperatorT, sycl::minimum<T>> &&
+     (std::is_floating_point_v<T> ||
+      std::is_same_v<std::remove_cv_t<T>, sycl::half>)) ||
+    (std::is_same_v<OperatorT, sycl::maximum<T>> && std::is_integral_v<T>) ||
+    (std::is_same_v<OperatorT, sycl::maximum<T>> &&
+     (std::is_floating_point_v<T> ||
+      std::is_same_v<std::remove_cv_t<T>, sycl::half>))>;
+
+/**
+ Checks whether \p T and \p OperatorT form a valid SYCL operator. */
+template <typename T, typename OperatorT>
+inline constexpr bool is_legal_operator_v{
+    is_legal_operator<T, OperatorT>::value};
+}  // namespace group_algorithms
 }  // namespace type_traits
 
 #endif  // __SYCLCTS_UTIL_TYPE_TRAITS_H


### PR DESCRIPTION
Added checks for rest operations for scan tests, some fixes in reduce tests (added guards to run tests with valid combinations of tested type and operation, e.g. bitwise operations can't be tested with float types, fixed the type of input data in `init_reduce_over_group()` function)