### PR TITLE
Improve vector tests compilation time

### DIFF
--- a/tests/common/vector_swizzle_assignment.template
+++ b/tests/common/vector_swizzle_assignment.template
@@ -20,6 +20,9 @@
 //
 **************************************************************************/
 
+// Note: this is essentially a copy of vector.template, but it has extra
+// #define SYCL_SIMPLE_SWIZZLES which is required for the swizzles test.
+
 $IFDEF
 #define SYCL_SIMPLE_SWIZZLES
 

--- a/tests/common/vector_swizzle_assignment.template
+++ b/tests/common/vector_swizzle_assignment.template
@@ -4,7 +4,7 @@
 //
 //
 //  Copyright (c) 2018-2022 Codeplay Software LTD. All Rights Reserved.
-//  Copyright (c) 2022 The Khronos Group Inc.
+//  Copyright (c) 2023 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 **************************************************************************/
 
 $IFDEF
+#define SYCL_SIMPLE_SWIZZLES
 
 #include "../common/common.h"
 #include "../common/common_vec.h"

--- a/tests/vector_swizzle_assignment/CMakeLists.txt
+++ b/tests/vector_swizzle_assignment/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(TY IN LISTS TYPE_LIST)
   generate_cts_test(TESTS TEST_CASES_LIST
     GENERATOR "generate_vector_swizzle_assignment.py"
     OUTPUT ${OUT_FILE}
-    INPUT "../common/vector.template"
+    INPUT "../common/vector_swizzle_assignment.template"
     EXTRA_ARGS -type "${TY}")
 endforeach()
 


### PR DESCRIPTION
Refactored test templates to avoid defining `SYCL_SIMPLE_SWIZZLES` for most of `vector_*` tests. Even though simple swizzles are not used by those tests, defining the macro still increases amount of input source code a compiler should look through, thus unnecessary increasing compilation time.