### PR TITLE
Fix `-Wc++11-narrowing` warnings

### DIFF
--- a/tests/buffer/buffer_deduction_guides.cpp
+++ b/tests/buffer/buffer_deduction_guides.cpp
@@ -41,9 +41,9 @@ class check_buffer_deduction {
   void operator()(const std::string& type) {
     // create container
     // using this API because of no_cnstr and no_def_cnstr types
-    std::array<T, size> arr = {user_def_types::get_init_value_helper<T>(0),
-                               user_def_types::get_init_value_helper<T>(0),
-                               user_def_types::get_init_value_helper<T>(0)};
+    std::array<T, size> arr = {user_def_types::get_init_value<T>(0),
+                               user_def_types::get_init_value<T>(0),
+                               user_def_types::get_init_value<T>(0)};
     type_name = type;
 
     test_inputiterator(arr);
@@ -123,9 +123,9 @@ class check_buffer_deduction {
     const int arr_size = r.size();
 
     std::unique_ptr<T[]> data(
-        new T[size]{user_def_types::get_init_value_helper<T>(0),
-                    user_def_types::get_init_value_helper<T>(0),
-                    user_def_types::get_init_value_helper<T>(0)});
+        new T[size]{user_def_types::get_init_value<T>(0),
+                    user_def_types::get_init_value<T>(0),
+                    user_def_types::get_init_value<T>(0)});
 
     INFO("buffer_ctors_deduction::test_type() " + type_name);
     // buffer with no alloccator and no property list

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -175,10 +175,12 @@ struct vec_marray_element_type<sycl::vec<T, N>> {
   using type = T;
 };
 
+#ifndef SYCL_CTS_COMPILING_WITH_HIPSYCL
 template <typename T, int N>
 struct vec_marray_element_type<sycl::marray<T, N>> {
   using type = T;
 };
+#endif
 
 // Returns instance of type T
 template <typename T>

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -165,9 +165,7 @@ struct arrow_operator_overloaded {
 // Returns instance of type T
 template <typename T>
 struct init_value_helper {
-  static constexpr auto get(int x) {
-    return static_cast<T>(x);
-  }
+  static constexpr auto get(int x) { return static_cast<T>(x); }
 };
 
 // Returns instance of type T
@@ -189,9 +187,7 @@ struct init_value_helper<sycl::marray<T, N>> {
 // Returns instance of type bool
 template <>
 struct init_value_helper<bool> {
-  static constexpr bool get(int x) {
-    return x % 2 != 0;
-  }
+  static constexpr bool get(int x) { return x % 2 != 0; }
 };
 
 // Returns instance of user defined struct with no constructor

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -164,31 +164,55 @@ struct arrow_operator_overloaded {
 
 // Returns instance of type T
 template <typename T>
-inline constexpr auto get_init_value_helper(int x) {
-  return x;
-}
+struct init_value_helper {
+  static constexpr auto get(int x) {
+    return static_cast<T>(x);
+  }
+};
+
+// Returns instance of type T
+template <typename T, int N>
+struct init_value_helper<sycl::vec<T, N>> {
+  static constexpr auto get(int x) {
+    return sycl::vec<T, N>{static_cast<T>(x)};
+  }
+};
+
+// Returns instance of type T
+template <typename T, int N>
+struct init_value_helper<sycl::marray<T, N>> {
+  static constexpr auto get(int x) {
+    return sycl::marray<T, N>{static_cast<T>(x)};
+  }
+};
 
 // Returns instance of type bool
 template <>
-inline constexpr auto get_init_value_helper<bool>(int x) {
-  return (x % 2 != 0);
-}
+struct init_value_helper<bool> {
+  static constexpr bool get(int x) {
+    return x % 2 != 0;
+  }
+};
 
 // Returns instance of user defined struct with no constructor
 template <>
-inline constexpr auto get_init_value_helper<no_cnstr>(int x) {
-  no_cnstr instance{};
-  instance = x;
-  return instance;
-}
+struct init_value_helper<no_cnstr> {
+  static constexpr auto get(int x) {
+    no_cnstr instance{};
+    instance = x;
+    return instance;
+  }
+};
 
 // Returns instance of user defined struct default constructor
 template <>
-inline constexpr auto get_init_value_helper<def_cnstr>(int x) {
-  def_cnstr instance;
-  instance = x;
-  return instance;
-}
+struct init_value_helper<def_cnstr> {
+  static constexpr auto get(int x) {
+    def_cnstr instance;
+    instance = x;
+    return instance;
+  }
+};
 
 }  // namespace user_def_types
 

--- a/tests/multi_ptr/multi_ptr_access_members.h
+++ b/tests/multi_ptr/multi_ptr_access_members.h
@@ -51,14 +51,10 @@ struct test_result {
   int value_to_init = 49;
   // Variables that will be used to check that access members returns correct
   // value
-  T dereference_ret_value =
-      user_def_types::get_init_value_helper<T>(value_to_init);
-  T dereference_op_ret_value =
-      user_def_types::get_init_value_helper<T>(value_to_init);
-  T get_member_ret_value =
-      user_def_types::get_init_value_helper<T>(value_to_init);
-  T get_raw_member_ret_value =
-      user_def_types::get_init_value_helper<T>(value_to_init);
+  T dereference_ret_value = user_def_types::get_init_value<T>(value_to_init);
+  T dereference_op_ret_value = user_def_types::get_init_value<T>(value_to_init);
+  T get_member_ret_value = user_def_types::get_init_value<T>(value_to_init);
+  T get_raw_member_ret_value = user_def_types::get_init_value<T>(value_to_init);
 };
 
 }  // namespace detail
@@ -92,7 +88,7 @@ class run_access_members_tests {
                   const std::string &is_decorated_name) {
     auto queue = once_per_unit::get_queue();
     constexpr int val_to_init = 42;
-    T value = user_def_types::get_init_value_helper<T>(val_to_init);
+    T value = user_def_types::get_init_value<T>(val_to_init);
 
     // Variable that contains all variables that will be used to verify test
     // result
@@ -170,7 +166,7 @@ class run_access_members_tests {
         }
       });
     }
-    T expected_value = user_def_types::get_init_value_helper<T>(val_to_init);
+    T expected_value = user_def_types::get_init_value<T>(val_to_init);
     // Dereference and multi_ptr::operator->() available only when:
     // !std::is_void<sycl::multi_ptr::value_type>::value
     if constexpr (!std::is_void_v<typename multi_ptr_t::value_type>) {

--- a/tests/multi_ptr/multi_ptr_accessor_constructor.h
+++ b/tests/multi_ptr/multi_ptr_accessor_constructor.h
@@ -63,8 +63,7 @@ void run_tests(sycl_cts::util::logger& log, const std::string& type_name) {
   bool same_value = false;
 
   // default value
-  T init_value =
-      user_def_types::get_init_value_helper<std::remove_const_t<T>>(10);
+  T init_value = user_def_types::get_init_value<std::remove_const_t<T>>(10);
 
   auto queue = once_per_unit::get_queue();
 

--- a/tests/multi_ptr/multi_ptr_common_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_common_assignment_ops.h
@@ -60,7 +60,7 @@ class run_common_assign_tests {
                   const std::string &address_space_name,
                   const std::string &is_decorated_name) {
     auto queue = once_per_unit::get_queue();
-    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    T value = user_def_types::get_init_value<T>(expected_val);
     sycl::range r(1);
     std::array<bool, 3> res;
     res.fill(false);
@@ -96,7 +96,7 @@ class run_common_assign_tests {
                   check(const_mptr_in, mptr_in, ref, res_acc);
                 } else {
                   T private_val =
-                      user_def_types::get_init_value_helper<T>(expected_val);
+                      user_def_types::get_init_value<T>(expected_val);
 
                   multi_ptr_t mptr_in =
                       sycl::address_space_cast<space, decorated, T>(

--- a/tests/multi_ptr/multi_ptr_common_constructors.h
+++ b/tests/multi_ptr/multi_ptr_common_constructors.h
@@ -79,7 +79,7 @@ void run_tests(sycl_cts::util::logger &log, const std::string &type_name) {
   // Arrays for result values
   bool same_type[types_size]{};
   bool same_value[values_size]{};
-  T ref_value{user_def_types::get_init_value_helper<T>(0)};
+  T ref_value{user_def_types::get_init_value<T>(0)};
   auto queue = once_per_unit::get_queue();
 
   using GlobalAccType = sycl::accessor<T, 1, sycl::access_mode::read_write>;

--- a/tests/multi_ptr/multi_ptr_comparison_op.h
+++ b/tests/multi_ptr/multi_ptr_comparison_op.h
@@ -142,8 +142,8 @@ class run_multi_ptr_comparison_op_test {
 
   using multi_ptr_t = sycl::multi_ptr<T, space, decorated>;
 
-  const T m_small_value = user_def_types::get_init_value_helper<T>(1);
-  const T m_great_value = user_def_types::get_init_value_helper<T>(2);
+  const T m_small_value = user_def_types::get_init_value<T>(1);
+  const T m_great_value = user_def_types::get_init_value<T>(2);
   // Use an array to be sure that we have two elements that has consecutive
   // memory addresses
   const T m_values_arr[2] = {m_small_value, m_great_value};

--- a/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
+++ b/tests/multi_ptr/multi_ptr_convert_assignment_ops.h
@@ -59,7 +59,7 @@ class run_convert_assignment_operators_tests {
                   const std::string &src_is_decorated_name,
                   const std::string &dst_is_decorated_name) {
     auto queue = once_per_unit::get_queue();
-    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    T value = user_def_types::get_init_value<T>(expected_val);
     auto r = sycl::range(1);
     SECTION(
         sycl_cts::section_name(
@@ -113,7 +113,7 @@ class run_convert_assignment_operators_tests {
                     res_acc[0] = *(mptr_out.get_raw()) == ref;
                   } else {
                     T private_val =
-                        user_def_types::get_init_value_helper<T>(expected_val);
+                        user_def_types::get_init_value<T>(expected_val);
 
                     const src_multi_ptr_t mptr_in(
                         sycl::address_space_cast<
@@ -184,7 +184,7 @@ class run_convert_assignment_operators_tests {
                     res_acc[0] = *(mptr_out.get_raw()) == ref;
                   } else {
                     T private_val =
-                        user_def_types::get_init_value_helper<T>(expected_val);
+                        user_def_types::get_init_value<T>(expected_val);
 
                     const src_multi_ptr_t mptr_in(
                         sycl::address_space_cast<

--- a/tests/multi_ptr/multi_ptr_deduction_guides.cpp
+++ b/tests/multi_ptr/multi_ptr_deduction_guides.cpp
@@ -70,7 +70,7 @@ class check_multi_ptr_deduction {
                                      accessor<T, dims, Mode, target::device>,
                                      local_accessor<T, dims>>;
     bool res = false;
-    T data{user_def_types::get_init_value_helper<T>(0)};
+    T data{user_def_types::get_init_value<T>(0)};
     auto r = sycl_cts::util::get_cts_object::range<dims>::get(1, 1, 1);
     {
       sycl::buffer<bool, 1> buf_res(&res, {1});

--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -66,7 +66,7 @@ class run_explicit_convert_tests {
   template <typename T1>
   void run_test(sycl::queue &queue, sycl::range<1> &r) {
     bool res = false;
-    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    T value = user_def_types::get_init_value<T>(expected_val);
     {
       sycl::buffer<bool> res_buf(&res, sycl::range<1>(1));
       sycl::buffer<T> val_buffer(&value, sycl::range<1>(1));
@@ -103,7 +103,7 @@ class run_explicit_convert_tests {
                   res_acc[0] = (*(mptr_out.get()) == ref);
                 } else {
                   T private_val =
-                      user_def_types::get_init_value_helper<T>(expected_val);
+                      user_def_types::get_init_value<T>(expected_val);
 
                   input_multi_ptr_t<T> mptr_in = sycl::address_space_cast<
                       sycl::access::address_space::generic_space, decorated, T>(

--- a/tests/multi_ptr/multi_ptr_implicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_implicit_conversions.h
@@ -76,7 +76,7 @@ class run_implicit_convert_tests {
   template <typename src_multi_ptr_t, typename dest_multi_ptr_t>
   void preform_implicit_conversion_test() {
     auto queue = once_per_unit::get_queue();
-    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    T value = user_def_types::get_init_value<T>(expected_val);
     bool res = false;
 
     constexpr sycl::access::decorated src_multi_ptr_decorated =
@@ -128,7 +128,7 @@ class run_implicit_convert_tests {
           const T value_dest = *(reinterpret_cast<const T *>(mptr_dest.get()));
 
           res_acc[0] = (value_dest ==
-                        user_def_types::get_init_value_helper<T>(expected_val));
+                        user_def_types::get_init_value<T>(expected_val));
         };
 
         using kname =

--- a/tests/multi_ptr/multi_ptr_implicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_implicit_conversions.h
@@ -127,8 +127,8 @@ class run_implicit_convert_tests {
           // for cases, when dest_multi_ptr_t equals to multi_ptr<void>
           const T value_dest = *(reinterpret_cast<const T *>(mptr_dest.get()));
 
-          res_acc[0] = (value_dest ==
-                        user_def_types::get_init_value<T>(expected_val));
+          res_acc[0] =
+              (value_dest == user_def_types::get_init_value<T>(expected_val));
         };
 
         using kname =

--- a/tests/multi_ptr/multi_ptr_prefetch_member.h
+++ b/tests/multi_ptr/multi_ptr_prefetch_member.h
@@ -60,7 +60,7 @@ class run_prefetch_test {
                   "Data type shouldn't be is same to void type");
 
     auto queue = once_per_unit::get_queue();
-    T value = user_def_types::get_init_value_helper<T>(expected_val);
+    T value = user_def_types::get_init_value<T>(expected_val);
     SECTION(sycl_cts::section_name("Check multi_ptr::prefetch()")
                 .with("T", type_name)
                 .with("address_space", "access::address_space::global_space")

--- a/tests/spec_constants/spec_constants_common.h
+++ b/tests/spec_constants/spec_constants_common.h
@@ -48,11 +48,11 @@ constexpr int default_val = 20;
 
 template <typename T, int case_num>
 constexpr sycl::specialization_id<T> spec_const(
-    user_def_types::init_value_helper<T>::get(default_val));
+    user_def_types::get_init_value<T>(default_val));
 
 template <typename T>
 void fill_init_values(T &result, int val) {
-  result = user_def_types::init_value_helper<T>::get(val);
+  result = user_def_types::get_init_value<T>(val);
 }
 
 template <typename T, int numElements>

--- a/tests/spec_constants/spec_constants_common.h
+++ b/tests/spec_constants/spec_constants_common.h
@@ -48,11 +48,11 @@ constexpr int default_val = 20;
 
 template <typename T, int case_num>
 constexpr sycl::specialization_id<T> spec_const(
-    user_def_types::get_init_value_helper<T>(default_val));
+    user_def_types::init_value_helper<T>::get(default_val));
 
 template <typename T>
 void fill_init_values(T &result, int val) {
-  result = user_def_types::get_init_value_helper<T>(val);
+  result = user_def_types::init_value_helper<T>::get(val);
 }
 
 template <typename T, int numElements>

--- a/tests/spec_constants/spec_constants_defined_various_ways.h
+++ b/tests/spec_constants/spec_constants_defined_various_ways.h
@@ -35,8 +35,8 @@ void perform_test(util::logger &log, const std::string &type_name,
     }
   }
   sycl::range<1> range(1);
-  T result{user_def_types::init_value_helper<T>::get(0)};
-  T ref{user_def_types::init_value_helper<T>::get(0)};
+  T result{user_def_types::get_init_value<T>(0)};
+  T ref{user_def_types::get_init_value<T>(0)};
   {
     fill_init_values(ref, case_num);
     sycl::buffer<T, 1> result_buffer(&result, range);

--- a/tests/spec_constants/spec_constants_defined_various_ways.h
+++ b/tests/spec_constants/spec_constants_defined_various_ways.h
@@ -35,8 +35,8 @@ void perform_test(util::logger &log, const std::string &type_name,
     }
   }
   sycl::range<1> range(1);
-  T result { user_def_types::get_init_value_helper<T>(0) };
-  T ref { user_def_types::get_init_value_helper<T>(0) };
+  T result { user_def_types::init_value_helper<T>::get(0) };
+  T ref { user_def_types::init_value_helper<T>::get(0) };
   {
     fill_init_values(ref, case_num);
     sycl::buffer<T, 1> result_buffer(&result, range);

--- a/tests/spec_constants/spec_constants_defined_various_ways.h
+++ b/tests/spec_constants/spec_constants_defined_various_ways.h
@@ -35,8 +35,8 @@ void perform_test(util::logger &log, const std::string &type_name,
     }
   }
   sycl::range<1> range(1);
-  T result { user_def_types::init_value_helper<T>::get(0) };
-  T ref { user_def_types::init_value_helper<T>::get(0) };
+  T result{user_def_types::init_value_helper<T>::get(0)};
+  T ref{user_def_types::init_value_helper<T>::get(0)};
   {
     fill_init_values(ref, case_num);
     sycl::buffer<T, 1> result_buffer(&result, range);

--- a/tests/spec_constants/spec_constants_defined_various_ways_helper.h
+++ b/tests/spec_constants/spec_constants_defined_various_ways_helper.h
@@ -56,14 +56,14 @@ static std::string get_hint(sc_vw_id test_id) {
 // Defined in a non-global named namespace
 template <typename T, int case_num>
 constexpr sycl::specialization_id<T> sc_nonglob(
-    user_def_types::get_init_value_helper<T>(case_num));
+    user_def_types::init_value_helper<T>::get(case_num));
 
 // A static member variable of a struct in a non-global namespace
 struct struct_nonglob {
   constexpr struct_nonglob() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      user_def_types::get_init_value_helper<T>(case_num)};
+      user_def_types::init_value_helper<T>::get(case_num)};
 };
 }  // namespace spec_const_help
 
@@ -71,33 +71,33 @@ namespace {
 // Defined in an unnamed namespace
 template <typename T, int case_num>
 constexpr sycl::specialization_id<T> sc_unnamed(
-    user_def_types::get_init_value_helper<T>(case_num));
+    user_def_types::init_value_helper<T>::get(case_num));
 
 // A static member variable of a struct in an unnamed namespace
 struct struct_unnamed {
   constexpr struct_unnamed() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      user_def_types::get_init_value_helper<T>(case_num)};
+      user_def_types::init_value_helper<T>::get(case_num)};
 };
 }  // unnamed namespace
 
 // Defined in the global namespace as inline constexpr
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> sc_glob_inl(
-    user_def_types::get_init_value_helper<T>(case_num));
+    user_def_types::init_value_helper<T>::get(case_num));
 
 // Defined in the global namespace as static constexpr
 template <typename T, int case_num>
 static constexpr sycl::specialization_id<T> sc_glob_static(
-    user_def_types::get_init_value_helper<T>(case_num));
+    user_def_types::init_value_helper<T>::get(case_num));
 
 // A static member variable of a struct in the global namespace
 struct struct_glob {
   constexpr struct_glob() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      user_def_types::get_init_value_helper<T>(case_num)};
+      user_def_types::init_value_helper<T>::get(case_num)};
 };
 
 // A static member variable declared inline constexpr of a struct in the global
@@ -106,7 +106,7 @@ struct struct_glob_inl {
   constexpr struct_glob_inl() {}
   template <typename T, int case_num>
   static inline constexpr sycl::specialization_id<T> sc{
-      user_def_types::get_init_value_helper<T>(case_num)};
+      user_def_types::init_value_helper<T>::get(case_num)};
 };
 
 // A static member variable of a templated struct in the global namespace
@@ -115,7 +115,7 @@ struct struct_glob_tmpl {
   constexpr struct_glob_tmpl() {}
   template <int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      user_def_types::get_init_value_helper<T>(case_num)};
+      user_def_types::init_value_helper<T>::get(case_num)};
 };
 
 #endif  // __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_HELPER_H

--- a/tests/spec_constants/spec_constants_defined_various_ways_helper.h
+++ b/tests/spec_constants/spec_constants_defined_various_ways_helper.h
@@ -56,14 +56,14 @@ static std::string get_hint(sc_vw_id test_id) {
 // Defined in a non-global named namespace
 template <typename T, int case_num>
 constexpr sycl::specialization_id<T> sc_nonglob(
-    user_def_types::init_value_helper<T>::get(case_num));
+    user_def_types::get_init_value<T>(case_num));
 
 // A static member variable of a struct in a non-global namespace
 struct struct_nonglob {
   constexpr struct_nonglob() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      user_def_types::init_value_helper<T>::get(case_num)};
+      user_def_types::get_init_value<T>(case_num)};
 };
 }  // namespace spec_const_help
 
@@ -71,33 +71,33 @@ namespace {
 // Defined in an unnamed namespace
 template <typename T, int case_num>
 constexpr sycl::specialization_id<T> sc_unnamed(
-    user_def_types::init_value_helper<T>::get(case_num));
+    user_def_types::get_init_value<T>(case_num));
 
 // A static member variable of a struct in an unnamed namespace
 struct struct_unnamed {
   constexpr struct_unnamed() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      user_def_types::init_value_helper<T>::get(case_num)};
+      user_def_types::get_init_value<T>(case_num)};
 };
 }  // unnamed namespace
 
 // Defined in the global namespace as inline constexpr
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> sc_glob_inl(
-    user_def_types::init_value_helper<T>::get(case_num));
+    user_def_types::get_init_value<T>(case_num));
 
 // Defined in the global namespace as static constexpr
 template <typename T, int case_num>
 static constexpr sycl::specialization_id<T> sc_glob_static(
-    user_def_types::init_value_helper<T>::get(case_num));
+    user_def_types::get_init_value<T>(case_num));
 
 // A static member variable of a struct in the global namespace
 struct struct_glob {
   constexpr struct_glob() {}
   template <typename T, int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      user_def_types::init_value_helper<T>::get(case_num)};
+      user_def_types::get_init_value<T>(case_num)};
 };
 
 // A static member variable declared inline constexpr of a struct in the global
