### PR TITLE
Fix vector_api test

### DIFF
--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -211,7 +211,7 @@ void handleFPToUnsignedConv(sycl::vec<vecType, N>& inputVec) {
   }
 }
 
-#define DO_OPERATION_ON_SWIZZLE(inputVec, ResVariable, Op)                    \
+#define DO_OPERATION_ON_SWIZZLE(N, inputVec, ResVariable, Op)                 \
   if constexpr (N == 1) {                                                     \
     ResVariable = inputVec.template swizzle<sycl::elem::s0>().Op;             \
   } else if constexpr (N == 2) {                                              \
@@ -286,7 +286,7 @@ bool check_vector_convert_result(sycl::vec<vecType, N> inputVec) {
       inputVec, convertedVec);
 
   sycl::vec<convertType, N> convertedSwizzle;
-  DO_OPERATION_ON_SWIZZLE(inputVec, convertedSwizzle,
+  DO_OPERATION_ON_SWIZZLE(N, inputVec, convertedSwizzle,
                           template convert<convertType COMMA mode>())
   result &= check_vector_convert_result_impl<vecType, N, convertType, mode>(
       inputVec, convertedSwizzle);
@@ -327,7 +327,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (count != N || !noexcept(inputVec.size())) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, count, size())
+  DO_OPERATION_ON_SWIZZLE(N, inputVec, count, size())
 
   if (count != N) {
     return false;
@@ -339,7 +339,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (count_depr != N) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, count_depr, get_count())
+  DO_OPERATION_ON_SWIZZLE(N, inputVec, count_depr, get_count())
   if (count_depr != N) {
     return false;
   }
@@ -350,7 +350,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (size != sizeof(vecType) * M || !noexcept(inputVec.byte_size())) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, size, byte_size())
+  DO_OPERATION_ON_SWIZZLE(N, inputVec, size, byte_size())
   if (size != sizeof(vecType) * M) {
     return false;
   }
@@ -361,7 +361,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (size_depr != sizeof(vecType) * M) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, size_depr, get_size())
+  DO_OPERATION_ON_SWIZZLE(N, inputVec, size_depr, get_size())
   if (size_depr != sizeof(vecType) * M) {
     return false;
   }
@@ -407,7 +407,7 @@ bool check_vector_as(sycl::vec<vecType, N> inputVec) {
   using asVecType = sycl::vec<asType, asN>;
   asVecType asVec = inputVec.template as<asVecType>();
   asVecType asVecSwizzle;
-  DO_OPERATION_ON_SWIZZLE(inputVec, asVecSwizzle, template as<asVecType>())
+  DO_OPERATION_ON_SWIZZLE(N, inputVec, asVecSwizzle, template as<asVecType>())
 
   return check_as_result(inputVec, asVec) &&
          check_as_result(inputVec, asVecSwizzle);

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -213,27 +213,37 @@ void handleFPToUnsignedConv(sycl::vec<vecType, N>& inputVec) {
 
 #define DO_OPERATION_ON_SWIZZLE(inputVec, ResVariable, Op)                    \
   if constexpr (N == 1) {                                                     \
-    ResVariable = inputVec.template swizzle<sycl::elem::s0>() Op;             \
+    ResVariable = inputVec.template swizzle<sycl::elem::s0>().Op;             \
   } else if constexpr (N == 2) {                                              \
     ResVariable =                                                             \
-        inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1>() Op;       \
+        inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1>().Op;       \
   } else if constexpr (N == 3) {                                              \
-    ResVariable = inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1,   \
-                                            sycl::elem::s2>() Op;             \
+    ResVariable = inputVec                                                    \
+                      .template swizzle<sycl::elem::s0, sycl::elem::s1,       \
+                                        sycl::elem::s2>()                     \
+                      .Op;                                                    \
   } else if constexpr (N == 4) {                                              \
-    ResVariable =                                                             \
-        inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1,             \
-                                  sycl::elem::s2, sycl::elem::s3>() Op;       \
+    ResVariable = inputVec                                                    \
+                      .template swizzle<sycl::elem::s0, sycl::elem::s1,       \
+                                        sycl::elem::s2, sycl::elem::s3>()     \
+                      .Op;                                                    \
   } else if constexpr (N == 8) {                                              \
-    ResVariable = inputVec.template swizzle<                                  \
-        sycl::elem::s0, sycl::elem::s1, sycl::elem::s2, sycl::elem::s3,       \
-        sycl::elem::s4, sycl::elem::s5, sycl::elem::s6, sycl::elem::s7>() Op; \
+    ResVariable =                                                             \
+        inputVec                                                              \
+            .template swizzle<sycl::elem::s0, sycl::elem::s1, sycl::elem::s2, \
+                              sycl::elem::s3, sycl::elem::s4, sycl::elem::s5, \
+                              sycl::elem::s6, sycl::elem::s7>()               \
+            .Op;                                                              \
   } else if constexpr (N == 16) {                                             \
-    ResVariable = inputVec.template swizzle<                                  \
-        sycl::elem::s0, sycl::elem::s1, sycl::elem::s2, sycl::elem::s3,       \
-        sycl::elem::s4, sycl::elem::s5, sycl::elem::s6, sycl::elem::s7,       \
-        sycl::elem::s8, sycl::elem::s9, sycl::elem::sA, sycl::elem::sB,       \
-        sycl::elem::sC, sycl::elem::sD, sycl::elem::sE, sycl::elem::sF>() Op; \
+    ResVariable =                                                             \
+        inputVec                                                              \
+            .template swizzle<sycl::elem::s0, sycl::elem::s1, sycl::elem::s2, \
+                              sycl::elem::s3, sycl::elem::s4, sycl::elem::s5, \
+                              sycl::elem::s6, sycl::elem::s7, sycl::elem::s8, \
+                              sycl::elem::s9, sycl::elem::sA, sycl::elem::sB, \
+                              sycl::elem::sC, sycl::elem::sD, sycl::elem::sE, \
+                              sycl::elem::sF>()                               \
+            .Op;                                                              \
   }
 
 template <typename vecType, int N, typename convertType,
@@ -277,7 +287,7 @@ bool check_vector_convert_result(sycl::vec<vecType, N> inputVec) {
 
   sycl::vec<convertType, N> convertedSwizzle;
   DO_OPERATION_ON_SWIZZLE(inputVec, convertedSwizzle,
-                          .template convert<convertType COMMA mode>())
+                          template convert<convertType COMMA mode>())
   result &= check_vector_convert_result_impl<vecType, N, convertType, mode>(
       inputVec, convertedSwizzle);
   return result;
@@ -317,7 +327,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (count != N || !noexcept(inputVec.size())) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, count, .size())
+  DO_OPERATION_ON_SWIZZLE(inputVec, count, size())
 
   if (count != N) {
     return false;
@@ -329,7 +339,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (count_depr != N) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, count_depr, .get_count())
+  DO_OPERATION_ON_SWIZZLE(inputVec, count_depr, get_count())
   if (count_depr != N) {
     return false;
   }
@@ -340,7 +350,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (size != sizeof(vecType) * M || !noexcept(inputVec.byte_size())) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, size, .byte_size())
+  DO_OPERATION_ON_SWIZZLE(inputVec, size, byte_size())
   if (size != sizeof(vecType) * M) {
     return false;
   }
