### PR TITLE
Fix host_accessor_api_core test

### DIFF
--- a/tests/accessor/host_accessor_api_common.h
+++ b/tests/accessor/host_accessor_api_common.h
@@ -116,13 +116,13 @@ class run_api_tests {
       SECTION(get_section_name<dims>(
           type_name, access_mode_name,
           "Check api for ranged host_accessor with offset")) {
-        constexpr size_t acc_range_size = 4;
-        constexpr size_t buff_range_size = 8;
-        constexpr size_t buff_size = (dims == 3)   ? 8 * 8 * 8
-                                     : (dims == 2) ? 8 * 8
-                                                   : 8;
-        constexpr size_t offset = 4;
-        constexpr size_t index = 2;
+        constexpr size_t acc_range_size = 2;
+        constexpr size_t buff_range_size = 4;
+        constexpr size_t buff_size = (dims == 3)   ? 4 * 4 * 4
+                                     : (dims == 2) ? 4 * 4
+                                                   : 4;
+        constexpr size_t offset = 2;
+        constexpr size_t index = 1;
         int linear_index = 0;
         for (size_t i = 0; i < dims; i++) {
           linear_index += (offset + index) * pow(buff_range_size, dims - i - 1);

--- a/tests/accessor/host_accessor_api_common.h
+++ b/tests/accessor/host_accessor_api_common.h
@@ -116,6 +116,11 @@ class run_api_tests {
       SECTION(get_section_name<dims>(
           type_name, access_mode_name,
           "Check api for ranged host_accessor with offset")) {
+        // The maximum value of the linear_index variable should not be more
+        // than CHAR_MAX (usually 127 for schar). Otherwise the test fails here
+        // with the char type:
+        // CHECK(value_operations::are_equal(acc_ref1, linear_index));
+        // As acc_ref1 contains corrupted by the overflow value.
         constexpr size_t acc_range_size = 2;
         constexpr size_t buff_range_size = 4;
         constexpr size_t buff_size = (dims == 3)   ? 4 * 4 * 4


### PR DESCRIPTION
Reduce the numbers, so linear_index doesn't exceed CHAR_MAX. Otherwise the test fails here with the char type:

CHECK(value_operations::are_equal(acc_ref1, linear_index));

As acc_ref1 contains corrupted by the overflow value.