### PR TITLE
Disable invalid `vec::as` test cases

### DIFF
--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -467,7 +467,8 @@ bool check_vector_as(sycl::vec<vecType, N> inputVec) {
 template <typename vecType, int N, typename asType, int asN>
 bool check_vectorN_as(sycl::vec<vecType, N> inputVec) {
   if constexpr (sizeof(sycl::vec<vecType, N>) ==
-                sizeof(sycl::vec<asType, asN>))
+                    sizeof(sycl::vec<asType, asN>) &&
+                (sizeof(vecType) * N) == (sizeof(asType) * asN))
     return check_vector_as<vecType, N, asType, asN>(inputVec);
   else
     return true;


### PR DESCRIPTION
Disable `check_vector_as` comparisons for cases where the size of the elements differs after conversion. This matches the restriction described in KhronosGroup/SYCL-Docs#447.