### PR TITLE
Fix checks for local_accessor ctors

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -585,7 +585,9 @@ void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor,
     compare_res = compare_res_arr[0];
   }
 
-  if constexpr (AccessMode != sycl::access_mode::write) {
+  if constexpr (AccessMode != sycl::access_mode::write &&
+                !(accessor_type::local_accessor == AccType &&
+                  sycl::access_mode::read == AccessMode)) {
     CHECK(compare_res);
   }
 
@@ -661,7 +663,7 @@ void check_common_constructor(const sycl::range<Dimension>& r,
 
     queue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor res_acc(res_buf);
+          sycl::accessor res_acc(res_buf, cgh);
           auto acc = get_accessor_functor(data_buf, cgh);
 
           if constexpr (AccType == accessor_type::generic_accessor) {
@@ -701,7 +703,9 @@ void check_common_constructor(const sycl::range<Dimension>& r,
     compare_res = compare_res_arr[0];
   }
 
-  if constexpr (AccessMode != sycl::access_mode::write) {
+  if constexpr (AccessMode != sycl::access_mode::write &&
+                !(accessor_type::local_accessor == AccType &&
+                  sycl::access_mode::read == AccessMode)) {
     CHECK(compare_res);
   }
 


### PR DESCRIPTION
Value checks for local_accessor<const T, Dim> disabled due to the impossibility of passing data to such local_accessor.