### PR TITLE
Cover gaps for explicit memory operation copy(acc, acc)

### DIFF
--- a/tests/handler/handler_copy_common.h
+++ b/tests/handler/handler_copy_common.h
@@ -831,6 +831,7 @@ static void test_write_acc_copy_functions(log_helper lh,
             "copy(accessor<$dataT, $dim_src, $mode_src, $target>, "
             "accessor<$dataT, $dim_dst, $mode_dst, $target>)"));
   }
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS  
   {
     if constexpr (mode_src == mode_t::read) {
       // Check copy(accessor, accessor) with constant_buffer target
@@ -851,6 +852,7 @@ static void test_write_acc_copy_functions(log_helper lh,
               "accessor<$dataT, $dim_dst, $mode_dst, $target>)"));
     };
   }
+#endif
   {
     // Check fill(accessor, dataT)
     const auto pattern = type_helper<dataT>::make(117);
@@ -1051,6 +1053,7 @@ class CheckCopyAccToAccException {
           sycl_cts::util::equals_exception(sycl::errc::invalid));
     }
 
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
     if constexpr (mode_src == mode_t::read) {
       auto check_exception_with_invalid_dst_range_constant_buffer = [&] {
         q.submit([&](sycl::handler& cgh) {
@@ -1069,6 +1072,7 @@ class CheckCopyAccToAccException {
           sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
     }
+#endif
   }
 };
 

--- a/tests/handler/handler_copy_common.h
+++ b/tests/handler/handler_copy_common.h
@@ -831,7 +831,7 @@ static void test_write_acc_copy_functions(log_helper lh,
             "copy(accessor<$dataT, $dim_src, $mode_src, $target>, "
             "accessor<$dataT, $dim_dst, $mode_dst, $target>)"));
   }
-#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS  
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
   {
     if constexpr (mode_src == mode_t::read) {
       // Check copy(accessor, accessor) with constant_buffer target

--- a/tests/handler/handler_copy_common.h
+++ b/tests/handler/handler_copy_common.h
@@ -969,6 +969,8 @@ static void test_all_variants(log_helper lh, sycl::queue& queue) {
   test_all_dimensions<dataT, true, true>(lh, queue);
 }
 
+// FIXME: re-enable when sycl::errc is implemented in computecpp
+#ifndef SYCL_CTS_COMPILING_WITH_COMPUTECPP
 /**
  * @brief Class provides a test that checks if exception is thrown on explicit
  * memory operation copy(acc, acc) in case of destination accessor range less
@@ -1072,9 +1074,9 @@ class CheckCopyAccToAccException {
           sycl::exception,
           sycl_cts::util::equals_exception(sycl::errc::invalid));
     }
-#endif
+#endif  // SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
   }
 };
-
+#endif  // SYCL_CTS_COMPILING_WITH_COMPUTECPP
 }  // namespace handler_copy_common
 #endif  // __SYCLCTS_TESTS_HANDLER_COPY_COMMON_H

--- a/tests/handler/handler_copy_core.cpp
+++ b/tests/handler/handler_copy_core.cpp
@@ -14,6 +14,8 @@
 
 #include "../common/string_makers.h"
 
+#include "../common/disabled_for_test_case.h"
+
 namespace handler_copy_core {
 using namespace handler_copy_common;
 
@@ -38,10 +40,11 @@ TEST_CASE("Tests the API for sycl::handler::copy", "[handler]") {
 #endif
 }
 
-TEST_CASE(
-    "Check exception on copy(accessor, accessor) in case of invalid "
-    "destination accessor size",
-    "[handler]") {
+// FIXME: re-enable when sycl::errc is implemented in computecpp
+DISABLED_FOR_TEST_CASE(ComputeCpp)
+("Check exception on copy(accessor, accessor) in case of invalid "
+ "destination accessor size",
+ "[handler]")({
   auto queue = util::get_cts_object::queue();
 
   const auto types =
@@ -75,6 +78,6 @@ TEST_CASE(
 
   for_all_combinations<CheckCopyAccToAccException>(types, dims, dims, src_modes,
                                                    dst_modes, queue);
-}
+});
 
 }  // namespace handler_copy_core


### PR DESCRIPTION
Added checking of `copy(acc, acc)` operation with source accessor which target is `constant_buffer`.
Added checking if exception is thrown on `copy(acc, acc)` operation in case of destination memory size is too small.