### PR TITLE
Fix invalid argument for nd-range kernels

### DIFF
--- a/tests/accessor_legacy/accessor_api_common_buffer_local.h
+++ b/tests/accessor_legacy/accessor_api_common_buffer_local.h
@@ -349,9 +349,7 @@ class buffer_accessor_get_pointer {
   void operator()() const {
     check_get_pointer(acc_mode_tag::get<mode>());
   }
-  void operator()(sycl_id_t<dim>) const {
-    operator()();
-  }
+  void operator()(common_id<dim>) const { operator()(); }
 
  private:
   void check_get_pointer(acc_mode_tag::generic) const {
@@ -534,7 +532,7 @@ class buffer_accessor_api_rw {
         m_range(rng),
         size(size_) {}
 
-  void operator()(sycl_id_t<dim> idx) const {
+  void operator()(common_id<dim> idx) const {
     // We do not need work-item synchronization for atomic mode because of:
     // - load-store consistency within single work-item
     // - access to the different elements from different work-items

--- a/tests/accessor_legacy/accessor_api_utility.h
+++ b/tests/accessor_legacy/accessor_api_utility.h
@@ -763,6 +763,23 @@ inline std::unique_ptr<int[]> get_error_data(size_t count) {
   return get_buffer_input_data<int>(count, dims, useIndexes);
 }
 
+/**
+ * @brief Common class for nd_item and item arguments to allow for a common
+ *        kernel definition for different parallel_for.
+ */
+template <int Dimensions>
+struct common_id {
+  common_id(sycl_id_t<Dimensions> I) : Id{I} {}
+  common_id(sycl::item<data_dim<Dimensions>::value> I) : Id{I} {}
+  common_id(sycl::nd_item<data_dim<Dimensions>::value> I)
+      : Id{I.get_global_id()} {}
+
+  operator sycl_id_t<Dimensions>() const { return Id; }
+
+ private:
+  sycl_id_t<Dimensions> Id;
+};
+
 }  // namespace
 
 #endif  // SYCL_1_2_1_TESTS_ACCESSOR_ACCESSOR_API_UTILITY_H

--- a/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
+++ b/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
@@ -165,8 +165,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 
   if (max_wg_size >= testing_wg_size[0]) {
     {
-      const auto separate_lambda_item_arg = [](sycl::item<1>)
-          [[sycl::reqd_work_group_size(testing_wg_size[0])]]{};
+      const auto separate_lambda_item_arg =
+          [](sycl::nd_item<1>)
+              [[sycl::reqd_work_group_size(testing_wg_size[0])]] {};
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_work_group_size(testing_wg_size[0])]]{};
 
@@ -191,8 +192,9 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
 
   if (max_wg_size >= testing_wg_size[1]) {
     {
-      const auto separate_lambda_item_arg = [](sycl::item<1>)
-          [[sycl::reqd_work_group_size(testing_wg_size[1])]]{};
+      const auto separate_lambda_item_arg =
+          [](sycl::nd_item<1>)
+              [[sycl::reqd_work_group_size(testing_wg_size[1])]] {};
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_work_group_size(testing_wg_size[1])]]{};
 
@@ -224,7 +226,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   if (find_res != sg_sizes_vec.end()) {
     {
       const auto separate_lambda_item_arg =
-          [](sycl::item<1>) [[sycl::reqd_sub_group_size(testing_sg_size[0])]]{};
+          [](sycl::nd_item<1>)
+              [[sycl::reqd_sub_group_size(testing_sg_size[0])]] {};
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_sub_group_size(testing_sg_size[0])]]{};
 
@@ -252,7 +255,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   if (find_res != sg_sizes_vec.end()) {
     {
       const auto separate_lambda_item_arg =
-          [](sycl::item<1>) [[sycl::reqd_sub_group_size(testing_sg_size[1])]]{};
+          [](sycl::nd_item<1>)
+              [[sycl::reqd_sub_group_size(testing_sg_size[1])]] {};
       const auto separate_lambda_group_arg = [](sycl::group<1>)
           [[sycl::reqd_sub_group_size(testing_sg_size[1])]]{};
 


### PR DESCRIPTION
This commit fixes the use of item and id arguments in nd_range parallel_for kernels.