### PR TITLE
Add cmath include to oneapi_bfloat16 test

### DIFF
--- a/tests/extension/oneapi_bfloat16/bfloat16_api.cpp
+++ b/tests/extension/oneapi_bfloat16/bfloat16_api.cpp
@@ -20,6 +20,8 @@
 
 #include "../../common/common.h"
 
+#include <cmath>
+
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 
 TEST_CASE("Common interface members", "[bfloat16]") {


### PR DESCRIPTION
This commit adds an include of cmath to the tests/extension/oneapi_bfloat16/bfloat16_api.cpp test to allow the use of std math functions.