### PR TITLE
Avoid empty accessors in tests/accessor_legacy/accessor_api_buffer_common.h

### DIFF
--- a/tests/accessor_legacy/accessor_api_buffer_common.h
+++ b/tests/accessor_legacy/accessor_api_buffer_common.h
@@ -66,8 +66,11 @@ class check_buffer_accessor_api_methods {
 
     // Ensure accessor doesn't target an empty range. If it were the case, even
     // get_pointer() would return unspecified value.
-    for (int i = 0; i < dims; ++i)
-      if (accessRange[i] == 0) accessRange[i] = 1;
+    for (int i = 0; i < dims; ++i) {
+      if (accessRange[i] == 0) {
+        accessRange[i] = 1;
+      }
+    }
 
     const size_t accessedCount = dims == 0 ? 1 : accessRange.size();
     const size_t accessedSize = accessedCount * sizeof(T);

--- a/tests/accessor_legacy/accessor_api_buffer_common.h
+++ b/tests/accessor_legacy/accessor_api_buffer_common.h
@@ -67,8 +67,7 @@ class check_buffer_accessor_api_methods {
     // Ensure accessor doesn't target an empty range. If it were the case, even
     // get_pointer() would return unspecified value.
     for (int i = 0; i < dims; ++i)
-      if (accessRange[i] == 0)
-        accessRange[i] = 1;
+      if (accessRange[i] == 0) accessRange[i] = 1;
 
     const size_t accessedCount = dims == 0 ? 1 : accessRange.size();
     const size_t accessedSize = accessedCount * sizeof(T);

--- a/tests/accessor_legacy/accessor_api_buffer_common.h
+++ b/tests/accessor_legacy/accessor_api_buffer_common.h
@@ -62,7 +62,14 @@ class check_buffer_accessor_api_methods {
     buffer_t<T, dims> buffer(data.get(), range);
 
     // Prepare access range and access offset
-    const auto accessRange = range / 2;
+    auto accessRange = range / 2;
+
+    // Ensure accessor doesn't target an empty range. If it were the case, even
+    // get_pointer() would return unspecified value.
+    for (int i = 0; i < dims; ++i)
+      if (accessRange[i] == 0)
+        accessRange[i] = 1;
+
     const size_t accessedCount = dims == 0 ? 1 : accessRange.size();
     const size_t accessedSize = accessedCount * sizeof(T);
     auto accessOffset = sycl_id_t<dims>{};


### PR DESCRIPTION
In
https://github.com/KhronosGroup/SYCL-CTS/blob/2c00dc28a7ecd29a0b4422407e35ccdaec976c71/tests/accessor_legacy/accessor_api_buffer_common.h#L1186-L1189 and
https://github.com/KhronosGroup/SYCL-CTS/blob/2c00dc28a7ecd29a0b4422407e35ccdaec976c71/tests/accessor_legacy/accessor_api_buffer_common.h#L1214-L1219 we create a buffer with {1, 4, 2} dimensions. Later in 
https://github.com/KhronosGroup/SYCL-CTS/blob/2c00dc28a7ecd29a0b4422407e35ccdaec976c71/tests/accessor_legacy/accessor_api_buffer_common.h#L65
we create an accessor with range {0, 2, 1} which is empty. As such, any tests that try to verify its content or make any check against its `get_pointer()` are invalid. Fix that by adjusting accessor's range so it is not empty.