### PR TITLE
Test plan for oneapi "queue empty" extension

### DIFF
--- a/test_plans/oneapi_queue_empty.asciidoc
+++ b/test_plans/oneapi_queue_empty.asciidoc
@@ -45,7 +45,7 @@ queue are completed and `false` otherwise.
 ===== Test 1:
 
 * Create queue
-* Define and submit two kernels performing some actions in long loop, save
+* Define and submit a kernel performing some actions in long loop, save
   returned event E
 * Call `ext_oneapi_empty()`
 * If `E.get_info<command_execution_status>() != complete` check that returned

--- a/test_plans/oneapi_queue_empty.asciidoc
+++ b/test_plans/oneapi_queue_empty.asciidoc
@@ -5,7 +5,7 @@
 
 This is a test plan for the extension adding a new API that tells whether a
 queue is empty. The extension is described in
-https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc[sycl_ext_oneapi_local_memory.asciidoc].
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_queue_empty.asciidoc[sycl_ext_oneapi_queue_empty.asciidoc].
 
 == Testing scope
 
@@ -13,14 +13,6 @@ https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_o
 
 All of the tests described below are performed only on the default device that
 is selected on the CTS command line.
-
-[NOTE]
-====
-Currently the extension support for OpenCL backend is limited, API 
-introduced by this extension can be called only for `in-order` queues which
-doesn’t have `discard_events` property. So the queue used for the tests should
-be created with `in-order` property if backend is OpenCL.
-====
 
 === Feature test macro
 
@@ -53,9 +45,11 @@ queue are completed and `false` otherwise.
 ===== Test 1:
 
 * Create queue
-* Define and submit two kernels performing some actions in long loop
+* Define and submit two kernels performing some actions in long loop, save
+  returned event E
 * Call `ext_oneapi_empty()`
-* Check that returned value is `false`
+* If `E.get_info<command_execution_status>() != complete` check that returned
+  value of `ext_oneapi_empty()` is `false`
 * Call `wait()` for the queue
 * Call `ext_oneapi_empty()` again
 * Check that returned value is `true`
@@ -70,7 +64,8 @@ queue are completed and `false` otherwise.
 * Submit kernel `A` and `B`, save events `Ea` and `Eb`
 * Call `wait()` for event `Ea`
 * Call `ext_oneapi_empty()`
-* Check that returned value is `false`
+* If `Eb.get_info<command_execution_status>() != complete` check that returned
+  value of `ext_oneapi_empty()` is `false`
 * Call `wait()` for event `Eb`
 * Call `ext_oneapi_empty()` again
 * Check that returned value is `true`

--- a/test_plans/oneapi_queue_empty.asciidoc
+++ b/test_plans/oneapi_queue_empty.asciidoc
@@ -1,0 +1,76 @@
+:sectnums:
+:xrefstyle: short
+
+= Test plan for sycl extension oneapi queue empty
+
+This is a test plan for the extension adding a new API that tells whether a
+queue is empty. The extension is described in
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc[sycl_ext_oneapi_local_memory.asciidoc].
+
+== Testing scope
+
+=== Device coverage
+
+All of the tests described below are performed only on the default device that
+is selected on the CTS command line.
+
+[NOTE]
+====
+Currently the extension support for OpenCL backend is limited, API 
+introduced by this extension can be called only for `in-order` queues which
+doesn’t have `discard_events` property. So the queue used for the tests should
+be created with `in-order` property if backend is OpenCL.
+====
+
+=== Feature test macro
+
+All of the tests should use `#ifdef SYCL_EXT_ONEAPI_QUEUE_EMPTY` so they can
+be skipped if feature is not supported.
+
+== Tests
+
+Extension introduces the following member function for the `sycl::queue` class:
+
+[source, c++]
+----
+bool ext_oneapi_empty() const
+----
+
+We should check the function returns `true` when all commands submitted to the
+queue are completed and `false` otherwise.
+
+=== Test description
+
+==== `ext_oneapi_empty()` is called when no commands are submitted
+
+* Create queue
+* Call `ext_oneapi_empty()`
+* Check the type of returned value
+* Check that returned value is `true`
+
+==== `ext_oneapi_empty()` is called after commands submission
+
+===== Test 1:
+
+* Create queue
+* Define and submit two kernels performing some actions in long loop
+* Call `ext_oneapi_empty()`
+* Check that returned value is `false`
+* Call `wait()` for the queue
+* Call `ext_oneapi_empty()` again
+* Check that returned value is `true`
+
+===== Test 2:
+
+* Create queue
+* Define two kernels performing some actions in long loop, let it be kernels
+  `A` and `B`
+* Kernel `B` must depends on kernel `A` so that it can only be started its work
+  after kernel `A` has completed
+* Submit kernel `A` and `B`, save events `Ea` and `Eb`
+* Call `wait()` for event `Ea`
+* Call `ext_oneapi_empty()`
+* Check that returned value is `false`
+* Call `wait()` for event `Eb`
+* Call `ext_oneapi_empty()` again
+* Check that returned value is `true`


### PR DESCRIPTION
Added test plan according to the [spec](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_queue_empty.asciidoc).