### PR TITLE
Remove invalid use of get_pointer on placeholder accessor

### DIFF
--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -161,25 +161,17 @@ class run_api_tests {
       bool res = false;
       {
         sycl::buffer<T, buf_dims> data_buf(&data, r);
-        sycl::buffer res_buf(&res, sycl::range(1));
-        queue
-            .submit([&](sycl::handler &cgh) {
-              AccT acc(data_buf);
+        AccT acc(data_buf);
 
-              test_accessor_methods(acc, sizeof(T) /* expected_byte_size*/,
-                                    1 /*expected_size*/,
-                                    true /*expected_isPlaceholder*/);
-              if constexpr (0 < dims) {
-                test_accessor_range_methods(
-                    acc,
-                    util::get_cts_object::range<dims>::get(
-                        1, 1, 1) /*expected_range*/,
-                    sycl::id<dims>() /*&expected_offset*/);
-              }
-
-              test_accessor_ptr(acc, data);
-            })
-            .wait_and_throw();
+        test_accessor_methods(acc, sizeof(T) /* expected_byte_size*/,
+                              1 /*expected_size*/,
+                              true /*expected_isPlaceholder*/);
+        if constexpr (0 < dims) {
+          test_accessor_range_methods(acc,
+                                      util::get_cts_object::range<dims>::get(
+                                          1, 1, 1) /*expected_range*/,
+                                      sycl::id<dims>() /*&expected_offset*/);
+        }
       }
     }
 

--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -166,7 +166,7 @@ class run_api_tests {
         test_accessor_methods(acc, sizeof(T) /* expected_byte_size*/,
                               1 /*expected_size*/,
                               true /*expected_isPlaceholder*/);
-        if constexpr (0 < dims) {
+        if constexpr (dims > 0) {
           test_accessor_range_methods(acc,
                                       util::get_cts_object::range<dims>::get(
                                           1, 1, 1) /*expected_range*/,


### PR DESCRIPTION
The SYCL specification states that get_pointer on an accessor or local_accessor can only be called inside a command. This commit fixes a use of get_pointer outside a command. Additionally it moves the surrounding code out of the encapsulating submission.