### PR TITLE
Cover gaps in oneapi_sub_group_mask extension

### DIFF
--- a/tests/common/type_coverage.h
+++ b/tests/common/type_coverage.h
@@ -606,7 +606,7 @@ void for_type_and_marrays(argsT &&...args) {
  */
 template <template <typename, typename...> class action, typename T,
           typename... actionArgsT, typename... argsT>
-void for_marrays_of_type(argsT &&...args) {
+void for_marrays_of_type(argsT&&... args) {
   for_all_types<action, actionArgsT...>(
       type_pack<typename sycl::template marray<T, 2>,
                 typename sycl::template marray<T, 5>,
@@ -657,8 +657,8 @@ void for_all_types_and_marrays(const named_type_pack<types...> &typeList,
  */
 template <template <typename, typename...> class action,
           typename... actionArgsT, typename... types, typename... argsT>
-void for_marrays_of_all_types(const named_type_pack<types...> &typeList,
-                              argsT &&...args) {
+void for_marrays_of_all_types(const named_type_pack<types...>& typeList,
+                              argsT&&... args) {
   // run action for each type from types... parameter pack
   // Using fold expression to iterate over all types within type pack
 

--- a/tests/common/type_coverage.h
+++ b/tests/common/type_coverage.h
@@ -57,7 +57,7 @@ struct type_name_string<sycl::vec<T, nElements>> {
   }
 };
 
-// FIXME: re-enable when marrray is implemented in hipsycl
+// FIXME: re-enable when marray is implemented in hipsycl
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Specialization of type name retrieve for sycl::marray class
@@ -457,7 +457,7 @@ void for_all_types_and_vectors(const named_type_pack<types...> &typeList,
   assert((typeNameIndex == sizeof...(types)) && "Pack expansion failed");
 }
 
-// FIXME: re-enable when marrray is implemented in hipsycl
+// FIXME: re-enable when marray is implemented in hipsycl
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Run action for type, vectors and marrays of this type
@@ -542,7 +542,7 @@ void for_type_vectors_marray_reduced(argsT&&... args) {
 }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 
-// FIXME: re-enable when marrray is implemented in hipsycl
+// FIXME: re-enable when marray is implemented in hipsycl
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Run action for each of types, vectors and marrays of types given by
@@ -573,7 +573,7 @@ void for_all_types_vectors_marray(const named_type_pack<types...> &typeList,
 }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 
-// FIXME: re-enable when marrray is implemented in hipsycl
+// FIXME: re-enable when marray is implemented in hipsycl
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Run action for type and marrays of this type
@@ -594,7 +594,28 @@ void for_type_and_marrays(argsT &&...args) {
 }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 
-// FIXME: re-enable when marrray is implemented in hipsycl
+// FIXME: re-enable when marray is implemented in hipsycl
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+/**
+ * @brief Run action for marrays of type T
+ * @tparam action Functor template for action to run
+ * @tparam T Type to instantiate functor template with
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action, typename T,
+          typename... actionArgsT, typename... argsT>
+void for_marrays_of_type(argsT &&...args) {
+  for_all_types<action, actionArgsT...>(
+      type_pack<typename sycl::template marray<T, 2>,
+                typename sycl::template marray<T, 5>,
+                typename sycl::template marray<T, 10>>{},
+      std::forward<argsT>(args)...);
+}
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+// FIXME: re-enable when marray is implemented in hipsycl
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL
 /**
  * @brief Run action for each of types and marrays of types given by
@@ -616,6 +637,34 @@ void for_all_types_and_marrays(const named_type_pack<types...> &typeList,
   size_t typeNameIndex = 0;
 
   ((for_type_and_marrays<action, types, actionArgsT...>(
+        std::forward<argsT>(args)..., typeList.names[typeNameIndex]),
+    ++typeNameIndex),
+   ...);
+}
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+// FIXME: re-enable when marray is implemented in hipsycl
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+/**
+ * @brief Run action for marrays of each type of types given by
+ *        named_type_pack instance
+ * @tparam action Functor template for action to run
+ * @tparam actionArgsT Parameter pack to use for functor template instantiation
+ * @tparam types Deduced from type_pack parameter pack for list of types to use
+ * @tparam argsT Deduced parameter pack for arguments to forward into the call
+ * @param typeList Named type pack instance with underlying type names stored
+ * @param args Arguments to forward into the call
+ */
+template <template <typename, typename...> class action,
+          typename... actionArgsT, typename... types, typename... argsT>
+void for_marrays_of_all_types(const named_type_pack<types...> &typeList,
+                              argsT &&...args) {
+  // run action for each type from types... parameter pack
+  // Using fold expression to iterate over all types within type pack
+
+  size_t typeNameIndex = 0;
+
+  ((for_marrays_of_type<action, types, actionArgsT...>(
         std::forward<argsT>(args)..., typeList.names[typeNameIndex]),
     ++typeNameIndex),
    ...);

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_all.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_all.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask all()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_all
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_all_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -45,32 +59,22 @@ using verification_func_for_true_predicate =
                    true_predicate, const sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check all() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    log.note("Check all() for mask with even predicate");
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
-
-    log.note("Check all() for mask with true predicate");
-    check_diff_sub_group_sizes<verification_func_for_true_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
 };
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
+TEST_CASE("Check all() for mask with true predicate",
+          "[oneapi_sub_group_mask]") {
+#ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
+  check_diff_sub_group_sizes<verification_func_for_true_predicate>();
+#else
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+};
 
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_all_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_any.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_any.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask any()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_any
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_any_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -45,33 +59,22 @@ using verification_func_for_false_predicate =
                    false_predicate, const sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check any() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    log.note("Check any() for mask with even predicate");
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
-
-    log.note("Check any() for mask with false predicate");
-    check_diff_sub_group_sizes<verification_func_for_false_predicate>(log);
-
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
+TEST_CASE("Check any() for mask with false predicate",
+          "[oneapi_sub_group_mask]") {
+#ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
+  check_diff_sub_group_sizes<verification_func_for_false_predicate>();
+#else
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_any_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_common.h
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_common.h
@@ -175,7 +175,7 @@ struct check_mask_ctors {
     {
       auto buffer = sycl::buffer(resultArr.data(), globalRange);
 
-      testQueue.submit([&](sycl::handler &h) {
+      testQueue.submit([&](sycl::handler& h) {
         auto resultPtr =
             buffer.template get_access<sycl::access_mode::read_write>(h);
 

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_common.h
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_common.h
@@ -176,8 +176,7 @@ struct check_mask_ctors {
       auto buffer = sycl::buffer(resultArr.data(), globalRange);
 
       testQueue.submit([&](sycl::handler& h) {
-        auto resultPtr =
-            buffer.template get_access<sycl::access_mode::read_write>(h);
+        auto resultPtr = sycl::accessor(buffer, h, sycl::read_write);
 
         h.parallel_for(
             dataRange,

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_constructors.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_constructors.cpp
@@ -1,0 +1,192 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides tests to check sub_group_mask constructors()
+//
+*******************************************************************************/
+
+#include "catch2/catch_test_macros.hpp"
+
+#include "sub_group_mask_common.h"
+
+namespace sub_group_mask_constructors_test {
+
+using namespace sycl_cts;
+
+#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+template <typename T, size_t dim>
+void copy_ulong_long2marray(sycl::marray<T, dim>& marray,
+                            unsigned long long value) {
+  size_t elem_size = sizeof(T);
+  size_t num_bytes =
+      elem_size * dim > sizeof(value) ? sizeof(value) : elem_size * dim;
+  size_t shift = 0;
+  size_t i = 0;
+  while (shift + elem_size <= num_bytes && i < dim) {
+    memcpy(&(marray[i]), &value + shift, elem_size);
+    ++i;
+    shift += elem_size;
+  }
+}
+
+template <typename T, size_t dim>
+void copy_marray2ulong_long(unsigned long long& value,
+                            const sycl::marray<T, dim>& marray) {
+  size_t elem_size = sizeof(T);
+  size_t num_bytes =
+      elem_size * dim > sizeof(value) ? sizeof(value) : elem_size * dim;
+  size_t shift = 0;
+  size_t i = 0;
+  while (shift + elem_size <= num_bytes && i < dim) {
+    memcpy(&value + shift, &(marray[i]), elem_size);
+    ++i;
+    shift += elem_size;
+  }
+}
+
+bool compare_mask_and_init_value(sycl::ext::oneapi::sub_group_mask& mask,
+                                 unsigned long long init_value) {
+  for (size_t i = 0; i < mask.size(); ++i) {
+    if (mask[sycl::id<1>(i)] != (((init_value >> i) & 1))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T, size_t dim>
+bool compare_mask_and_init_value(sycl::ext::oneapi::sub_group_mask& mask,
+                                 const sycl::marray<T, dim>& val) {
+  unsigned long long result = 0;
+  size_t num_bytes = (sizeof(val) >= mask.size()) ? mask.size() : sizeof(val);
+  copy_marray2ulong_long(result, val);
+  return compare_mask_and_init_value(mask, result);
+}
+
+unsigned long long init_even_bits() {
+  unsigned long long value = 0;
+  for (size_t i = 0; i < CHAR_BIT * sizeof(value); i += 2) {
+    value |= 1UL << i;
+  }
+  return value;
+}
+
+template <typename T>
+res_array check_mask_constructors(sycl::ext::oneapi::sub_group_mask& mask,
+                                  T& value) {
+  res_array result;
+  result[ctor_error::ctor_wrong] = compare_mask_and_init_value(mask, value);
+  sycl::ext::oneapi::sub_group_mask copy(mask);
+  result[ctor_error::copy_ctor_wrong] =
+      compare_mask_and_init_value(copy, value);
+  auto assign = (copy = mask);
+  result[ctor_error::assign_type_wrong] =
+      std::is_same_v<decltype(assign), decltype(copy)>;
+  result[ctor_error::assign_wrong] = compare_mask_and_init_value(assign, value);
+  return result;
+}
+
+struct check_result_default_ctor {
+  res_array operator()(sycl::nd_item<1>& nd_item) {
+    sycl::ext::oneapi::sub_group_mask mask;
+    unsigned long long value = 0;
+    return check_mask_constructors(mask, value);
+  }
+};
+
+struct check_result_ctor_ulong_long {
+  res_array operator()(sycl::nd_item<1>& item) {
+    // Check for value = item.get_local_linear_id()
+    unsigned long long val = item.get_local_linear_id();
+    sycl::ext::oneapi::sub_group_mask mask(val);
+    res_array result = check_mask_constructors(mask, val);
+    // Check for value = 0b1010...
+    val = init_even_bits();
+    sycl::ext::oneapi::sub_group_mask mask_even(val);
+    result |= check_mask_constructors(mask_even, val);
+    return result;
+  }
+};
+
+template <typename T>
+struct check_result_ctor_marray {
+  res_array operator()(sycl::nd_item<1>& item) {
+    // Check for value = item.get_local_linear_id()
+    unsigned long long value = item.get_local_linear_id();
+    T val{};
+    copy_ulong_long2marray(val, value);
+    sycl::ext::oneapi::sub_group_mask mask(val);
+    res_array result = check_mask_constructors(mask, val);
+    // Check for value = 0b1010...
+    value = init_even_bits();
+    val = T{};
+    copy_ulong_long2marray(val, value);
+    sycl::ext::oneapi::sub_group_mask mask_even(val);
+    result |= check_mask_constructors(mask_even, val);
+    return result;
+  }
+};
+
+template <size_t SGSize>
+using verification_func_for_def_ctor =
+    check_mask_ctors<SGSize, check_result_default_ctor>;
+
+template <size_t SGSize>
+using verification_func_for_ulong_long_ctor =
+    check_mask_ctors<SGSize, check_result_ctor_ulong_long>;
+
+template <typename T>
+struct check_for_type {
+  template <size_t SGSize>
+  using verification_func_for_marray_ctor =
+      check_mask_ctors<SGSize, check_result_ctor_marray<T>>;
+
+  void operator()(const std::string& typeName) {
+    check_diff_sub_group_sizes<verification_func_for_marray_ctor>();
+  }
+};
+
+#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+
+TEST_CASE("Check sub_group_mask empty constructor", "[oneapi_sub_group_mask]") {
+#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+  check_diff_sub_group_sizes<verification_func_for_def_ctor>();
+#else
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined or revision less than 2");
+#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+};
+
+TEST_CASE("Check sub_group_mask(unsigned long long) constructor",
+          "[oneapi_sub_group_mask]") {
+#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+  check_diff_sub_group_sizes<verification_func_for_ulong_long_ctor>();
+#else
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined or revision less than 2");
+#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+};
+
+TEST_CASE("Check sub_group_mask(marray<T,dim>) constructor",
+          "[oneapi_sub_group_mask]") {
+#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+  for_marrays_of_all_types<check_for_type>(types);
+#else
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined or revision less than 2");
+#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+};
+
+}  // namespace sub_group_mask_constructors_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_count.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_count.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask count()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_count
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_count_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -35,28 +49,13 @@ using verification_func_for_first_half_predicate =
                    const sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check count() for mask with first half predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_first_half_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_first_half_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_count_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_extract_bits.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_extract_bits.cpp
@@ -2,15 +2,29 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 //  Provides tests to check sub_group_mask extract_bits()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_extract_bits
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_extract_bits_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -66,35 +80,21 @@ struct check_for_type {
                      check_type_extract_bits<T>, even_predicate,
                      const sycl::ext::oneapi::sub_group_mask>;
 
-  void operator()(util::logger &log, const std::string &typeName) {
-    log.note("testing: " + type_name_string<T>::get(typeName));
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  void operator()(const std::string &typeName) {
+    SECTION("testing: " + type_name_string<T>::get(typeName)) {
+      check_diff_sub_group_sizes<verification_func_for_even_predicate>();
+    }
   }
 };
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check extract_bits() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    for_all_types_and_marrays<check_for_type>(types, log);
+  for_all_types_and_marrays<check_for_type>(types);
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_extract_bits_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_extract_bits.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_extract_bits.cpp
@@ -80,7 +80,7 @@ struct check_for_type {
                      check_type_extract_bits<T>, even_predicate,
                      const sycl::ext::oneapi::sub_group_mask>;
 
-  void operator()(const std::string &typeName) {
+  void operator()(const std::string& typeName) {
     SECTION("testing: " + type_name_string<T>::get(typeName)) {
       check_diff_sub_group_sizes<verification_func_for_even_predicate>();
     }

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_find_high.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_find_high.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask find_high()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_find_high
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_find_high_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -51,32 +65,22 @@ using verification_func_for_false_predicate =
 
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check find_high() for mask with first half predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    log.note("Check find_high() for mask with first half predicate");
-    check_diff_sub_group_sizes<verification_func_for_first_half_predicate>(log);
-
-    log.note("Check find_high() for mask with false predicate");
-    check_diff_sub_group_sizes<verification_func_for_false_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_first_half_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
+TEST_CASE("Check find_high() for mask with false predicate",
+          "[oneapi_sub_group_mask]") {
+#ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
+  check_diff_sub_group_sizes<verification_func_for_false_predicate>();
+#else
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_find_high_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_find_low.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_find_low.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask find_low()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_find_low
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_find_low_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -50,33 +64,22 @@ using verification_func_for_false_predicate =
                    const sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check find_low() for mask with second half predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    log.note("Check find_low() for mask with second half predicate");
-    check_diff_sub_group_sizes<verification_func_for_second_half_predicate>(
-        log);
-
-    log.note("Check find_low() for mask with false predicate");
-    check_diff_sub_group_sizes<verification_func_for_false_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_second_half_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
+TEST_CASE("Check find_low() for mask with false predicate",
+          "[oneapi_sub_group_mask]") {
+#ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
+  check_diff_sub_group_sizes<verification_func_for_false_predicate>();
+#else
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_find_low_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_flip_api.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_flip_api.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask flip()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_flip_api
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_flip_api_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -44,28 +58,13 @@ using verification_func_for_even_predicate =
                    sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check flip() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_flip_api_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_flip_id.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_flip_id.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask flip_id()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_flip_id
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_flip_id_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -39,29 +53,13 @@ using verification_func_for_even_predicate =
                    even_predicate, sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check flip_id() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
-
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_flip_id_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_insert_bits.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_insert_bits.cpp
@@ -2,15 +2,29 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 //  Provides tests to check sub_group_mask insert_bits()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_insert_bits
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_insert_bits_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -67,35 +81,21 @@ struct check_for_type {
                      check_type_insert_bits<T>, mod3_predicate,
                      sycl::ext::oneapi::sub_group_mask>;
 
-  void operator()(util::logger &log, const std::string &typeName) {
-    log.note("testing: " + type_name_string<T>::get(typeName));
-    check_diff_sub_group_sizes<verification_func_for_mod3_predicate>(log);
+  void operator()(const std::string &typeName) {
+    SECTION("testing: " + type_name_string<T>::get(typeName)) {
+      check_diff_sub_group_sizes<verification_func_for_mod3_predicate>();
+    }
   }
 };
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check insert_bits() for mask with mod3 predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    for_all_types_and_marrays<check_for_type>(types, log);
+  for_all_types_and_marrays<check_for_type>(types);
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_insert_bits_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_insert_bits.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_insert_bits.cpp
@@ -81,7 +81,7 @@ struct check_for_type {
                      check_type_insert_bits<T>, mod3_predicate,
                      sycl::ext::oneapi::sub_group_mask>;
 
-  void operator()(const std::string &typeName) {
+  void operator()(const std::string& typeName) {
     SECTION("testing: " + type_name_string<T>::get(typeName)) {
       check_diff_sub_group_sizes<verification_func_for_mod3_predicate>();
     }

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_none.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_none.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask none()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_none
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_none_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -45,32 +59,22 @@ using verification_func_for_false_predicate =
                    false_predicate, const sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check none() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    log.note("Check none() for mask with even predicate");
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
-
-    log.note("Check none() for mask with false predicate");
-    check_diff_sub_group_sizes<verification_func_for_false_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
+TEST_CASE("Check none() for mask with false predicate",
+          "[oneapi_sub_group_mask]") {
+#ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
+  check_diff_sub_group_sizes<verification_func_for_false_predicate>();
+#else
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_none_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_reference.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_reference.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask operator[] const and reference
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_reference
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_reference_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -71,28 +85,13 @@ using verification_func_for_even_predicate =
                    even_predicate, sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check operator[] and reference for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-     check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_reference_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_reset_api.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_reset_api.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask reset()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_reset_api
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_reset_api_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -37,28 +51,13 @@ using verification_func_for_even_predicate =
                    sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check reset() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_reset_api_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_reset_high.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_reset_high.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask reset_high()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_reset_high
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_reset_high_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -39,28 +53,13 @@ using verification_func_for_even_predicate =
                    first_half_predicate, sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check reset_high() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_reset_high_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_reset_id.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_reset_id.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask reset(id)
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_reset_id
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_reset_id_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -48,28 +62,13 @@ using verification_func_for_even_predicate =
                    even_predicate, sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check reset_id() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_reset_id_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_reset_low.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_reset_low.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask reset_low()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_reset_low
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_reset_low_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -39,28 +53,13 @@ using verification_func_for_even_predicate =
                    second_half_predicate, sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check reset_low() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_reset_low_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_set_api.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_set_api.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask set()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_set_api
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_set_api_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -44,28 +58,13 @@ using verification_func_for_even_predicate =
                    sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check set() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_set_api_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_set_id.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_set_id.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask set(id)
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_set_id
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_set_id_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -54,28 +68,13 @@ using verification_func_for_even_predicate =
                    even_predicate, sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check set(id) for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_set_id_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_size.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_size.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask size()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_size
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_size_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -34,28 +48,13 @@ using verification_func_for_true_predicate =
                    const sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check size() for mask with true predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_true_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_true_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_size_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_subscript.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_subscript.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask operator[]
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_subscript
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_subsscript_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -37,28 +51,13 @@ using verification_func_for_even_predicate =
                    even_predicate, const sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check subscript[] for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_subsscript_test

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_test.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_test.cpp
@@ -1,16 +1,30 @@
 /*******************************************************************************
 //
-//  SYCL 2020 Extension Conformance Test
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 //  Provides tests to check sub_group_mask test()
 //
 *******************************************************************************/
 
+#include "catch2/catch_test_macros.hpp"
+
 #include "sub_group_mask_common.h"
 
-#define TEST_NAME sub_group_mask_test
-
-namespace TEST_NAMESPACE {
+namespace sub_group_mask_test_test {
 
 using namespace sycl_cts;
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
@@ -37,28 +51,13 @@ using verification_func_for_even_predicate =
                    const sycl::ext::oneapi::sub_group_mask>;
 #endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 
-/** test sycl::oneapi::sub_group_mask interface
- */
-class TEST_NAME : public util::test_base {
- public:
-  /** return information about this test
-   */
-  void get_info(test_base::info &out) const override {
-    set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
-  }
-
-  /** execute the test
-   */
-  void run(util::logger &log) override {
+TEST_CASE("Check test() for mask with even predicate",
+          "[oneapi_sub_group_mask]") {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-    check_diff_sub_group_sizes<verification_func_for_even_predicate>(log);
+  check_diff_sub_group_sizes<verification_func_for_even_predicate>();
 #else
-    SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
-#endif  // SYCL_EXT_ONEAPI_SUB_GROUP_MASK
-  }
-};
+  SKIP("SYCL_EXT_ONEAPI_SUB_GROUP_MASK is not defined");
+#endif
+}
 
-// register this test with the test_collection.
-util::test_proxy<TEST_NAME> proxy;
-
-} /* namespace TEST_NAMESPACE */
+}  // namespace sub_group_mask_test_test


### PR DESCRIPTION
Cover gaps in oneapi_sub_group_mask extension according to  [oneapi_ext_sub_group_mask test plan](https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/sub_group_mask.asciidoc) test plan and refactor existing tests.