### PR TITLE
Fix oneapi_bfloat16 compfail

### DIFF
--- a/tests/extension/oneapi_bfloat16/bfloat16_api.cpp
+++ b/tests/extension/oneapi_bfloat16/bfloat16_api.cpp
@@ -67,7 +67,7 @@ TEST_CASE("Special values", "[bfloat16]") {
   }
 
   SECTION("Check minimum positive normal value") {
-    bfloat16 bf_min = sycl::bit_cast<bfloat16>(0b0000000010000000);
+    bfloat16 bf_min = sycl::bit_cast<bfloat16>(uint16_t(0b0000000010000000));
 
     CHECK(bf_min == std::numeric_limits<float>::min());
   }


### PR DESCRIPTION
This patch fixes the following compfail in oneapi_bfloat16 test:

```
error: no matching function for call to 'bit_cast'
  bfloat16 bf_min = sycl::bit_cast<bfloat16>(0b0000000010000000);
                    ^~~~~~~~~~~~~~~~~~~~~~~~
```