### PR TITLE
Fix memcpy2d tests

### DIFF
--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler.h
@@ -82,7 +82,7 @@ class run_handler_tests {
           cgh.ext_oneapi_memcpy2d(dest_address, dest_pitch, src_address,
                                   src_pitch, region_width, region_height);
         });
-        queue.wait();
+        queue.wait_and_throw();
         copy_destination_to_host_result<DestPtrType>(dst.get(), result,
                                                      result_size, queue);
         for_index([&](size_t index) {
@@ -104,7 +104,7 @@ class run_handler_tests {
         cgh.ext_oneapi_copy2d(src_address, src_pitch, dest_address, dest_pitch,
                               region_width, region_height);
       });
-      queue.wait();
+      queue.wait_and_throw();
       copy_destination_to_host_result<DestPtrType>(dst.get(), result,
                                                    result_size, queue);
       for_index([&](size_t index) {
@@ -127,7 +127,7 @@ class run_handler_tests {
           cgh.ext_oneapi_memset2d(dest_address, dest_pitch, value, region_width,
                                   region_height);
         });
-        queue.wait();
+        queue.wait_and_throw();
         copy_destination_to_host_result<DestPtrType>(dst.get(), result,
                                                      result_size, queue);
         for_index([&](size_t index) {
@@ -150,7 +150,7 @@ class run_handler_tests {
         cgh.ext_oneapi_fill2d(dest_address, dest_pitch, value, region_width,
                               region_height);
       });
-      queue.wait();
+      queue.wait_and_throw();
       copy_destination_to_host_result<DestPtrType>(dst.get(), result,
                                                    result_size, queue);
       for_index([&](size_t index) {

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_handler_exceptions.h
@@ -98,6 +98,7 @@ class run_handler_exceptions_tests {
             action(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
       }
+      queue.wait_and_throw();
     }
     SECTION(
         sycl_cts::section_name(std::string("Check copy2d exception with T = ") +
@@ -125,6 +126,7 @@ class run_handler_exceptions_tests {
       CHECK_THROWS_MATCHES(
           action(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
+      queue.wait_and_throw();
     }
     if constexpr (std::is_same_v<T, unsigned char>) {
       SECTION(sycl_cts::section_name(std::string("Check memset2d with T = ") +
@@ -148,6 +150,7 @@ class run_handler_exceptions_tests {
         CHECK_THROWS_MATCHES(
             action(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
+        queue.wait_and_throw();
       }
     }
     SECTION(sycl_cts::section_name(std::string("Check fill2d with T = ") +
@@ -171,6 +174,7 @@ class run_handler_exceptions_tests {
       CHECK_THROWS_MATCHES(
           action(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
+      queue.wait_and_throw();
     }
   }
 };

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut.h
@@ -106,7 +106,7 @@ class run_queue_shortcut_tests {
                                   dest_pitch, region_width, region_height,
                                   {event1, event2});
 
-        queue.wait();
+        queue.wait_and_throw();
         copy_destination_to_host_result<DestPtrType>(dst3.get(), result,
                                                      result_size, queue);
 
@@ -140,7 +140,7 @@ class run_queue_shortcut_tests {
       queue.ext_oneapi_copy2d(src_address, dest_pitch, dest_address, dest_pitch,
                               region_width, region_height, {event1, event2});
 
-      queue.wait();
+      queue.wait_and_throw();
       copy_destination_to_host_result<DestPtrType>(dst3.get(), result,
                                                    result_size, queue);
 
@@ -175,7 +175,7 @@ class run_queue_shortcut_tests {
         queue.ext_oneapi_memset2d(dest_address, dest_pitch, value, region_width,
                                   region_height, {event1, event2});
 
-        queue.wait();
+        queue.wait_and_throw();
         copy_destination_to_host_result<DestPtrType>(dst1.get(), result,
                                                      result_size, queue);
         for_index([&](size_t index) {
@@ -222,7 +222,7 @@ class run_queue_shortcut_tests {
       queue.ext_oneapi_fill2d(dest_address, dest_pitch, value, region_width,
                               region_height, {event1, event2});
 
-      queue.wait();
+      queue.wait_and_throw();
       copy_destination_to_host_result<DestPtrType>(dst1.get(), result,
                                                    result_size, queue);
       for_index([&](size_t index) {

--- a/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions.h
+++ b/tests/extension/oneapi_memcpy2d/memcpy2d_queue_shortcut_exceptions.h
@@ -132,7 +132,7 @@ class run_queue_shortcut_exceptions_tests {
         CHECK_THROWS_MATCHES(
             action3(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
-        queue.wait();
+        queue.wait_and_throw();
       }
     }
     SECTION(sycl_cts::section_name(std::string("Check copy2d with T = ") +
@@ -193,7 +193,7 @@ class run_queue_shortcut_exceptions_tests {
       CHECK_THROWS_MATCHES(
           action3(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
-      queue.wait();
+      queue.wait_and_throw();
     }
     if constexpr (std::is_same_v<T, unsigned char>) {
       SECTION(sycl_cts::section_name(std::string("Check memset2d with T = ") +
@@ -237,7 +237,7 @@ class run_queue_shortcut_exceptions_tests {
         CHECK_THROWS_MATCHES(
             action3(dest_pitch + extra_bit), sycl::exception,
             sycl_cts::util::equals_exception(sycl::errc::invalid));
-        queue.wait();
+        queue.wait_and_throw();
       }
     }
     SECTION(sycl_cts::section_name(std::string("Check fill2d with T = ") +
@@ -281,7 +281,7 @@ class run_queue_shortcut_exceptions_tests {
       CHECK_THROWS_MATCHES(
           action3(dest_pitch + extra_bit), sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
-      queue.wait();
+      queue.wait_and_throw();
     }
   }
 };


### PR DESCRIPTION
Added missed queue.wait_and_throw() call to avoid memory corruption.