### PR TITLE
Make accessor test cases templated on non-type arguments

### DIFF
--- a/tests/accessor/accessor_default_values.h
+++ b/tests/accessor/accessor_default_values.h
@@ -193,21 +193,33 @@ class test_for_generic_acc_placeholder_val_verification {
   }
 };
 
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack,
+                              targets_pack>::type;
+
 /**
  * @brief Struct with functor that will be used in type coverage to call all
  *        verification functions.
  * @tparam T Current data type
+ * @tparam ArgCombination A tuple containing the packs representing the current
+ *         test configuration. The packs appear in the following order:
+ *         access_mode, dimension, target
  * @param type_name Current data type string representation
  */
-template <typename T>
+template <typename T, typename ArgCombination>
 class run_tests {
  public:
   void operator()(const std::string& type_name) {
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
     // Type packs instances have to be const, otherwise for_all_combination
     // will not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // Run test with non const data type
     // Run test for local_accessor

--- a/tests/accessor/accessor_default_values_core.cpp
+++ b/tests/accessor/accessor_default_values_core.cpp
@@ -25,8 +25,8 @@ using namespace accessor_tests_common;
 namespace accessor_default_values_test_core {
 using namespace sycl_cts;
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Accessors constructor default values test core types.",
- "[accessor]")({ common_run_tests<run_tests>(); });
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Accessors constructor default values test core types.", "[accessor]",
+ test_combinations)({ common_run_tests<run_tests, TestType>(); });
 
 }  // namespace accessor_default_values_test_core

--- a/tests/accessor/accessor_default_values_fp16.cpp
+++ b/tests/accessor/accessor_default_values_fp16.cpp
@@ -24,8 +24,9 @@ using namespace accessor_tests_common;
 namespace accessor_exceptions_test_fp16 {
 using namespace sycl_cts;
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Accessors constructor default values test fp16 types.", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Accessors constructor default values test fp16 types.", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -35,9 +36,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_tests, sycl::half>("sycl::half");
+  for_type_vectors_marray<run_tests, sycl::half, TestType>("sycl::half");
 #else
-  run_tests<sycl::half>{}("sycl::half");
+  run_tests<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/accessor_default_values_fp64.cpp
+++ b/tests/accessor/accessor_default_values_fp64.cpp
@@ -24,8 +24,9 @@ using namespace accessor_tests_common;
 namespace accessor_default_values_test_fp64 {
 using namespace sycl_cts;
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Accessors constructor default values test fp64 types.", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Accessors constructor default values test fp64 types.", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -35,9 +36,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_tests, double>("double");
+  for_type_vectors_marray<run_tests, double, TestType>("double");
 #else
-  run_tests<double>{}("double");
+  run_tests<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/accessor_exceptions.h
+++ b/tests/accessor/accessor_exceptions.h
@@ -349,6 +349,9 @@ class test_exception_for_generic_acc {
   }
 };
 
+using test_combinations =
+    typename get_combinations<access_modes_pack, dimensions_pack>::type;
+
 /**
  * @brief Struct that runs test with different input parameters types
  * @tparam AccT Current type of the accessor: generic_accessor,
@@ -358,14 +361,18 @@ class test_exception_for_generic_acc {
  * @param access_mode_name Current access mode string representation
  * @param target_name Current target string representation
  */
-template <typename T, typename AccT>
+template <typename T, typename AccT, typename ArgCombination>
 class run_tests_with_types {
  public:
   void operator()(const std::string& type_name) {
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+
     // Type packs instances have to be const, otherwise for_all_combination
     // will not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_dimensions();
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or for_all_device_copyable_std_containers.
@@ -376,7 +383,7 @@ class run_tests_with_types {
     constexpr accessor_tests_common::accessor_type acc_type = AccT::value;
     if constexpr (acc_type ==
                   accessor_tests_common::accessor_type::generic_accessor) {
-      const auto targets = get_targets();
+      const auto targets = targets_pack::generate_named();
       for_all_combinations<test_exception_for_generic_acc, AccT, T>(
           access_modes, dimensions, targets, actual_type_name);
     } else if constexpr (acc_type ==

--- a/tests/accessor/accessor_exceptions_core.cpp
+++ b/tests/accessor/accessor_exceptions_core.cpp
@@ -24,16 +24,22 @@ using namespace accessor_tests_common;
 namespace accessor_exceptions_test_core {
 using namespace sycl_cts;
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor constructor exceptions test. Core types.",
- "[accessor]")({ common_run_tests<run_tests_with_types, generic_accessor>(); });
+ "[accessor]", test_combinations)({
+  common_run_tests<run_tests_with_types, generic_accessor, TestType>();
+});
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor constructor exceptions test. Core types.",
- "[accessor]")({ common_run_tests<run_tests_with_types, local_accessor>(); });
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor constructor exceptions test. Core types.", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_tests_with_types, local_accessor, TestType>();
+});
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor constructor exceptions test. Core types.",
- "[accessor]")({ common_run_tests<run_tests_with_types, host_accessor>(); });
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor constructor exceptions test. Core types.", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_tests_with_types, host_accessor, TestType>();
+});
 
 }  // namespace accessor_exceptions_test_core

