### PR TITLE
Fix overflow issues in scan tests.

### DIFF
--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -61,7 +61,6 @@ template <typename T, typename U, typename I, typename OpT>
 struct JointScanDataStruct {
   JointScanDataStruct(size_t range_size, OpT op, bool with_init)
       : ref_input(range_size), res(range_size * 4, U(-1)) {
-
     std::iota(ref_input.begin(), ref_input.end(), T(1));
     if constexpr (std::is_same_v<OpT, sycl::multiplies<I>> ||
                   std::is_same_v<OpT, sycl::plus<I>>) {

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -65,7 +65,7 @@ struct JointScanDataStruct {
     if constexpr (std::is_same_v<OpT, sycl::multiplies<I>> ||
                   std::is_same_v<OpT, sycl::plus<I>>) {
       auto identity = sycl::known_identity_v<OpT, I>;
-      auto acc = with_init ? I(init) : identity;
+      auto acc = with_init ? I{init} : identity;
       for (size_t i = 0; i < range_size; ++i) {
         I tmp = op(I(acc), I(ref_input[i]));
         if (tmp > std::numeric_limits<U>::max()) {


### PR DESCRIPTION
Prior to this patch, there were a number of overflow issues when the output type of scan op was char and the init type was float. After local verification, all tests pass now.