### PR TITLE
Fix errors for some spec_constants tests when running in AOT mode

### DIFF
--- a/tests/spec_constants/spec_constants_defined_various_ways.h
+++ b/tests/spec_constants/spec_constants_defined_various_ways.h
@@ -27,7 +27,7 @@ void perform_test(util::logger &log, const std::string &type_name,
   auto queue = util::get_cts_object::queue();
   const sycl::context ctx = queue.get_context();
   const sycl::device dev = queue.get_device();
-  bool no_target_kernel = false;
+  bool has_target_kernel = true;
 
   if constexpr (via_kb::value) {
     if (!dev.has(sycl::aspect::online_compiler)) {
@@ -51,7 +51,7 @@ void perform_test(util::logger &log, const std::string &type_name,
             sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
                                                                {kernelId});
         if (!k_bundle.has_kernel(kernelId)) {
-          no_target_kernel = true;
+          has_target_kernel = false;
           log.note("kernel_bundle doesn't contain target kernel in case (" +
                    case_hint + ") for " + type_name_string<T>::get(type_name) +
                    " (skipped)");
@@ -74,8 +74,8 @@ void perform_test(util::logger &log, const std::string &type_name,
       }
     });
   }
-  if (!no_target_kernel) {
-    // Check results only if taget kernel is available
+  if (has_target_kernel) {
+    // Check results only if target kernel is available
     if (!check_equal_values(ref, result))
       FAIL(log, "case (" + case_hint + ") for " +
                     type_name_string<T>::get(type_name));

--- a/tests/spec_constants/spec_constants_multiple.h
+++ b/tests/spec_constants/spec_constants_multiple.h
@@ -47,7 +47,7 @@ class check_specialization_constants_multiple_for_type {
     auto queue = util::get_cts_object::queue();
     const sycl::context ctx = queue.get_context();
     const sycl::device dev = queue.get_device();
-    bool no_target_kernel = false;
+    bool has_target_kernel = true;
 
     if constexpr (via_kb::value) {
       if (!dev.has(sycl::aspect::online_compiler)) {
@@ -78,7 +78,7 @@ class check_specialization_constants_multiple_for_type {
               sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
                                                                  {kernelId});
           if (!k_bundle.has_kernel(kernelId)) {
-            no_target_kernel = true;
+            has_target_kernel = false;
             log.note(
                 "kernel_bundle doesn't contain target kernel;"
                 "multiple spec const for " +
@@ -113,8 +113,8 @@ class check_specialization_constants_multiple_for_type {
         }
       });
     }
-    if (!no_target_kernel) {
-      // Check results only if taget kernel is available
+    if (has_target_kernel) {
+      // Check results only if target kernel is available
       if (!check_equal_values(ref1, result_vec[0].value) ||
           !check_equal_values(ref2, result_vec[1].value) ||
           !check_equal_values(ref3, result_vec[2].value) ||

--- a/tests/spec_constants/spec_constants_multiple.h
+++ b/tests/spec_constants/spec_constants_multiple.h
@@ -47,6 +47,7 @@ class check_specialization_constants_multiple_for_type {
     auto queue = util::get_cts_object::queue();
     const sycl::context ctx = queue.get_context();
     const sycl::device dev = queue.get_device();
+    bool no_target_kernel = false;
 
     if constexpr (via_kb::value) {
       if (!dev.has(sycl::aspect::online_compiler)) {
@@ -77,6 +78,7 @@ class check_specialization_constants_multiple_for_type {
               sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
                                                                  {kernelId});
           if (!k_bundle.has_kernel(kernelId)) {
+            no_target_kernel = true;
             log.note(
                 "kernel_bundle doesn't contain target kernel;"
                 "multiple spec const for " +
@@ -111,17 +113,20 @@ class check_specialization_constants_multiple_for_type {
         }
       });
     }
-    if (!check_equal_values(ref1, result_vec[0].value) ||
-        !check_equal_values(ref2, result_vec[1].value) ||
-        !check_equal_values(ref3, result_vec[2].value) ||
-        !check_equal_values(user_def_types::get_init_value<T>(def_values[3]),
-                            result_vec[3].value) ||
-        !check_equal_values(user_def_types::get_init_value<T>(def_values[4]),
-                            result_vec[4].value) ||
-        !check_equal_values(user_def_types::get_init_value<T>(def_values[5]),
-                            result_vec[5].value))
-      FAIL(log,
-           "multiple spec const for " + type_name_string<T>::get(type_name));
+    if (!no_target_kernel) {
+      // Check results only if taget kernel is available
+      if (!check_equal_values(ref1, result_vec[0].value) ||
+          !check_equal_values(ref2, result_vec[1].value) ||
+          !check_equal_values(ref3, result_vec[2].value) ||
+          !check_equal_values(user_def_types::get_init_value<T>(def_values[3]),
+                              result_vec[3].value) ||
+          !check_equal_values(user_def_types::get_init_value<T>(def_values[4]),
+                              result_vec[4].value) ||
+          !check_equal_values(user_def_types::get_init_value<T>(def_values[5]),
+                              result_vec[5].value))
+        FAIL(log,
+             "multiple spec const for " + type_name_string<T>::get(type_name));
+    }
   }
 };
 

--- a/tests/spec_constants/spec_constants_same_name_inter_link.h
+++ b/tests/spec_constants/spec_constants_same_name_inter_link.h
@@ -40,7 +40,7 @@ class check_specialization_constants_same_name_inter_link_for_type {
       auto queue = util::get_cts_object::queue();
       const sycl::context ctx = queue.get_context();
       const sycl::device dev = queue.get_device();
-      bool no_target_kernel = false;
+      bool has_target_kernel = true;
 
       if constexpr (via_kb::value) {
         if (!dev.has(sycl::aspect::online_compiler)) {
@@ -68,7 +68,7 @@ class check_specialization_constants_same_name_inter_link_for_type {
                 sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
                                                                    {kernelId});
             if (!k_bundle.has_kernel(kernelId)) {
-              no_target_kernel = true;
+              has_target_kernel = false;
               log.note("kernel_bundle doesn't contain target kernel for " +
                        type_name_string<T>::get(type_name) + " (skipped)");
               return;
@@ -95,8 +95,8 @@ class check_specialization_constants_same_name_inter_link_for_type {
           }
         });
       }
-      if (!no_target_kernel) {
-        // Check results only if taget kernel is available
+      if (has_target_kernel) {
+        // Check results only if target kernel is available
         if (!check_equal_values(ref_def_value, def_value))
           FAIL(log, "Wrong linked spec const; (translation unit " +
                         std::to_string(TestConfig::tu) + ") for " +

--- a/tests/spec_constants/spec_constants_same_name_inter_link.h
+++ b/tests/spec_constants/spec_constants_same_name_inter_link.h
@@ -40,6 +40,7 @@ class check_specialization_constants_same_name_inter_link_for_type {
       auto queue = util::get_cts_object::queue();
       const sycl::context ctx = queue.get_context();
       const sycl::device dev = queue.get_device();
+      bool no_target_kernel = false;
 
       if constexpr (via_kb::value) {
         if (!dev.has(sycl::aspect::online_compiler)) {
@@ -67,6 +68,7 @@ class check_specialization_constants_same_name_inter_link_for_type {
                 sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {dev},
                                                                    {kernelId});
             if (!k_bundle.has_kernel(kernelId)) {
+              no_target_kernel = true;
               log.note("kernel_bundle doesn't contain target kernel for " +
                        type_name_string<T>::get(type_name) + " (skipped)");
               return;
@@ -93,14 +95,17 @@ class check_specialization_constants_same_name_inter_link_for_type {
           }
         });
       }
-      if (!check_equal_values(ref_def_value, def_value))
-        FAIL(log, "Wrong linked spec const; (translation unit " +
-                      std::to_string(TestConfig::tu) + ") for " +
-                      type_name_string<T>::get(type_name));
-      if (!check_equal_values(ref, result))
-        FAIL(log, "Wrong returned value; (translation unit " +
-                      std::to_string(TestConfig::tu) + ") for " +
-                      type_name_string<T>::get(type_name));
+      if (!no_target_kernel) {
+        // Check results only if taget kernel is available
+        if (!check_equal_values(ref_def_value, def_value))
+          FAIL(log, "Wrong linked spec const; (translation unit " +
+                        std::to_string(TestConfig::tu) + ") for " +
+                        type_name_string<T>::get(type_name));
+        if (!check_equal_values(ref, result))
+          FAIL(log, "Wrong returned value; (translation unit " +
+                        std::to_string(TestConfig::tu) + ") for " +
+                        type_name_string<T>::get(type_name));
+      }
     }
   } catch (...) {
     std::string message{"translation unit " + std::to_string(TestConfig::tu) +

--- a/tests/spec_constants/spec_constants_same_name_stress.h
+++ b/tests/spec_constants/spec_constants_same_name_stress.h
@@ -47,7 +47,7 @@ class check_specialization_constants_same_name_stress_for_type {
       auto queue = util::get_cts_object::queue();
       const sycl::context ctx = queue.get_context();
       const sycl::device dev = queue.get_device();
-      bool no_target_kernel = false;
+      bool has_target_kernel = true;
 
       if constexpr (via_kb::value) {
         if (!dev.has(sycl::aspect::online_compiler)) {
@@ -150,7 +150,7 @@ class check_specialization_constants_same_name_stress_for_type {
             auto k_bundle = sycl::get_kernel_bundle<sycl::bundle_state::input>(
                 ctx, {dev}, {kernelId});
             if (!k_bundle.has_kernel(kernelId)) {
-              no_target_kernel = true;
+              has_target_kernel = false;
               log.note("kernel_bundle doesn't contain target kernel for " +
                        type_name_string<T>::get(type_name) + " (skipped)");
               return;
@@ -162,8 +162,8 @@ class check_specialization_constants_same_name_stress_for_type {
           }
         });
       }
-      if (!no_target_kernel) {
-        // Check results only if taget kernel is available
+      if (has_target_kernel) {
+        // Check results only if target kernel is available
         for (int i = 0; i < size; ++i) {
           if (!check_equal_values(def_values_arr[i], ref_def_values_arr[i])) {
             FAIL(log, "Wrong default value for spec const defined in " +

--- a/tests/spec_constants/spec_constants_same_name_stress.h
+++ b/tests/spec_constants/spec_constants_same_name_stress.h
@@ -47,6 +47,7 @@ class check_specialization_constants_same_name_stress_for_type {
       auto queue = util::get_cts_object::queue();
       const sycl::context ctx = queue.get_context();
       const sycl::device dev = queue.get_device();
+      bool no_target_kernel = false;
 
       if constexpr (via_kb::value) {
         if (!dev.has(sycl::aspect::online_compiler)) {
@@ -149,6 +150,7 @@ class check_specialization_constants_same_name_stress_for_type {
             auto k_bundle = sycl::get_kernel_bundle<sycl::bundle_state::input>(
                 ctx, {dev}, {kernelId});
             if (!k_bundle.has_kernel(kernelId)) {
+              no_target_kernel = true;
               log.note("kernel_bundle doesn't contain target kernel for " +
                        type_name_string<T>::get(type_name) + " (skipped)");
               return;
@@ -160,14 +162,17 @@ class check_specialization_constants_same_name_stress_for_type {
           }
         });
       }
-      for (int i = 0; i < size; ++i) {
-        if (!check_equal_values(def_values_arr[i], ref_def_values_arr[i])) {
-          FAIL(log, "Wrong default value for spec const defined in " +
-                        get_hint(i) + " for type " + type_name);
-        }
-        if (!check_equal_values(result_arr[i], ref_arr[i])) {
-          FAIL(log, "Wrong result value for spec const defined in " +
-                        get_hint(i) + "for type " + type_name);
+      if (!no_target_kernel) {
+        // Check results only if taget kernel is available
+        for (int i = 0; i < size; ++i) {
+          if (!check_equal_values(def_values_arr[i], ref_def_values_arr[i])) {
+            FAIL(log, "Wrong default value for spec const defined in " +
+                          get_hint(i) + " for type " + type_name);
+          }
+          if (!check_equal_values(result_arr[i], ref_arr[i])) {
+            FAIL(log, "Wrong result value for spec const defined in " +
+                          get_hint(i) + "for type " + type_name);
+          }
         }
       }
     } catch (...) {


### PR DESCRIPTION
Let these spec_constants tests skip validation when no target kernel is available to make them pass in AOT mode (since no input state bundles will be available under AOT mode). Previously they do validate the results despite printing log statements like "kernel_bundle doesn't contain target kernel ... (**skipped**)", which cause these tests to fail unexpectedly when running under AOT mode.
Below is a listed of the affected (i.e. fixed) test cases:
specialization_constants_defined_various_ways_via_kb_core
specialization_constants_defined_various_ways_via_kb_fp16
specialization_constants_defined_various_ways_via_kb_fp64
specialization_constants_multiple_via_kb_core
specialization_constants_multiple_via_kb_fp16
specialization_constants_multiple_via_kb_fp64
specialization_constants_same_name_inter_link_1st_tu_via_kb_core
specialization_constants_same_name_inter_link_1st_tu_via_kb_fp16
specialization_constants_same_name_inter_link_1st_tu_via_kb_fp64
specialization_constants_same_name_inter_link_2nd_tu_via_kb_core
specialization_constants_same_name_inter_link_2nd_tu_via_kb_fp16
specialization_constants_same_name_inter_link_2nd_tu_via_kb_fp64
specialization_constants_same_name_stress_via_kb_core
specialization_constants_same_name_stress_via_kb_fp16
specialization_constants_same_name_stress_via_kb_fp64
