### PR TITLE
Fix placeholder_zero_length_buffer_constructor

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -442,7 +442,7 @@ void check_zero_length_buffer_constructor(GetAccFunctorT get_accessor_functor) {
 
     queue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor res_acc(res_buf);
+          sycl::accessor res_acc(res_buf, cgh);
           auto acc = get_accessor_functor(data_buf, cgh);
           if constexpr (Target == sycl::target::host_task) {
             cgh.host_task([=] {


### PR DESCRIPTION
`res_acc` is accessed through subscript operator under certain conditions, so it should not be a placeholder.