### PR TITLE
Explicitly include <cmath> where required

### DIFF
--- a/tests/accessor/generic_accessor_api_common.h
+++ b/tests/accessor/generic_accessor_api_common.h
@@ -21,6 +21,7 @@
 #ifndef SYCL_CTS_GENERIC_ACCESSOR_API_COMMON_H
 #define SYCL_CTS_GENERIC_ACCESSOR_API_COMMON_H
 #include "accessor_common.h"
+#include <cmath>
 
 namespace generic_accessor_api_common {
 using namespace sycl_cts;

--- a/tests/accessor/host_accessor_api_common.h
+++ b/tests/accessor/host_accessor_api_common.h
@@ -8,6 +8,7 @@
 #ifndef SYCL_CTS_HOST_ACCESSOR_API_COMMON_H
 #define SYCL_CTS_HOST_ACCESSOR_API_COMMON_H
 #include "accessor_common.h"
+#include <cmath>
 
 namespace host_accessor_api_common {
 using namespace sycl_cts;

--- a/tests/common/get_group_range.h
+++ b/tests/common/get_group_range.h
@@ -22,6 +22,8 @@
 #ifndef __SYCLCTS_TESTS_COMMON_GET_GROUP_RANGE_H
 #define __SYCLCTS_TESTS_COMMON_GET_GROUP_RANGE_H
 
+#include <cmath>
+
 namespace sycl_cts {
 namespace util {
 /**

--- a/tests/kernel/kernel_attributes_wg_hint.cpp
+++ b/tests/kernel/kernel_attributes_wg_hint.cpp
@@ -20,6 +20,7 @@
 
 #include "../common/common.h"
 #include "kernel_attributes.h"
+#include <cmath>
 
 using namespace kernel_attributes;
 

--- a/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
+++ b/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
@@ -25,6 +25,7 @@
 #include "../common/disabled_for_test_case.h"
 #include "catch2/catch_template_test_macros.hpp"
 #include "kernel_features_common.h"
+#include <cmath>
 
 namespace kernel_features_reqd_work_group_size {
 using namespace sycl_cts;


### PR DESCRIPTION
These tests were all relying on `<cmath>` being included by `<sycl/sycl.hpp>`, which cannot be relied upon.

See https://github.com/intel/llvm/commit/9bbbc77 for a change which exposed this problem when building with DPC++.