### PR TITLE
Add -fsycl-link-huge-device-code linker flags for DPCPP

### DIFF
--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -41,6 +41,12 @@ set(CMAKE_CXX_FLAGS "${DPCPP_FP_FLAG} ${CMAKE_CXX_FLAGS}")
 # Disable range rounding feature to reduce # of SYCL kernels.
 set(CMAKE_CXX_FLAGS "-D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ ${CMAKE_CXX_FLAGS}")
 
+# Set flag to allow linking of large device code files. This option is currently
+# not available on Windows.
+if(NOT WIN32)
+    set(CMAKE_CXX_LINK_FLAGS "-fsycl-link-huge-device-code ${CMAKE_CXX_LINK_FLAGS}")
+endif()
+
 option(DPCPP_DISABLE_SYCL2020_DEPRECATION_WARNINGS
   "Disable SYCL 2020 deprecation warnings" ON)
 if(DPCPP_DISABLE_SYCL2020_DEPRECATION_WARNINGS)


### PR DESCRIPTION
This commit adds the -fsycl-link-huge-device-code to the linker flags for DPC++. This allows the linking of very large device-code object files, which can be produced by select categories in the CTS in full conformance mode. This flag is currently not supported on Windows.