### PR TITLE
CI: Bring back ccache for DPC++

### DIFF
--- a/docker/dpcpp/Dockerfile
+++ b/docker/dpcpp/Dockerfile
@@ -4,4 +4,11 @@ ARG IMPL_VERSION
 
 FROM ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers-$IMPL_VERSION
 
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt update && \
+    apt install -y --no-install-recommends \
+      ccache && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists*
+
 COPY configure.sh /scripts/


### PR DESCRIPTION
I just randomly noticed that CI run times are going absolutely through the roof again, with runs taking anywhere from [FOUR](https://github.com/KhronosGroup/SYCL-CTS/actions/runs/5527166953) to [SIX](https://github.com/KhronosGroup/SYCL-CTS/actions/runs/5513029710) hours. While not really addressing the root problem, our fix for this so far was to use `ccache`, which has worked rather well.

It looks like `ccache` was lost in the switch to the DPC++ nightly containers (#712), so with this I'm bringing it back.

Note: I haven't tested this, so after the cache has been primed by the CI run for this PR we'll have to launch a second run to see if it actually works.

---

Side node / reminder: we generate a [detailed report](https://github.com/KhronosGroup/SYCL-CTS/suites/14194910821/artifacts/796494763) of what is taking up the time, looks like the marray operators test is the new champion with a whopping 25 minutes - in case anybody from Intel wants to take a look.