### PR TITLE
[CI] Empty DPC++ filter

### DIFF
--- a/ci/dpcpp.filter
+++ b/ci/dpcpp.filter
@@ -1,2 +1,0 @@
-math_builtin_api
-image_accessor


### PR DESCRIPTION
This enables compilation of all tests with DPC++ in CI.
