### PR TITLE
[group_functions] Reduce test size to avoid overflow

### DIFF
--- a/tests/group_functions/group_reduce.h
+++ b/tests/group_functions/group_reduce.h
@@ -23,7 +23,8 @@
 #include "group_functions_common.h"
 #include <optional>
 
-constexpr size_t init = 1412;
+constexpr size_t init = 8;
+constexpr size_t test_size = 4;
 static const auto Dims = integer_pack<1, 2, 3>::generate_unnamed();
 
 template <bool with_init, typename OpT, typename IteratorT>
@@ -103,7 +104,7 @@ void joint_reduce_group(sycl::queue& queue, const std::string& op_name) {
       "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, Ptr "
       "first, Ptr last, BinaryOperation binary_op)"};
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -209,7 +210,7 @@ void init_joint_reduce_group(sycl::queue& queue, const std::string& op_name) {
       "T joint_reduce(sub_group g, Ptr first, Ptr last, T init, "
       "BinaryOperation binary_op)"};
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -315,7 +316,7 @@ void reduce_over_group(sycl::queue& queue, const std::string& op_name) {
       "T reduce_over_group(group g, T x, BinaryOperation binary_op)",
       "T reduce_over_group(sub_group g, T x, BinaryOperation binary_op)"};
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   bool res = false;
@@ -432,7 +433,7 @@ void init_reduce_over_group(sycl::queue& queue, const std::string& op_name) {
       "T reduce_over_group(sub_group g, V x, T init, BinaryOperation "
       "binary_op)"};
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue);
+  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   bool res = false;

--- a/tests/group_functions/group_reduce.h
+++ b/tests/group_functions/group_reduce.h
@@ -104,7 +104,8 @@ void joint_reduce_group(sycl::queue& queue, const std::string& op_name) {
       "std::iterator_traits<Ptr>::value_type joint_reduce(sub_group g, Ptr "
       "first, Ptr last, BinaryOperation binary_op)"};
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
+  sycl::range<D> work_group_range =
+      sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -210,7 +211,8 @@ void init_joint_reduce_group(sycl::queue& queue, const std::string& op_name) {
       "T joint_reduce(sub_group g, Ptr first, Ptr last, T init, "
       "BinaryOperation binary_op)"};
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
+  sycl::range<D> work_group_range =
+      sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
@@ -316,7 +318,8 @@ void reduce_over_group(sycl::queue& queue, const std::string& op_name) {
       "T reduce_over_group(group g, T x, BinaryOperation binary_op)",
       "T reduce_over_group(sub_group g, T x, BinaryOperation binary_op)"};
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
+  sycl::range<D> work_group_range =
+      sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   bool res = false;
@@ -433,7 +436,8 @@ void init_reduce_over_group(sycl::queue& queue, const std::string& op_name) {
       "T reduce_over_group(sub_group g, V x, T init, BinaryOperation "
       "binary_op)"};
 
-  sycl::range<D> work_group_range = sycl_cts::util::work_group_range<D>(queue, test_size);
+  sycl::range<D> work_group_range =
+      sycl_cts::util::work_group_range<D>(queue, test_size);
   size_t work_group_size = work_group_range.size();
 
   bool res = false;


### PR DESCRIPTION
This avoids meaningless overflowed results for reducing over smaller types (e.g. `char`).

Signed-off-by: Yilong Guo <yilong.guo@intel.com>
Co-authored-by: Jie Zhang <jiez.zhang@intel.com>