### PR TITLE
Switch nan-tests to verify fixed-width arg types for marray

### DIFF
--- a/tests/math_builtin_api/modules/sycl_functions.py
+++ b/tests/math_builtin_api/modules/sycl_functions.py
@@ -950,31 +950,31 @@ def create_float_signatures():
     sig_list.append(f_modf_3)
 
 
-    f_nan_1 = funsig("sycl", "float", "nan", ["unsigned"])
+    f_nan_1 = funsig("sycl", "float", "nan", ["uint32_t"])
     sig_list.append(f_nan_1)
 
     f_nan_2 = funsig("sycl", "vgenfloatf", "nan", ["ugenint"], "0", "", [], [["vgenfloatf", "ugenint", "base_type"]], template_arg_map=[0])
     sig_list.append(f_nan_2)
 
-    f_nan_3 = funsig("sycl", "mgenfloatf", "nan", ["ugenint"], "0", "", [], [["mgenfloatf", "ugenint", "base_type"]], template_arg_map=[0])
+    f_nan_3 = funsig("sycl", "mgenfloatf", "nan", ["muint32n"], "0", "", [], [["mgenfloatf", "muint32n", "base_type"]], template_arg_map=[0])
     sig_list.append(f_nan_3)
 
-    f_nan_4 = funsig("sycl", "double", "nan", ["unsigned long"], "0")
+    f_nan_4 = funsig("sycl", "double", "nan", ["uint64_t"], "0")
     sig_list.append(f_nan_4)
 
     f_nan_5 = funsig("sycl", "vgenfloatd", "nan", ["ugenlonginteger"], "0", "", [], [["vgenfloatd", "ugenlonginteger", "base_type"]], template_arg_map=[0])
     sig_list.append(f_nan_5)
 
-    f_nan_6 = funsig("sycl", "mgenfloatd", "nan", ["ugenlonginteger"], "0", "", [], [["mgenfloatd", "ugenlonginteger", "base_type"]], template_arg_map=[0])
+    f_nan_6 = funsig("sycl", "mgenfloatd", "nan", ["muint64n"], "0", "", [], [["mgenfloatd", "muint64n", "base_type"]], template_arg_map=[0])
     sig_list.append(f_nan_6)
 
-    f_nan_7 = funsig("sycl", "sycl::half", "nan", ["unsigned short"], "0")
+    f_nan_7 = funsig("sycl", "sycl::half", "nan", ["uint16_t"], "0")
     sig_list.append(f_nan_7)
 
     f_nan_8 = funsig("sycl", "vgenfloath", "nan", ["ugenshort"], "0", "", [], [["vgenfloath", "ugenshort", "base_type"]], template_arg_map=[0])
     sig_list.append(f_nan_8)
 
-    f_nan_9 = funsig("sycl", "mgenfloath", "nan", ["ugenshort"], "0", "", [], [["mgenfloath", "ugenshort", "base_type"]], template_arg_map=[0])
+    f_nan_9 = funsig("sycl", "mgenfloath", "nan", ["muint16n"], "0", "", [], [["mgenfloath", "muint16n", "base_type"]], template_arg_map=[0])
     sig_list.append(f_nan_9)
 
 

--- a/tests/math_builtin_api/modules/sycl_types.py
+++ b/tests/math_builtin_api/modules/sycl_types.py
@@ -1250,6 +1250,9 @@ def create_types():
     t_mushort_n = argtype("mushortn", "NULL", "NULL", 0, ["sycl::marray<unsigned short, 2>","sycl::marray<unsigned short, 3>","sycl::marray<unsigned short, 4>","sycl::marray<unsigned short, 5>","sycl::marray<unsigned short, 17>"])
     type_dic["mushortn"] = t_mushort_n
 
+    t_muint16_n = argtype("muint16n", "NULL", "NULL", 0, ["sycl::marray<uint16_t, 2>","sycl::marray<uint16_t, 3>","sycl::marray<uint16_t, 4>","sycl::marray<uint16_t, 5>","sycl::marray<uint16_t, 17>"])
+    type_dic["muint16n"] = t_muint16_n
+
     t_ushort_n = argtype("ushortn", "NULL", "NULL", 0, ["vuint16n","mushortn"])
     type_dic["ushortn"] = t_ushort_n
 
@@ -1278,6 +1281,9 @@ def create_types():
     t_muint_n = argtype("muintn", "NULL", "NULL", 0, ["sycl::marray<unsigned, 2>","sycl::marray<unsigned, 3>","sycl::marray<unsigned, 4>","sycl::marray<unsigned, 5>","sycl::marray<unsigned, 17>"])
     type_dic["muintn"] = t_muint_n
 
+    t_muint32_n = argtype("muint32n", "NULL", "NULL", 0, ["sycl::marray<uint32_t, 2>","sycl::marray<uint32_t, 3>","sycl::marray<uint32_t, 4>","sycl::marray<uint32_t, 5>","sycl::marray<uint32_t, 17>"])
+    type_dic["muint32n"] = t_muint32_n
+
     t_uint_n = argtype("uintn", "NULL", "NULL", 0, ["vuint32n","muintn"])
     type_dic["uintn"] = t_uint_n
 
@@ -1305,6 +1311,9 @@ def create_types():
 
     t_mulong_n = argtype("mulongn", "NULL", "NULL", 0, ["sycl::marray<unsigned long, 2>","sycl::marray<unsigned long, 3>","sycl::marray<unsigned long, 4>","sycl::marray<unsigned long, 5>","sycl::marray<unsigned long, 17>"])
     type_dic["mulongn"] = t_mulong_n
+
+    t_muint64_n = argtype("muint64n", "NULL", "NULL", 0, ["sycl::marray<uint64_t, 2>","sycl::marray<uint64_t, 3>","sycl::marray<uint64_t, 4>","sycl::marray<uint64_t, 5>","sycl::marray<uint64_t, 17>"])
+    type_dic["muint64n"] = t_muint64_n
 
     t_ulong_n = argtype("ulongn", "NULL", "NULL", 0, ["vuint64n","mulongn"])
     type_dic["ulongn"] = t_ulong_n


### PR DESCRIPTION
The spec has been updated in
https://github.com/KhronosGroup/SYCL-Docs/pull/519/, this PR aligns CTS with it.