### PR TITLE
Cover gap for local_accessor ctor

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -341,8 +341,8 @@ struct tag_factory<accessor_type::host_accessor> {
  * @param res_acc Instance of result accessor
  */
 template <typename TestingAccT, typename ResultAccT>
-void check_empty_accessor_constructor_post_conditions(TestingAccT testing_acc,
-                                                      ResultAccT res_acc) {
+void check_empty_accessor_constructor_post_conditions(
+    TestingAccT testing_acc, ResultAccT res_acc, bool check_iterator_methods) {
   size_t res_i = 0;
   // (empty() == true)
   res_acc[res_i++] = testing_acc.empty() == true;
@@ -352,11 +352,13 @@ void check_empty_accessor_constructor_post_conditions(TestingAccT testing_acc,
   res_acc[res_i++] = testing_acc.size() == 0;
   res_acc[res_i++] = testing_acc.max_size() == 0;
 
-  // The only iterator that can be obtained is nullptr
-  res_acc[res_i++] = testing_acc.begin() == testing_acc.end();
-  res_acc[res_i++] = testing_acc.cbegin() == testing_acc.cend();
-  res_acc[res_i++] = testing_acc.rbegin() == testing_acc.rend();
-  res_acc[res_i++] = testing_acc.crbegin() == testing_acc.crend();
+  if (check_iterator_methods) {
+    // The only iterator that can be obtained is nullptr
+    res_acc[res_i++] = testing_acc.begin() == testing_acc.end();
+    res_acc[res_i++] = testing_acc.cbegin() == testing_acc.cend();
+    res_acc[res_i++] = testing_acc.rbegin() == testing_acc.rend();
+    res_acc[res_i++] = testing_acc.crbegin() == testing_acc.crend();
+  }
 }
 // FIXME: re-enable when handler.host_task and sycl::errc is implemented in
 // hipsycl and computcpp
@@ -380,35 +382,16 @@ void check_def_constructor(GetAccFunctorT get_accessor_functor) {
   auto queue = once_per_unit::get_queue();
   sycl::range<1> r(1);
   const size_t conditions_checks_size = 8;
-  bool conditions_check[conditions_checks_size]{false};
+  bool conditions_check[conditions_checks_size];
+  std::fill(conditions_check, conditions_check + conditions_checks_size, true);
 
+  auto acc = get_accessor_functor();
   if constexpr (AccType != accessor_type::host_accessor) {
-    sycl::buffer res_buf(conditions_check, sycl::range(conditions_checks_size));
-
-    queue
-        .submit([&](sycl::handler& cgh) {
-          sycl::accessor<bool, 1, sycl::access_mode::read_write, Target>
-              res_acc(res_buf, cgh);
-          auto acc = get_accessor_functor();
-          if constexpr (AccType == accessor_type::generic_accessor) {
-            if (acc.is_placeholder()) {
-              cgh.require(acc);
-            }
-          }
-          if constexpr (Target == sycl::target::host_task) {
-            cgh.host_task([=] {
-              check_empty_accessor_constructor_post_conditions(acc, res_acc);
-            });
-          } else if constexpr (Target == sycl::target::device) {
-            cgh.parallel_for_work_group(r, [=](sycl::group<1>) {
-              check_empty_accessor_constructor_post_conditions(acc, res_acc);
-            });
-          }
-        })
-        .wait_and_throw();
+    check_empty_accessor_constructor_post_conditions(acc, conditions_check,
+                                                     false);
   } else {
-    auto acc = get_accessor_functor();
-    check_empty_accessor_constructor_post_conditions(acc, conditions_check);
+    check_empty_accessor_constructor_post_conditions(acc, conditions_check,
+                                                     true);
   }
 
   for (size_t i = 0; i < conditions_checks_size; i++) {
@@ -436,7 +419,8 @@ void check_zero_length_buffer_constructor(GetAccFunctorT get_accessor_functor) {
       util::get_cts_object::range<Dimension>::get(0, 0, 0);
   sycl::buffer<DataT, Dimension> data_buf(r);
   const size_t conditions_checks_size = 8;
-  bool conditions_check[conditions_checks_size]{false};
+  bool conditions_check[conditions_checks_size];
+  std::fill(conditions_check, conditions_check + conditions_checks_size, true);
 
   if constexpr (AccType != accessor_type::host_accessor) {
     sycl::buffer res_buf(conditions_check, sycl::range(conditions_checks_size));
@@ -448,18 +432,18 @@ void check_zero_length_buffer_constructor(GetAccFunctorT get_accessor_functor) {
           auto acc = get_accessor_functor(data_buf, cgh);
           if constexpr (Target == sycl::target::host_task) {
             cgh.host_task([=] {
-              check_empty_accessor_constructor_post_conditions(acc, res_acc);
+              check_empty_accessor_constructor_post_conditions(acc, res_acc, false);
             });
           } else if constexpr (Target == sycl::target::device) {
             cgh.parallel_for_work_group(r, [=](sycl::group<Dimension>) {
-              check_empty_accessor_constructor_post_conditions(acc, res_acc);
+              check_empty_accessor_constructor_post_conditions(acc, res_acc, false);
             });
           }
         })
         .wait_and_throw();
   } else {
     auto acc = get_accessor_functor(data_buf);
-    check_empty_accessor_constructor_post_conditions(acc, conditions_check);
+    check_empty_accessor_constructor_post_conditions(acc, conditions_check, true);
   }
 
   for (size_t i = 0; i < conditions_checks_size; i++) {
@@ -590,7 +574,9 @@ void check_zero_dim_constructor(GetAccFunctorT get_accessor_functor,
     compare_res = compare_res_arr[0];
   }
 
-  if constexpr (AccessMode != sycl::access_mode::write) {
+  if constexpr (AccessMode != sycl::access_mode::write &&
+                !(accessor_type::local_accessor == AccType &&
+                  sycl::access_mode::read == AccessMode)) {
     CHECK(compare_res);
   }
 
@@ -707,7 +693,9 @@ void check_common_constructor(const sycl::range<Dimension>& r,
     compare_res = compare_res_arr[0];
   }
 
-  if constexpr (AccessMode != sycl::access_mode::write) {
+  if constexpr (AccessMode != sycl::access_mode::write &&
+                !(accessor_type::local_accessor == AccType &&
+                  sycl::access_mode::read == AccessMode)) {
     CHECK(compare_res);
   }
 

--- a/tests/accessor/local_accessor_constructors.h
+++ b/tests/accessor/local_accessor_constructors.h
@@ -2,6 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 //  Provides tests for sycl::local_accessor constructors
 //
 *******************************************************************************/
@@ -16,6 +30,26 @@ using namespace sycl_cts;
 using namespace accessor_tests_common;
 
 constexpr accessor_type AccType = accessor_type::local_accessor;
+
+/**
+ * @brief Functor to assign value to local accessor
+ * @tparam AccT accessor type
+ * @tparam Dimension AccT dimension
+ * @param src_acc Instance of a source accessor type
+ */
+template <typename AccT, int Dimension>
+struct assign_value_to_accessor {
+  auto operator()(const AccT& acc) const {
+    AccT result(acc);
+    if constexpr (0 != Dimension) {
+      value_operations::assign(result[sycl::id<Dimension>()], expected_val);
+    } else {
+      typename AccT::value_type& ref = result;
+      value_operations::assign(ref, expected_val);
+    }
+    return result;
+  }
+};
 
 template <typename DataT, int Dimension>
 void test_default_constructor(const std::string& type_name) {
@@ -41,18 +75,19 @@ template <typename DataT>
 void test_zero_dimension_buffer_constructor(const std::string& type_name) {
   const auto section_name =
       get_section_name<0>(type_name, "Zero dimension constructor");
+  using Acc = sycl::local_accessor<DataT, 0>;
 
   SECTION(section_name) {
     auto get_acc_functor = [](sycl::buffer<DataT, 1>& data_buf,
-                              sycl::handler& cgh) {
-      return sycl::local_accessor<DataT, 0>(cgh);
-    };
+                              sycl::handler& cgh) { return Acc(cgh); };
     if constexpr (std::is_const_v<DataT>) {
       check_zero_dim_constructor<AccType, DataT, sycl::access_mode::read,
                                  sycl::target::device>(get_acc_functor);
     } else {
+      const assign_value_to_accessor<Acc, 0> modify_acc_functor;
       check_zero_dim_constructor<AccType, DataT, sycl::access_mode::read_write,
-                                 sycl::target::device>(get_acc_functor);
+                                 sycl::target::device>(get_acc_functor,
+                                                       modify_acc_functor);
     }
   }
 }
@@ -61,23 +96,59 @@ template <typename DataT, int Dimension>
 void test_common_constructors(const std::string& type_name) {
   const auto r = util::get_cts_object::range<Dimension>::get(1, 1, 1);
   const auto offset = sycl::id<Dimension>();
+  using Acc = sycl::local_accessor<DataT, Dimension>;
 
   auto section_name =
       get_section_name<Dimension>(type_name, "From sycl::range constructor");
 
   SECTION(section_name) {
     auto get_acc_functor = [r](sycl::buffer<DataT, Dimension>& data_buf,
+                               sycl::handler& cgh) { return Acc(r, cgh); };
+    if constexpr (std::is_const_v<DataT>) {
+      check_common_constructor<AccType, DataT, Dimension,
+                               sycl::access_mode::read, sycl::target::device>(
+          r, get_acc_functor);
+    } else {
+      const assign_value_to_accessor<Acc, Dimension> modify_acc_functor;
+      check_common_constructor<AccType, DataT, Dimension,
+                               sycl::access_mode::read_write,
+                               sycl::target::device>(r, get_acc_functor,
+                                                     modify_acc_functor);
+    }
+  }
+}
+
+template <typename DataT, int Dimension>
+void test_constructor_with_empty_property_list(const std::string& type_name) {
+  constexpr int buf_dims = (0 == Dimension) ? 1 : Dimension;
+  const auto r = util::get_cts_object::range<buf_dims>::get(1, 1, 1);
+  const sycl::property_list prop_list;
+  using Acc = sycl::local_accessor<DataT, Dimension>;
+
+  auto section_name = get_section_name<Dimension>(
+      type_name, "From constructor with empty property list");
+
+  SECTION(section_name) {
+    auto get_acc_functor = [&](sycl::buffer<DataT, buf_dims>& data_buf,
                                sycl::handler& cgh) {
-      return sycl::local_accessor<DataT, Dimension>(r, cgh);
+      if constexpr (0 != Dimension) {
+        auto acc = Acc(r, cgh, prop_list);
+        return acc;
+      } else {
+        auto acc = Acc(cgh, prop_list);
+        return acc;
+      }
     };
     if constexpr (std::is_const_v<DataT>) {
       check_common_constructor<AccType, DataT, Dimension,
                                sycl::access_mode::read, sycl::target::device>(
           r, get_acc_functor);
     } else {
+      const assign_value_to_accessor<Acc, Dimension> modify_acc_functor;
       check_common_constructor<AccType, DataT, Dimension,
                                sycl::access_mode::read_write,
-                               sycl::target::device>(r, get_acc_functor);
+                               sycl::target::device>(r, get_acc_functor,
+                                                     modify_acc_functor);
     }
   }
 }
@@ -91,6 +162,7 @@ class run_tests_constructors {
     test_zero_dimension_buffer_constructor<T>(type_name);
     test_default_constructor<T, Dimension>(type_name);
     test_common_constructors<T, Dimension>(type_name);
+    test_constructor_with_empty_property_list<T, Dimension>(type_name);
   }
 };
 

--- a/tests/accessor/local_accessor_constructors_core.cpp
+++ b/tests/accessor/local_accessor_constructors_core.cpp
@@ -2,6 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 //  Provides sycl::local_accessor constructors test for generic types
 //
 *******************************************************************************/

--- a/tests/accessor/local_accessor_constructors_fp16.cpp
+++ b/tests/accessor/local_accessor_constructors_fp16.cpp
@@ -2,6 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 //  Provides sycl::local_accessor test for the sycl::half type
 //
 *******************************************************************************/

--- a/tests/accessor/local_accessor_constructors_fp64.cpp
+++ b/tests/accessor/local_accessor_constructors_fp64.cpp
@@ -2,6 +2,20 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 //  Provides sycl::local_accessor test for the double type
 //
 *******************************************************************************/


### PR DESCRIPTION
Added test for local_accessor ctor with empty property_list. Fixed checks in check_empty_accessor_constructor_post_conditions for accessor constructed with def ctor. Added accessor modifier to local_accessor common_constructor test for correct checking.