### PR TITLE
Fix expected return type for get_pointer().

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -925,7 +925,7 @@ void test_accessor_ptr(AccT& accessor, T expected_data) {
 // hipsycl and computecpp
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_COMPUTECPP
 template <typename T, typename AccT, typename AccRes>
-void test_accessor_ptr_device(AccT& accessor, T expected_data,
+void test_accessor_ptr_device(AccT& accessor, T& expected_data,
                               AccRes& res_acc) {
   auto acc_multi_ptr_no =
       accessor.template get_multi_ptr<sycl::access::decorated::no>();
@@ -943,8 +943,7 @@ void test_accessor_ptr_device(AccT& accessor, T expected_data,
                                             expected_data);
 
   auto acc_pointer = accessor.get_pointer();
-  res_acc[0] &= std::is_same_v<decltype(acc_pointer),
-                               std::add_pointer_t<typename AccT::value_type>>;
+  res_acc[0] &= std::is_same_v<decltype(acc_pointer), sycl::global_ptr<T>>;
   res_acc[0] &= value_operations::are_equal(*acc_pointer, expected_data);
 }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL &&

--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -239,7 +239,10 @@ class run_api_tests {
                     kernel_buffer_accessor<T, AccessT, DimensionT, TargetT>;
                 sycl::accessor res_acc(res_buf, cgh);
                 cgh.single_task<kname>([acc, res_acc]() {
-                  test_accessor_ptr_device(acc, expected_val, res_acc);
+                  T converted_expected_val =
+                      value_operations::init<T>(expected_val);
+                  test_accessor_ptr_device(acc, converted_expected_val,
+                                           res_acc);
                   res_acc[0] &= test_begin_end_device(acc, expected_val,
                                                       expected_val, true);
                   if constexpr (0 < dims) {
@@ -351,7 +354,8 @@ class run_api_tests {
                   using kname = kernel_offset<T, AccessT, DimensionT, TargetT>;
                   sycl::accessor res_acc(res_buf, cgh);
                   cgh.single_task<kname>([=]() {
-                    test_accessor_ptr_device(acc, T(), res_acc);
+                    T empty_val = T();
+                    test_accessor_ptr_device(acc, empty_val, res_acc);
                     res_acc[0] &= test_begin_end_device(
                         acc, value_operations::init<T>(first_elem),
                         value_operations::init<T>(last_elem), true);

--- a/tests/accessor/local_accessor_api_common.h
+++ b/tests/accessor/local_accessor_api_common.h
@@ -115,7 +115,7 @@ void test_local_accessor_ptr(AccT &accessor, T expected_data, AccRes &res_acc,
   auto acc_pointer = accessor.get_pointer();
   res_acc[sycl::id<2>(to_integral(check::get_pointer_type), item_id)] =
       std::is_same_v<decltype(acc_pointer),
-                     std::add_pointer_t<typename AccT::value_type>>;
+                     sycl::local_ptr<typename AccT::value_type>>;
   if constexpr (!std::is_const_v<typename AccT::value_type>) {
     res_acc[sycl::id<2>(to_integral(check::get_multi_ptr_no_result), item_id)] =
         value_operations::are_equal(*acc_multi_ptr_no, expected_data);


### PR DESCRIPTION
According to recent changes in SYCL2020 spec (https://github.com/KhronosGroup/SYCL-Docs/pull/432), update expected return types for `get_pointer()` in different cases.