### PR TITLE
Catching the right type of exception

### DIFF
--- a/tests/kernel_args/kernel_args.cpp
+++ b/tests/kernel_args/kernel_args.cpp
@@ -128,7 +128,7 @@ class TEST_NAME : public util::test_base {
               FAIL(log, "outer_struct capture error");
             }
           }
-        } catch (const sycl::feature_not_supported &fnse) {
+        } catch (const sycl::exception &e) {
           if (!my_queue.get_device()
                    .get_info<sycl::info::device::image_support>()) {
             SKIP("device does not support images");

--- a/tests/kernel_args/kernel_args.cpp
+++ b/tests/kernel_args/kernel_args.cpp
@@ -128,7 +128,7 @@ class TEST_NAME : public util::test_base {
               FAIL(log, "outer_struct capture error");
             }
           }
-        } catch (const sycl::exception &e) {
+        } catch (const sycl::exception& e) {
           if (!my_queue.get_device()
                    .get_info<sycl::info::device::image_support>()) {
             SKIP("device does not support images");


### PR DESCRIPTION
It throws sycl::exception instead of sycl::feature_not_supported when failed to test kernel args with samplers.