### PR TITLE
Do not check for undefined behavior in abs_diff

### DIFF
--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -306,31 +306,15 @@ sycl_cts::resultRef<sycl::marray<T, N>> abs(sycl::marray<T, N> a) {
 /* absolute difference */
 template <typename T>
 sycl_cts::resultRef<T> abs_diff(T a, T b) {
-  if constexpr (std::is_unsigned_v<T>) {
-    T h = (a > b) ? a : b;
-    T l = (a <= b) ? a : b;
-    return h - l;
-  } else {
-    using U = std::make_unsigned_t<T>;
-    constexpr T TMax = std::numeric_limits<T>::max();
-    // For unsigned integers, negative values might not be representable by
-    // an absolute value, so we compute the overflow separately.
-    T ao = a < -TMax ? a + TMax : 0;
-    T bo = b < -TMax ? b + TMax : 0;
-    // Then find the absolute values (without the overflow) and compute the
-    // unsigned difference.
-    U au = static_cast<U>(std::abs(a - ao));
-    U bu = static_cast<U>(std::abs(b - bo));
-    U h = (au > bu) ? au : bu;
-    U l = (au <= bu) ? au : bu;
-    U result = (a < 0) == (b < 0) ? h - l : h + l;
-    // Now re-add the absolute distance in overflow. Both ao and bo will be
-    // <= 0.
-    result += (ao <= bo ? U(bo - ao) : U(ao - bo));
-    // If the unsigned difference is larger than the signed maximum value, we
-    // have UB. Otherwise we have our valid result.
-    return result > U(TMax) ? sycl_cts::resultRef<T>(0, true) : T(result);
-  }
+  using U = std::make_unsigned_t<T>;
+  T h = (a > b) ? a : b;
+  T l = (a <= b) ? a : b;
+  // Use knowledge of 2-complement encoding while we know the difference is
+  // positive, so no overflow/underflow.
+  U result = static_cast<U>(h) - static_cast<U>(l);
+  return result > static_cast<U>(std::numeric_limits<T>::max())
+             ? sycl_cts::resultRef<T>(0, true)
+             : T(result);
 }
 template <typename T, int N>
 sycl_cts::resultRef<sycl::vec<T, N>> abs_diff(sycl::vec<T, N> a,

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -309,10 +309,11 @@ sycl_cts::resultRef<T> abs_diff(T a, T b) {
   using U = std::make_unsigned_t<T>;
   T h = (a > b) ? a : b;
   T l = (a <= b) ? a : b;
-  // Use knowledge of 2-complement encoding while we know the difference is
-  // positive, so no overflow/underflow.
+  // Using two's-complement and that unsigned integer underflow is defined as
+  // modulo 2^n we get the result by computing the distance based on signed
+  // comparison.
   U result = static_cast<U>(h) - static_cast<U>(l);
-  return result > static_cast<U>(std::numeric_limits<T>::max())
+  return result > std::numeric_limits<T>::max()
              ? sycl_cts::resultRef<T>(0, true)
              : T(result);
 }


### PR DESCRIPTION
Similar to sycl::abs, sycl::abs_diff now has undefined behavior for unrepresentable results. This patch changes the generated tests for abs_diff to avoid UB, similar to how it was done for abs in https://github.com/KhronosGroup/SYCL-CTS/pull/831.