### PR TITLE
Add tests sycl::atomic_ref atomicity with respect to host code 

### DIFF
--- a/tests/atomic_ref_stress/atomic_ref_stress_atomic64.cpp
+++ b/tests/atomic_ref_stress/atomic_ref_stress_atomic64.cpp
@@ -142,4 +142,51 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   atomic_ref_stress_test::run_ordering<double>{}("double");
 });
 
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity with respect to atomic operations in host code. "
+ "long long type",
+ "[atomic_ref_stress]")({
+#ifdef __cpp_lib_atomic_ref
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  if (!queue.get_device().has(sycl::aspect::usm_atomic_shared_allocations))
+    SKIP(
+        "Device does not support usm_atomic_shared_allocations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_atomicity_with_host_code<long long>{}(
+      "long long");
+#else
+  SKIP("std::atomic_ref is not available");
+#endif
+});
+
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity with respect to atomic operations in host code. "
+ "double type",
+ "[atomic_ref_stress]")({
+#ifdef __cpp_lib_atomic_ref
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::atomic64))
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  if (!queue.get_device().has(sycl::aspect::fp64))
+    SKIP(
+        "Device does not support fp64 operations. "
+        "Skipping the test case.");
+  if (!queue.get_device().has(sycl::aspect::usm_atomic_shared_allocations))
+    SKIP(
+        "Device does not support usm_atomic_shared_allocations. "
+        "Skipping the test case.");
+
+  atomic_ref_stress_test::run_atomicity_with_host_code<double>{}("double");
+#else
+  SKIP("std::atomic_ref is not available");
+#endif
+});
+
 }  // namespace atomic_ref_stress_test_atomic64

--- a/tests/atomic_ref_stress/atomic_ref_stress_core.cpp
+++ b/tests/atomic_ref_stress/atomic_ref_stress_core.cpp
@@ -60,4 +60,22 @@ DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
   for_all_types<atomic_ref_stress_test::run_ordering>(type_pack);
 });
 
+DISABLED_FOR_TEST_CASE(ComputeCpp, hipSYCL)
+("sycl::atomic_ref atomicity with respect to atomic operations in host code. "
+ "core types",
+ "[atomic_ref_stress]")({
+#ifdef __cpp_lib_atomic_ref
+  auto queue = once_per_unit::get_queue();
+  if (!queue.get_device().has(sycl::aspect::usm_atomic_shared_allocations))
+    SKIP(
+        "Device does not support usm_atomic_shared_allocations. "
+        "Skipping the test case.");
+  const auto type_pack = named_type_pack<int, float>::generate("int", "float");
+  for_all_types<atomic_ref_stress_test::run_atomicity_with_host_code>(
+      type_pack);
+#else
+  SKIP("std::atomic_ref is not available");
+#endif
+});
+
 }  // namespace atomic_ref_stress_test_core


### PR DESCRIPTION
Add sycl::atomic_ref stress tests according to  test plan section [3.2.5. Atomicity with respect to atomic operations in host code](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/atomic_ref.asciidoc#325-atomicity-with-respect-to-atomic-operations-in-host-code).