### PR TITLE
Fix sub_group_mask_constructors

### DIFF
--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_constructors.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_constructors.cpp
@@ -37,7 +37,7 @@ void copy_ulong_long2marray(sycl::marray<T, dim>& marray,
       elem_size * dim > sizeof(value) ? sizeof(value) : elem_size * dim;
   size_t shift = 0;
   size_t i = 0;
-  char* valuePtr = reinterpret_cast<char*>(&value);
+  auto valuePtr = reinterpret_cast<char*>(&value);
   while (shift + elem_size <= num_bytes && i < dim) {
     memcpy(&(marray[i]), valuePtr + shift, elem_size);
     ++i;
@@ -53,7 +53,7 @@ void copy_marray2ulong_long(unsigned long long& value,
       elem_size * dim > sizeof(value) ? sizeof(value) : elem_size * dim;
   size_t shift = 0;
   size_t i = 0;
-  char* valuePtr = reinterpret_cast<char*>(&value);
+  auto valuePtr = reinterpret_cast<char*>(&value);
   while (shift + elem_size <= num_bytes && i < dim) {
     memcpy(valuePtr + shift, &(marray[i]), elem_size);
     ++i;

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_constructors.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_constructors.cpp
@@ -37,7 +37,7 @@ void copy_ulong_long2marray(sycl::marray<T, dim>& marray,
       elem_size * dim > sizeof(value) ? sizeof(value) : elem_size * dim;
   size_t shift = 0;
   size_t i = 0;
-  char *valuePtr = reinterpret_cast<char *>(&value);
+  char* valuePtr = reinterpret_cast<char*>(&value);
   while (shift + elem_size <= num_bytes && i < dim) {
     memcpy(&(marray[i]), valuePtr + shift, elem_size);
     ++i;
@@ -53,7 +53,7 @@ void copy_marray2ulong_long(unsigned long long& value,
       elem_size * dim > sizeof(value) ? sizeof(value) : elem_size * dim;
   size_t shift = 0;
   size_t i = 0;
-  char *valuePtr = reinterpret_cast<char *>(&value);
+  char* valuePtr = reinterpret_cast<char*>(&value);
   while (shift + elem_size <= num_bytes && i < dim) {
     memcpy(valuePtr + shift, &(marray[i]), elem_size);
     ++i;

--- a/tests/extension/oneapi_sub_group_mask/sub_group_mask_constructors.cpp
+++ b/tests/extension/oneapi_sub_group_mask/sub_group_mask_constructors.cpp
@@ -37,8 +37,9 @@ void copy_ulong_long2marray(sycl::marray<T, dim>& marray,
       elem_size * dim > sizeof(value) ? sizeof(value) : elem_size * dim;
   size_t shift = 0;
   size_t i = 0;
+  char *valuePtr = reinterpret_cast<char *>(&value);
   while (shift + elem_size <= num_bytes && i < dim) {
-    memcpy(&(marray[i]), &value + shift, elem_size);
+    memcpy(&(marray[i]), valuePtr + shift, elem_size);
     ++i;
     shift += elem_size;
   }
@@ -52,8 +53,9 @@ void copy_marray2ulong_long(unsigned long long& value,
       elem_size * dim > sizeof(value) ? sizeof(value) : elem_size * dim;
   size_t shift = 0;
   size_t i = 0;
+  char *valuePtr = reinterpret_cast<char *>(&value);
   while (shift + elem_size <= num_bytes && i < dim) {
-    memcpy(&value + shift, &(marray[i]), elem_size);
+    memcpy(valuePtr + shift, &(marray[i]), elem_size);
     ++i;
     shift += elem_size;
   }


### PR DESCRIPTION
`&value + shift` is invalid.

It's assumed to get the address of &value + (N = shift) bytes.
But we're actually getting &value + sizeof(value) * shift and running out of buffer.