--- a/tests/accessor/accessor_exceptions_fp16.cpp
+++ b/tests/accessor/accessor_exceptions_fp16.cpp
@@ -23,8 +23,9 @@ using namespace accessor_tests_common;
 namespace accessor_exceptions_test_fp16 {
 using namespace sycl_cts;
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor constructor exceptions. fp16 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor constructor exceptions. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -34,15 +35,16 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_tests_with_types, sycl::half, generic_accessor>(
-      "sycl::half");
+  for_type_vectors_marray<run_tests_with_types, sycl::half, generic_accessor,
+                          TestType>("sycl::half");
 #else
-  run_tests_with_types<sycl::half, generic_accessor>{}("sycl::half");
+  run_tests_with_types<sycl::half, generic_accessor, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor constructor exceptions. fp16 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor constructor exceptions. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -52,15 +54,16 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_tests_with_types, sycl::half, local_accessor>(
-      "sycl::half");
+  for_type_vectors_marray<run_tests_with_types, sycl::half, local_accessor,
+                          TestType>("sycl::half");
 #else
-  run_tests_with_types<sycl::half, local_accessor>{}("sycl::half");
+  run_tests_with_types<sycl::half, local_accessor, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor constructor exceptions. fp16 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor constructor exceptions. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -70,10 +73,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_tests_with_types, sycl::half, host_accessor>(
-      "sycl::half");
+  for_type_vectors_marray<run_tests_with_types, sycl::half, host_accessor,
+                          TestType>("sycl::half");
 #else
-  run_tests_with_types<sycl::half, host_accessor>{}("sycl::half");
+  run_tests_with_types<sycl::half, host_accessor, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/accessor_exceptions_fp64.cpp
+++ b/tests/accessor/accessor_exceptions_fp64.cpp
@@ -23,8 +23,9 @@ using namespace accessor_tests_common;
 namespace accessor_exceptions_test_fp64 {
 using namespace sycl_cts;
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor constructor exceptions. fp64 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor constructor exceptions. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -34,15 +35,16 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_tests_with_types, double, generic_accessor>(
-      "double");
+  for_type_vectors_marray<run_tests_with_types, double, generic_accessor,
+                          TestType>("double");
 #else
-  run_tests_with_types<double, generic_accessor>{}("double");
+  run_tests_with_types<double, generic_accessor, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor constructor exceptions. fp64 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor constructor exceptions. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -52,15 +54,16 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_tests_with_types, double, local_accessor>(
-      "double");
+  for_type_vectors_marray<run_tests_with_types, double, local_accessor,
+                          TestType>("double");
 #else
-  run_tests_with_types<double, local_accessor>{}("double");
+  run_tests_with_types<double, local_accessor, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor constructor exceptions. fp64 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor constructor exceptions. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -70,10 +73,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_tests_with_types, double, host_accessor>(
-      "double");
+  for_type_vectors_marray<run_tests_with_types, double, host_accessor,
+                          TestType>("double");
 #else
-  run_tests_with_types<double, host_accessor>{}("double");
+  run_tests_with_types<double, host_accessor, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/accessor_implicit_conversions.h
+++ b/tests/accessor/accessor_implicit_conversions.h
@@ -327,17 +327,27 @@ class check_conversion_host {
   }
 };
 
+using generic_test_combinations =
+    typename get_combinations<all_dimensions_pack, targets_pack>::type;
+
+using host_local_test_combinations =
+    typename get_combinations<all_dimensions_pack>::type;
+
 /**
  * @brief Run tests for generic sycl::accessor
  * @detail A wrapper around for_all_combinations call to make possible extended
  *         type coverage - e.g. vectors and marrays
  */
-template <typename DataT>
+template <typename DataT, typename ArgCombination>
 struct run_test_generic {
   void operator()(const std::string& type_name) {
+    // Get the packs from the test combination type.
+    using DimensionsPack = typename std::tuple_element<0, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<1, ArgCombination>::type;
+
     // TODO: make for_all_combinations recognize non-const type packs
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     for_all_combinations<check_conversion_generic, DataT>(dimensions, targets,
                                                           type_name);
@@ -347,10 +357,11 @@ struct run_test_generic {
 /**
  * @brief Run tests for sycl::local_accessor
  */
-template <typename DataT>
+template <typename DataT, typename ArgCombination>
 struct run_test_local {
   void operator()(const std::string& type_name) {
-    const auto dimensions = get_all_dimensions();
+    using DimensionsPack = typename std::tuple_element<0, ArgCombination>::type;
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     for_all_combinations<check_conversion_local, DataT>(dimensions, type_name);
   }
@@ -359,10 +370,11 @@ struct run_test_local {
 /**
  * @brief Run tests for sycl::host_accessor
  */
-template <typename DataT>
+template <typename DataT, typename ArgCombination>
 struct run_test_host {
   void operator()(const std::string& type_name) {
-    const auto dimensions = get_all_dimensions();
+    using DimensionsPack = typename std::tuple_element<0, ArgCombination>::type;
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     for_all_combinations<check_conversion_host, DataT>(dimensions, type_name);
   }

--- a/tests/accessor/accessor_implicit_conversions_core.cpp
+++ b/tests/accessor/accessor_implicit_conversions_core.cpp
@@ -25,22 +25,22 @@ using namespace accessor_implicit_conversions;
 
 namespace accessor_implicit_conversions_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor implicit conversion. core types",
- "[accessor][generic_accessor][conversion][core]")({
-  common_run_tests<run_test_generic>();
+ "[accessor][generic_accessor][conversion][core]", generic_test_combinations)({
+  common_run_tests<run_test_generic, TestType>();
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("The sycl::local_accessor implicit conversion. core types",
- "[accessor][local_accessor][conversion][core]")({
-  common_run_tests<run_test_local>();
+ "[accessor][local_accessor][conversion][core]", host_local_test_combinations)({
+  common_run_tests<run_test_local, TestType>();
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("The sycl::host_accessor implicit conversion. core types",
- "[accessor][host_accessor][conversion][core]")({
-  common_run_tests<run_test_host>();
+ "[accessor][host_accessor][conversion][core]", host_local_test_combinations)({
+  common_run_tests<run_test_host, TestType>();
 });
 
 }  // namespace accessor_implicit_conversions_core

--- a/tests/accessor/accessor_implicit_conversions_fp16.cpp
+++ b/tests/accessor/accessor_implicit_conversions_fp16.cpp
@@ -25,9 +25,9 @@ using namespace accessor_implicit_conversions;
 
 namespace accessor_implicit_conversions_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor implicit conversion. fp16 type",
- "[accessor][generic_accessor][conversion][fp16]")({
+ "[accessor][generic_accessor][conversion][fp16]", generic_test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (!queue.get_device().has(sycl::aspect::fp16)) {
@@ -56,15 +56,15 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   //    for_all_combinations<test_conversion_within_command>(
   //        types, targets, dimensions);
   //
-  for_type_vectors_marray<run_test_generic, sycl::half>("sycl::half");
+  for_type_vectors_marray<run_test_generic, sycl::half, TestType>("sycl::half");
 #else
-  run_test_generic<sycl::half>{}("sycl::half");
+  run_test_generic<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("The sycl::local_accessor implicit conversion. fp16 type",
- "[accessor][local_accessor][conversion][fp16]")({
+ "[accessor][local_accessor][conversion][fp16]", host_local_test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (!queue.get_device().has(sycl::aspect::fp16)) {
@@ -73,15 +73,15 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_test_local, sycl::half>("sycl::half");
+  for_type_vectors_marray<run_test_local, sycl::half, TestType>("sycl::half");
 #else
-  run_test_local<sycl::half>{}("sycl::half");
+  run_test_local<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("The sycl::host_accessor implicit conversion. fp16 type",
- "[accessor][host_accessor][conversion][fp16]")({
+ "[accessor][host_accessor][conversion][fp16]", host_local_test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (!queue.get_device().has(sycl::aspect::fp16)) {
@@ -90,9 +90,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_test_host, sycl::half>("sycl::half");
+  for_type_vectors_marray<run_test_host, sycl::half, TestType>("sycl::half");
 #else
-  run_test_host<sycl::half>{}("sycl::half");
+  run_test_host<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/accessor_implicit_conversions_fp64.cpp
+++ b/tests/accessor/accessor_implicit_conversions_fp64.cpp
@@ -25,9 +25,9 @@ using namespace accessor_implicit_conversions;
 
 namespace accessor_implicit_conversions_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor implicit conversion. fp64 type",
- "[accessor][generic_accessor][conversion][fp64]")({
+ "[accessor][generic_accessor][conversion][fp64]", generic_test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (!queue.get_device().has(sycl::aspect::fp64)) {
@@ -36,15 +36,15 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_test_generic, double>("double");
+  for_type_vectors_marray<run_test_generic, double, TestType>("double");
 #else
-  run_test_generic<double>{}("double");
+  run_test_generic<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("The sycl::local_accessor implicit conversion. fp64 type",
- "[accessor][local_accessor][conversion][fp64]")({
+ "[accessor][local_accessor][conversion][fp64]", host_local_test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (!queue.get_device().has(sycl::aspect::fp64)) {
@@ -53,15 +53,15 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_test_local, double>("double");
+  for_type_vectors_marray<run_test_local, double, TestType>("double");
 #else
-  run_test_local<double>{}("double");
+  run_test_local<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("The sycl::host_accessor implicit conversion. fp64 type",
- "[accessor][host_accessor][conversion][fp64]")({
+ "[accessor][host_accessor][conversion][fp64]", host_local_test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
 
   if (!queue.get_device().has(sycl::aspect::fp64)) {
@@ -70,9 +70,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_test_host, double>("double");
+  for_type_vectors_marray<run_test_host, double, TestType>("double");
 #else
-  run_test_host<double>{}("double");
+  run_test_host<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -438,13 +438,24 @@ class run_api_tests {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_api_for_type {
  public:
   void operator()(const std::string &type_name) {
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or for_all_device_copyable_std_containers.

--- a/tests/accessor/generic_accessor_api_core.cpp
+++ b/tests/accessor/generic_accessor_api_core.cpp
@@ -13,14 +13,16 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_api_common.h"
+
+using namespace generic_accessor_api_common;
 #endif
 
 namespace generic_accessor_api_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor api. core types", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor api. core types", "[accessor]", test_combinations)({
   using namespace generic_accessor_api_common;
-  common_run_tests<run_generic_api_for_type>();
+  common_run_tests<run_generic_api_for_type, TestType>();
 });
 
 }  // namespace generic_accessor_api_core

--- a/tests/accessor/generic_accessor_api_fp16.cpp
+++ b/tests/accessor/generic_accessor_api_fp16.cpp
@@ -13,12 +13,14 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_api_common.h"
+
+using namespace generic_accessor_api_common;
 #endif
 
 namespace generic_accessor_api_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor api. fp16 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor api. fp16 type", "[accessor]", test_combinations)({
   using namespace generic_accessor_api_common;
 
   auto queue = sycl_cts::util::get_cts_object::queue();
@@ -30,9 +32,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_generic_api_for_type, sycl::half>("sycl::half");
+  for_type_vectors_marray<run_generic_api_for_type, sycl::half, TestType>(
+      "sycl::half");
 #else
-  run_generic_api_for_type<sycl::half>{}("sycl::half");
+  run_generic_api_for_type<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace generic_accessor_api_fp16

--- a/tests/accessor/generic_accessor_api_fp64.cpp
+++ b/tests/accessor/generic_accessor_api_fp64.cpp
@@ -12,12 +12,14 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_api_common.h"
+
+using namespace generic_accessor_api_common;
 #endif
 
 namespace generic_accessor_api_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor api. fp64 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor api. fp64 type", "[accessor]", test_combinations)({
   using namespace generic_accessor_api_common;
 
   auto queue = sycl_cts::util::get_cts_object::queue();
@@ -29,9 +31,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_generic_api_for_type, double>("double");
+  for_type_vectors_marray<run_generic_api_for_type, double, TestType>("double");
 #else
-  run_generic_api_for_type<double>{}("double");
+  run_generic_api_for_type<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace generic_accessor_api_fp64

--- a/tests/accessor/generic_accessor_common_buffer_constructors.h
+++ b/tests/accessor/generic_accessor_common_buffer_constructors.h
@@ -144,15 +144,24 @@ class run_tests_common_buffer_constructors {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_common_buffer_constructors_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_common_buffer_constructors_core.cpp
+++ b/tests/accessor/generic_accessor_common_buffer_constructors_core.cpp
@@ -27,16 +27,18 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_common_buffer_constructors.h"
+
+using namespace generic_accessor_common_buffer_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_common_buffer_constructors_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor buffer constructors. core types", "[accessor]")({
-  using namespace generic_accessor_common_buffer_constructors;
-  common_run_tests<run_generic_common_buffer_constructors_test>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor buffer constructors. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_generic_common_buffer_constructors_test, TestType>();
 });
 
 }  // namespace generic_accessor_common_buffer_constructors_core

--- a/tests/accessor/generic_accessor_common_buffer_constructors_fp16.cpp
+++ b/tests/accessor/generic_accessor_common_buffer_constructors_fp16.cpp
@@ -27,23 +27,25 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_common_buffer_constructors.h"
+
+using namespace generic_accessor_common_buffer_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_common_buffer_constructors_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor buffer constructors. fp16 type", "[accessor]")({
-  using namespace generic_accessor_common_buffer_constructors;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor buffer constructors. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<run_generic_common_buffer_constructors_test,
-                            sycl::half>("sycl::half");
+                            sycl::half, TestType>("sycl::half");
 #else
-    run_generic_common_buffer_constructors_test<sycl::half>{}("sycl::half");
+    run_generic_common_buffer_constructors_test<sycl::half, TestType>{}(
+        "sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support half precision floating point operations");

--- a/tests/accessor/generic_accessor_common_buffer_constructors_fp64.cpp
+++ b/tests/accessor/generic_accessor_common_buffer_constructors_fp64.cpp
@@ -27,23 +27,24 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_common_buffer_constructors.h"
+
+using namespace generic_accessor_common_buffer_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_common_buffer_constructors_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor buffer constructors. fp64 type", "[accessor]")({
-  using namespace generic_accessor_common_buffer_constructors;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor buffer constructors. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-    for_type_vectors_marray<run_generic_common_buffer_constructors_test,
-                            double>("double");
+    for_type_vectors_marray<run_generic_common_buffer_constructors_test, double,
+                            TestType>("double");
 #else
-    run_generic_common_buffer_constructors_test<double>{}("double");
+    run_generic_common_buffer_constructors_test<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/generic_accessor_common_buffer_tag_constructors.h
+++ b/tests/accessor/generic_accessor_common_buffer_tag_constructors.h
@@ -141,15 +141,24 @@ class run_tests_common_buffer_tag_constructors {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_common_buffer_tag_constructors_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_common_buffer_tag_constructors_core.cpp
+++ b/tests/accessor/generic_accessor_common_buffer_tag_constructors_core.cpp
@@ -27,16 +27,18 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_common_buffer_tag_constructors.h"
+
+using namespace generic_accessor_common_buffer_tag_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_common_buffer_tag_constructors_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor buffer tag constructors. core types", "[accessor]")({
-  using namespace generic_accessor_common_buffer_tag_constructors;
-  common_run_tests<run_generic_common_buffer_tag_constructors_test>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor buffer tag constructors. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_generic_common_buffer_tag_constructors_test, TestType>();
 });
 
 }  // namespace generic_accessor_common_buffer_tag_constructors_core

--- a/tests/accessor/generic_accessor_common_buffer_tag_constructors_fp16.cpp
+++ b/tests/accessor/generic_accessor_common_buffer_tag_constructors_fp16.cpp
@@ -27,23 +27,25 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_common_buffer_tag_constructors.h"
+
+using namespace generic_accessor_common_buffer_tag_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_common_buffer_tag_constructors_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor buffer tag constructors. fp16 type", "[accessor]")({
-  using namespace generic_accessor_common_buffer_tag_constructors;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor buffer tag constructors. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<run_generic_common_buffer_tag_constructors_test,
-                            sycl::half>("sycl::half");
+                            sycl::half, TestType>("sycl::half");
 #else
-    run_generic_common_buffer_tag_constructors_test<sycl::half>{}("sycl::half");
+    run_generic_common_buffer_tag_constructors_test<sycl::half, TestType>{}(
+        "sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support half precision floating point operations");

--- a/tests/accessor/generic_accessor_common_buffer_tag_constructors_fp64.cpp
+++ b/tests/accessor/generic_accessor_common_buffer_tag_constructors_fp64.cpp
@@ -27,23 +27,25 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_common_buffer_tag_constructors.h"
+
+using namespace generic_accessor_common_buffer_tag_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_common_buffer_tag_constructors_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor buffer tag constructors. fp64 type", "[accessor]")({
-  using namespace generic_accessor_common_buffer_tag_constructors;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor buffer tag constructors. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<run_generic_common_buffer_tag_constructors_test,
-                            double>("double");
+                            double, TestType>("double");
 #else
-    run_generic_common_buffer_tag_constructors_test<double>{}("double");
+    run_generic_common_buffer_tag_constructors_test<double, TestType>{}(
+        "double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/generic_accessor_def_constructor.h
+++ b/tests/accessor/generic_accessor_def_constructor.h
@@ -63,15 +63,24 @@ class run_tests_def_constructor {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_def_constructor_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_def_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_def_constructor_core.cpp
@@ -26,16 +26,18 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_def_constructor.h"
+
+using namespace generic_accessor_def_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_def_constructor_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor def constructors. core types", "[accessor]")({
-  using namespace generic_accessor_def_constructor;
-  common_run_tests<run_generic_def_constructor_test>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor def constructors. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_generic_def_constructor_test, TestType>();
 });
 
 }  // namespace generic_accessor_def_constructor_core

--- a/tests/accessor/generic_accessor_def_constructor_fp16.cpp
+++ b/tests/accessor/generic_accessor_def_constructor_fp16.cpp
@@ -27,23 +27,24 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_def_constructor.h"
+
+using namespace generic_accessor_def_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_def_constructor_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor def constructors. fp16 type", "[accessor]")({
-  using namespace generic_accessor_def_constructor;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor def constructors. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-    for_type_vectors_marray<run_generic_def_constructor_test, sycl::half>(
-        "sycl::half");
+    for_type_vectors_marray<run_generic_def_constructor_test, sycl::half,
+                            TestType>("sycl::half");
 #else
-    run_generic_def_constructor_test<sycl::half>{}("sycl::half");
+    run_generic_def_constructor_test<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support half precision floating point operations");

--- a/tests/accessor/generic_accessor_def_constructor_fp64.cpp
+++ b/tests/accessor/generic_accessor_def_constructor_fp64.cpp
@@ -27,22 +27,24 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_def_constructor.h"
+
+using namespace generic_accessor_def_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_def_constructor_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor def constructors. fp64 type", "[accessor]")({
-  using namespace generic_accessor_def_constructor;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor def constructors. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-    for_type_vectors_marray<run_generic_def_constructor_test, double>("double");
+    for_type_vectors_marray<run_generic_def_constructor_test, double, TestType>(
+        "double");
 #else
-    run_generic_def_constructor_test<double>{}("double");
+    run_generic_def_constructor_test<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/generic_accessor_linearization.h
+++ b/tests/accessor/generic_accessor_linearization.h
@@ -50,13 +50,25 @@ class run_linearization_tests {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, integer_pack<2, 3>,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_linearization_for_type {
  public:
   void operator()(const std::string &type_name) {
-    const auto access_modes = get_access_modes();
-    const auto dimensions = integer_pack<2, 3>::generate_unnamed();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
+
     auto actual_type_name = type_name_string<T>::get(type_name);
 
     for_all_combinations<run_linearization_tests, T>(access_modes, dimensions,

--- a/tests/accessor/generic_accessor_linearization_core.cpp
+++ b/tests/accessor/generic_accessor_linearization_core.cpp
@@ -27,6 +27,8 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_linearization.h"
+
+using namespace generic_accessor_linearization;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -34,10 +36,10 @@
 
 namespace generic_accessor_linearization_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor linearization test. core types", "[accessor]")({
-  using namespace generic_accessor_linearization;
-  common_run_tests<run_generic_linearization_for_type>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor linearization test. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_generic_linearization_for_type, TestType>();
 });
 
 }  // namespace generic_accessor_linearization_core

--- a/tests/accessor/generic_accessor_linearization_fp16.cpp
+++ b/tests/accessor/generic_accessor_linearization_fp16.cpp
@@ -27,6 +27,8 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_linearization.h"
+
+using namespace generic_accessor_linearization;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -34,9 +36,9 @@
 
 namespace generic_accessor_linearization_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor linearization test. fp16 type", "[accessor]")({
-  using namespace generic_accessor_linearization;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor linearization test. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -46,10 +48,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_generic_linearization_for_type, sycl::half>(
-      "sycl::half");
+  for_type_vectors_marray<run_generic_linearization_for_type, sycl::half,
+                          TestType>("sycl::half");
 #else
-  run_generic_linearization_for_type<sycl::half>{}("sycl::half");
+  run_generic_linearization_for_type<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/generic_accessor_linearization_fp64.cpp
+++ b/tests/accessor/generic_accessor_linearization_fp64.cpp
@@ -27,6 +27,8 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_linearization.h"
+
+using namespace generic_accessor_linearization;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -34,9 +36,9 @@
 
 namespace generic_accessor_linearization_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor linearization test. fp64 type", "[accessor]")({
-  using namespace generic_accessor_linearization;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor linearization test. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -46,9 +48,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_generic_linearization_for_type, double>("double");
+  for_type_vectors_marray<run_generic_linearization_for_type, double, TestType>(
+      "double");
 #else
-  run_generic_linearization_for_type<double>{}("double");
+  run_generic_linearization_for_type<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/generic_accessor_placeholder_buffer_constructor.h
+++ b/tests/accessor/generic_accessor_placeholder_buffer_constructor.h
@@ -68,15 +68,24 @@ class run_tests_placeholder_buffer_constructor {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_placeholder_buffer_constructor_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_placeholder_buffer_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_constructor_core.cpp
@@ -28,16 +28,18 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_constructor_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor placeholder constructors. core types", "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_constructor;
-  common_run_tests<run_generic_placeholder_buffer_constructor_test>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor placeholder constructors. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_generic_placeholder_buffer_constructor_test, TestType>();
 });
 
 }  // namespace generic_accessor_placeholder_buffer_constructor_core

--- a/tests/accessor/generic_accessor_placeholder_buffer_constructor_fp16.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_constructor_fp16.cpp
@@ -28,24 +28,25 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_constructor_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer constructor. fp16 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<run_generic_placeholder_buffer_constructor_test,
-                            sycl::half>("sycl::half");
+                            sycl::half, TestType>("sycl::half");
 #else
-    run_generic_placeholder_buffer_constructor_test<sycl::half>{}("sycl::half");
+    run_generic_placeholder_buffer_constructor_test<sycl::half, TestType>{}(
+        "sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support half precision floating point operations");

--- a/tests/accessor/generic_accessor_placeholder_buffer_constructor_fp64.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_constructor_fp64.cpp
@@ -28,24 +28,25 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_constructor_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer constructor. fp64 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<run_generic_placeholder_buffer_constructor_test,
-                            double>("double");
+                            double, TestType>("double");
 #else
-    run_generic_placeholder_buffer_constructor_test<double>{}("double");
+    run_generic_placeholder_buffer_constructor_test<double, TestType>{}(
+        "double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_constructor.h
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_constructor.h
@@ -70,15 +70,24 @@ class run_tests_placeholder_buffer_range_constructor {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_placeholder_buffer_range_constructor_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_core.cpp
@@ -28,17 +28,19 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_range_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_range_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_range_constructor_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer range constructor. core types",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_range_constructor;
-  common_run_tests<run_generic_placeholder_buffer_range_constructor_test>();
+ "[accessor]", test_combinations)({
+  common_run_tests<run_generic_placeholder_buffer_range_constructor_test,
+                   TestType>();
 });
 
 }  // namespace generic_accessor_placeholder_buffer_range_constructor_core

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_fp16.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_fp16.cpp
@@ -28,25 +28,26 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_range_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_range_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_range_constructor_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer range constructor. fp16 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_range_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
-        run_generic_placeholder_buffer_range_constructor_test, sycl::half>(
-        "sycl::half");
+        run_generic_placeholder_buffer_range_constructor_test, sycl::half,
+        TestType>("sycl::half");
 #else
-    run_generic_placeholder_buffer_range_constructor_test<sycl::half>{}(
+    run_generic_placeholder_buffer_range_constructor_test<sycl::half,
+                                                          TestType>{}(
         "sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_fp64.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_constructor_fp64.cpp
@@ -28,25 +28,26 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_range_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_range_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_range_constructor_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer range constructor. fp64 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_range_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
-        run_generic_placeholder_buffer_range_constructor_test, double>(
-        "double");
+        run_generic_placeholder_buffer_range_constructor_test, double,
+        TestType>("double");
 #else
-    run_generic_placeholder_buffer_range_constructor_test<double>{}("double");
+    run_generic_placeholder_buffer_range_constructor_test<double, TestType>{}(
+        "double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor.h
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor.h
@@ -72,15 +72,24 @@ class run_tests_placeholder_buffer_range_offset_constructor {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_placeholder_buffer_range_offset_constructor_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_core.cpp
@@ -28,19 +28,20 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_range_offset_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_range_offset_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_range_offset_constructor_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer range offset constructor. core "
  "types",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_range_offset_constructor;
-  common_run_tests<
-      run_generic_placeholder_buffer_range_offset_constructor_test>();
+ "[accessor]", test_combinations)({
+  common_run_tests<run_generic_placeholder_buffer_range_offset_constructor_test,
+                   TestType>();
 });
 
 }  // namespace

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_fp16.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_fp16.cpp
@@ -28,26 +28,27 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_range_offset_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_range_offset_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_range_offset_constructor_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer range offset constructor. fp16 "
  "type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_range_offset_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
         run_generic_placeholder_buffer_range_offset_constructor_test,
-        sycl::half>("sycl::half");
+        sycl::half, TestType>("sycl::half");
 #else
-    run_generic_placeholder_buffer_range_offset_constructor_test<sycl::half>{}(
+    run_generic_placeholder_buffer_range_offset_constructor_test<sycl::half,
+                                                                 TestType>{}(
         "sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {

--- a/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_fp64.cpp
+++ b/tests/accessor/generic_accessor_placeholder_buffer_range_offset_constructor_fp64.cpp
@@ -28,26 +28,27 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_buffer_range_offset_constructor.h"
+
+using namespace generic_accessor_placeholder_buffer_range_offset_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_buffer_range_offset_constructor_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder buffer range offset constructor. fp64 "
  "type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_buffer_range_offset_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
-        run_generic_placeholder_buffer_range_offset_constructor_test, double>(
-        "double");
+        run_generic_placeholder_buffer_range_offset_constructor_test, double,
+        TestType>("double");
 #else
-    run_generic_placeholder_buffer_range_offset_constructor_test<double>{}(
+    run_generic_placeholder_buffer_range_offset_constructor_test<double,
+                                                                 TestType>{}(
         "double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor.h
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor.h
@@ -68,15 +68,24 @@ class run_tests_placeholder_zero_length_buffer_constructor {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_placeholder_zero_length_buffer_constructor {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor_core.cpp
@@ -28,18 +28,20 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_constructor_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer constructor. core "
  "types",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_constructor;
-  common_run_tests<run_generic_placeholder_zero_length_buffer_constructor>();
+ "[accessor]", test_combinations)({
+  common_run_tests<run_generic_placeholder_zero_length_buffer_constructor,
+                   TestType>();
 });
 
 }  // namespace generic_accessor_placeholder_zero_length_buffer_constructor_core

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor_fp16.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor_fp16.cpp
@@ -28,25 +28,26 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_constructor_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer constructor. fp16 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
-        run_generic_placeholder_zero_length_buffer_constructor, sycl::half>(
-        "sycl::half");
+        run_generic_placeholder_zero_length_buffer_constructor, sycl::half,
+        TestType>("sycl::half");
 #else
-    run_generic_placeholder_zero_length_buffer_constructor<sycl::half>{}(
+    run_generic_placeholder_zero_length_buffer_constructor<sycl::half,
+                                                           TestType>{}(
         "sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor_fp64.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_constructor_fp64.cpp
@@ -28,25 +28,26 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_constructor_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer constructor. fp64 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
-        run_generic_placeholder_zero_length_buffer_constructor, double>(
-        "double");
+        run_generic_placeholder_zero_length_buffer_constructor, double,
+        TestType>("double");
 #else
-    run_generic_placeholder_zero_length_buffer_constructor<double>{}("double");
+    run_generic_placeholder_zero_length_buffer_constructor<double, TestType>{}(
+        "double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor.h
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor.h
@@ -72,15 +72,24 @@ class run_tests_placeholder_zero_length_buffer_range_constructor {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_placeholder_zero_length_buffer_range_constructor_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor_core.cpp
@@ -28,19 +28,21 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_range_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_range_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_range_constructor_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer range constructor. "
  "core types",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_range_constructor;
+ "[accessor]", test_combinations)({
   common_run_tests<
-      run_generic_placeholder_zero_length_buffer_range_constructor_test>();
+      run_generic_placeholder_zero_length_buffer_range_constructor_test,
+      TestType>();
 });
 
 }  // namespace

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor_fp16.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor_fp16.cpp
@@ -28,27 +28,27 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_range_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_range_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_range_constructor_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer range constructor. "
  "fp16 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_range_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
         run_generic_placeholder_zero_length_buffer_range_constructor_test,
-        sycl::half>("sycl::half");
+        sycl::half, TestType>("sycl::half");
 #else
     run_generic_placeholder_zero_length_buffer_range_constructor_test<
-        sycl::half>{}("sycl::half");
+        sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support half precision floating point operations");

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor_fp64.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_constructor_fp64.cpp
@@ -28,27 +28,27 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_range_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_range_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_range_constructor_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer range constructor. "
  "fp64 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_range_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
         run_generic_placeholder_zero_length_buffer_range_constructor_test,
-        double>("double");
+        double, TestType>("double");
 #else
-    run_generic_placeholder_zero_length_buffer_range_constructor_test<double>{}(
-        "double");
+    run_generic_placeholder_zero_length_buffer_range_constructor_test<
+        double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor.h
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor.h
@@ -73,15 +73,24 @@ class run_tests_placeholder_zero_length_buffer_range_offset_constructor {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_placeholder_zero_length_buffer_range_offset_constructor_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_dimensions();
-    const auto targets = get_targets();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_core.cpp
@@ -28,19 +28,21 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_range_offset_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer range offset "
  "constructor. core types",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor;
+ "[accessor]", test_combinations)({
   common_run_tests<
-      run_generic_placeholder_zero_length_buffer_range_offset_constructor_test>();
+      run_generic_placeholder_zero_length_buffer_range_offset_constructor_test,
+      TestType>();
 });
 
 }  // namespace

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_fp16.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_fp16.cpp
@@ -28,27 +28,27 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_range_offset_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer range offset "
  "constructor. fp16 type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
         run_generic_placeholder_zero_length_buffer_range_offset_constructor_test,
-        sycl::half>("sycl::half");
+        sycl::half, TestType>("sycl::half");
 #else
     run_generic_placeholder_zero_length_buffer_range_offset_constructor_test<
-        sycl::half>{}("sycl::half");
+        sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support half precision floating point operations");

--- a/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_fp64.cpp
+++ b/tests/accessor/generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_fp64.cpp
@@ -28,27 +28,27 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_placeholder_zero_length_buffer_range_offset_constructor.h"
+
+using namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
 ("Generic sycl::accessor placeholder zero-length buffer range offset. fp64 "
  "type",
- "[accessor]")({
-  using namespace generic_accessor_placeholder_zero_length_buffer_range_offset_constructor;
-
+ "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_vectors_marray<
         run_generic_placeholder_zero_length_buffer_range_offset_constructor_test,
-        double>("double");
+        double, TestType>("double");
 #else
     run_generic_placeholder_zero_length_buffer_range_offset_constructor_test<
-        double>{}("double");
+        double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/generic_accessor_properties.h
+++ b/tests/accessor/generic_accessor_properties.h
@@ -415,15 +415,24 @@ class run_tests_properties {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_properties_tests {
  public:
   void operator()(const std::string& type_name) {
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
+
     // Type packs instances have to be const, otherwise for_all_combination
     // will not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
-    const auto targets = get_targets();
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or for_all_device_copyable_std_containers.

--- a/tests/accessor/generic_accessor_properties_core.cpp
+++ b/tests/accessor/generic_accessor_properties_core.cpp
@@ -13,6 +13,8 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_properties.h"
+
+using namespace generic_accessor_properties;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -20,10 +22,10 @@
 
 namespace generic_accessor_properties_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor properties test. core types", "[accessor]")({
-  using namespace generic_accessor_properties;
-  common_run_tests<run_generic_properties_tests>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor properties test. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_generic_properties_tests, TestType>();
 });
 
 }  // namespace generic_accessor_properties_core

--- a/tests/accessor/generic_accessor_properties_fp16.cpp
+++ b/tests/accessor/generic_accessor_properties_fp16.cpp
@@ -13,6 +13,8 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_properties.h"
+
+using namespace generic_accessor_properties;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -20,9 +22,9 @@
 
 namespace generic_accessor_properties_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor properties test. fp16 type", "[accessor]")({
-  using namespace generic_accessor_properties;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor properties test. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -32,10 +34,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_generic_properties_tests, sycl::half>(
+  for_type_vectors_marray<run_generic_properties_tests, sycl::half, TestType>(
       "sycl::half");
 #else
-  run_generic_properties_tests<sycl::half>{}("sycl::half");
+  run_generic_properties_tests<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/generic_accessor_properties_fp64.cpp
+++ b/tests/accessor/generic_accessor_properties_fp64.cpp
@@ -13,6 +13,8 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_properties.h"
+
+using namespace generic_accessor_properties;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -20,9 +22,9 @@
 
 namespace generic_accessor_properties_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor properties test. fp64 type", "[accessor]")({
-  using namespace generic_accessor_properties;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor properties test. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -32,9 +34,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_generic_properties_tests, double>("double");
+  for_type_vectors_marray<run_generic_properties_tests, double, TestType>(
+      "double");
 #else
-  run_generic_properties_tests<double>{}("double");
+  run_generic_properties_tests<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/generic_accessor_zero_dim_constructor.h
+++ b/tests/accessor/generic_accessor_zero_dim_constructor.h
@@ -63,16 +63,24 @@ class run_tests_zero_dim_constructor {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, integer_pack<0>,
+                              targets_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_generic_zero_dim_constructor_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+    using TargetsPack = typename std::tuple_element<2, ArgCombination>::type;
 
-    const auto dimensions = integer_pack<0>::generate_unnamed();
-    const auto targets = get_targets();
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+    const auto targets = TargetsPack::generate_named();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/generic_accessor_zero_dim_constructor_core.cpp
+++ b/tests/accessor/generic_accessor_zero_dim_constructor_core.cpp
@@ -28,16 +28,18 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_zero_dim_constructor.h"
+
+using namespace generic_accessor_zero_dim_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_zero_dim_constructor_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor zero-dim constructors. core types", "[accessor]")({
-  using namespace generic_accessor_zero_dim_constructor;
-  common_run_tests<run_generic_zero_dim_constructor_test>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor zero-dim constructors. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_generic_zero_dim_constructor_test, TestType>();
 });
 
 }  // namespace generic_accessor_zero_dim_constructor_core

--- a/tests/accessor/generic_accessor_zero_dim_constructor_fp16.cpp
+++ b/tests/accessor/generic_accessor_zero_dim_constructor_fp16.cpp
@@ -27,23 +27,24 @@
 
 #include "accessor_common.h"
 #include "generic_accessor_zero_dim_constructor.h"
+
+using namespace generic_accessor_zero_dim_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_zero_dim_constructor_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor zero-dim constructors. fp16 type", "[accessor]")({
-  using namespace generic_accessor_zero_dim_constructor;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor zero-dim constructors. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-    for_type_vectors_marray<run_generic_zero_dim_constructor_test, sycl::half>(
-        "sycl::half");
+    for_type_vectors_marray<run_generic_zero_dim_constructor_test, sycl::half,
+                            TestType>("sycl::half");
 #else
-    run_generic_zero_dim_constructor_test<sycl::half>{}("sycl::half");
+    run_generic_zero_dim_constructor_test<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support half precision floating point operations");

--- a/tests/accessor/generic_accessor_zero_dim_constructor_fp64.cpp
+++ b/tests/accessor/generic_accessor_zero_dim_constructor_fp64.cpp
@@ -26,23 +26,24 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "generic_accessor_zero_dim_constructor.h"
+
+using namespace generic_accessor_zero_dim_constructor;
 #endif
 
 #include "../common/disabled_for_test_case.h"
 
 namespace generic_accessor_zero_dim_constructor_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("Generic sycl::accessor zero-dim constructors. fp64 type", "[accessor]")({
-  using namespace generic_accessor_zero_dim_constructor;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("Generic sycl::accessor zero-dim constructors. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-    for_type_vectors_marray<run_generic_zero_dim_constructor_test, double>(
-        "double");
+    for_type_vectors_marray<run_generic_zero_dim_constructor_test, double,
+                            TestType>("double");
 #else
-    run_generic_zero_dim_constructor_test<double>{}("double");
+    run_generic_zero_dim_constructor_test<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/host_accessor_api_common.h
+++ b/tests/accessor/host_accessor_api_common.h
@@ -197,12 +197,21 @@ class run_api_tests {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_host_accessor_api_for_type {
  public:
   void operator()(const std::string &type_name) {
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or

--- a/tests/accessor/host_accessor_api_core.cpp
+++ b/tests/accessor/host_accessor_api_core.cpp
@@ -12,14 +12,15 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "host_accessor_api_common.h"
+
+using namespace host_accessor_api_common;
 #endif
 
 namespace host_accessor_api_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor api. core types", "[accessor]")({
-  using namespace host_accessor_api_common;
-  common_run_tests<run_host_accessor_api_for_type>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor api. core types", "[accessor]", test_combinations)({
+  common_run_tests<run_host_accessor_api_for_type, TestType>();
 });
 
 }  // namespace host_accessor_api_core

--- a/tests/accessor/host_accessor_api_fp16.cpp
+++ b/tests/accessor/host_accessor_api_fp16.cpp
@@ -12,14 +12,14 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "host_accessor_api_common.h"
+
+using namespace host_accessor_api_common;
 #endif
 
 namespace host_accessor_api_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor api. fp16 type", "[accessor]")({
-  using namespace host_accessor_api_common;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor api. fp16 type", "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -29,10 +29,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_host_accessor_api_for_type, sycl::half>(
+  for_type_vectors_marray<run_host_accessor_api_for_type, sycl::half, TestType>(
       "sycl::half");
 #else
-  run_host_accessor_api_for_type<sycl::half>{}("sycl::half");
+  run_host_accessor_api_for_type<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace host_accessor_api_fp16

--- a/tests/accessor/host_accessor_api_fp64.cpp
+++ b/tests/accessor/host_accessor_api_fp64.cpp
@@ -12,14 +12,14 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "host_accessor_api_common.h"
+
+using namespace host_accessor_api_common;
 #endif
 
 namespace host_accessor_api_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor api. fp64 type", "[accessor]")({
-  using namespace host_accessor_api_common;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor api. fp64 type", "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -29,9 +29,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_host_accessor_api_for_type, double>("double");
+  for_type_vectors_marray<run_host_accessor_api_for_type, double, TestType>(
+      "double");
 #else
-  run_host_accessor_api_for_type<double>{}("double");
+  run_host_accessor_api_for_type<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace host_accessor_api_fp64

--- a/tests/accessor/host_accessor_constructors.h
+++ b/tests/accessor/host_accessor_constructors.h
@@ -253,14 +253,21 @@ class run_tests_constructors {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_host_constructors_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or for_all_device_copyable_std_containers.

--- a/tests/accessor/host_accessor_constructors_core.cpp
+++ b/tests/accessor/host_accessor_constructors_core.cpp
@@ -25,6 +25,8 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "host_accessor_constructors.h"
+
+using namespace host_accessor_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -32,10 +34,10 @@
 
 namespace host_accessor_constructors_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor constructors. core types", "[accessor]")({
-  using namespace host_accessor_constructors;
-  common_run_tests<run_host_constructors_test>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor constructors. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_host_constructors_test, TestType>();
 });
 
 }  // namespace host_accessor_constructors_core

--- a/tests/accessor/host_accessor_constructors_fp16.cpp
+++ b/tests/accessor/host_accessor_constructors_fp16.cpp
@@ -26,6 +26,8 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "host_accessor_constructors.h"
+
+using namespace host_accessor_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -33,9 +35,9 @@
 
 namespace host_accessor_constructors_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor constructors. fp16 type", "[accessor]")({
-  using namespace host_accessor_constructors;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor constructors. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -45,9 +47,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_host_constructors_test, sycl::half>("sycl::half");
+  for_type_vectors_marray<run_host_constructors_test, sycl::half, TestType>(
+      "sycl::half");
 #else
-  run_host_constructors_test<sycl::half>{}("sycl::half");
+  run_host_constructors_test<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace host_accessor_constructors_fp16

--- a/tests/accessor/host_accessor_constructors_fp64.cpp
+++ b/tests/accessor/host_accessor_constructors_fp64.cpp
@@ -26,6 +26,8 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "host_accessor_constructors.h"
+
+using namespace host_accessor_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -33,9 +35,9 @@
 
 namespace host_accessor_constructors_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor constructors. fp64 type", "[accessor]")({
-  using namespace host_accessor_constructors;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor constructors. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -45,9 +47,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_host_constructors_test, double>("double");
+  for_type_vectors_marray<run_host_constructors_test, double, TestType>(
+      "double");
 #else
-  run_host_constructors_test<double>{}("double");
+  run_host_constructors_test<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace host_accessor_constructors_fp64

--- a/tests/accessor/host_accessor_linearization.h
+++ b/tests/accessor/host_accessor_linearization.h
@@ -43,12 +43,22 @@ class run_linearization_tests {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, integer_pack<2, 3>>::type;
+
+template <typename T, typename ArgCombination>
 class run_host_linearization_for_type {
  public:
   void operator()(const std::string &type_name) {
-    const auto access_modes = get_access_modes();
-    const auto dimensions = integer_pack<2, 3>::generate_unnamed();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
+
     auto actual_type_name = type_name_string<T>::get(type_name);
 
     for_all_combinations<run_linearization_tests, T>(access_modes, dimensions,

--- a/tests/accessor/host_accessor_linearization_core.cpp
+++ b/tests/accessor/host_accessor_linearization_core.cpp
@@ -27,14 +27,16 @@
 
 #include "accessor_common.h"
 #include "host_accessor_linearization.h"
+
+using namespace host_accessor_linearization;
 #endif
 
 namespace host_accessor_liniarization_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor linearization. core types", "[accessor]")({
-  using namespace host_accessor_linearization;
-  common_run_tests<run_host_linearization_for_type>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor linearization. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_host_linearization_for_type, TestType>();
 });
 
 }  // namespace host_accessor_liniarization_core

--- a/tests/accessor/host_accessor_linearization_fp16.cpp
+++ b/tests/accessor/host_accessor_linearization_fp16.cpp
@@ -27,6 +27,8 @@
 
 #include "accessor_common.h"
 #include "host_accessor_linearization.h"
+
+using namespace host_accessor_linearization;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -34,9 +36,9 @@
 
 namespace host_accessor_linearization_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor linearization test. fp16 type", "[accessor]")({
-  using namespace host_accessor_linearization;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor linearization test. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -46,10 +48,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_host_linearization_for_type, sycl::half>(
-      "sycl::half");
+  for_type_vectors_marray<run_host_linearization_for_type, sycl::half,
+                          TestType>("sycl::half");
 #else
-  run_host_linearization_for_type<sycl::half>{}("sycl::half");
+  run_host_linearization_for_type<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/host_accessor_linearization_fp64.cpp
+++ b/tests/accessor/host_accessor_linearization_fp64.cpp
@@ -27,6 +27,8 @@
 
 #include "accessor_common.h"
 #include "host_accessor_linearization.h"
+
+using namespace host_accessor_linearization;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -34,9 +36,9 @@
 
 namespace host_accessor_linearization_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor linearization test. fp64 type", "[accessor]")({
-  using namespace host_accessor_linearization;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor linearization test. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -46,9 +48,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_host_linearization_for_type, double>("double");
+  for_type_vectors_marray<run_host_linearization_for_type, double, TestType>(
+      "double");
 #else
-  run_host_linearization_for_type<double>{}("double");
+  run_host_linearization_for_type<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/host_accessor_properties.h
+++ b/tests/accessor/host_accessor_properties.h
@@ -320,14 +320,21 @@ class run_tests_properties {
   }
 };
 
-template <typename T>
+using test_combinations =
+    typename get_combinations<access_modes_pack, all_dimensions_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_host_properties_tests {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto access_modes = get_access_modes();
-    const auto dimensions = get_all_dimensions();
+    // Get the packs from the test combination type.
+    using AccessModePack = typename std::tuple_element<0, ArgCombination>::type;
+    using DimensionsPack = typename std::tuple_element<1, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto access_modes = AccessModePack::generate_named();
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or for_all_device_copyable_std_containers.

--- a/tests/accessor/host_accessor_properties_core.cpp
+++ b/tests/accessor/host_accessor_properties_core.cpp
@@ -12,6 +12,8 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "host_accessor_properties.h"
+
+using namespace host_accessor_properties;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -19,10 +21,10 @@
 
 namespace host_accessor_properties_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor properties. core types", "[accessor]")({
-  using namespace host_accessor_properties;
-  common_run_tests<run_host_properties_tests>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor properties. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_host_properties_tests, TestType>();
 });
 
 }  // namespace host_accessor_properties_core

--- a/tests/accessor/host_accessor_properties_fp16.cpp
+++ b/tests/accessor/host_accessor_properties_fp16.cpp
@@ -13,6 +13,8 @@
 
 #include "accessor_common.h"
 #include "host_accessor_properties.h"
+
+using namespace host_accessor_properties;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -20,9 +22,8 @@
 
 namespace host_accessor_properties_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor properties. fp16 type", "[accessor]")({
-  using namespace host_accessor_properties;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor properties. fp16 type", "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -32,9 +33,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_host_properties_tests, sycl::half>("sycl::half");
+  for_type_vectors_marray<run_host_properties_tests, sycl::half, TestType>(
+      "sycl::half");
 #else
-  run_host_properties_tests<sycl::half>{}("sycl::half");
+  run_host_properties_tests<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace host_accessor_properties_fp16

--- a/tests/accessor/host_accessor_properties_fp64.cpp
+++ b/tests/accessor/host_accessor_properties_fp64.cpp
@@ -13,6 +13,8 @@
 
 #include "accessor_common.h"
 #include "host_accessor_properties.h"
+
+using namespace host_accessor_properties;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -20,9 +22,8 @@
 
 namespace host_accessor_properties_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::host_accessor properties. fp64 type", "[accessor]")({
-  using namespace host_accessor_properties;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::host_accessor properties. fp64 type", "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -32,9 +33,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_host_properties_tests, double>("double");
+  for_type_vectors_marray<run_host_properties_tests, double, TestType>(
+      "double");
 #else
-  run_host_properties_tests<double>{}("double");
+  run_host_properties_tests<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace host_accessor_properties_fp64

--- a/tests/accessor/local_accessor_access_among_work_items.h
+++ b/tests/accessor/local_accessor_access_among_work_items.h
@@ -102,13 +102,18 @@ class run_test {
   }
 };
 
-template <typename T>
+using test_combinations = typename get_combinations<dimensions_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_local_accessor_access_among_work_items_tests {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto dimensions = get_dimensions();
+    // Get the packs from the test combination type.
+    using DimensionsPack = typename std::tuple_element<0, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     for_all_combinations<run_test, T>(dimensions, type_name);
   }

--- a/tests/accessor/local_accessor_access_among_work_items_core.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_core.cpp
@@ -23,9 +23,11 @@ using namespace accessor_tests_common;
 
 namespace local_accessor_access_among_work_items_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor access among work items. core types", "[accessor]")({
-  common_run_tests<run_local_accessor_access_among_work_items_tests>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor access among work items. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_local_accessor_access_among_work_items_tests,
+                   TestType>();
 });
 
 }  // namespace local_accessor_access_among_work_items_core

--- a/tests/accessor/local_accessor_access_among_work_items_fp16.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_fp16.cpp
@@ -22,8 +22,9 @@ using namespace accessor_tests_common;
 
 namespace local_accessor_access_among_work_items_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor access among work items. fp16 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor access among work items. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -34,9 +35,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   for_type_vectors_marray<run_local_accessor_access_among_work_items_tests,
-                          sycl::half>("sycl::half");
+                          sycl::half, TestType>("sycl::half");
 #else
-  run_local_accessor_access_among_work_items_tests<sycl::half>{}("sycl::half");
+  run_local_accessor_access_among_work_items_tests<sycl::half, TestType>{}(
+      "sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/local_accessor_access_among_work_items_fp64.cpp
+++ b/tests/accessor/local_accessor_access_among_work_items_fp64.cpp
@@ -22,8 +22,9 @@ using namespace accessor_tests_common;
 
 namespace local_accessor_access_among_work_items_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor access among work items. fp64 type", "[accessor]")({
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor access among work items. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -34,9 +35,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   for_type_vectors_marray<run_local_accessor_access_among_work_items_tests,
-                          double>("double");
+                          double, TestType>("double");
 #else
-  run_local_accessor_access_among_work_items_tests<double>{}("double");
+  run_local_accessor_access_among_work_items_tests<double, TestType>{}(
+      "double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/local_accessor_api_common.h
+++ b/tests/accessor/local_accessor_api_common.h
@@ -341,11 +341,18 @@ class run_api_tests {
   }
 };
 
-template <typename T>
+using test_combinations = typename get_combinations<dimensions_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_local_api_for_type {
  public:
   void operator()(const std::string &type_name) {
-    const auto dimensions = get_all_dimensions();
+    // Get the packs from the test combination type.
+    using DimensionsPack = typename std::tuple_element<0, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or for_all_device_copyable_std_containers.

--- a/tests/accessor/local_accessor_api_core.cpp
+++ b/tests/accessor/local_accessor_api_core.cpp
@@ -12,14 +12,14 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "local_accessor_api_common.h"
+
+using namespace local_accessor_api_common;
 #endif
 
 namespace local_accessor_api_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor api. core types", "[accessor]")({
-  using namespace local_accessor_api_common;
-  common_run_tests<run_local_api_for_type>();
-});
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor api. core types", "[accessor]",
+ test_combinations)({ common_run_tests<run_local_api_for_type, TestType>(); });
 
 }  // namespace local_accessor_api_core

--- a/tests/accessor/local_accessor_api_fp16.cpp
+++ b/tests/accessor/local_accessor_api_fp16.cpp
@@ -12,14 +12,14 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "local_accessor_api_common.h"
+
+using namespace local_accessor_api_common;
 #endif
 
 namespace local_accessor_api_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor api. fp16 type", "[accessor]")({
-  using namespace local_accessor_api_common;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor api. fp16 type", "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -29,9 +29,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_local_api_for_type, sycl::half>("sycl::half");
+  for_type_vectors_marray<run_local_api_for_type, sycl::half, TestType>(
+      "sycl::half");
 #else
-  run_local_api_for_type<sycl::half>{}("sycl::half");
+  run_local_api_for_type<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace local_accessor_api_fp16

--- a/tests/accessor/local_accessor_api_fp64.cpp
+++ b/tests/accessor/local_accessor_api_fp64.cpp
@@ -12,14 +12,14 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "local_accessor_api_common.h"
+
+using namespace local_accessor_api_common;
 #endif
 
 namespace local_accessor_api_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor api. fp64 type", "[accessor]")({
-  using namespace local_accessor_api_common;
-
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor api. fp64 type", "[accessor]", test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -29,9 +29,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_local_api_for_type, double>("double");
+  for_type_vectors_marray<run_local_api_for_type, double, TestType>("double");
 #else
-  run_local_api_for_type<double>{}("double");
+  run_local_api_for_type<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 }  // namespace local_accessor_api_fp64

--- a/tests/accessor/local_accessor_constructors.h
+++ b/tests/accessor/local_accessor_constructors.h
@@ -174,13 +174,18 @@ class run_tests_constructors {
   }
 };
 
-template <typename T>
+using test_combinations = typename get_combinations<dimensions_pack>::type;
+
+template <typename T, typename ArgCombination>
 class run_local_constructors_test {
  public:
   void operator()(const std::string& type_name) {
-    // Type packs instances have to be const, otherwise for_all_combination will
-    // not compile
-    const auto dimensions = get_all_dimensions();
+    // Get the packs from the test combination type.
+    using DimensionsPack = typename std::tuple_element<0, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto dimensions = DimensionsPack::generate_unnamed();
 
     // To handle cases when class was called from functions
     // like for_all_types_vectors_marray or for_all_device_copyable_std_containers.

--- a/tests/accessor/local_accessor_constructors_core.cpp
+++ b/tests/accessor/local_accessor_constructors_core.cpp
@@ -27,6 +27,8 @@
 
 #include "accessor_common.h"
 #include "local_accessor_constructors.h"
+
+using namespace local_accessor_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -34,9 +36,9 @@
 
 namespace local_accessor_constructors_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor constructors. core types", "[accessor]")({
-  using namespace local_accessor_constructors;
-  common_run_tests<run_local_constructors_test>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor constructors. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_local_constructors_test, TestType>();
 });
 }  // namespace local_accessor_constructors_core

--- a/tests/accessor/local_accessor_constructors_fp16.cpp
+++ b/tests/accessor/local_accessor_constructors_fp16.cpp
@@ -25,6 +25,8 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "local_accessor_constructors.h"
+
+using namespace local_accessor_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -32,16 +34,16 @@
 
 namespace local_accessor_constructors_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor constructors. fp16 type", "[accessor]")({
-  using namespace local_accessor_constructors;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor constructors. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp16)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-    for_type_vectors_marray<run_local_constructors_test, sycl::half>(
+    for_type_vectors_marray<run_local_constructors_test, sycl::half, TestType>(
         "sycl::half");
 #else
-    run_local_constructors_test<sycl::half>{}("sycl::half");
+    run_local_constructors_test<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support half precision floating point operations");

--- a/tests/accessor/local_accessor_constructors_fp64.cpp
+++ b/tests/accessor/local_accessor_constructors_fp64.cpp
@@ -25,6 +25,8 @@
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 #include "accessor_common.h"
 #include "local_accessor_constructors.h"
+
+using namespace local_accessor_constructors;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -32,15 +34,16 @@
 
 namespace local_accessor_constructors_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor constructors. fp64 type", "[accessor]")({
-  using namespace local_accessor_constructors;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor constructors. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (queue.get_device().has(sycl::aspect::fp64)) {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-    for_type_vectors_marray<run_local_constructors_test, double>("double");
+    for_type_vectors_marray<run_local_constructors_test, double, TestType>(
+        "double");
 #else
-    run_local_constructors_test<double>{}("double");
+    run_local_constructors_test<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   } else {
     WARN("Device does not support double precision floating point operations");

--- a/tests/accessor/local_accessor_linearization.h
+++ b/tests/accessor/local_accessor_linearization.h
@@ -77,11 +77,19 @@ class run_linearization_tests {
   }
 };
 
-template <typename T>
+using test_combinations = typename get_combinations<integer_pack<2, 3>>::type;
+
+template <typename T, typename ArgCombination>
 class run_local_linearization_for_type {
  public:
   void operator()(const std::string &type_name) {
-    const auto dimensions = integer_pack<2, 3>::generate_unnamed();
+    // Get the packs from the test combination type.
+    using DimensionsPack = typename std::tuple_element<0, ArgCombination>::type;
+
+    // Type packs instances have to be const, otherwise for_all_combination
+    // will not compile
+    const auto dimensions = DimensionsPack::generate_unnamed();
+
     auto actual_type_name = type_name_string<T>::get(type_name);
 
     for_all_combinations<run_linearization_tests, T>(dimensions,

--- a/tests/accessor/local_accessor_linearization_core.cpp
+++ b/tests/accessor/local_accessor_linearization_core.cpp
@@ -27,14 +27,16 @@
 
 #include "accessor_common.h"
 #include "local_accessor_linearization.h"
+
+using namespace local_accessor_linearization;
 #endif
 
 namespace local_accessor_liniarization_core {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor linearization. core types", "[accessor]")({
-  using namespace local_accessor_linearization;
-  common_run_tests<run_local_linearization_for_type>();
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor linearization. core types", "[accessor]",
+ test_combinations)({
+  common_run_tests<run_local_linearization_for_type, TestType>();
 });
 
 }  // namespace local_accessor_liniarization_core

--- a/tests/accessor/local_accessor_linearization_fp16.cpp
+++ b/tests/accessor/local_accessor_linearization_fp16.cpp
@@ -27,6 +27,8 @@
 
 #include "accessor_common.h"
 #include "local_accessor_linearization.h"
+
+using namespace local_accessor_linearization;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -34,9 +36,9 @@
 
 namespace local_accessor_linearization_fp16 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor linearization test. fp16 type", "[accessor]")({
-  using namespace local_accessor_linearization;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor linearization test. fp16 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
@@ -46,10 +48,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_local_linearization_for_type, sycl::half>(
-      "sycl::half");
+  for_type_vectors_marray<run_local_linearization_for_type, sycl::half,
+                          TestType>("sycl::half");
 #else
-  run_local_linearization_for_type<sycl::half>{}("sycl::half");
+  run_local_linearization_for_type<sycl::half, TestType>{}("sycl::half");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/accessor/local_accessor_linearization_fp64.cpp
+++ b/tests/accessor/local_accessor_linearization_fp64.cpp
@@ -27,6 +27,8 @@
 
 #include "accessor_common.h"
 #include "local_accessor_linearization.h"
+
+using namespace local_accessor_linearization;
 #endif
 
 #include "../common/disabled_for_test_case.h"
@@ -34,9 +36,9 @@
 
 namespace local_accessor_linearization_fp64 {
 
-DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
-("sycl::local_accessor linearization test. fp64 type", "[accessor]")({
-  using namespace local_accessor_linearization;
+DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(hipSYCL, ComputeCpp)
+("sycl::local_accessor linearization test. fp64 type", "[accessor]",
+ test_combinations)({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
@@ -46,9 +48,10 @@ DISABLED_FOR_TEST_CASE(hipSYCL, ComputeCpp)
   }
 
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
-  for_type_vectors_marray<run_local_linearization_for_type, double>("double");
+  for_type_vectors_marray<run_local_linearization_for_type, double, TestType>(
+      "double");
 #else
-  run_local_linearization_for_type<double>{}("double");
+  run_local_linearization_for_type<double, TestType>{}("double");
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 });
 

--- a/tests/common/disabled_for_test_case.h
+++ b/tests/common/disabled_for_test_case.h
@@ -11,6 +11,7 @@
 
 // This is required for detecting the active SYCL implementation
 #include "macro_utils.h"
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <sycl/sycl.hpp>
 
@@ -42,6 +43,9 @@
 
 #define DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(...) \
   INTERNAL_CTS_DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(__VA_ARGS__)
+
+#define DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(...) \
+  INTERNAL_CTS_DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(__VA_ARGS__)
 
 // ------------------------------------------------------------------------------------
 
@@ -145,5 +149,11 @@
 #define INTERNAL_CTS_DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(...) \
   INTERNAL_CTS_MAYBE_DISABLE_TEST_CASE(                       \
       INTERNAL_CTS_ENABLED_TEMPLATE_TEST_CASE_SIG, __VA_ARGS__)
+
+#define INTERNAL_CTS_ENABLED_TEMPLATE_LIST_TEST_CASE(...) \
+  TEMPLATE_LIST_TEST_CASE(__VA_ARGS__) INTERNAL_CTS_ENABLED_TEST_CASE_BODY
+#define INTERNAL_CTS_DISABLED_FOR_TEMPLATE_LIST_TEST_CASE(...) \
+  INTERNAL_CTS_MAYBE_DISABLE_TEST_CASE(                        \
+      INTERNAL_CTS_ENABLED_TEMPLATE_LIST_TEST_CASE, __VA_ARGS__)
 
 #endif


### PR DESCRIPTION
Currently the tests for accessors iterate through all combinations of valid arguments each time they try to run a specific section for a specific combination. Though the irrelevant combinations for a given section run no checks or do any significant work, they still introduce an overhead that accumulates, causing it to increase drastically when any of the argument spaces increase, e.g. as the type arguments do in full-conformance mode.

To decrease the overhead, this commit changes the accessor tests to use "templated" test cases which each get a combination of arguments and will not check for their relevant sections under other combinations. This should not affect the coverage of the tests, but should decrease the width of the search each section run has to do.

Note that this only currently templates the test cases on access mode, dimensions, and targets. Including the types in this to further focus testing runs is left for future work.