### PR TITLE
Fix reqd_work_group_size test

### DIFF
--- a/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
+++ b/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
@@ -104,9 +104,19 @@ void test_size() {
         is_exception_expected, expected_errc, queue);
   }
   {
-    RUN_SUBMISSION_CALL_ND_RANGE(
-        N, Dimensions, is_exception_expected, expected_errc, queue,
-        [[sycl::reqd_work_group_size(N)]], kname, NO_KERNEL_BODY);
+    if constexpr (Dimensions == 1) {
+      RUN_SUBMISSION_CALL_ND_RANGE(
+          N, Dimensions, is_exception_expected, expected_errc, queue,
+          [[sycl::reqd_work_group_size(N)]], kname, NO_KERNEL_BODY);
+    } else if constexpr (Dimensions == 2) {
+      RUN_SUBMISSION_CALL_ND_RANGE(
+          N, Dimensions, is_exception_expected, expected_errc, queue,
+          [[sycl::reqd_work_group_size(N, N)]], kname, NO_KERNEL_BODY);
+    } else {
+      RUN_SUBMISSION_CALL_ND_RANGE(
+          N, Dimensions, is_exception_expected, expected_errc, queue,
+          [[sycl::reqd_work_group_size(N, N, N)]], kname, NO_KERNEL_BODY);
+    }
   }
 }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL


### PR DESCRIPTION
The test was using a 1-dimensional kernel attribute even with 2- and 3-dimensional work-group sizes. This is against the semantics of the attribute, and the implementation may throw an `nd_range` exception (though the specification isn't entirely clear).

Regardless, the test is not intentionally testing this aspect of the specification; it's instead checking whether an implementation throws a `kernel_not_supported` exception if N > "max work-group size", and a `nd_range` exception otherwise.