### PR TITLE
Handle `marray` in `equal` helper for group function tests

### DIFF
--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -42,6 +42,20 @@ bool equal_impl(const T& a, const U& b) {
 }
 
 template <typename T, int N>
+bool equal_impl(const sycl::marray<T, N>& a, const sycl::marray<T, N>& b) {
+  bool res = true;
+  for (int i = 0; i < N; ++i) res &= (a[i] == b[i]);
+  return res;
+}
+
+template <typename T, int N, typename U>
+bool equal_impl(const sycl::marray<T, N>& a, const U& b) {
+  bool res = true;
+  for (int i = 0; i < N; ++i) res &= (a[i] == b);
+  return res;
+}
+
+template <typename T, int N>
 bool equal_impl(const sycl::vec<T, N>& a, const sycl::vec<T, N>& b) {
   bool res = true;
   for (int i = 0; i < N; ++i) {


### PR DESCRIPTION
Before a recent fix to `marray` implementation
(https://github.com/intel/llvm/pull/10596) it was possible to convert `marray<T, N>` to `T` (incorrect behaviour), after the fix, we require a helper to traverse all elements of the array to check for equality.