### PR TITLE
Improve support detection for USM copy tests

### DIFF
--- a/tests/usm/usm_api.h
+++ b/tests/usm/usm_api.h
@@ -251,6 +251,13 @@ class copy : public copyGeneric<T, count, sourceAllocation> {
    */
   static constexpr bool has_non_usm_support() { return true; }
 
+  /** @brief This test only works on devices with `sourceAllocation` support
+   */
+  static bool supports_device(sycl_cts::util::logger& log,
+                              const sycl::queue& queue) {
+    return check_device_support<sourceAllocation>(log, queue);
+  }
+
   template <allocation alloc>
   static std::string description() {
     return "copy from " + get_allocation_decription<sourceAllocation>() +
@@ -275,6 +282,13 @@ class memcpy : public copyGeneric<T, count, sourceAllocation> {
   /** @brief The memcpy() member function supports non-USM pointers
    */
   static constexpr bool has_non_usm_support() { return true; }
+
+  /** @brief This test only works on devices with `sourceAllocation` support
+   */
+  static bool supports_device(sycl_cts::util::logger& log,
+                              const sycl::queue& queue) {
+    return check_device_support<sourceAllocation>(log, queue);
+  }
 
   template <allocation alloc>
   static std::string description() {
@@ -322,6 +336,13 @@ class fill {
    */
   static constexpr bool has_non_usm_support() { return false; }
 
+  /** @brief This test doesn't have any device requirements
+   */
+  static bool supports_device(sycl_cts::util::logger& log,
+                              const sycl::queue& queue) {
+    return true;
+  }
+
   template <allocation alloc>
   static std::string description() {
     return "fill using " + get_allocation_decription<alloc>();
@@ -355,6 +376,13 @@ class memset {
    */
   static constexpr bool has_non_usm_support() { return false; }
 
+  /** @brief This test doesn't have any device requirements
+   */
+  static bool supports_device(sycl_cts::util::logger& log,
+                              const sycl::queue& queue) {
+    return true;
+  }
+
   template <allocation alloc>
   static std::string description() {
     return "memset using " + get_allocation_decription<alloc>();
@@ -386,6 +414,13 @@ class prefetch {
    */
   static constexpr bool has_non_usm_support() { return false; }
 
+  /** @brief This test doesn't have any device requirements
+   */
+  static bool supports_device(sycl_cts::util::logger& log,
+                              const sycl::queue& queue) {
+    return true;
+  }
+
   template <allocation alloc>
   static std::string description() {
     return "prefetch using " + get_allocation_decription<alloc>();
@@ -413,6 +448,13 @@ class mem_advise {
   /** @brief The mem_advise() member function doesn't support non-USM pointers
    */
   static constexpr bool has_non_usm_support() { return false; }
+
+  /** @brief This test doesn't have any device requirements
+   */
+  static bool supports_device(sycl_cts::util::logger& log,
+                              const sycl::queue& queue) {
+    return true;
+  }
 
   template <allocation alloc>
   static std::string description() {
@@ -565,6 +607,7 @@ struct test {
     try {
       auto queue = sycl_cts::util::get_cts_object::queue();
 
+      if (!verifier_t::supports_device(log, queue)) return;
       if (!check_device_support<alloc>(log, queue)) return;
 
       log.debug("... allocate USM memory storage");


### PR DESCRIPTION
Different USM allocation types are locked behind different aspects. The USM tests account for this by skipping the test if the aspect for the destination allocation is not present. However, two tests (copy and memcpy) have an allocation for the source memory, which is not checked.

This change adds a "supports_device" method to the USM tests that takes a queue and returns whether the test supports that queue. For the copy and memcpy tests, this checks that the source allocation is supported by the device. All other tests just return true.

(For the avoidance of doubt; I'm employed by Codeplay, a subsidiary of Intel)