### PR TITLE
Add inline to function definitions in headers

### DIFF
--- a/tests/accessor_legacy/accessor_api_utility.h
+++ b/tests/accessor_legacy/accessor_api_utility.h
@@ -37,22 +37,22 @@
 namespace {
 /** computes the linear id for 1 dimension
 */
-size_t compute_linear_id(sycl::id<1> id, sycl::range<1> r) {
+inline size_t compute_linear_id(sycl::id<1> id, sycl::range<1> r) {
   return id[0];
 }
 
 /** computes the linear id for 2 dimension
 */
-size_t compute_linear_id(sycl::id<2> id, sycl::range<2> r) {
+inline size_t compute_linear_id(sycl::id<2> id, sycl::range<2> r) {
   return id[1] + (id[0] * r[1]);
 }
 
 /** computes the linear id for 3 dimension
 */
-size_t compute_linear_id(sycl::id<3> id, sycl::range<3> r) {
+inline size_t compute_linear_id(sycl::id<3> id, sycl::range<3> r) {
   return id[2] + (id[1] * r[2]) + (id[0] * r[2] * r[1]);
 }
-};
+}
 
 namespace accessor_utility {
 
@@ -757,7 +757,7 @@ std::unique_ptr<T[]> get_buffer_input_data(size_t count, int dims,
  * @param count Number of error categories
  * @return unique_ptr to initialized array
  */
-std::unique_ptr<int[]> get_error_data(size_t count) {
+inline std::unique_ptr<int[]> get_error_data(size_t count) {
   static constexpr int dims = 1;
   static constexpr bool useIndexes = false;
   return get_buffer_input_data<int>(count, dims, useIndexes);

--- a/tests/accessor_legacy/accessor_api_utility.h
+++ b/tests/accessor_legacy/accessor_api_utility.h
@@ -52,7 +52,7 @@ inline size_t compute_linear_id(sycl::id<2> id, sycl::range<2> r) {
 inline size_t compute_linear_id(sycl::id<3> id, sycl::range<3> r) {
   return id[2] + (id[1] * r[2]) + (id[0] * r[2] * r[1]);
 }
-}
+}  // namespace
 
 namespace accessor_utility {
 

--- a/tests/common/cts_selector.h
+++ b/tests/common/cts_selector.h
@@ -34,7 +34,7 @@ namespace {
  *  return <  0  : device will never be selected
  *  return >= 0  : positive device rating
  */
-int cts_selector(const sycl::device& dev) {
+inline int cts_selector(const sycl::device& dev) {
   using namespace sycl_cts;
   using namespace sycl_cts::util;
 

--- a/tests/common/once_per_unit.h
+++ b/tests/common/once_per_unit.h
@@ -41,7 +41,7 @@ inline sycl::queue &get_queue() {
 /**
  * @brief Provide possibility to log message once per translation unit
  */
-inline void log(sycl_cts::util::logger &log, const std::string &message) {
+inline void log(sycl_cts::util::logger& log, const std::string& message) {
   static const detail::log_notice log_just_once(log, message);
 }
 }  // namespace once_per_unit

--- a/tests/common/once_per_unit.h
+++ b/tests/common/once_per_unit.h
@@ -41,7 +41,7 @@ inline sycl::queue &get_queue() {
 /**
  * @brief Provide possibility to log message once per translation unit
  */
-static void log(sycl_cts::util::logger &log, const std::string &message) {
+inline void log(sycl_cts::util::logger &log, const std::string &message) {
   static const detail::log_notice log_just_once(log, message);
 }
 }  // namespace once_per_unit

--- a/tests/exceptions/exceptions.h
+++ b/tests/exceptions/exceptions.h
@@ -16,7 +16,7 @@
  */
 namespace {
 
-const std::array<sycl::errc, 15>& get_err_codes() {
+inline const std::array<sycl::errc, 15>& get_err_codes() {
   static const std::array all_err_codes{
       sycl::errc::success,
       sycl::errc::runtime,
@@ -36,7 +36,7 @@ const std::array<sycl::errc, 15>& get_err_codes() {
   return all_err_codes;
 }
 
-std::string errc_to_string(const sycl::errc& errc) {
+inline std::string errc_to_string(const sycl::errc& errc) {
   switch (errc) {
     case sycl::errc::success:
       return "success";


### PR DESCRIPTION
This should suppress the warning about defining unused functions.
