### PR TITLE
Use accessor and feature more in optional kernel features tests

### DIFF
--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -73,9 +73,9 @@ template <typename T>
 inline void use_feature_function_non_decorated_with_accessor(
     const sycl::accessor<bool, 1> &acc) {
   unsigned long long temp = acc[0];
-  T feature1(temp);
-  feature1 += 1;
-  acc[0] = (feature1 * 4 / 3 > 2);
+  T feature(temp);
+  feature += 1;
+  acc[0] = (feature * 4 / 3 > 2);
 }
 
 /**
@@ -88,9 +88,9 @@ template <typename T, sycl::aspect aspect>
 [[sycl::device_has(aspect)]] void use_feature_function_decorated(
     const sycl::accessor<bool, 1> &acc) {
   unsigned long long temp = acc[0];
-  T feature1(temp);
-  feature1 += 1;
-  acc[0] = (feature1 * 4 / 3 > 2);
+  T feature(temp);
+  feature += 1;
+  acc[0] = (feature * 4 / 3 > 2);
 }
 
 /**
@@ -126,9 +126,9 @@ inline void dummy_function_non_decorated(const sycl::accessor<bool, 1> &acc) {
  */
 #define USE_FEATURE(TYPE)           \
   unsigned long long temp = acc[0]; \
-  TYPE feature1(temp);              \
-  feature1 += 1;                    \
-  acc[0] = (feature1 * 4 / 3 > 2);
+  TYPE feature(temp);               \
+  feature += 1;                     \
+  acc[0] = (feature * 4 / 3 > 2);
 
 /**
  * @brief Not decorated functor that use feature defined in FeatureTypeT

--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -65,6 +65,15 @@ inline void use_feature_function_non_decorated() {
 }
 
 /**
+ * @brief Macro for generating code that will use TYPE
+ */
+#define USE_FEATURE(TYPE)           \
+  unsigned long long temp = acc[0]; \
+  TYPE feature(temp);               \
+  feature += 1;                     \
+  acc[0] = feature * 4 / 3 > 2;
+
+/**
  * @brief The function that use T
  *
  * @tparam T The type of variable that will use inside the function
@@ -72,10 +81,7 @@ inline void use_feature_function_non_decorated() {
 template <typename T>
 inline void use_feature_function_non_decorated_with_accessor(
     const sycl::accessor<bool, 1> &acc) {
-  unsigned long long temp = acc[0];
-  T feature(temp);
-  feature += 1;
-  acc[0] = feature * 4 / 3 > 2;
+  USE_FEATURE(T)
 }
 
 /**
@@ -87,10 +93,7 @@ inline void use_feature_function_non_decorated_with_accessor(
 template <typename T, sycl::aspect aspect>
 [[sycl::device_has(aspect)]] void use_feature_function_decorated(
     const sycl::accessor<bool, 1> &acc) {
-  unsigned long long temp = acc[0];
-  T feature(temp);
-  feature += 1;
-  acc[0] = feature * 4 / 3 > 2;
+  USE_FEATURE(T)
 }
 
 /**
@@ -120,15 +123,6 @@ inline void dummy_function_non_decorated(const sycl::accessor<bool, 1> &acc) {
   var1 += 42;
   acc[0] = (var1 == var2);
 }
-
-/**
- * @brief Macro for generating code that will use TYPE
- */
-#define USE_FEATURE(TYPE)           \
-  unsigned long long temp = acc[0]; \
-  TYPE feature(temp);               \
-  feature += 1;                     \
-  acc[0] = feature * 4 / 3 > 2;
 
 /**
  * @brief Not decorated functor that use feature defined in FeatureTypeT

--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -72,11 +72,10 @@ inline void use_feature_function_non_decorated() {
 template <typename T>
 inline void use_feature_function_non_decorated_with_accessor(
     const sycl::accessor<bool, 1> &acc) {
-  unsigned long long temp = 42;
+  unsigned long long temp = acc[0];
   T feature1(temp);
-  T feature2(temp);
-  feature1 += 42;
-  acc[0] = (feature1 == feature2);
+  feature1 += 1;
+  acc[0] = (feature1 * 4 / 3 > 2);
 }
 
 /**
@@ -88,11 +87,10 @@ inline void use_feature_function_non_decorated_with_accessor(
 template <typename T, sycl::aspect aspect>
 [[sycl::device_has(aspect)]] void use_feature_function_decorated(
     const sycl::accessor<bool, 1> &acc) {
-  unsigned long long temp = 42;
+  unsigned long long temp = acc[0];
   T feature1(temp);
-  T feature2(temp);
-  feature1 += 42;
-  acc[0] = (feature1 == feature2);
+  feature1 += 1;
+  acc[0] = (feature1 * 4 / 3 > 2);
 }
 
 /**
@@ -126,12 +124,11 @@ inline void dummy_function_non_decorated(const sycl::accessor<bool, 1> &acc) {
 /**
  * @brief Macro for generating code that will use TYPE
  */
-#define USE_FEATURE(TYPE)       \
-  unsigned long long temp = 42; \
-  TYPE feature1(temp);          \
-  TYPE feature2(temp);          \
-  feature1 += 42;               \
-  acc[0] = (feature1 == feature2);
+#define USE_FEATURE(TYPE)           \
+  unsigned long long temp = acc[0]; \
+  TYPE feature1(temp);              \
+  feature1 += 1;                    \
+  acc[0] = (feature1 * 4 / 3 > 2);
 
 /**
  * @brief Not decorated functor that use feature defined in FeatureTypeT

--- a/tests/optional_kernel_features/kernel_features_common.h
+++ b/tests/optional_kernel_features/kernel_features_common.h
@@ -75,7 +75,7 @@ inline void use_feature_function_non_decorated_with_accessor(
   unsigned long long temp = acc[0];
   T feature(temp);
   feature += 1;
-  acc[0] = (feature * 4 / 3 > 2);
+  acc[0] = feature * 4 / 3 > 2;
 }
 
 /**
@@ -90,7 +90,7 @@ template <typename T, sycl::aspect aspect>
   unsigned long long temp = acc[0];
   T feature(temp);
   feature += 1;
-  acc[0] = (feature * 4 / 3 > 2);
+  acc[0] = feature * 4 / 3 > 2;
 }
 
 /**
@@ -128,7 +128,7 @@ inline void dummy_function_non_decorated(const sycl::accessor<bool, 1> &acc) {
   unsigned long long temp = acc[0]; \
   TYPE feature(temp);               \
   feature += 1;                     \
-  acc[0] = (feature * 4 / 3 > 2);
+  acc[0] = feature * 4 / 3 > 2;
 
 /**
  * @brief Not decorated functor that use feature defined in FeatureTypeT


### PR DESCRIPTION
In these functions, the current usage of these features when they are `half` or `double` can be optimized out (ultimately, the kernel always stores `false` to the accessor), which can lead tests in `kernel_features_device_has_exceptions.cpp` to expect an exception to be thrown when one will not be thrown. 