### PR TITLE
usm_device_read_only extension test plan

### DIFF
--- a/test_plans/usm_device_read_only.asciidoc
+++ b/test_plans/usm_device_read_only.asciidoc
@@ -1,0 +1,81 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for usm_device_read_only
+
+This is a test plan for the USM property described in
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_usm_device_read_only.asciidoc[sycl_ext_oneapi_usm_device_read_only]
+
+== Testing scope
+
+=== Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line.
+
+=== Feature test macro
+
+All of the tests should use `#ifdef SYCL_EXT_ONEAPI_USM_DEVICE_READ_ONLY` so they can be skipped
+if feature is not supported.
+
+== Tests
+
+=== malloc_device
+
+* Create `property_list pl{usm_device_read_only()}`;
+* Allocate `int *ptr` using `malloc_shared` with `queue` on the host;
+* Allocate `int *ptr_read_only` using `malloc_device` with `queue` and `pl` on the host;
+* Submit kernel with assigning value of `ptr_read_only` to `ptr`;
+* Create `int var` variable with `buffer` and `accessor` to it;
+* Submit kernel with assigning value of `ptr` to `accessor`;
+
+Check that `var` has the same value as `ptr`, which means that this property allows memory to be accessed on the device.
+
+=== malloc_host
+
+* Create `property_list pl{usm_device_read_only()}`;
+* Allocate `int *ptr_read_only` using `malloc_host` with `queue` and `pl` on the host;
+* Assign some value to `*ptr_read_only` on the host;
+* Create `int var` variable with `buffer` and `accessor` to it;
+* Submit kernel with assigning value of `ptr_read_only` to the `accessor`.
+
+Check that `var` has the same value as `ptr_read_only`, which means that this property allows memory to be modified on the host and accessed on the device.
+
+=== malloc_shared
+
+Same as the above, but with `malloc_shared` instead of `malloc_host`.
+
+[source, c++]
+----
+property_list pl{
+    ext::oneapi::property::usm::device_read_only()};
+
+int *ptr_read_only = malloc_host<int>(1, queue, pl);
+*ptr_read_only = 42;
+
+int val;
+{
+  buffer buf(&val, {1});
+  queue.submit([&](handler& cgh) {
+    auto acc = buf.template get_access<access_mode::write>(cgh);
+    cgh.single_task([=] {
+      acc[0] = *ptr_read_only;
+    });
+  }).wait_and_throw();
+}
+
+if (val != *ptr_read_only) { /* tests failed */ }
+----
+
+=== usm_allocator
+
+* Create `usm_allocator` with `usm_device_read_only` property using all combinations of
+  ** constructors:
+    *** `usm_allocator(context&, device&, property_list&)`;
+    *** `usm_allocator(queue&, property_list&)`. +
+  ** allocator kinds
+    *** `usm::alloc::host`;
+    *** `usm::alloc::device`;
+    *** `usm::alloc::shared` .
+* Check that `usm_allocator::has_property<device_read_only>()` returns `true`;
+* Check that `usm_allocator::get_property<device_read_only>()` does not throw any exceptions.


### PR DESCRIPTION
Test plan for USM property extension described [here](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_usm_device_read_only.asciidoc)