### PR TITLE
Test marray on device

### DIFF
--- a/tests/marray/marray_common.h
+++ b/tests/marray/marray_common.h
@@ -77,6 +77,11 @@ constexpr sycl::marray<DataT, NumElements> iota_marray() {
       std::make_index_sequence<NumElements>());
 }
 
+template <class ForwardIt, class T>
+void iota(ForwardIt first, ForwardIt last, T value) {
+  for (; first != last; ++first) *first = value++;
+}
+
 }  // namespace marray_common
 
 #endif  // SYCL_CTS_TEST_MARRAY_MARRAY_COMMON_H

--- a/tests/marray/marray_operators_arithmetic_assignment_core.cpp
+++ b/tests/marray/marray_operators_arithmetic_assignment_core.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_arithmetic_assignment_core {
+
+using namespace marray_operators;
+
+TEST_CASE("arithmetic assignment operators core", "[marray]") {
+  const auto types = marray_common::get_types();
+  for_all_types<check_marray_arithmetic_assignment_operators_for_type>(types);
+}
+
+}  // namespace marray_operators_arithmetic_assignment_core

--- a/tests/marray/marray_operators_arithmetic_assignment_fp16.cpp
+++ b/tests/marray/marray_operators_arithmetic_assignment_fp16.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_arithmetic_assignment_fp16 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("arithmetic assignment operators fp16", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support half precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_arithmetic_assignment_operators_for_type<sycl::half>{}(
+      "sycl::half");
+}
+
+}  // namespace marray_operators_arithmetic_assignment_fp16

--- a/tests/marray/marray_operators_arithmetic_assignment_fp64.cpp
+++ b/tests/marray/marray_operators_arithmetic_assignment_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_arithmetic_assignment_fp64 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("arithmetic assignment operators fp64", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp64>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support double precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_arithmetic_assignment_operators_for_type<double>{}("double");
+}
+
+}  // namespace marray_operators_arithmetic_assignment_fp64

--- a/tests/marray/marray_operators_arithmetic_binary_core.cpp
+++ b/tests/marray/marray_operators_arithmetic_binary_core.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_arithmetic_binary_core {
+
+using namespace marray_operators;
+
+TEST_CASE("arithmetic binary operators core", "[marray]") {
+  const auto types = marray_common::get_types();
+  for_all_types<check_marray_arithmetic_binary_operators_for_type>(types);
+}
+
+}  // namespace marray_operators_arithmetic_binary_core

