### PR TITLE
Split double * atomic_ref testing

### DIFF
--- a/tests/atomic_ref/atomic_ref_T_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_T_op_test_pointers_fp64.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::operator T() test for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_T_op_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref::operator T() test. double *", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_T_op_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_T_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_T_op_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_T_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_T_op_test_pointers_fp64.cpp
@@ -44,7 +44,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   }
   const auto type_pack =
       atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_pointers_fp64.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref operator+=()/operator-=() tests for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_add_sub_op_all_types_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref operator+=()/operator-=() test. double *", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_add_sub_op_all_types_test>(
+      type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_add_sub_op_all_types_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_assign_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_assign_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_pointers_fp64.cpp
@@ -44,7 +44,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   }
   const auto type_pack =
       atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_assign_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_assign_op_test_pointers_fp64.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::operator=() tests for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_assign_op_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref::operator=() test. double *", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_assign_op_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_common.h
+++ b/tests/atomic_ref/atomic_ref_common.h
@@ -166,11 +166,10 @@ inline auto get_conformance_type_pack() {
 inline auto get_full_conformance_pointers_type_pack() {
   static const auto types =
       named_type_pack<int*, unsigned int*, long int*, unsigned long int*,
-                      long long*, unsigned long long*, float*,
-                      double*>::generate("int *", "unsigned int *",
-                                         "long int *", "unsigned long int *",
-                                         "long long *", "unsigned long long *",
-                                         "float *", "double *");
+                      long long*, unsigned long long*,
+                      float*>::generate("int *", "unsigned int *", "long int *",
+                                        "unsigned long int *", "long long *",
+                                        "unsigned long long *", "float *");
   return types;
 }
 
@@ -180,6 +179,14 @@ inline auto get_full_conformance_pointers_type_pack() {
 inline auto get_lightweight_pointers_type_pack() {
   static const auto types =
       named_type_pack<int*, float*>::generate("int *", "float *");
+  return types;
+}
+
+/**
+ * @brief Factory function for getting type_pack with generic pointers types
+ */
+inline auto get_fp64_pointers_type_pack() {
+  static const auto types = named_type_pack<double*>::generate("double *");
   return types;
 }
 

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers_fp64.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref compare_exchange_strong()/compare_exchange_weak()
+//  tests for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_compare_exchange_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref compare_exchange_strong()/compare_exchange_weak() test. "
+ "double *",
+ "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_compare_exchange_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_compare_exchange_test_pointers_fp64.cpp
@@ -47,7 +47,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   }
   const auto type_pack =
       atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_constructors_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_constructors_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_pointers_fp64.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref constructors test for double *.
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_constructors.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::constructors::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref constructors. double *", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto types =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::constructors::run_test>(types);
+});
+
+}  // namespace atomic_ref::tests::constructors::core

--- a/tests/atomic_ref/atomic_ref_constructors_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_constructors_pointers_fp64.cpp
@@ -42,9 +42,8 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
         "Device does not support double precision floating point "
         "operations.");
   }
-  const auto types =
-      atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  const auto types = atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_exchange_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_exchange_test_pointers_fp64.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::exchange() tests for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_exchange_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref::exchange() test. double *", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_exchange_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_exchange_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_exchange_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_exchange_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_exchange_test_pointers_fp64.cpp
@@ -44,7 +44,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   }
   const auto type_pack =
       atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers_fp64.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref fetch_add()/fetch_sub() tests for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_fetch_add_sub_all_types_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref fetch_add()/fetch_sub() test. double *",
+ "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_fetch_add_sub_all_types_test>(
+      type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_fetch_add_sub_all_types_test_pointers_fp64.cpp
@@ -35,8 +35,7 @@ namespace atomic_ref::tests::api::core {
 // sycl::info::device::atomic_memory_scope_capabilities are implemented in
 // hipsycl
 DISABLED_FOR_TEST_CASE(hipSYCL)
-("sycl::atomic_ref fetch_add()/fetch_sub() test. double *",
- "[atomic_ref]")({
+("sycl::atomic_ref fetch_add()/fetch_sub() test. double *", "[atomic_ref]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
   if (!queue.get_device().has(sycl::aspect::fp64)) {
     SKIP(
@@ -45,7 +44,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   }
   const auto type_pack =
       atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers_fp64.cpp
@@ -47,7 +47,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   }
   const auto type_pack =
       atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_incr_decr_op_test_pointers_fp64.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref
+//  operator++(int)/operator++()/operator--(int)/operator--() tests
+//  for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_incr_decr_op_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref increment/decrement operators test. double *",
+ "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_incr_decr_op_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_is_lock_free_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_is_lock_free_test_pointers_fp64.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::is_lock_free() test for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_is_lock_free_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref::is_lock_free() test. double *", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_is_lock_free_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core

--- a/tests/atomic_ref/atomic_ref_is_lock_free_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_is_lock_free_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_is_lock_free_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_is_lock_free_test_pointers_fp64.cpp
@@ -44,7 +44,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   }
   const auto type_pack =
       atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_store_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_store_test_pointers_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-//  Copyright (c) 2023 The Khronos Group Inc.
+//  Copyright (c) 2024 The Khronos Group Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/tests/atomic_ref/atomic_ref_store_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_store_test_pointers_fp64.cpp
@@ -44,7 +44,7 @@ DISABLED_FOR_TEST_CASE(hipSYCL)
   }
   const auto type_pack =
       atomic_ref::tests::common::get_fp64_pointers_type_pack();
-  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+  if (is_64_bits_pointer<void*>() && device_has_not_aspect_atomic64()) {
     SKIP(
         "Device does not support atomic64 operations. "
         "Skipping the test case.");

--- a/tests/atomic_ref/atomic_ref_store_test_pointers_fp64.cpp
+++ b/tests/atomic_ref/atomic_ref_store_test_pointers_fp64.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Provides sycl::atomic_ref::store() test for double *
+//
+*******************************************************************************/
+#include "../common/disabled_for_test_case.h"
+#include "catch2/catch_test_macros.hpp"
+
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+#include "atomic_ref_store_test.h"
+
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
+
+namespace atomic_ref::tests::api::core {
+
+// FIXME: re-enable for hipsycl
+// when sycl::info::device::atomic_memory_order_capabilities and
+// sycl::info::device::atomic_memory_scope_capabilities are implemented in
+// hipsycl
+DISABLED_FOR_TEST_CASE(hipSYCL)
+("sycl::atomic_ref::store() test. double *", "[atomic_ref]")({
+  auto queue = sycl_cts::util::get_cts_object::queue();
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
+        "Device does not support double precision floating point "
+        "operations.");
+  }
+  const auto type_pack =
+      atomic_ref::tests::common::get_fp64_pointers_type_pack();
+  if (is_64_bits_pointer<void *>() && device_has_not_aspect_atomic64()) {
+    SKIP(
+        "Device does not support atomic64 operations. "
+        "Skipping the test case.");
+  }
+  for_all_types<atomic_ref::tests::api::run_store_test>(type_pack);
+});
+
+}  // namespace atomic_ref::tests::api::core


### PR DESCRIPTION
This commit splits the testing of atomic_ref with double * into separate tests to allow for fp64 support checks. This is related to https://github.com/KhronosGroup/SYCL-Docs/issues/526.