@@ -106,7 +106,7 @@ struct struct_glob_inl {
   constexpr struct_glob_inl() {}
   template <typename T, int case_num>
   static inline constexpr sycl::specialization_id<T> sc{
-      user_def_types::init_value_helper<T>::get(case_num)};
+      user_def_types::get_init_value<T>(case_num)};
 };
 
 // A static member variable of a templated struct in the global namespace
@@ -115,7 +115,7 @@ struct struct_glob_tmpl {
   constexpr struct_glob_tmpl() {}
   template <int case_num>
   static constexpr sycl::specialization_id<T> sc{
-      user_def_types::init_value_helper<T>::get(case_num)};
+      user_def_types::get_init_value<T>(case_num)};
 };
 
 #endif  // __SYCLCTS_TESTS_SPEC_CONST_DEFINED_VARIOUS_WAYS_HELPER_H

--- a/tests/spec_constants/spec_constants_exceptions_throwing_common.h
+++ b/tests/spec_constants/spec_constants_exceptions_throwing_common.h
@@ -51,7 +51,7 @@ class check_spec_constant_exception_throw_for_type {
     // kernel_bundle
     {
       bool exception_was_thrown = false;
-      T res{user_def_types::get_init_value_helper<T>(0)};
+      T res{user_def_types::init_value_helper<T>::get(0)};
       const int case_num = 1;
       auto queue = sycl_cts::util::get_cts_object::queue();
 
@@ -85,7 +85,7 @@ class check_spec_constant_exception_throw_for_type {
     // kernel_bundle
     {
       bool exception_was_thrown = false;
-      T sc_val{user_def_types::get_init_value_helper<T>(0)};
+      T sc_val{user_def_types::init_value_helper<T>::get(0)};
       const int case_num = 2;
       auto queue = sycl_cts::util::get_cts_object::queue();
 

--- a/tests/spec_constants/spec_constants_exceptions_throwing_common.h
+++ b/tests/spec_constants/spec_constants_exceptions_throwing_common.h
@@ -51,7 +51,7 @@ class check_spec_constant_exception_throw_for_type {
     // kernel_bundle
     {
       bool exception_was_thrown = false;
-      T res{user_def_types::init_value_helper<T>::get(0)};
+      T res{user_def_types::get_init_value<T>(0)};
       const int case_num = 1;
       auto queue = sycl_cts::util::get_cts_object::queue();
 
@@ -85,7 +85,7 @@ class check_spec_constant_exception_throw_for_type {
     // kernel_bundle
     {
       bool exception_was_thrown = false;
-      T sc_val{user_def_types::init_value_helper<T>::get(0)};
+      T sc_val{user_def_types::get_init_value<T>(0)};
       const int case_num = 2;
       auto queue = sycl_cts::util::get_cts_object::queue();
 

--- a/tests/spec_constants/spec_constants_external.h
+++ b/tests/spec_constants/spec_constants_external.h
@@ -17,7 +17,7 @@ using namespace get_spec_const;
 
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> spec_const_external(
-    user_def_types::get_init_value_helper<T>(default_val));
+    user_def_types::init_value_helper<T>::get(default_val));
 
 #define FUNC_DECLARE(TYPE)                                               \
   SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_handler( \
@@ -74,7 +74,7 @@ class check_specialization_constants_external {
     // handler
     bool passed = false;
     {
-      T ref { user_def_types::get_init_value_helper<T>(5) };
+      T ref { user_def_types::init_value_helper<T>::get(5) };
       const int case_num =
           static_cast<int>(test_cases_external::by_reference_via_handler);
       sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -99,7 +99,7 @@ class check_specialization_constants_external {
     // handler
     passed = false;
     {
-      T ref { user_def_types::get_init_value_helper<T>(10) };
+      T ref { user_def_types::init_value_helper<T>::get(10) };
       const int case_num =
           static_cast<int>(test_cases_external::by_value_via_handler);
       sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -128,7 +128,7 @@ class check_specialization_constants_external {
       // via kernel_bundle
       passed = false;
       {
-        T ref { user_def_types::get_init_value_helper<T>(15) };
+        T ref { user_def_types::init_value_helper<T>::get(15) };
         const int case_num =
             static_cast<int>(test_cases_external::by_reference_via_bundle);
         sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -170,7 +170,7 @@ class check_specialization_constants_external {
       // kernel_bundle
       passed = false;
       {
-        T ref { user_def_types::get_init_value_helper<T>(20) };
+        T ref { user_def_types::init_value_helper<T>::get(20) };
         const int case_num =
             static_cast<int>(test_cases_external::by_value_via_bundle);
         sycl::buffer<bool, 1> result_buffer(&passed, range);

--- a/tests/spec_constants/spec_constants_external.h
+++ b/tests/spec_constants/spec_constants_external.h
@@ -17,7 +17,7 @@ using namespace get_spec_const;
 
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> spec_const_external(
-    user_def_types::init_value_helper<T>::get(default_val));
+    user_def_types::get_init_value<T>(default_val));
 
 #define FUNC_DECLARE(TYPE)                                               \
   SYCL_EXTERNAL bool check_kernel_handler_by_reference_external_handler( \
@@ -74,7 +74,7 @@ class check_specialization_constants_external {
     // handler
     bool passed = false;
     {
-      T ref{user_def_types::init_value_helper<T>::get(5)};
+      T ref{user_def_types::get_init_value<T>(5)};
       const int case_num =
           static_cast<int>(test_cases_external::by_reference_via_handler);
       sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -99,7 +99,7 @@ class check_specialization_constants_external {
     // handler
     passed = false;
     {
-      T ref{user_def_types::init_value_helper<T>::get(10)};
+      T ref{user_def_types::get_init_value<T>(10)};
       const int case_num =
           static_cast<int>(test_cases_external::by_value_via_handler);
       sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -128,7 +128,7 @@ class check_specialization_constants_external {
       // via kernel_bundle
       passed = false;
       {
-        T ref{user_def_types::init_value_helper<T>::get(15)};
+        T ref{user_def_types::get_init_value<T>(15)};
         const int case_num =
             static_cast<int>(test_cases_external::by_reference_via_bundle);
         sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -170,7 +170,7 @@ class check_specialization_constants_external {
       // kernel_bundle
       passed = false;
       {
-        T ref{user_def_types::init_value_helper<T>::get(20)};
+        T ref{user_def_types::get_init_value<T>(20)};
         const int case_num =
             static_cast<int>(test_cases_external::by_value_via_bundle);
         sycl::buffer<bool, 1> result_buffer(&passed, range);

--- a/tests/spec_constants/spec_constants_external.h
+++ b/tests/spec_constants/spec_constants_external.h
@@ -74,7 +74,7 @@ class check_specialization_constants_external {
     // handler
     bool passed = false;
     {
-      T ref { user_def_types::init_value_helper<T>::get(5) };
+      T ref{user_def_types::init_value_helper<T>::get(5)};
       const int case_num =
           static_cast<int>(test_cases_external::by_reference_via_handler);
       sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -99,7 +99,7 @@ class check_specialization_constants_external {
     // handler
     passed = false;
     {
-      T ref { user_def_types::init_value_helper<T>::get(10) };
+      T ref{user_def_types::init_value_helper<T>::get(10)};
       const int case_num =
           static_cast<int>(test_cases_external::by_value_via_handler);
       sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -128,7 +128,7 @@ class check_specialization_constants_external {
       // via kernel_bundle
       passed = false;
       {
-        T ref { user_def_types::init_value_helper<T>::get(15) };
+        T ref{user_def_types::init_value_helper<T>::get(15)};
         const int case_num =
             static_cast<int>(test_cases_external::by_reference_via_bundle);
         sycl::buffer<bool, 1> result_buffer(&passed, range);
@@ -170,7 +170,7 @@ class check_specialization_constants_external {
       // kernel_bundle
       passed = false;
       {
-        T ref { user_def_types::init_value_helper<T>::get(20) };
+        T ref{user_def_types::init_value_helper<T>::get(20)};
         const int case_num =
             static_cast<int>(test_cases_external::by_value_via_bundle);
         sycl::buffer<bool, 1> result_buffer(&passed, range);

--- a/tests/spec_constants/spec_constants_multiple.h
+++ b/tests/spec_constants/spec_constants_multiple.h
@@ -16,7 +16,7 @@
 
 template <typename T, int def_val>
 constexpr sycl::specialization_id<T> sc_multiple(
-    user_def_types::init_value_helper<T>::get(def_val));
+    user_def_types::get_init_value<T>(def_val));
 
 namespace specialization_constants_multiple {
 using namespace sycl_cts;
@@ -57,9 +57,9 @@ class check_specialization_constants_multiple_for_type {
     int val_A = 5;
     int val_B = 10;
     int val_C = 30;
-    T ref1{user_def_types::init_value_helper<T>::get(0)};
-    T ref2{user_def_types::init_value_helper<T>::get(0)};
-    T ref3{user_def_types::init_value_helper<T>::get(0)};
+    T ref1{user_def_types::get_init_value<T>(0)};
+    T ref2{user_def_types::get_init_value<T>(0)};
+    T ref3{user_def_types::get_init_value<T>(0)};
     fill_init_values(ref1, val_A);
     fill_init_values(ref2, val_B);
     fill_init_values(ref3, val_C);
@@ -115,13 +115,13 @@ class check_specialization_constants_multiple_for_type {
         !check_equal_values(ref2, result_vec[1].value) ||
         !check_equal_values(ref3, result_vec[2].value) ||
         !check_equal_values(
-            T(user_def_types::init_value_helper<T>::get(def_values[3])),
+            T(user_def_types::get_init_value<T>(def_values[3])),
             result_vec[3].value) ||
         !check_equal_values(
-            T(user_def_types::init_value_helper<T>::get(def_values[4])),
+            T(user_def_types::get_init_value<T>(def_values[4])),
             result_vec[4].value) ||
         !check_equal_values(
-            T(user_def_types::init_value_helper<T>::get(def_values[5])),
+            T(user_def_types::get_init_value<T>(def_values[5])),
             result_vec[5].value))
       FAIL(log,
            "multiple spec const for " + type_name_string<T>::get(type_name));

--- a/tests/spec_constants/spec_constants_multiple.h
+++ b/tests/spec_constants/spec_constants_multiple.h
@@ -114,15 +114,12 @@ class check_specialization_constants_multiple_for_type {
     if (!check_equal_values(ref1, result_vec[0].value) ||
         !check_equal_values(ref2, result_vec[1].value) ||
         !check_equal_values(ref3, result_vec[2].value) ||
-        !check_equal_values(
-            T(user_def_types::get_init_value<T>(def_values[3])),
-            result_vec[3].value) ||
-        !check_equal_values(
-            T(user_def_types::get_init_value<T>(def_values[4])),
-            result_vec[4].value) ||
-        !check_equal_values(
-            T(user_def_types::get_init_value<T>(def_values[5])),
-            result_vec[5].value))
+        !check_equal_values(user_def_types::get_init_value<T>(def_values[3]),
+                            result_vec[3].value) ||
+        !check_equal_values(user_def_types::get_init_value<T>(def_values[4]),
+                            result_vec[4].value) ||
+        !check_equal_values(user_def_types::get_init_value<T>(def_values[5]),
+                            result_vec[5].value))
       FAIL(log,
            "multiple spec const for " + type_name_string<T>::get(type_name));
   }

--- a/tests/spec_constants/spec_constants_multiple.h
+++ b/tests/spec_constants/spec_constants_multiple.h
@@ -16,7 +16,7 @@
 
 template <typename T, int def_val>
 constexpr sycl::specialization_id<T> sc_multiple(
-    user_def_types::get_init_value_helper<T>(def_val));
+    user_def_types::init_value_helper<T>::get(def_val));
 
 namespace specialization_constants_multiple {
 using namespace sycl_cts;
@@ -57,9 +57,9 @@ class check_specialization_constants_multiple_for_type {
     int val_A = 5;
     int val_B = 10;
     int val_C = 30;
-    T ref1{user_def_types::get_init_value_helper<T>(0)};
-    T ref2{user_def_types::get_init_value_helper<T>(0)};
-    T ref3{user_def_types::get_init_value_helper<T>(0)};
+    T ref1{user_def_types::init_value_helper<T>::get(0)};
+    T ref2{user_def_types::init_value_helper<T>::get(0)};
+    T ref3{user_def_types::init_value_helper<T>::get(0)};
     fill_init_values(ref1, val_A);
     fill_init_values(ref2, val_B);
     fill_init_values(ref3, val_C);
@@ -115,13 +115,13 @@ class check_specialization_constants_multiple_for_type {
         !check_equal_values(ref2, result_vec[1].value) ||
         !check_equal_values(ref3, result_vec[2].value) ||
         !check_equal_values(
-            T(user_def_types::get_init_value_helper<T>(def_values[3])),
+            T(user_def_types::init_value_helper<T>::get(def_values[3])),
             result_vec[3].value) ||
         !check_equal_values(
-            T(user_def_types::get_init_value_helper<T>(def_values[4])),
+            T(user_def_types::init_value_helper<T>::get(def_values[4])),
             result_vec[4].value) ||
         !check_equal_values(
-            T(user_def_types::get_init_value_helper<T>(def_values[5])),
+            T(user_def_types::init_value_helper<T>::get(def_values[5])),
             result_vec[5].value))
       FAIL(log,
            "multiple spec const for " + type_name_string<T>::get(type_name));

--- a/tests/spec_constants/spec_constants_same_command_group_common.h
+++ b/tests/spec_constants/spec_constants_same_command_group_common.h
@@ -46,13 +46,13 @@ template <typename T>
 class check_specialization_constants_same_command_group {
  public:
   void operator()(util::logger &log, const std::string &type_name) {
-    T ref_A{user_def_types::get_init_value_helper<T>(5)};
-    T ref_B{user_def_types::get_init_value_helper<T>(10)};
+    T ref_A{user_def_types::init_value_helper<T>::get(5)};
+    T ref_B{user_def_types::init_value_helper<T>::get(10)};
     auto queue = util::get_cts_object::queue();
     sycl::range<1> range(1);
     {
-      T result1{user_def_types::get_init_value_helper<T>(0)};
-      T result2{user_def_types::get_init_value_helper<T>(0)};
+      T result1{user_def_types::init_value_helper<T>::get(0)};
+      T result2{user_def_types::init_value_helper<T>::get(0)};
       {
         command_group_object<T, 1> cmo;
         sycl::buffer<T> result_buffer1(&result1, range);
@@ -73,8 +73,8 @@ class check_specialization_constants_same_command_group {
     }
 
     {
-      T result1{user_def_types::get_init_value_helper<T>(0)};
-      T result2{user_def_types::get_init_value_helper<T>(0)};
+      T result1{user_def_types::init_value_helper<T>::get(0)};
+      T result2{user_def_types::init_value_helper<T>::get(0)};
       {
         command_group_object<T, 2> cmo;
         sycl::buffer<T> result_buffer1(&result1, range);
@@ -91,7 +91,7 @@ class check_specialization_constants_same_command_group {
       if (!check_equal_values(ref_A, result1))
         FAIL(log, "case 2 failed for value A for " + type_name);
       if (!check_equal_values(
-              T(user_def_types::get_init_value_helper<T>(default_val)),
+              T(user_def_types::init_value_helper<T>::get(default_val)),
               result2))
         FAIL(log, "case 2 failed for default value for " + type_name);
     }

--- a/tests/spec_constants/spec_constants_same_command_group_common.h
+++ b/tests/spec_constants/spec_constants_same_command_group_common.h
@@ -90,9 +90,8 @@ class check_specialization_constants_same_command_group {
       }
       if (!check_equal_values(ref_A, result1))
         FAIL(log, "case 2 failed for value A for " + type_name);
-      if (!check_equal_values(
-              T(user_def_types::get_init_value<T>(default_val)),
-              result2))
+      if (!check_equal_values(user_def_types::get_init_value<T>(default_val),
+                              result2))
         FAIL(log, "case 2 failed for default value for " + type_name);
     }
   }

--- a/tests/spec_constants/spec_constants_same_command_group_common.h
+++ b/tests/spec_constants/spec_constants_same_command_group_common.h
@@ -46,13 +46,13 @@ template <typename T>
 class check_specialization_constants_same_command_group {
  public:
   void operator()(util::logger &log, const std::string &type_name) {
-    T ref_A{user_def_types::init_value_helper<T>::get(5)};
-    T ref_B{user_def_types::init_value_helper<T>::get(10)};
+    T ref_A{user_def_types::get_init_value<T>(5)};
+    T ref_B{user_def_types::get_init_value<T>(10)};
     auto queue = util::get_cts_object::queue();
     sycl::range<1> range(1);
     {
-      T result1{user_def_types::init_value_helper<T>::get(0)};
-      T result2{user_def_types::init_value_helper<T>::get(0)};
+      T result1{user_def_types::get_init_value<T>(0)};
+      T result2{user_def_types::get_init_value<T>(0)};
       {
         command_group_object<T, 1> cmo;
         sycl::buffer<T> result_buffer1(&result1, range);
@@ -73,8 +73,8 @@ class check_specialization_constants_same_command_group {
     }
 
     {
-      T result1{user_def_types::init_value_helper<T>::get(0)};
-      T result2{user_def_types::init_value_helper<T>::get(0)};
+      T result1{user_def_types::get_init_value<T>(0)};
+      T result2{user_def_types::get_init_value<T>(0)};
       {
         command_group_object<T, 2> cmo;
         sycl::buffer<T> result_buffer1(&result1, range);
@@ -91,7 +91,7 @@ class check_specialization_constants_same_command_group {
       if (!check_equal_values(ref_A, result1))
         FAIL(log, "case 2 failed for value A for " + type_name);
       if (!check_equal_values(
-              T(user_def_types::init_value_helper<T>::get(default_val)),
+              T(user_def_types::get_init_value<T>(default_val)),
               result2))
         FAIL(log, "case 2 failed for default value for " + type_name);
     }

--- a/tests/spec_constants/spec_constants_same_name_inter_link.h
+++ b/tests/spec_constants/spec_constants_same_name_inter_link.h
@@ -48,10 +48,10 @@ class check_specialization_constants_same_name_inter_link_for_type {
         }
       }
       sycl::range<1> range(1);
-      T def_value{user_def_types::init_value_helper<T>::get(0)};
-      T ref_def_value{user_def_types::init_value_helper<T>::get(0)};
-      T result{user_def_types::init_value_helper<T>::get(0)};
-      T ref{user_def_types::init_value_helper<T>::get(0)};
+      T def_value{user_def_types::get_init_value<T>(0)};
+      T ref_def_value{user_def_types::get_init_value<T>(0)};
+      T result{user_def_types::get_init_value<T>(0)};
+      T ref{user_def_types::get_init_value<T>(0)};
       {
         // Setting ref values according to TU number
         fill_init_values(ref_def_value, TestConfig::tu);

--- a/tests/spec_constants/spec_constants_same_name_inter_link.h
+++ b/tests/spec_constants/spec_constants_same_name_inter_link.h
@@ -48,10 +48,10 @@ class check_specialization_constants_same_name_inter_link_for_type {
         }
       }
       sycl::range<1> range(1);
-      T def_value{user_def_types::get_init_value_helper<T>(0)};
-      T ref_def_value{user_def_types::get_init_value_helper<T>(0)};
-      T result{user_def_types::get_init_value_helper<T>(0)};
-      T ref{user_def_types::get_init_value_helper<T>(0)};
+      T def_value{user_def_types::init_value_helper<T>::get(0)};
+      T ref_def_value{user_def_types::init_value_helper<T>::get(0)};
+      T result{user_def_types::init_value_helper<T>::get(0)};
+      T ref{user_def_types::init_value_helper<T>::get(0)};
       {
         // Setting ref values according to TU number
         fill_init_values(ref_def_value, TestConfig::tu);

--- a/tests/spec_constants/spec_constants_same_name_inter_link_helper.h
+++ b/tests/spec_constants/spec_constants_same_name_inter_link_helper.h
@@ -30,7 +30,7 @@ namespace {
 // SC_SN_IL_TU_NUM is defined in every TU
 template <typename T, typename via_kb>
 constexpr sycl::specialization_id<T> sc_same_name_inter_link(
-    user_def_types::init_value_helper<T>::get(SC_SN_IL_TU_NUM));
+    user_def_types::get_init_value<T>(SC_SN_IL_TU_NUM));
 
 }  // namespace
 

--- a/tests/spec_constants/spec_constants_same_name_inter_link_helper.h
+++ b/tests/spec_constants/spec_constants_same_name_inter_link_helper.h
@@ -30,7 +30,7 @@ namespace {
 // SC_SN_IL_TU_NUM is defined in every TU
 template <typename T, typename via_kb>
 constexpr sycl::specialization_id<T> sc_same_name_inter_link(
-    user_def_types::get_init_value_helper<T>(SC_SN_IL_TU_NUM));
+    user_def_types::init_value_helper<T>::get(SC_SN_IL_TU_NUM));
 
 }  // namespace
 

--- a/tests/spec_constants/spec_constants_same_name_stress_helper.h
+++ b/tests/spec_constants/spec_constants_same_name_stress_helper.h
@@ -56,21 +56,21 @@ static std::string get_hint(int test_id) {
 // Specialization constant defined in global namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::glob)));
 
 namespace g_outer {
 // Specialization constant defined in outer namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::outer)));
 
 namespace g_inner {
 // Specialization constant defined in outer::inner namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::outer_inner)));
 }  // namespace g_inner
 
@@ -78,7 +78,7 @@ namespace {
 // Specialization constant defined in outer::unnamed namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::outer_unnamed)));
 
 template <typename T>
@@ -88,7 +88,7 @@ namespace g_u_inner {
 // Specialization constant defined in outer::unnamed::inner namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::outer_unnamed_inner)));
 
 template <typename T>
@@ -99,7 +99,7 @@ namespace {
 // namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::outer_unnamed_inner_unnamed)));
 
 template <typename T>
@@ -113,7 +113,7 @@ namespace {
 // Specialization constant defined in unnamed namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::unnamed)));
 
 template <typename T>
@@ -123,7 +123,7 @@ namespace u_outer {
 // Specialization constant defined in unnamed::outer namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::unnamed_outer)));
 
 template <typename T>
@@ -133,7 +133,7 @@ namespace {
 // Specialization constant defined in unnamed::outer::unnamed namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::unnamed_outer_unnamed)));
 
 template <typename T>
@@ -144,7 +144,7 @@ namespace u_inner {
 // namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         to_integral(spec_const_help::sc_st_id::unnamed_outer_unnamed_inner)));
 
 template <typename T>

--- a/tests/spec_constants/spec_constants_same_name_stress_helper.h
+++ b/tests/spec_constants/spec_constants_same_name_stress_helper.h
@@ -56,21 +56,21 @@ static std::string get_hint(int test_id) {
 // Specialization constant defined in global namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::glob)));
 
 namespace g_outer {
 // Specialization constant defined in outer namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::outer)));
 
 namespace g_inner {
 // Specialization constant defined in outer::inner namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::outer_inner)));
 }  // namespace g_inner
 
@@ -78,7 +78,7 @@ namespace {
 // Specialization constant defined in outer::unnamed namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::outer_unnamed)));
 
 template <typename T>
@@ -88,7 +88,7 @@ namespace g_u_inner {
 // Specialization constant defined in outer::unnamed::inner namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::outer_unnamed_inner)));
 
 template <typename T>
@@ -99,7 +99,7 @@ namespace {
 // namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::outer_unnamed_inner_unnamed)));
 
 template <typename T>
@@ -113,7 +113,7 @@ namespace {
 // Specialization constant defined in unnamed namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::unnamed)));
 
 template <typename T>
@@ -123,7 +123,7 @@ namespace u_outer {
 // Specialization constant defined in unnamed::outer namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::unnamed_outer)));
 
 template <typename T>
@@ -133,7 +133,7 @@ namespace {
 // Specialization constant defined in unnamed::outer::unnamed namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::unnamed_outer_unnamed)));
 
 template <typename T>
@@ -144,7 +144,7 @@ namespace u_inner {
 // namespace
 template <typename T>
 constexpr sycl::specialization_id<T> sc_same_name(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         to_integral(spec_const_help::sc_st_id::unnamed_outer_unnamed_inner)));
 
 template <typename T>

--- a/tests/spec_constants/spec_constants_separate_unit.cpp
+++ b/tests/spec_constants/spec_constants_separate_unit.cpp
@@ -14,7 +14,7 @@ using namespace get_spec_const;
 
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> spec_const_external(
-    user_def_types::get_init_value_helper<T>(default_val));
+    user_def_types::init_value_helper<T>::get(default_val));
 
 template <typename T, test_cases_external TestCase>
 bool check_kernel_handler_by_reference_external(sycl::kernel_handler &h,

--- a/tests/spec_constants/spec_constants_separate_unit.cpp
+++ b/tests/spec_constants/spec_constants_separate_unit.cpp
@@ -14,7 +14,7 @@ using namespace get_spec_const;
 
 template <typename T, int case_num>
 inline constexpr sycl::specialization_id<T> spec_const_external(
-    user_def_types::init_value_helper<T>::get(default_val));
+    user_def_types::get_init_value<T>(default_val));
 
 template <typename T, test_cases_external TestCase>
 bool check_kernel_handler_by_reference_external(sycl::kernel_handler &h,

--- a/tests/spec_constants/spec_constants_via_handler_common.h
+++ b/tests/spec_constants/spec_constants_via_handler_common.h
@@ -22,14 +22,14 @@ inline constexpr int val_A = 5;
 
 template <typename T, int case_num>
 constexpr sycl::specialization_id<T> sc_multiple(
-    user_def_types::get_init_value_helper<T>(case_num));
+    user_def_types::init_value_helper<T>::get(case_num));
 
 template <typename T, int case_num>
 class kernel;
 
 template <typename T, int case_num>
 bool check_kernel_handler_by_reference(sycl::kernel_handler &h) {
-  T ref{user_def_types::get_init_value_helper<T>(0)};
+  T ref{user_def_types::init_value_helper<T>::get(0)};
   fill_init_values(ref, val_A);
   return check_equal_values(
       ref, h.get_specialization_constant<spec_const<T, case_num>>());
@@ -37,7 +37,7 @@ bool check_kernel_handler_by_reference(sycl::kernel_handler &h) {
 
 template <typename T, int case_num>
 bool check_kernel_handler_by_value(sycl::kernel_handler h) {
-  T ref{user_def_types::get_init_value_helper<T>(0)};
+  T ref{user_def_types::init_value_helper<T>::get(0)};
   fill_init_values(ref, val_A);
   return check_equal_values(
       ref, h.get_specialization_constant<spec_const<T, case_num>>());
@@ -49,9 +49,9 @@ class check_spec_constant_with_handler_for_type {
   void operator()(util::logger &log, const std::string &type_name) {
     auto queue = util::get_cts_object::queue();
     sycl::range<1> range(1);
-    T result{user_def_types::get_init_value_helper<T>(0)};
-    T ref{user_def_types::get_init_value_helper<T>(0)};
-    T ref_other{user_def_types::get_init_value_helper<T>(0)};
+    T result{user_def_types::init_value_helper<T>::get(0)};
+    T ref{user_def_types::init_value_helper<T>::get(0)};
+    T ref_other{user_def_types::init_value_helper<T>::get(0)};
     int val_B = 10;
     fill_init_values(ref, val_A);
     fill_init_values(ref_other, val_B);
@@ -59,7 +59,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 1;
       {
-        result = user_def_types::get_init_value_helper<T>(0);
+        result = user_def_types::init_value_helper<T>::get(0);
         queue.submit([&](sycl::handler &cgh) {
           cgh.set_specialization_constant<spec_const<T, case_num>>(ref);
           result = cgh.get_specialization_constant<spec_const<T, case_num>>();
@@ -74,7 +74,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 2;
       {
-        result = user_def_types::get_init_value_helper<T>(0);
+        result = user_def_types::init_value_helper<T>::get(0);
         queue.submit([&](sycl::handler &cgh) {
           cgh.set_specialization_constant<spec_const<T, case_num>>(ref);
           cgh.set_specialization_constant<spec_const<T, case_num>>(ref_other);
@@ -91,7 +91,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 3;
       {
-        result = user_def_types::get_init_value_helper<T>(0);
+        result = user_def_types::init_value_helper<T>::get(0);
         sycl::buffer<T, 1> result_buffer(&result, range);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -113,7 +113,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 4;
       {
-        result = user_def_types::get_init_value_helper<T>(0);
+        result = user_def_types::init_value_helper<T>::get(0);
         sycl::buffer<T, 1> result_buffer(&result, range);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -164,13 +164,14 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 6;
       {
-        result = user_def_types::get_init_value_helper<T>(0);
+        result = user_def_types::init_value_helper<T>::get(0);
         queue.submit([&](sycl::handler &cgh) {
           result = cgh.get_specialization_constant<spec_const<T, case_num>>();
         });
       }
       if (!check_equal_values(
-              T(user_def_types::get_init_value_helper<T>(default_val)), result))
+              T(user_def_types::init_value_helper<T>::get(default_val)),
+              result))
         FAIL(log, "case " + std::to_string(case_num) + " for " +
                       type_name_string<T>::get(type_name));
     }
@@ -180,7 +181,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 7;
       {
-        result = user_def_types::get_init_value_helper<T>(0);
+        result = user_def_types::init_value_helper<T>::get(0);
         sycl::buffer<T, 1> result_buffer(&result, range);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -192,7 +193,8 @@ class check_spec_constant_with_handler_for_type {
         });
       }
       if (!check_equal_values(
-              T(user_def_types::get_init_value_helper<T>(default_val)), result))
+              T(user_def_types::init_value_helper<T>::get(default_val)),
+              result))
         FAIL(log, "case " + std::to_string(case_num) + " for " +
                       type_name_string<T>::get(type_name));
     }

--- a/tests/spec_constants/spec_constants_via_handler_common.h
+++ b/tests/spec_constants/spec_constants_via_handler_common.h
@@ -169,9 +169,8 @@ class check_spec_constant_with_handler_for_type {
           result = cgh.get_specialization_constant<spec_const<T, case_num>>();
         });
       }
-      if (!check_equal_values(
-              T(user_def_types::get_init_value<T>(default_val)),
-              result))
+      if (!check_equal_values(user_def_types::get_init_value<T>(default_val),
+                              result))
         FAIL(log, "case " + std::to_string(case_num) + " for " +
                       type_name_string<T>::get(type_name));
     }
@@ -192,9 +191,8 @@ class check_spec_constant_with_handler_for_type {
           });
         });
       }
-      if (!check_equal_values(
-              T(user_def_types::get_init_value<T>(default_val)),
-              result))
+      if (!check_equal_values(user_def_types::get_init_value<T>(default_val),
+                              result))
         FAIL(log, "case " + std::to_string(case_num) + " for " +
                       type_name_string<T>::get(type_name));
     }

--- a/tests/spec_constants/spec_constants_via_handler_common.h
+++ b/tests/spec_constants/spec_constants_via_handler_common.h
@@ -22,14 +22,14 @@ inline constexpr int val_A = 5;
 
 template <typename T, int case_num>
 constexpr sycl::specialization_id<T> sc_multiple(
-    user_def_types::init_value_helper<T>::get(case_num));
+    user_def_types::get_init_value<T>(case_num));
 
 template <typename T, int case_num>
 class kernel;
 
 template <typename T, int case_num>
 bool check_kernel_handler_by_reference(sycl::kernel_handler &h) {
-  T ref{user_def_types::init_value_helper<T>::get(0)};
+  T ref{user_def_types::get_init_value<T>(0)};
   fill_init_values(ref, val_A);
   return check_equal_values(
       ref, h.get_specialization_constant<spec_const<T, case_num>>());
@@ -37,7 +37,7 @@ bool check_kernel_handler_by_reference(sycl::kernel_handler &h) {
 
 template <typename T, int case_num>
 bool check_kernel_handler_by_value(sycl::kernel_handler h) {
-  T ref{user_def_types::init_value_helper<T>::get(0)};
+  T ref{user_def_types::get_init_value<T>(0)};
   fill_init_values(ref, val_A);
   return check_equal_values(
       ref, h.get_specialization_constant<spec_const<T, case_num>>());
@@ -49,9 +49,9 @@ class check_spec_constant_with_handler_for_type {
   void operator()(util::logger &log, const std::string &type_name) {
     auto queue = util::get_cts_object::queue();
     sycl::range<1> range(1);
-    T result{user_def_types::init_value_helper<T>::get(0)};
-    T ref{user_def_types::init_value_helper<T>::get(0)};
-    T ref_other{user_def_types::init_value_helper<T>::get(0)};
+    T result{user_def_types::get_init_value<T>(0)};
+    T ref{user_def_types::get_init_value<T>(0)};
+    T ref_other{user_def_types::get_init_value<T>(0)};
     int val_B = 10;
     fill_init_values(ref, val_A);
     fill_init_values(ref_other, val_B);
@@ -59,7 +59,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 1;
       {
-        result = user_def_types::init_value_helper<T>::get(0);
+        result = user_def_types::get_init_value<T>(0);
         queue.submit([&](sycl::handler &cgh) {
           cgh.set_specialization_constant<spec_const<T, case_num>>(ref);
           result = cgh.get_specialization_constant<spec_const<T, case_num>>();
@@ -74,7 +74,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 2;
       {
-        result = user_def_types::init_value_helper<T>::get(0);
+        result = user_def_types::get_init_value<T>(0);
         queue.submit([&](sycl::handler &cgh) {
           cgh.set_specialization_constant<spec_const<T, case_num>>(ref);
           cgh.set_specialization_constant<spec_const<T, case_num>>(ref_other);
@@ -91,7 +91,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 3;
       {
-        result = user_def_types::init_value_helper<T>::get(0);
+        result = user_def_types::get_init_value<T>(0);
         sycl::buffer<T, 1> result_buffer(&result, range);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -113,7 +113,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 4;
       {
-        result = user_def_types::init_value_helper<T>::get(0);
+        result = user_def_types::get_init_value<T>(0);
         sycl::buffer<T, 1> result_buffer(&result, range);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -164,13 +164,13 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 6;
       {
-        result = user_def_types::init_value_helper<T>::get(0);
+        result = user_def_types::get_init_value<T>(0);
         queue.submit([&](sycl::handler &cgh) {
           result = cgh.get_specialization_constant<spec_const<T, case_num>>();
         });
       }
       if (!check_equal_values(
-              T(user_def_types::init_value_helper<T>::get(default_val)),
+              T(user_def_types::get_init_value<T>(default_val)),
               result))
         FAIL(log, "case " + std::to_string(case_num) + " for " +
                       type_name_string<T>::get(type_name));
@@ -181,7 +181,7 @@ class check_spec_constant_with_handler_for_type {
     {
       const int case_num = 7;
       {
-        result = user_def_types::init_value_helper<T>::get(0);
+        result = user_def_types::get_init_value<T>(0);
         sycl::buffer<T, 1> result_buffer(&result, range);
         queue.submit([&](sycl::handler &cgh) {
           auto res_acc =
@@ -193,7 +193,7 @@ class check_spec_constant_with_handler_for_type {
         });
       }
       if (!check_equal_values(
-              T(user_def_types::init_value_helper<T>::get(default_val)),
+              T(user_def_types::get_init_value<T>(default_val)),
               result))
         FAIL(log, "case " + std::to_string(case_num) + " for " +
                       type_name_string<T>::get(type_name));

--- a/tests/spec_constants/spec_constants_via_kernel_bundle.h
+++ b/tests/spec_constants/spec_constants_via_kernel_bundle.h
@@ -136,7 +136,7 @@ struct values<containerT<bool, size>> : values<bool> {};
  */
 template <typename T, typename id>
 constexpr sycl::specialization_id<T> spec_const_by_kernel_bundle(
-    user_def_types::init_value_helper<T>::get(
+    user_def_types::get_init_value<T>(
         specialization_constants_via_kernel_bundle::values<T>::initial));
 
 namespace specialization_constants_via_kernel_bundle {
@@ -300,7 +300,7 @@ void set_value(sycl::kernel_bundle<id::state>& bundle) {
                   " set_specialization_constant");
     for (int i = 0; i < id::n_set; ++i) {
       // Prepare value to store
-      T value{user_def_types::init_value_helper<T>::get(0)};
+      T value{user_def_types::get_init_value<T>(0)};
       fill_init_values(value, values<T>::reference(i));
 
       bundle.template set_specialization_constant<
@@ -323,11 +323,11 @@ bool check_value(specStorageT&& storage) {
   using namespace get_spec_const;
 
   // Prepare to read value
-  T value{user_def_types::init_value_helper<T>::get(0)};
+  T value{user_def_types::get_init_value<T>(0)};
   fill_init_values(value, values<T>::empty);
 
   // Prepare to compare values
-  T expected{user_def_types::init_value_helper<T>::get(0)};
+  T expected{user_def_types::get_init_value<T>(0)};
   if constexpr (id::n_set == 0) {
     fill_init_values(expected, values<T>::initial);
   } else {

--- a/tests/spec_constants/spec_constants_via_kernel_bundle.h
+++ b/tests/spec_constants/spec_constants_via_kernel_bundle.h
@@ -300,7 +300,7 @@ void set_value(sycl::kernel_bundle<id::state>& bundle) {
                   " set_specialization_constant");
     for (int i = 0; i < id::n_set; ++i) {
       // Prepare value to store
-      T value { user_def_types::init_value_helper<T>::get(0) };
+      T value{user_def_types::init_value_helper<T>::get(0)};
       fill_init_values(value, values<T>::reference(i));
 
       bundle.template set_specialization_constant<
@@ -323,11 +323,11 @@ bool check_value(specStorageT&& storage) {
   using namespace get_spec_const;
 
   // Prepare to read value
-  T value { user_def_types::init_value_helper<T>::get(0) };
+  T value{user_def_types::init_value_helper<T>::get(0)};
   fill_init_values(value, values<T>::empty);
 
   // Prepare to compare values
-  T expected { user_def_types::init_value_helper<T>::get(0) };
+  T expected{user_def_types::init_value_helper<T>::get(0)};
   if constexpr (id::n_set == 0) {
     fill_init_values(expected, values<T>::initial);
   } else {

--- a/tests/spec_constants/spec_constants_via_kernel_bundle.h
+++ b/tests/spec_constants/spec_constants_via_kernel_bundle.h
@@ -136,7 +136,7 @@ struct values<containerT<bool, size>> : values<bool> {};
  */
 template <typename T, typename id>
 constexpr sycl::specialization_id<T> spec_const_by_kernel_bundle(
-    user_def_types::get_init_value_helper<T>(
+    user_def_types::init_value_helper<T>::get(
         specialization_constants_via_kernel_bundle::values<T>::initial));
 
 namespace specialization_constants_via_kernel_bundle {
@@ -300,7 +300,7 @@ void set_value(sycl::kernel_bundle<id::state>& bundle) {
                   " set_specialization_constant");
     for (int i = 0; i < id::n_set; ++i) {
       // Prepare value to store
-      T value { user_def_types::get_init_value_helper<T>(0) };
+      T value { user_def_types::init_value_helper<T>::get(0) };
       fill_init_values(value, values<T>::reference(i));
 
       bundle.template set_specialization_constant<
@@ -323,11 +323,11 @@ bool check_value(specStorageT&& storage) {
   using namespace get_spec_const;
 
   // Prepare to read value
-  T value { user_def_types::get_init_value_helper<T>(0) };
+  T value { user_def_types::init_value_helper<T>::get(0) };
   fill_init_values(value, values<T>::empty);
 
   // Prepare to compare values
-  T expected { user_def_types::get_init_value_helper<T>(0) };
+  T expected { user_def_types::init_value_helper<T>::get(0) };
   if constexpr (id::n_set == 0) {
     fill_init_values(expected, values<T>::initial);
   } else {


### PR DESCRIPTION
Newer versions of `clang` make it error by default, which affect clang-based implementations (like DPCPP).