### PR TITLE
Setting correct target for res_acc

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -387,7 +387,7 @@ void check_def_constructor(GetAccFunctorT get_accessor_functor) {
 
     queue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor res_acc(res_buf, cgh);
+          sycl::accessor<bool, 1, sycl::access_mode::read_write, Target> res_acc(res_buf, cgh);
           auto acc = get_accessor_functor();
           if constexpr (AccType == accessor_type::generic_accessor) {
             if (acc.is_placeholder()) {
@@ -442,7 +442,7 @@ void check_zero_length_buffer_constructor(GetAccFunctorT get_accessor_functor) {
 
     queue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor res_acc(res_buf);
+          sycl::accessor<bool, 1, sycl::access_mode::read_write, Target> res_acc(res_buf);
           auto acc = get_accessor_functor(data_buf, cgh);
           if constexpr (Target == sycl::target::host_task) {
             cgh.host_task([=] {
@@ -547,7 +547,7 @@ void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor,
 
     queue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor res_acc(res_buf, cgh);
+          sycl::accessor<bool, 1, sycl::access_mode::read_write, Target> res_acc(res_buf, cgh);
 
           auto acc = get_accessor_functor(data_buf, cgh);
           if constexpr (AccType == accessor_type::generic_accessor) {
@@ -663,7 +663,7 @@ void check_common_constructor(const sycl::range<Dimension>& r,
 
     queue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor res_acc(res_buf, cgh);
+          sycl::accessor<bool, 1, sycl::access_mode::read_write, Target> res_acc(res_buf, cgh);
           auto acc = get_accessor_functor(data_buf, cgh);
 
           if constexpr (AccType == accessor_type::generic_accessor) {
@@ -934,7 +934,7 @@ void check_no_init_prop(GetAccFunctorT get_accessor_functor,
 
     queue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor res_acc(res_buf, cgh);
+          sycl::accessor<bool, 1, sycl::access_mode::read_write, Target> res_acc(res_buf, cgh);
 
           auto acc = get_accessor_functor(data_buf, cgh);
 
@@ -1308,7 +1308,7 @@ void check_linearization() {
             sycl::accessor<T, dims, AccessMode, Target> acc(data_buf, cgh);
 
             if constexpr (Target == sycl::target::device) {
-              sycl::accessor res_acc(res_buf, cgh);
+              sycl::accessor<bool, 1, sycl::access_mode::read_write, Target> res_acc(res_buf, cgh);
               cgh.single_task([=] {
                 sycl::id<dims> id{};
                 for (auto& elem : acc) {


### PR DESCRIPTION
According to SYCL2020 [4.7.6.9](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_buffer_accessor_for_commands):
```
Programs which specify the access target as target::device and then capture the accessor in a [host task](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#host-task) can only use the accessor for interoperability through the interop_handle, any other uses result in undefined behavior.
```
This PR enforces the right target for `res_acc`.