@@ -351,7 +361,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (size_depr != sizeof(vecType) * M) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, size_depr, .get_size())
+  DO_OPERATION_ON_SWIZZLE(inputVec, size_depr, get_size())
   if (size_depr != sizeof(vecType) * M) {
     return false;
   }
@@ -397,7 +407,7 @@ bool check_vector_as(sycl::vec<vecType, N> inputVec) {
   using asVecType = sycl::vec<asType, asN>;
   asVecType asVec = inputVec.template as<asVecType>();
   asVecType asVecSwizzle;
-  DO_OPERATION_ON_SWIZZLE(inputVec, asVecSwizzle, .template as<asVecType>())
+  DO_OPERATION_ON_SWIZZLE(inputVec, asVecSwizzle, template as<asVecType>())
 
   return check_as_result(inputVec, asVec) &&
          check_as_result(inputVec, asVecSwizzle);

--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -211,29 +211,29 @@ void handleFPToUnsignedConv(sycl::vec<vecType, N>& inputVec) {
   }
 }
 
-#define DO_OPERATION_ON_SWIZZLE(inputVec, ResVariable, Op)                   \
-  if constexpr (N == 1) {                                                    \
-    ResVariable = inputVec.template swizzle<sycl::elem::s0>() Op             \
-  } else if constexpr (N == 2) {                                             \
-    ResVariable =                                                            \
-        inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1>() Op       \
-  } else if constexpr (N == 3) {                                             \
-    ResVariable = inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1,  \
-                                            sycl::elem::s2>() Op             \
-  } else if constexpr (N == 4) {                                             \
-    ResVariable =                                                            \
-        inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1,            \
-                                  sycl::elem::s2, sycl::elem::s3>() Op       \
-  } else if constexpr (N == 8) {                                             \
-    ResVariable = inputVec.template swizzle<                                 \
-        sycl::elem::s0, sycl::elem::s1, sycl::elem::s2, sycl::elem::s3,      \
-        sycl::elem::s4, sycl::elem::s5, sycl::elem::s6, sycl::elem::s7>() Op \
-  } else if constexpr (N == 16) {                                            \
-    ResVariable = inputVec.template swizzle<                                 \
-        sycl::elem::s0, sycl::elem::s1, sycl::elem::s2, sycl::elem::s3,      \
-        sycl::elem::s4, sycl::elem::s5, sycl::elem::s6, sycl::elem::s7,      \
-        sycl::elem::s8, sycl::elem::s9, sycl::elem::sA, sycl::elem::sB,      \
-        sycl::elem::sC, sycl::elem::sD, sycl::elem::sE, sycl::elem::sF>() Op \
+#define DO_OPERATION_ON_SWIZZLE(inputVec, ResVariable, Op)                    \
+  if constexpr (N == 1) {                                                     \
+    ResVariable = inputVec.template swizzle<sycl::elem::s0>() Op;             \
+  } else if constexpr (N == 2) {                                              \
+    ResVariable =                                                             \
+        inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1>() Op;       \
+  } else if constexpr (N == 3) {                                              \
+    ResVariable = inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1,   \
+                                            sycl::elem::s2>() Op;             \
+  } else if constexpr (N == 4) {                                              \
+    ResVariable =                                                             \
+        inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1,             \
+                                  sycl::elem::s2, sycl::elem::s3>() Op;       \
+  } else if constexpr (N == 8) {                                              \
+    ResVariable = inputVec.template swizzle<                                  \
+        sycl::elem::s0, sycl::elem::s1, sycl::elem::s2, sycl::elem::s3,       \
+        sycl::elem::s4, sycl::elem::s5, sycl::elem::s6, sycl::elem::s7>() Op; \
+  } else if constexpr (N == 16) {                                             \
+    ResVariable = inputVec.template swizzle<                                  \
+        sycl::elem::s0, sycl::elem::s1, sycl::elem::s2, sycl::elem::s3,       \
+        sycl::elem::s4, sycl::elem::s5, sycl::elem::s6, sycl::elem::s7,       \
+        sycl::elem::s8, sycl::elem::s9, sycl::elem::sA, sycl::elem::sB,       \
+        sycl::elem::sC, sycl::elem::sD, sycl::elem::sE, sycl::elem::sF>() Op; \
   }
 
 template <typename vecType, int N, typename convertType,
@@ -277,7 +277,7 @@ bool check_vector_convert_result(sycl::vec<vecType, N> inputVec) {
 
   sycl::vec<convertType, N> convertedSwizzle;
   DO_OPERATION_ON_SWIZZLE(inputVec, convertedSwizzle,
-                          .template convert<convertType COMMA mode>();)
+                          .template convert<convertType COMMA mode>())
   result &= check_vector_convert_result_impl<vecType, N, convertType, mode>(
       inputVec, convertedSwizzle);
   return result;
@@ -317,7 +317,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (count != N || !noexcept(inputVec.size())) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, count, .size();)
+  DO_OPERATION_ON_SWIZZLE(inputVec, count, .size())
 
   if (count != N) {
     return false;
@@ -329,7 +329,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (count_depr != N) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, count_depr, .get_count();)
+  DO_OPERATION_ON_SWIZZLE(inputVec, count_depr, .get_count())
   if (count_depr != N) {
     return false;
   }
