### PR TITLE
Fix typos in atomic_ref test names

### DIFF
--- a/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_core.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer operator+=()/operator-=() test. core types",
+("sycl::atomic_ref operator+=()/operator-=() test. core types",
  "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_add_sub_op_all_types_test>(

--- a/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_pointers.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer operator+=()/operator-=() test. pointers types",
+("sycl::atomic_ref operator+=()/operator-=() test. pointers types",
  "[atomic_ref]")({
   const auto type_pack =
       atomic_ref::tests::common::get_conformance_pointers_type_pack();

--- a/tests/atomic_ref/atomic_ref_assign_op_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_core.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer::operator=() test. core types", "[atomic_ref]")({
+("sycl::atomic_ref::operator=() test. core types", "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_assign_op_test>(type_pack);
 });

--- a/tests/atomic_ref/atomic_ref_assign_op_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_pointers.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer::operator=() test. pointers types", "[atomic_ref]")({
+("sycl::atomic_ref::operator=() test. pointers types", "[atomic_ref]")({
   const auto type_pack =
       atomic_ref::tests::common::get_conformance_pointers_type_pack();
   if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {

--- a/tests/atomic_ref/atomic_ref_bitwise_op_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_bitwise_op_test_core.cpp
@@ -36,7 +36,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer operator^=()/operator|=()/operator&=() test. core types",
+("sycl::atomic_ref operator^=()/operator|=()/operator&=() test. core types",
  "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_bitwise_op_test>(type_pack);

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test_core.cpp
@@ -36,7 +36,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer compare_exchange_strong()/compare_exchange_weak() test. "
+("sycl::atomic_ref compare_exchange_strong()/compare_exchange_weak() test. "
  "core types",
  "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers.cpp
@@ -36,7 +36,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer compare_exchange_strong()/compare_exchange_weak() test. "
+("sycl::atomic_ref compare_exchange_strong()/compare_exchange_weak() test. "
  "pointers types",
  "[atomic_ref]")({
   const auto type_pack =

--- a/tests/atomic_ref/atomic_ref_exchange_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_exchange_test_core.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer::exchange() test. core types", "[atomic_ref]")({
+("sycl::atomic_ref::exchange() test. core types", "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_exchange_test>(type_pack);
 });

--- a/tests/atomic_ref/atomic_ref_exchange_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_exchange_test_pointers.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer::exchange() test. pointers types", "[atomic_ref]")({
+("sycl::atomic_ref::exchange() test. pointers types", "[atomic_ref]")({
   const auto type_pack =
       atomic_ref::tests::common::get_conformance_pointers_type_pack();
   if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_core.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer fetch_add()/fetch_sub() test. core types", "[atomic_ref]")({
+("sycl::atomic_ref fetch_add()/fetch_sub() test. core types", "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_fetch_add_sub_all_types_test>(
       type_pack);

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer fetch_add()/fetch_sub() test. pointers types",
+("sycl::atomic_ref fetch_add()/fetch_sub() test. pointers types",
  "[atomic_ref]")({
   const auto type_pack =
       atomic_ref::tests::common::get_conformance_pointers_type_pack();

--- a/tests/atomic_ref/atomic_ref_fetch_bitwise_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_bitwise_test_core.cpp
@@ -36,7 +36,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer fetch_xor()/fetch_or()/fetch_and() test. core types",
+("sycl::atomic_ref fetch_xor()/fetch_or()/fetch_and() test. core types",
  "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_fetch_bitwise_test>(type_pack);

--- a/tests/atomic_ref/atomic_ref_fetch_min_max_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_min_max_test_core.cpp
@@ -35,7 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer fetch_min()/fetch_max() test. core types", "[atomic_ref]")({
+("sycl::atomic_ref fetch_min()/fetch_max() test. core types", "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_fetch_min_max_test>(type_pack);
 });

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test_core.cpp
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test_core.cpp
@@ -37,7 +37,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer increment/decrement operators test. core types",
+("sycl::atomic_ref increment/decrement operators test. core types",
  "[atomic_ref]")({
   const auto type_pack = atomic_ref::tests::common::get_conformance_type_pack();
   for_all_types<atomic_ref::tests::api::run_incr_decr_op_test>(type_pack);

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers.cpp
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers.cpp
@@ -37,7 +37,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_rer increment/decrement operators test. pointers types",
+("sycl::atomic_ref increment/decrement operators test. pointers types",
  "[atomic_ref]")({
   const auto type_pack =
       atomic_ref::tests::common::get_conformance_pointers_type_pack();


### PR DESCRIPTION
I'm assuming these are typos.

There are some inconsistencies about how we style the test names for ostensibly the same operations: see tests covering one operator (`atomic_ref::operator`) vs those that cover two (`atomic_ref operator/operator` - no colons). I see why it was done, but the inconsistency is noticeable.