### PR TITLE
Enable dimension item/id/range dimension checks for DPC++

### DIFF
--- a/tests/h_item/h_item_members.cpp
+++ b/tests/h_item/h_item_members.cpp
@@ -34,9 +34,7 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::h_item<Dim>, Dim>(type_name);
 }
 
-// FIXME: re-enable when sycl::h_item<>::dimensions is implemented
-// Issue link https://github.com/intel/llvm/issues/9786
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
+DISABLED_FOR_TEST_CASE(ComputeCpp)
 ("sycl::h_item members", "[h_item]")({
   run_test<1>();
   run_test<2>();

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -284,9 +284,7 @@ TEMPLATE_TEST_CASE_SIG("id supports get() and operator[]", "[id]", ((int D), D),
   }
 }
 
-// FIXME: re-enable when sycl::id<>::dimensions is implemented
-// Issue link https://github.com/intel/llvm/issues/9786
-DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(DPCPP, hipSYCL)
+DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(hipSYCL)
 ("id provides static constexpr member 'dimensions'", "[id]", ((int D), D), 1, 2,
  3)({
   CHECK(std::is_same_v<decltype(sycl::id<D>::dimensions), const int>);

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -286,6 +286,8 @@ TEMPLATE_TEST_CASE_SIG("id supports get() and operator[]", "[id]", ((int D), D),
 
 DISABLED_FOR_TEST_CASE(hipSYCL)
 ("id provides static constexpr member 'dimensions'", "[id]")({
+  // Dimension arguments in this test case are expanded to avoid conflicting
+  // kernel names for different instantiations of sycl::id.
   CHECK(std::is_same_v<decltype(sycl::id<1>::dimensions), const int>);
   CHECK(std::is_same_v<decltype(sycl::id<2>::dimensions), const int>);
   CHECK(std::is_same_v<decltype(sycl::id<3>::dimensions), const int>);

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -284,14 +284,21 @@ TEMPLATE_TEST_CASE_SIG("id supports get() and operator[]", "[id]", ((int D), D),
   }
 }
 
-DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(hipSYCL)
-("id provides static constexpr member 'dimensions'", "[id]", ((int D), D), 1, 2,
- 3)({
-  CHECK(std::is_same_v<decltype(sycl::id<D>::dimensions), const int>);
-  KCHECK(EVAL((std::is_same_v<decltype(sycl::id<D>::dimensions), const int>)));
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("id provides static constexpr member 'dimensions'", "[id]")({
+  CHECK(std::is_same_v<decltype(sycl::id<1>::dimensions), const int>);
+  CHECK(std::is_same_v<decltype(sycl::id<2>::dimensions), const int>);
+  CHECK(std::is_same_v<decltype(sycl::id<3>::dimensions), const int>);
+  KCHECK(EVAL((std::is_same_v<decltype(sycl::id<1>::dimensions), const int>)));
+  KCHECK(EVAL((std::is_same_v<decltype(sycl::id<2>::dimensions), const int>)));
+  KCHECK(EVAL((std::is_same_v<decltype(sycl::id<3>::dimensions), const int>)));
 
-  CHECK(sycl::id<D>::dimensions == D);
-  KCHECK(EVAL(sycl::id<D>::dimensions) == D);
+  CHECK(sycl::id<1>::dimensions == 1);
+  CHECK(sycl::id<2>::dimensions == 2);
+  CHECK(sycl::id<3>::dimensions == 3);
+  KCHECK(EVAL(sycl::id<1>::dimensions) == 1);
+  KCHECK(EVAL(sycl::id<2>::dimensions) == 2);
+  KCHECK(EVAL(sycl::id<3>::dimensions) == 3);
 });
 
 TEST_CASE("id can be converted to size_t if Dimensions == 1", "[id]") {

--- a/tests/item/item_members.cpp
+++ b/tests/item/item_members.cpp
@@ -34,9 +34,7 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::item<Dim>, Dim>(type_name);
 }
 
-// FIXME: re-enable when sycl::item<>::dimensions is implemented
-// Issue link https://github.com/intel/llvm/issues/9786
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
+DISABLED_FOR_TEST_CASE(ComputeCpp)
 ("sycl::item members", "[item]")({
   run_test<1>();
   run_test<2>();

--- a/tests/nd_item/nd_item_members.cpp
+++ b/tests/nd_item/nd_item_members.cpp
@@ -34,13 +34,10 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::nd_item<Dim>, Dim>(type_name);
 }
 
-// FIXME: re-enable when sycl::nd_item<>::dimensions is implemented
-// Issue link https://github.com/intel/llvm/issues/9786
-DISABLED_FOR_TEST_CASE(DPCPP)
-("sycl::nd_item members", "[nd_item]")({
+TEST_CASE("sycl::nd_item members", "[nd_item]") {
   run_test<1>();
   run_test<2>();
   run_test<3>();
-});
+}
 
 }  // namespace nd_item_members

--- a/tests/nd_range/nd_range_members.cpp
+++ b/tests/nd_range/nd_range_members.cpp
@@ -34,9 +34,7 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::nd_range<Dim>, Dim>(type_name);
 }
 
-// FIXME: re-enable when sycl::nd_range<>::dimensions is implemented
-// Issue link https://github.com/intel/llvm/issues/9786
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
+DISABLED_FOR_TEST_CASE(ComputeCpp)
 ("sycl::nd_range members", "[nd_range]")({
   run_test<1>();
   run_test<2>();

--- a/tests/range/range_members.cpp
+++ b/tests/range/range_members.cpp
@@ -34,9 +34,7 @@ void run_test() {
   range_index_space_id::check_members_test<sycl::range<Dim>, Dim>(type_name);
 }
 
-// FIXME: re-enable when sycl::range<>::dimensions is implemented
-// Issue link https://github.com/intel/llvm/issues/9786
-DISABLED_FOR_TEST_CASE(DPCPP, ComputeCpp)
+DISABLED_FOR_TEST_CASE(ComputeCpp)
 ("sycl::range members", "[range]")({
   run_test<1>();
   run_test<2>();


### PR DESCRIPTION
This commit enables a number of test cases previously disabled for DPC++ due to missing `dimensions` member in `id`, `range`, `nd_range`, `h_item`, `item`, and `nd_item`.