### PR TITLE
Fix defects in vector `check_*` functions

### DIFF
--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -433,8 +433,21 @@ bool check_vector_convert(sycl::vec<vecType, N> inputVec) {
 template <typename vecType, int N, typename asType, int asN>
 bool check_as_result(sycl::vec<vecType, N> inputVec,
                      sycl::vec<asType, asN> asVec) {
-  constexpr int n = std::min(N * sizeof(vecType), asN * sizeof(asVec));
-  return std::memcmp(&inputVec[0], &asVec[0], n) == 0;
+  vecType tmp_ptr[N];
+  for (size_t i = 0; i < N; ++i) {
+    tmp_ptr[i] = getElement(inputVec, i);
+  }
+  asType exp_ptr[asN];
+  for (size_t i = 0; i < asN; ++i) {
+    exp_ptr[i] = getElement(asVec, i);
+  }
+  std::memcpy(exp_ptr, tmp_ptr, std::min(sizeof(exp_ptr), sizeof(tmp_ptr)));
+  for (size_t i = 0; i < asN; ++i) {
+    if (exp_ptr[i] != getElement(asVec, i)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
Change the return type of `check_as_result` to `bool` to match its definition.

Fix `check_convert_as_all_dims` and `check_convert_as_all_types` to combine `check_*` results using the `&=` operator rather than the `+=` operator. This change is consistent with the definition of `check_vector_convert_modes`.

Fix `check_vector_convert_result` to use the `rte` or `rtz` conversion functions when the `mode` is `rounding_mode::automatic`.