### PR TITLE
Do not check for undefined behavior in abs.

### DIFF
--- a/util/math_reference.cpp
+++ b/util/math_reference.cpp
@@ -203,7 +203,7 @@ T mad_sat_signed_long(T x, T y, T z) {
   if ((x > 0 && y > 0) || (x < 0 && y < 0))
     if (mul > 0 && std::abs(mul) > std::abs(x) && std::abs(mul) > std::abs(y))
       return add_sat(mul, z);
-    else if (z < 0 && mul - std::numeric_limits<T>::min() < abs(z))
+    else if (z < 0 && mul - std::numeric_limits<T>::min() < std::abs(z))
       return std::numeric_limits<T>::max() + z;
     else
       return std::numeric_limits<T>::max();

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -285,10 +285,23 @@ sycl::marray<T, N> select(sycl::marray<T, N> a, sycl::marray<T, N> b,
 
 /* absolute value */
 template <typename T>
-T abs(T x) {
-  return x < 0 ? -x : x;
+sycl_cts::resultRef<T> abs(T x) {
+  using U = std::make_unsigned_t<T>;
+  T result = x < 0 ? T(-U(x)) : x;
+  return result < 0 ? sycl_cts::resultRef<T>(0, true) : result;
 }
-MAKE_VEC_AND_MARRAY_VERSIONS(abs)
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> abs(sycl::vec<T, N> a) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x) { return abs(x); }, a);
+}
+#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> abs(sycl::marray<T, N> a) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x) { return abs(x); }, a);
+}
+#endif
 
 /* absolute difference */
 template <typename T>


### PR DESCRIPTION
Unlike OpenCL abs, but like C and C++ abs, in SYCL 2020, taking the absolute value of a signed type produces a signed result and the behavior is undefined if the absolute value is not representable (i.e. if the input is the greatest negative value), so do not check that the SYCL results match the reference results for this case.