### PR TITLE
Change abs_diff return type

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - sycl-impl: dpcpp
-            version: 9dfaf274e2cbe42e992be0519fa7d2b0eb0face5
+            version: 2a3e1ab824f072670c186ec715f29b88c9df9d45
           - sycl-impl: hipsycl
             version: 3d8b1cd
     steps:
@@ -114,7 +114,7 @@ jobs:
       matrix:
         include:
           - sycl-impl: dpcpp
-            version: 9dfaf274e2cbe42e992be0519fa7d2b0eb0face5
+            version: 2a3e1ab824f072670c186ec715f29b88c9df9d45
           - sycl-impl: hipsycl
             version: 3d8b1cd
     env:

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - sycl-impl: dpcpp
-            version: 2a3e1ab824f072670c186ec715f29b88c9df9d45
+            version: 6bce7f64f51a4370052bffa3fa257ca16d8aad9e
           - sycl-impl: hipsycl
             version: 3d8b1cd
     steps:
@@ -114,7 +114,7 @@ jobs:
       matrix:
         include:
           - sycl-impl: dpcpp
-            version: 2a3e1ab824f072670c186ec715f29b88c9df9d45
+            version: 6bce7f64f51a4370052bffa3fa257ca16d8aad9e
           - sycl-impl: hipsycl
             version: 3d8b1cd
     env:

--- a/tests/math_builtin_api/modules/sycl_functions.py
+++ b/tests/math_builtin_api/modules/sycl_functions.py
@@ -39,7 +39,7 @@ def create_integer_signatures():
     f_abs = funsig("sycl", "geninteger", "abs", ["geninteger"])
     sig_list.append(f_abs)
 
-    f_abs_diff = funsig("sycl", "ugeninteger", "abs_diff", ["geninteger", "geninteger"], "0", "", [], [["geninteger", "ugeninteger", "base_type_but_same_sizeof"]])
+    f_abs_diff = funsig("sycl", "geninteger", "abs_diff", ["geninteger", "geninteger"])
     sig_list.append(f_abs_diff)
 
     f_add_sat = funsig("sycl", "geninteger", "add_sat", ["geninteger", "geninteger"])

--- a/tests/math_builtin_api/modules/sycl_functions.py
+++ b/tests/math_builtin_api/modules/sycl_functions.py
@@ -39,7 +39,7 @@ def create_integer_signatures():
     f_abs = funsig("sycl", "geninteger", "abs", ["geninteger"])
     sig_list.append(f_abs)
 
-    f_abs_diff = funsig("sycl", "geninteger", "abs_diff", ["geninteger", "geninteger"])
+    f_abs_diff = funsig("sycl", "geninteger", "abs_diff", ["geninteger", "geninteger"], "0")
     sig_list.append(f_abs_diff)
 
     f_add_sat = funsig("sycl", "geninteger", "add_sat", ["geninteger", "geninteger"])

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -305,23 +305,21 @@ sycl_cts::resultRef<sycl::marray<T, N>> abs(sycl::marray<T, N> a) {
 
 /* absolute difference */
 template <typename T>
-auto abs_diff(T a, T b) {
-  using R = typename std::make_unsigned<T>::type;
-  R h = (a > b) ? a : b;
-  R l = (a <= b) ? a : b;
+T abs_diff(T a, T b) {
+  T h = (a > b) ? a : b;
+  T l = (a <= b) ? a : b;
   return h - l;
 }
-template <typename T, int N, typename R = typename std::make_unsigned<T>::type>
-sycl::vec<R, N> abs_diff(sycl::vec<T, N> a, sycl::vec<T, N> b) {
-  return sycl_cts::math::run_func_on_vector<R, T, N>(
+template <typename T, int N>
+sycl::vec<T, N> abs_diff(sycl::vec<T, N> a, sycl::vec<T, N> b) {
+  return sycl_cts::math::run_func_on_vector<T, T, N>(
       [](T x, T y) { return abs_diff(x, y); }, a, b);
 }
 // FIXME: hipSYCL does not support marray
 #ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL
-template <typename T, size_t N,
-          typename R = typename std::make_unsigned<T>::type>
-sycl::marray<R, N> abs_diff(sycl::marray<T, N> a, sycl::marray<T, N> b) {
-  return sycl_cts::math::run_func_on_marray<R, T, N>(
+template <typename T, size_t N>
+sycl::marray<T, N> abs_diff(sycl::marray<T, N> a, sycl::marray<T, N> b) {
+  return sycl_cts::math::run_func_on_marray<T, T, N>(
       [](T x, T y) { return abs_diff(x, y); }, a, b);
 }
 #endif


### PR DESCRIPTION
Following https://github.com/KhronosGroup/SYCL-Docs/pull/458 the return
type of abs_diff was changed to be the same as the input types. This
commit makes the corresponding changes to the CTS tests for it.

Signed-off-by: Larsen, Steffen <steffen.larsen@intel.com>