### PR TITLE
[NFC] USM test device support refactored

### DIFF
--- a/tests/usm/usm_api.h
+++ b/tests/usm/usm_api.h
@@ -223,8 +223,7 @@ void check_values(const T *begin, const ReferenceIt &reference) {
  * the destination memory location.
  */
 struct noAdditionalDeviceRequirements {
-  static bool supports_device(sycl_cts::util::logger&,
-                              const sycl::queue&) {
+  static bool supports_device(sycl_cts::util::logger&, const sycl::queue&) {
     return true;
   }
 };

--- a/tests/usm/usm_api.h
+++ b/tests/usm/usm_api.h
@@ -223,11 +223,12 @@ void check_values(const T *begin, const ReferenceIt &reference) {
  * the destination memory location.
  */
 struct noAdditionalDeviceRequirements {
-  static bool supports_device(sycl_cts::util::logger& log,
-                              const sycl::queue& queue) {
+  static bool supports_device(sycl_cts::util::logger&,
+                              const sycl::queue&) {
     return true;
   }
 };
+
 /** @brief Trait for tests that require support for a given USM alloc type
  *
  * Tests implementing this trait require device support for a specific


### PR DESCRIPTION
The USM API tests previously each had a "supports_device" method that either returned true or checked whether a specific USM allocation type was supported.

This change moves that duplicated code to two inheritable classes that provide those methods instead.

----

This is a follow up implementing the suggestion made by @keryell here: https://github.com/KhronosGroup/SYCL-CTS/pull/822#discussion_r1380420474 .

(For the avoidance of doubt; I'm employed by Codeplay, a subsidiary of Intel)