@@ -340,7 +340,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (size != sizeof(vecType) * M || !noexcept(inputVec.byte_size())) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, size, .byte_size();)
+  DO_OPERATION_ON_SWIZZLE(inputVec, size, .byte_size())
   if (size != sizeof(vecType) * M) {
     return false;
   }
@@ -351,7 +351,7 @@ bool check_vector_size_byte_size(sycl::vec<vecType, N> inputVec) {
   if (size_depr != sizeof(vecType) * M) {
     return false;
   }
-  DO_OPERATION_ON_SWIZZLE(inputVec, size_depr, .get_size();)
+  DO_OPERATION_ON_SWIZZLE(inputVec, size_depr, .get_size())
   if (size_depr != sizeof(vecType) * M) {
     return false;
   }
@@ -397,7 +397,7 @@ bool check_vector_as(sycl::vec<vecType, N> inputVec) {
   using asVecType = sycl::vec<asType, asN>;
   asVecType asVec = inputVec.template as<asVecType>();
   asVecType asVecSwizzle;
-  DO_OPERATION_ON_SWIZZLE(inputVec, asVecSwizzle, .template as<asVecType>();)
+  DO_OPERATION_ON_SWIZZLE(inputVec, asVecSwizzle, .template as<asVecType>())
 
   return check_as_result(inputVec, asVec) &&
          check_as_result(inputVec, asVecSwizzle);


### PR DESCRIPTION
1. According to https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#swizzled-vec-class __swizzled_vec__ shouldn't escape the expression it was constructed in. So I refactored the test to create __swizzled_vec__ and then call a required function in the same place.

2. There is a bug in check_vector_convert() Since check_vector_convert_modes() accepts sycl::vec argument, we don't really test convert() method for __swizzled_vec__ as it's impicitly converted to sycl::vec. Also refactored this part to fix it.