### PR TITLE
[group] Refine scan_over_group for sub-group

### DIFF
--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -458,7 +458,7 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op,
           sycl::accessor<T, 1> res_acc(res_sycl, cgh);
           sycl::accessor<bool, 1> ret_type_acc(ret_type_sycl, cgh);
           sycl::accessor<size_t, 1> local_id_acc(local_id_sycl, cgh);
-          sycl::accessor<size_t, 1> sub_group_id_acc(sub_group_id_acc, cgh);
+          sycl::accessor<size_t, 1> sub_group_id_acc(sub_group_id_sycl, cgh);
 
           cgh.parallel_for<scan_over_group_kernel<D, T, U, OpT>>(
               sycl::nd_range<D>(range, range), [=](sycl::nd_item<D> item) {

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -339,16 +339,14 @@ struct ScanOverGroupDataStruct {
     // res consists of 4 series of results: two pairs of exclusive and inclusive
     // scan results made over 'group' and 'sub_group' accordingly.
     {
-      std::string group_name = "group";
       std::vector<T> reference(range_size, T(-1));
       // There is only one work-group so we can scan over all the input data.
       std::exclusive_scan(ref_input.begin(), ref_input.end(), reference.begin(),
                           init_value, op);
       for (int i = 0; i < range_size; i++) {
         int res_i = i;
-        INFO("Check exclusive_scan_over_group on " + group_name +
-             " for element " + std::to_string(i) + " (Operator: " + op_name +
-             ")");
+        INFO("Check exclusive_scan_over_group on group for element " +
+             std::to_string(i) + " (Operator: " + op_name + ")");
         INFO("Result: " + std::to_string(res[res_i]));
         INFO("Expected: " + std::to_string(reference[i]));
         CHECK(res[res_i] == reference[i]);
@@ -357,16 +355,14 @@ struct ScanOverGroupDataStruct {
                           op, init_value);
       for (int i = 0; i < range_size; i++) {
         int res_i = range_size + i;
-        INFO("Check inclusive_scan_over_group on " + group_name +
-             " for element " + std::to_string(i) + " (Operator: " + op_name +
-             ")");
+        INFO("Check inclusive_scan_over_group on group for element " +
+             std::to_string(i) + " (Operator: " + op_name + ")");
         INFO("Result: " + std::to_string(res[res_i]));
         INFO("Expected: " + std::to_string(reference[i]));
         CHECK(res[res_i] == reference[i]);
       }
     }
     {
-      std::string group_name = "sub_group";
       // Mapping from "sub-group id" to "vector of input data (ordered by item
       // linear id within the sub-group)"
       std::unordered_map<size_t, std::vector<T>> ref_input_per_sub_group;
@@ -391,9 +387,8 @@ struct ScanOverGroupDataStruct {
                             reference.begin(), init_value, op);
         {
           int res_i = range_size * 2 + i;
-          INFO("Check exclusive_scan_over_group on " + group_name +
-               " for element " + std::to_string(i) + " (Operator: " + op_name +
-               ")");
+          INFO("Check exclusive_scan_over_group on sub_group for element " +
+               std::to_string(i) + " (Operator: " + op_name + ")");
           INFO("Result: " + std::to_string(res[res_i]));
           INFO("Expected: " + std::to_string(reference[lid]));
           CHECK(res[res_i] == reference[lid]);
@@ -402,9 +397,8 @@ struct ScanOverGroupDataStruct {
                             reference.begin(), op, init_value);
         {
           int res_i = range_size * 3 + i;
-          INFO("Check inclusive_scan_over_group on " + group_name +
-               " for element " + std::to_string(i) + " (Operator: " + op_name +
-               ")");
+          INFO("Check inclusive_scan_over_group on sub_group for element " +
+               std::to_string(i) + " (Operator: " + op_name + ")");
           INFO("Result: " + std::to_string(res[res_i]));
           INFO("Expected: " + std::to_string(reference[lid]));
           CHECK(res[res_i] == reference[lid]);

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -436,7 +436,7 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op,
                 // Use the local id of the item in the sub-group to place
                 // results of the scan operation in the order of the items.
                 auto sg_index = sub_group.get_group_linear_id() *
-                                    sub_group.get_local_linear_range() +
+                                    sub_group.get_max_local_range()[0] +
                                 sub_group.get_local_linear_id();
                 local_id_acc[range_size + sg_index] =
                     sub_group.get_local_linear_id();

--- a/tests/group_functions/group_scan.h
+++ b/tests/group_functions/group_scan.h
@@ -416,11 +416,9 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op,
                 sycl::group<D> group = item.get_group();
                 sycl::sub_group sub_group = item.get_sub_group();
 
-                // Use the local id of the item in the group to place results of
-                // the scan operation in the order of the items.
-                auto g_index = group.get_group_linear_id() *
-                                   group.get_local_linear_range() +
-                               group.get_local_linear_id();
+                // Use the global linear id of the item in the group to place
+                // results of the scan operation in the order of the items.
+                auto g_index = item.get_global_linear_id();
                 local_id_acc[g_index] = group.get_local_linear_id();
 
                 auto res_g_e = exclusive_scan_over_group_helper<T>(
@@ -433,22 +431,17 @@ void check_scan_over_group(sycl::queue& queue, sycl::range<D> range, OpT op,
                 res_acc[range_size + g_index] = res_g_i;
                 ret_type_acc[1] = std::is_same_v<T, decltype(res_g_i)>;
 
-                // Use the local id of the item in the sub-group to place
-                // results of the scan operation in the order of the items.
-                auto sg_index = sub_group.get_group_linear_id() *
-                                    sub_group.get_max_local_range()[0] +
-                                sub_group.get_local_linear_id();
-                local_id_acc[range_size + sg_index] =
+                local_id_acc[range_size + g_index] =
                     sub_group.get_local_linear_id();
 
                 auto res_sg_e = exclusive_scan_over_group_helper<T>(
-                    sub_group, ref_input_acc[sg_index], op, with_init);
-                res_acc[range_size * 2 + sg_index] = res_sg_e;
+                    sub_group, ref_input_acc[g_index], op, with_init);
+                res_acc[range_size * 2 + g_index] = res_sg_e;
                 ret_type_acc[2] = std::is_same_v<T, decltype(res_sg_e)>;
 
                 auto res_sg_i = inclusive_scan_over_group_helper<T>(
-                    sub_group, ref_input_acc[sg_index], op, with_init);
-                res_acc[range_size * 3 + sg_index] = res_sg_i;
+                    sub_group, ref_input_acc[g_index], op, with_init);
+                res_acc[range_size * 3 + g_index] = res_sg_i;
                 ret_type_acc[3] = std::is_same_v<T, decltype(res_sg_i)>;
               });
         })


### PR DESCRIPTION
Use global linear id to index input data. Store both the sub-group id and item linear id within the sub-group to recover sub-group construction when verifying, so that we don't make any assumption on the implementation-defined sub-group partitioning and ordering.