--- a/tests/marray/marray_operators_arithmetic_binary_fp16.cpp
+++ b/tests/marray/marray_operators_arithmetic_binary_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_arithmetic_binary_fp16 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("arithmetic binary operators fp16", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support half precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_arithmetic_binary_operators_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace marray_operators_arithmetic_binary_fp16

--- a/tests/marray/marray_operators_arithmetic_binary_fp64.cpp
+++ b/tests/marray/marray_operators_arithmetic_binary_fp64.cpp
@@ -23,12 +23,12 @@
 #include "marray_common.h"
 #include "marray_operators.h"
 
-namespace marray_operators_fp64 {
+namespace marray_operators_arithmetic_binary_fp64 {
 
 using namespace sycl_cts;
 using namespace marray_operators;
 
-TEST_CASE("operators fp64", "[marray]") {
+TEST_CASE("arithmetic binary operators fp64", "[marray]") {
   auto queue = util::get_cts_object::queue();
   using availability =
       util::extensions::availability<util::extensions::tag::fp64>;
@@ -39,7 +39,7 @@ TEST_CASE("operators fp64", "[marray]") {
     return;
   }
 
-  check_marray_operators_for_type<double>{}("double");
+  check_marray_arithmetic_binary_operators_for_type<double>{}("double");
 }
 
-}  // namespace marray_operators_fp64
+}  // namespace marray_operators_arithmetic_binary_fp64

--- a/tests/marray/marray_operators_bitwise_assignment_core.cpp
+++ b/tests/marray/marray_operators_bitwise_assignment_core.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_bitwise_assignment_core {
+
+using namespace marray_operators;
+
+TEST_CASE("bitwise assignment operators core", "[marray]") {
+  const auto types = marray_common::get_types();
+  for_all_types<check_marray_bitwise_assignment_operators_for_type>(types);
+}
+
+}  // namespace marray_operators_bitwise_assignment_core

--- a/tests/marray/marray_operators_bitwise_assignment_fp16.cpp
+++ b/tests/marray/marray_operators_bitwise_assignment_fp16.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_bitwise_assignment_fp16 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("bitwise assignment operators fp16", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support half precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_bitwise_assignment_operators_for_type<sycl::half>{}(
+      "sycl::half");
+}
+
+}  // namespace marray_operators_bitwise_assignment_fp16

--- a/tests/marray/marray_operators_bitwise_assignment_fp64.cpp
+++ b/tests/marray/marray_operators_bitwise_assignment_fp64.cpp
@@ -23,23 +23,23 @@
 #include "marray_common.h"
 #include "marray_operators.h"
 
-namespace marray_operators_fp16 {
+namespace marray_operators_bitwise_assignment_fp64 {
 
 using namespace sycl_cts;
 using namespace marray_operators;
 
-TEST_CASE("operators fp16", "[marray]") {
+TEST_CASE("bitwise assignment operators fp64", "[marray]") {
   auto queue = util::get_cts_object::queue();
   using availability =
-      util::extensions::availability<util::extensions::tag::fp16>;
+      util::extensions::availability<util::extensions::tag::fp64>;
   if (!availability::check(queue)) {
     WARN(
-        "Device does not support half precision floating point operations."
+        "Device does not support double precision floating point operations."
         "Skipping the test case.");
     return;
   }
 
-  check_marray_operators_for_type<sycl::half>{}("sycl::half");
+  check_marray_bitwise_assignment_operators_for_type<double>{}("double");
 }
 
-}  // namespace marray_operators_fp16
+}  // namespace marray_operators_bitwise_assignment_fp64

--- a/tests/marray/marray_operators_bitwise_binary_core.cpp
+++ b/tests/marray/marray_operators_bitwise_binary_core.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_bitwise_binary_core {
+
+using namespace marray_operators;
+
+TEST_CASE("bitwise binary operators core", "[marray]") {
+  const auto types = marray_common::get_types();
+  for_all_types<check_marray_bitwise_binary_operators_for_type>(types);
+}
+
+}  // namespace marray_operators_bitwise_binary_core

--- a/tests/marray/marray_operators_bitwise_binary_fp16.cpp
+++ b/tests/marray/marray_operators_bitwise_binary_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_bitwise_binary_fp16 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("bitwise binary operators fp16", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support half precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_bitwise_binary_operators_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace marray_operators_bitwise_binary_fp16

--- a/tests/marray/marray_operators_bitwise_binary_fp64.cpp
+++ b/tests/marray/marray_operators_bitwise_binary_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_bitwise_binary_fp64 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("bitwise binary operators fp64", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp64>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support double precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_bitwise_binary_operators_for_type<double>{}("double");
+}
+
+}  // namespace marray_operators_bitwise_binary_fp64

--- a/tests/marray/marray_operators_post_unary_core.cpp
+++ b/tests/marray/marray_operators_post_unary_core.cpp
@@ -22,13 +22,13 @@
 #include "marray_common.h"
 #include "marray_operators.h"
 
-namespace marray_operators_core {
+namespace marray_operators_post_unary_core {
 
 using namespace marray_operators;
 
-TEST_CASE("operators core", "[marray]") {
+TEST_CASE("suffix unary operators core", "[marray]") {
   const auto types = marray_common::get_types();
-  for_all_types<check_marray_operators_for_type>(types);
+  for_all_types<check_marray_post_unary_operators_for_type>(types);
 }
 
-}  // namespace marray_operators_core
+}  // namespace marray_operators_post_unary_core

--- a/tests/marray/marray_operators_post_unary_fp16.cpp
+++ b/tests/marray/marray_operators_post_unary_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_post_unary_fp16 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("suffix unary operators fp16", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support half precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_post_unary_operators_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace marray_operators_post_unary_fp16

--- a/tests/marray/marray_operators_post_unary_fp64.cpp
+++ b/tests/marray/marray_operators_post_unary_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_post_unary_fp64 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("suffix unary operators fp64", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp64>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support double precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_post_unary_operators_for_type<double>{}("double");
+}
+
+}  // namespace marray_operators_post_unary_fp64

--- a/tests/marray/marray_operators_pre_unary_core.cpp
+++ b/tests/marray/marray_operators_pre_unary_core.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_pre_unary_core {
+
+using namespace marray_operators;
+
+TEST_CASE("prefix unary operators core", "[marray]") {
+  const auto types = marray_common::get_types();
+  for_all_types<check_marray_pre_unary_operators_for_type>(types);
+}
+
+}  // namespace marray_operators_pre_unary_core

--- a/tests/marray/marray_operators_pre_unary_fp16.cpp
+++ b/tests/marray/marray_operators_pre_unary_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_pre_unary_fp16 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("prefix unary operators fp16", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support half precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_pre_unary_operators_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace marray_operators_pre_unary_fp16

--- a/tests/marray/marray_operators_pre_unary_fp64.cpp
+++ b/tests/marray/marray_operators_pre_unary_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_pre_unary_fp64 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("prefix unary operators fp64", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp64>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support double precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_pre_unary_operators_for_type<double>{}("double");
+}
+
+}  // namespace marray_operators_pre_unary_fp64

--- a/tests/marray/marray_operators_relational_binary_core.cpp
+++ b/tests/marray/marray_operators_relational_binary_core.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_relational_binary_core {
+
+using namespace marray_operators;
+
+TEST_CASE("relational binary operators core", "[marray]") {
+  const auto types = marray_common::get_types();
+  for_all_types<check_marray_relational_binary_operators_for_type>(types);
+}
+
+}  // namespace marray_operators_relational_binary_core

--- a/tests/marray/marray_operators_relational_binary_fp16.cpp
+++ b/tests/marray/marray_operators_relational_binary_fp16.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_relational_binary_fp16 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("relational binary operators fp16", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp16>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support half precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_relational_binary_operators_for_type<sycl::half>{}("sycl::half");
+}
+
+}  // namespace marray_operators_relational_binary_fp16

--- a/tests/marray/marray_operators_relational_binary_fp64.cpp
+++ b/tests/marray/marray_operators_relational_binary_fp64.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2023 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../util/extensions.h"
+#include "../common/type_coverage.h"
+#include "marray_common.h"
+#include "marray_operators.h"
+
+namespace marray_operators_relational_binary_fp64 {
+
+using namespace sycl_cts;
+using namespace marray_operators;
+
+TEST_CASE("relational binary operators fp64", "[marray]") {
+  auto queue = util::get_cts_object::queue();
+  using availability =
+      util::extensions::availability<util::extensions::tag::fp64>;
+  if (!availability::check(queue)) {
+    WARN(
+        "Device does not support double precision floating point operations."
+        "Skipping the test case.");
+    return;
+  }
+
+  check_marray_relational_binary_operators_for_type<double>{}("double");
+}
+
+}  // namespace marray_operators_relational_binary_fp64


### PR DESCRIPTION
This commit makes marray tests run checks on both device and host, where they would only run on host previously. Additionally it splits operator tests up in separate categories to reduce compilation overhead.

Fixes https://github.com/KhronosGroup/SYCL-CTS/issues/821