### PR TITLE
Compatibility: Only use `sycl::half` if SYCL_CTS_ENABLE_HALF_TESTS is set

### DIFF
--- a/tests/accessor_basic/accessor_common.h
+++ b/tests/accessor_basic/accessor_common.h
@@ -143,6 +143,8 @@ inline std::string get_section_name(const std::string& type_name,
 // FIXME: re-enable when marrray is implemented in adaptivecpp and type_coverage
 // is enabled
 #ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+
+#if SYCL_CTS_ENABLE_HALF_TESTS
 /**
  * @brief Factory function for getting type_pack with fp16 type
  */
@@ -150,6 +152,7 @@ inline auto get_fp16_type() {
   static const auto types = named_type_pack<sycl::half>::generate("sycl::half");
   return types;
 }
+#endif
 
 /**
  * @brief Factory function for getting type_pack with fp64 type

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -237,6 +237,7 @@ bool check_type_sign(bool expected_sign) {
   return (std::is_signed<T>::value == expected_sign);
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 /**
  * @brief Helper function to see if sycl::half is of the wrong sign
  */
@@ -245,6 +246,7 @@ inline bool check_type_sign<sycl::half>(bool expected_sign) {
   bool is_signed = sycl::half(1) > sycl::half(-1);
   return is_signed == expected_sign;
 }
+#endif
 
 /**
  * @brief Helper function to log a failure if a type is of the wrong size or

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -18,6 +18,7 @@
 //
 *******************************************************************************/
 
+#include "../../util/type_traits.h"
 #include "../common/common.h"
 #include "../common/get_group_range.h"
 #include "../common/once_per_unit.h"
@@ -133,8 +134,10 @@ struct custom_type {
 template <typename T>
 inline constexpr uint64_t exact_max = std::numeric_limits<T>::max();
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <>
 inline constexpr uint64_t exact_max<sycl::half> = 1ull << 11;
+#endif
 template <>
 inline constexpr uint64_t exact_max<float> = 1ull << 24;
 template <>
@@ -256,8 +259,7 @@ template <typename T>
 inline auto get_op_types() {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   static const auto types = []() {
-    if constexpr (std::is_floating_point_v<T> ||
-                  std::is_same_v<std::remove_cv_t<T>, sycl::half>) {
+    if constexpr (is_sycl_floating_point_v<T>) {
       // Bitwise operations are not defined for floating point types.
       return named_type_pack<sycl::plus<T>, sycl::multiplies<T>,
                              sycl::logical_and<T>, sycl::logical_or<T>,

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -259,7 +259,7 @@ template <typename T>
 inline auto get_op_types() {
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
   static const auto types = []() {
-    if constexpr (is_sycl_floating_point_v<T>) {
+    if constexpr (is_sycl_scalar_floating_point_v<T>) {
       // Bitwise operations are not defined for floating point types.
       return named_type_pack<sycl::plus<T>, sycl::multiplies<T>,
                              sycl::logical_and<T>, sycl::logical_or<T>,

--- a/tests/group_functions/group_joint_reduce.cpp.in
+++ b/tests/group_functions/group_joint_reduce.cpp.in
@@ -32,12 +32,15 @@ TEST_CASE(CTS_TYPE_NAME + " group and sub-group joint reduce functions",
   const auto Operators = get_op_types<CTS_TYPE>();
   const auto RetType = unnamed_type_pack<CTS_TYPE>();
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
       SKIP(
           "Device does not support half precision floating point "
           "operations.");
-  } else if (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
+  }
+#endif
+  if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
     if (!queue.get_device().has(sycl::aspect::fp64))
       SKIP(
           "Device does not support double precision floating point "
@@ -57,12 +60,15 @@ TEMPLATE_LIST_TEST_CASE(
   const auto RetType = unnamed_type_pack<CTS_TYPE>();
   const auto ReducedType = unnamed_type_pack<TestType>();
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
       SKIP(
           "Device does not support half precision floating point "
           "operations.");
-  } else if (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
+  }
+#endif
+  if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
     if (!queue.get_device().has(sycl::aspect::fp64))
       SKIP(
           "Device does not support double precision floating point "

--- a/tests/group_functions/group_joint_scan.cpp.in
+++ b/tests/group_functions/group_joint_scan.cpp.in
@@ -49,12 +49,15 @@ DISABLED_FOR_TEST_CASE(AdaptiveCpp)
 #endif
 
   auto queue = once_per_unit::get_queue();
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
       SKIP(
           "Device does not support half precision floating point "
           "operations.");
-  } else if (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
+  }
+#endif
+  if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
     if (!queue.get_device().has(sycl::aspect::fp64))
       SKIP(
           "Device does not support double precision floating point "
@@ -86,12 +89,15 @@ DISABLED_FOR_TEST_CASE(AdaptiveCpp)
 #endif
 
   auto queue = once_per_unit::get_queue();
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
       SKIP(
           "Device does not support half precision floating point "
           "operations.");
-  } else if (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
+  }
+#endif
+  if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
     if (!queue.get_device().has(sycl::aspect::fp64))
       SKIP(
           "Device does not support double precision floating point "

--- a/tests/group_functions/group_reduce_over_group.cpp.in
+++ b/tests/group_functions/group_reduce_over_group.cpp.in
@@ -33,12 +33,15 @@ TEST_CASE(CTS_TYPE_NAME + " group and sub-group reduce functions",
   const auto Operators = get_op_types<CTS_TYPE>();
   const auto RetType = unnamed_type_pack<CTS_TYPE>();
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
       SKIP(
           "Device does not support half precision floating point "
           "operations.");
-  } else if (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
+  }
+#endif
+  if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
     if (!queue.get_device().has(sycl::aspect::fp64))
       SKIP(
           "Device does not support double precision floating point "
@@ -59,12 +62,15 @@ TEMPLATE_LIST_TEST_CASE(CTS_TYPE_NAME +
   const auto RetType = unnamed_type_pack<CTS_TYPE>();
   const auto ReducedType = unnamed_type_pack<TestType>();
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
       SKIP(
           "Device does not support half precision floating point "
           "operations.");
-  } else if (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
+  }
+#endif
+  if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
     if (!queue.get_device().has(sycl::aspect::fp64))
       SKIP(
           "Device does not support double precision floating point "

--- a/tests/group_functions/group_scan_over_group.cpp.in
+++ b/tests/group_functions/group_scan_over_group.cpp.in
@@ -39,12 +39,15 @@ DISABLED_FOR_TEST_CASE(AdaptiveCpp)
 (CTS_TYPE_NAME + " group and sub-group scan functions",
  "[group_func][type_list][dim]")({
   auto queue = once_per_unit::get_queue();
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
       SKIP(
           "Device does not support half precision floating point "
           "operations.");
-  } else if (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
+  }
+#endif
+  if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
     if (!queue.get_device().has(sycl::aspect::fp64))
       SKIP(
           "Device does not support double precision floating point "
@@ -59,12 +62,15 @@ DISABLED_FOR_TEST_CASE(AdaptiveCpp)
 (CTS_TYPE_NAME + " group and sub-group scan functions with init",
  "[group_func][type_list][dim]")({
   auto queue = once_per_unit::get_queue();
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
       SKIP(
           "Device does not support half precision floating point "
           "operations.");
-  } else if (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
+  }
+#endif
+  if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, double>) {
     if (!queue.get_device().has(sycl::aspect::fp64))
       SKIP(
           "Device does not support double precision floating point "

--- a/tests/kernel_bundle/kernels.h
+++ b/tests/kernel_bundle/kernels.h
@@ -221,6 +221,8 @@ struct kernel_atomic64_descriptor {
 // fp16, fp64, atomic64 kernels without sycl::requires attribute but with
 // explicit operations
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
+
 struct kernel_fp16_no_attr : kernel_base {
   void operator()(sycl::item<1> id) const {
     if (id.get_linear_id() == 0) {
@@ -238,6 +240,8 @@ struct kernel_fp16_no_attr_descriptor {
     return restrictions;
   }
 };
+
+#endif  // SYCL_CTS_ENABLE_HALF_TESTS
 
 struct kernel_fp64_no_attr : kernel_base {
   void operator()(sycl::item<1> id) const {

--- a/tests/kernel_bundle/sycl_is_compatible.cpp
+++ b/tests/kernel_bundle/sycl_is_compatible.cpp
@@ -102,10 +102,12 @@ TEST_CASE("Check is_compatible for kernels with no kernel attributes",
     CHECK(sycl::is_compatible(builtinKernelIds, device));
   }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
   SECTION("for a kernel that uses `sycl::half`") {
     check_with_optional_features<kernels::kernel_fp16_no_attr_descriptor>(
         device, queue, device.has(sycl::aspect::fp16));
   }
+#endif
 
   SECTION("for a kernel that uses `double`") {
     check_with_optional_features<kernels::kernel_fp64_no_attr_descriptor>(
@@ -204,10 +206,12 @@ TEST_CASE(
   const sycl::device device = sycl_cts::util::get_cts_object::device();
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
   SECTION("for a kernel that uses `sycl::half`") {
     check_with_optional_features<kernels::kernel_fp16_descriptor>(
         device, queue, device.has(sycl::aspect::fp16));
   }
+#endif
 
   SECTION("for a kernel that uses `double`") {
     check_with_optional_features<kernels::kernel_fp64_descriptor>(

--- a/tests/marray_basic/marray_operators.h
+++ b/tests/marray_basic/marray_operators.h
@@ -21,6 +21,7 @@
 #ifndef SYCLCTS_TESTS_MARRAY_MARRAY_OPERATOR_H
 #define SYCLCTS_TESTS_MARRAY_MARRAY_OPERATOR_H
 
+#include "../../util/type_traits.h"
 #include "../common/common.h"
 #include "../common/section_name_builder.h"
 #include "marray_common.h"
@@ -54,9 +55,8 @@ struct operators_helper {
 template <typename OpT, typename ElemT>
 struct skip_result_check
     : std::bool_constant<
-          (std::is_same_v<OpT, op_div> || std::is_same_v<OpT, op_assign_div>)&&(
-              std::is_same_v<ElemT, float> || std::is_same_v<ElemT, double> ||
-              std::is_same_v<ElemT, sycl::half>)> {};
+          (std::is_same_v<OpT, op_div> || std::is_same_v<OpT, op_assign_div>) &&
+              is_sycl_floating_point_v<ElemT>> {};
 
 template <typename OpT, typename ElemT>
 constexpr bool skip_result_check_v = skip_result_check<OpT, ElemT>::value;

--- a/tests/marray_basic/marray_operators.h
+++ b/tests/marray_basic/marray_operators.h
@@ -54,9 +54,10 @@ struct operators_helper {
 // similar to native::divide we can skip checking them.
 template <typename OpT, typename ElemT>
 struct skip_result_check
-    : std::bool_constant<
-          (std::is_same_v<OpT, op_div> || std::is_same_v<OpT, op_assign_div>) &&
-              is_sycl_floating_point_v<ElemT>> {};
+    : std::bool_constant<(
+          std::is_same_v<OpT, op_div> ||
+          std::is_same_v<
+              OpT, op_assign_div>)&&is_sycl_scalar_floating_point_v<ElemT>> {};
 
 template <typename OpT, typename ElemT>
 constexpr bool skip_result_check_v = skip_result_check<OpT, ElemT>::value;
@@ -67,10 +68,10 @@ bool are_equal_ignore_division(const T1& lhs, const T1& rhs) {
   // similar to native::divide we can skip checking them here.
   constexpr bool is_div =
       std::is_same_v<OpT, op_div> || std::is_same_v<OpT, op_assign_div>;
-  constexpr bool is_sycl_floating_point = std::is_same_v<ElemT, float> ||
-                                          std::is_same_v<ElemT, double> ||
-                                          std::is_same_v<ElemT, sycl::half>;
-  if constexpr (is_div && is_sycl_floating_point) return true;
+  constexpr bool is_sycl_scalar_floating_point =
+      std::is_same_v<ElemT, float> || std::is_same_v<ElemT, double> ||
+      std::is_same_v<ElemT, sycl::half>;
+  if constexpr (is_div && is_sycl_scalar_floating_point) return true;
   return value_operations::are_equal(lhs, rhs);
 }
 

--- a/tests/math_builtin_api/math_builtin.h
+++ b/tests/math_builtin_api/math_builtin.h
@@ -100,9 +100,9 @@ bool verify(sycl_cts::util::logger& log, T a, T b, float accuracy,
             AccuracyMode accuracy_mode, const std::string& comment);
 
 template <typename T>
-std::enable_if_t<is_sycl_floating_point_v<T>, bool>
-verify(sycl_cts::util::logger& log, T value, sycl_cts::resultRef<T> r,
-       float accuracy, AccuracyMode accuracy_mode, const std::string& comment) {
+std::enable_if_t<is_sycl_scalar_floating_point_v<T>, bool> verify(
+    sycl_cts::util::logger& log, T value, sycl_cts::resultRef<T> r,
+    float accuracy, AccuracyMode accuracy_mode, const std::string& comment) {
   const T reference = r.res;
 
   if (!r.undefined.empty())

--- a/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
+++ b/tests/optional_kernel_features/kernel_features_device_has_exceptions.cpp
@@ -42,8 +42,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]",
  ((typename FeatureTypeT, sycl::aspect FeatureAspectT), FeatureTypeT,
   FeatureAspectT),
- (sycl::half, sycl::aspect::fp16), (double, sycl::aspect::fp64),
- (AtomicRefT, sycl::aspect::atomic64))({
+#if SYCL_CTS_ENABLE_HALF_TESTS
+ (sycl::half, sycl::aspect::fp16),
+#endif
+ (double, sycl::aspect::fp64), (AtomicRefT, sycl::aspect::atomic64))({
   using kname = kernel_use_feature<FeatureTypeT, FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
 
@@ -84,8 +86,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]",
  ((typename FeatureTypeT, sycl::aspect FeatureAspectT), FeatureTypeT,
   FeatureAspectT),
- (sycl::half, sycl::aspect::fp16), (double, sycl::aspect::fp64),
- (AtomicRefT, sycl::aspect::atomic64))({
+#if SYCL_CTS_ENABLE_HALF_TESTS
+ (sycl::half, sycl::aspect::fp16),
+#endif
+ (double, sycl::aspect::fp64), (AtomicRefT, sycl::aspect::atomic64))({
   using kname =
       kernel_use_feature_function_non_decorated<FeatureTypeT, FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
@@ -134,8 +138,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]",
  ((typename FeatureTypeT, sycl::aspect FeatureAspectT), FeatureTypeT,
   FeatureAspectT),
- (sycl::half, sycl::aspect::fp16), (double, sycl::aspect::fp64),
- (AtomicRefT, sycl::aspect::atomic64))({
+#if SYCL_CTS_ENABLE_HALF_TESTS
+ (sycl::half, sycl::aspect::fp16),
+#endif
+ (double, sycl::aspect::fp64), (AtomicRefT, sycl::aspect::atomic64))({
   using kname = kernel_use_feature_function_external_decorated<FeatureTypeT,
                                                                FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
@@ -182,8 +188,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]",
  ((typename FeatureTypeT, sycl::aspect FeatureAspectT), FeatureTypeT,
   FeatureAspectT),
- (sycl::half, sycl::aspect::fp16), (double, sycl::aspect::fp64),
- (AtomicRefT, sycl::aspect::atomic64))({
+#if SYCL_CTS_ENABLE_HALF_TESTS
+ (sycl::half, sycl::aspect::fp16),
+#endif
+ (double, sycl::aspect::fp64), (AtomicRefT, sycl::aspect::atomic64))({
   using kname =
       kernel_dummy_function_non_decorated<FeatureTypeT, FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
@@ -227,8 +235,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]",
  ((typename FeatureTypeT, sycl::aspect FeatureAspectT), FeatureTypeT,
   FeatureAspectT),
- (sycl::half, sycl::aspect::fp16), (double, sycl::aspect::fp64),
- (AtomicRefT, sycl::aspect::atomic64))({
+#if SYCL_CTS_ENABLE_HALF_TESTS
+ (sycl::half, sycl::aspect::fp16),
+#endif
+ (double, sycl::aspect::fp64), (AtomicRefT, sycl::aspect::atomic64))({
   using kname = kernel_dummy_function_decorated<FeatureTypeT, FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
 
@@ -271,8 +281,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]",
  ((typename FeatureTypeT, sycl::aspect FeatureAspectT), FeatureTypeT,
   FeatureAspectT),
- (sycl::half, sycl::aspect::fp16), (double, sycl::aspect::fp64),
- (AtomicRefT, sycl::aspect::atomic64))({
+#if SYCL_CTS_ENABLE_HALF_TESTS
+ (sycl::half, sycl::aspect::fp16),
+#endif
+ (double, sycl::aspect::fp64), (AtomicRefT, sycl::aspect::atomic64))({
   using kname =
       kernel_use_feature_function_decorated<FeatureTypeT, FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
@@ -316,8 +328,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]",
  ((typename FeatureTypeT, sycl::aspect FeatureAspectT), FeatureTypeT,
   FeatureAspectT),
- (sycl::half, sycl::aspect::fp16), (double, sycl::aspect::fp64),
- (AtomicRefT, sycl::aspect::atomic64))({
+#if SYCL_CTS_ENABLE_HALF_TESTS
+ (sycl::half, sycl::aspect::fp16),
+#endif
+ (double, sycl::aspect::fp64), (AtomicRefT, sycl::aspect::atomic64))({
   using kname = kernel_use_another_feature<FeatureTypeT, FeatureAspectT>;
   auto queue = util::get_cts_object::queue();
 
@@ -351,7 +365,6 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
                         [[sycl::device_has(AnotherFeatureAspect)]], kname,
                         USE_FEATURE(FeatureTypeT));
   }
-
 });
 
 #ifdef SYCL_EXTERNAL
@@ -367,8 +380,10 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]",
  ((typename FeatureTypeT, sycl::aspect FeatureAspectT), FeatureTypeT,
   FeatureAspectT),
- (sycl::half, sycl::aspect::fp16), (double, sycl::aspect::fp64),
- (AtomicRefT, sycl::aspect::atomic64))({
+#if SYCL_CTS_ENABLE_HALF_TESTS
+ (sycl::half, sycl::aspect::fp16),
+#endif
+ (double, sycl::aspect::fp64), (AtomicRefT, sycl::aspect::atomic64))({
   using kname =
       kernel_use_feature_function_external_decorated_with_attr<FeatureTypeT,
                                                                FeatureAspectT>;

--- a/tests/optional_kernel_features/kernel_features_separate_unit.cpp
+++ b/tests/optional_kernel_features/kernel_features_separate_unit.cpp
@@ -15,6 +15,7 @@ template <typename T, sycl::aspect aspect>
 [[sycl::device_has(aspect)]] SYCL_EXTERNAL void
 use_feature_function_external_decorated(const sycl::accessor<bool, 1>& acc);
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <>
 SYCL_EXTERNAL void
 use_feature_function_external_decorated<sycl::half, sycl::aspect::fp16>(
@@ -25,6 +26,7 @@ use_feature_function_external_decorated<sycl::half, sycl::aspect::fp16>(
   feature1 += 42;
   acc[0] = (feature1 == feature2);
 }
+#endif
 
 template <>
 SYCL_EXTERNAL void

--- a/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
+++ b/tests/optional_kernel_features/kernel_features_speculative_compilation.cpp
@@ -72,6 +72,7 @@ DISABLED_FOR_TEST_CASE(AdaptiveCpp)
     }
   }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
   if (queue.get_device().has(sycl::aspect::fp16)) {
     {
       const auto separate_lambda_no_arg = []() {
@@ -100,6 +101,7 @@ DISABLED_FOR_TEST_CASE(AdaptiveCpp)
                           use_feature_function_non_decorated<sycl::half>());
     }
   }
+#endif
 
   if (queue.get_device().has(sycl::aspect::fp64)) {
     {

--- a/tests/reduction/identity_helper.h
+++ b/tests/reduction/identity_helper.h
@@ -21,6 +21,8 @@
 #ifndef __SYCL_CTS_TEST_IDENTITY_HELPER_H
 #define __SYCL_CTS_TEST_IDENTITY_HELPER_H
 
+#include "../../util/type_traits.h"
+
 #include <limits>
 #include <type_traits>
 
@@ -108,8 +110,7 @@ AccumulatorT get_identity() {
 template <typename AccumulatorT, typename OperatorT,
           std::enable_if_t<
               std::is_same_v<OperatorT, sycl::minimum<AccumulatorT>> &&
-                  (std::is_floating_point_v<AccumulatorT> ||
-                   std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>),
+                  is_sycl_floating_point_v<AccumulatorT>,
               bool> = true>
 AccumulatorT get_identity() {
   return std::numeric_limits<AccumulatorT>::infinity();

--- a/tests/reduction/identity_helper.h
+++ b/tests/reduction/identity_helper.h
@@ -107,11 +107,11 @@ AccumulatorT get_identity() {
 }
 
 /** minimum (floating point) */
-template <typename AccumulatorT, typename OperatorT,
-          std::enable_if_t<
-              std::is_same_v<OperatorT, sycl::minimum<AccumulatorT>> &&
-                  is_sycl_floating_point_v<AccumulatorT>,
-              bool> = true>
+template <
+    typename AccumulatorT, typename OperatorT,
+    std::enable_if_t<std::is_same_v<OperatorT, sycl::minimum<AccumulatorT>> &&
+                         is_sycl_scalar_floating_point_v<AccumulatorT>,
+                     bool> = true>
 AccumulatorT get_identity() {
   return std::numeric_limits<AccumulatorT>::infinity();
 }

--- a/tests/reduction/reduction_without_identity_param_common.h
+++ b/tests/reduction/reduction_without_identity_param_common.h
@@ -301,7 +301,7 @@ template <typename VariableT, bool UseCombineFlagT, bool UsePropertyFlag,
 void run_test_for_all_reductions_types(FunctorT functor, RangeT& range,
                                        sycl::queue& queue,
                                        const std::string& type_name) {
-  if constexpr (is_sycl_floating_point<VariableT>::value &&
+  if constexpr (is_sycl_scalar_floating_point<VariableT>::value &&
                 (std::is_same<FunctorT, sycl::bit_and<VariableT>>::value ||
                  std::is_same<FunctorT, sycl::bit_or<VariableT>>::value ||
                  std::is_same<FunctorT, sycl::bit_xor<VariableT>>::value)) {

--- a/tests/scalars/scalars_sycl_types.cpp
+++ b/tests/scalars/scalars_sycl_types.cpp
@@ -83,7 +83,9 @@ class TEST_NAME : public util::test_base {
                                            "size_t");
 
       // SYCL Floating Point Data Types
+#if SYCL_CTS_ENABLE_HALF_TESTS
       check_type_min_size_sign_log<sycl::half>(log, 2, true, "sycl::half");
+#endif
       check_type_min_size_sign_log<float>(log, 4, true, "float");
       check_type_min_size_sign_log<double>(log, 8, true, "double");
 
@@ -140,6 +142,7 @@ class TEST_NAME : public util::test_base {
           });
         });
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
         if (device_supports_fp16) {
           myQueue.submit([&](sycl::handler &cgh) {
             auto accSignResult =
@@ -157,6 +160,7 @@ class TEST_NAME : public util::test_base {
             });
           });
         }
+#endif
 
         if (device_supports_fp64) {
           myQueue
@@ -220,9 +224,11 @@ class TEST_NAME : public util::test_base {
         FAIL(log, errorStr + "sign: sycl::byte");
       }
 #endif
+#if SYCL_CTS_ENABLE_HALF_TESTS
       if (!signResults[12] && device_supports_fp16) {
         FAIL(log, errorStr + "sign: sycl::half");
       }
+#endif
       if (!signResults[13]) {
         FAIL(log, errorStr + "sign: float");
       }
@@ -272,9 +278,11 @@ class TEST_NAME : public util::test_base {
         FAIL(log, errorStr + "size: sycl::byte");
       }
 #endif
+#if SYCL_CTS_ENABLE_HALF_TESTS
       if (!sizeResults[13] && device_supports_fp16) {
         FAIL(log, errorStr + "size: sycl::half");
       }
+#endif
       if (!sizeResults[14]) {
         FAIL(log, errorStr + "size: float");
       }
@@ -285,11 +293,13 @@ class TEST_NAME : public util::test_base {
       myQueue.wait_and_throw();
     }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
     // Check sycl::half limits specialization
     {
       INFO("Check that std::numeric_limits is specialized for sycl::half type");
       CHECK(std::numeric_limits<sycl::half>::is_specialized);
     }
+#endif
   }
 };
 

--- a/tests/spec_constants/spec_constants_defined_various_ways.h
+++ b/tests/spec_constants/spec_constants_defined_various_ways.h
@@ -182,6 +182,7 @@ static void sc_run_test_core(util::logger &log) {
   }
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <typename via_kb>
 static void sc_run_test_fp16(util::logger &log) {
   using namespace specialization_constants_defined_various_ways;
@@ -205,6 +206,7 @@ static void sc_run_test_fp16(util::logger &log) {
 #endif
   }
 }
+#endif
 
 template <typename via_kb>
 static void sc_run_test_fp64(util::logger &log) {

--- a/tests/spec_constants/spec_constants_multiple.h
+++ b/tests/spec_constants/spec_constants_multiple.h
@@ -147,6 +147,7 @@ static void sc_run_test_core(util::logger &log) {
   }
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <typename via_kb>
 static void sc_run_test_fp16(util::logger &log) {
   using namespace specialization_constants_multiple;
@@ -168,6 +169,7 @@ static void sc_run_test_fp16(util::logger &log) {
 #endif
   }
 }
+#endif
 
 template <typename via_kb>
 static void sc_run_test_fp64(util::logger &log) {

--- a/tests/spec_constants/spec_constants_same_name_inter_link.h
+++ b/tests/spec_constants/spec_constants_same_name_inter_link.h
@@ -136,6 +136,7 @@ static void sc_run_test_core(util::logger &log) {
   }
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 // Test function for fp16 tests
 template <int tu_num, typename via_kb>
 static void sc_run_test_fp16(util::logger &log) {
@@ -160,6 +161,7 @@ static void sc_run_test_fp16(util::logger &log) {
 #endif
   }
 }
+#endif
 
 // Test function for fp64 tests
 template <int tu_num, typename via_kb>

--- a/tests/spec_constants/spec_constants_same_name_stress.h
+++ b/tests/spec_constants/spec_constants_same_name_stress.h
@@ -200,6 +200,7 @@ static void sc_run_test_core(util::logger &log) {
   }
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <typename via_kb>
 static void sc_run_test_fp16(util::logger &log) {
   using namespace specialization_constants_same_name_stress;
@@ -222,6 +223,7 @@ static void sc_run_test_fp16(util::logger &log) {
 #endif
   }
 }
+#endif
 
 template <typename via_kb>
 static void sc_run_test_fp64(util::logger &log) {

--- a/util/accuracy.h
+++ b/util/accuracy.h
@@ -24,6 +24,7 @@ T get_ulp_std(T x) {
   const T positive = std::fabs(std::nextafter(x, inf) - x);
   return std::fmin(negative, positive);
 }
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <>
 inline sycl::half get_ulp_std<sycl::half>(sycl::half x) {
   const auto ulp = get_ulp_std<float>(x);
@@ -31,6 +32,7 @@ inline sycl::half get_ulp_std<sycl::half>(sycl::half x) {
   // Multiplier is set according to the difference in precision
   return static_cast<sycl::half>(ulp * multiplier);
 }
+#endif
 /**
  * @brief Provides ulp(x) by definition given in OpenCL 1.2 rev. 19, 7.4
  *        See Jean-Michel Muller "On the definition of ulp (x)", definition 7
@@ -43,6 +45,7 @@ T get_ulp_sycl(T x) {
   const T positive = sycl::fabs(sycl::nextafter(x, inf) - x);
   return sycl::fmin(negative, positive);
 }
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <>
 inline sycl::half get_ulp_sycl<sycl::half>(sycl::half x) {
   const auto ulp = get_ulp_sycl<float>(x);
@@ -50,5 +53,6 @@ inline sycl::half get_ulp_sycl<sycl::half>(sycl::half x) {
   // Multiplier is set according to the difference in precision
   return static_cast<sycl::half>(ulp * multiplier);
 }
+#endif
 
 #endif  // __SYCLCTS_UTIL_ACCURACY_H

--- a/util/math_helper.h
+++ b/util/math_helper.h
@@ -192,10 +192,12 @@ sycl_cts::resultRef<sycl::marray<T, N>> run_func_on_marray_result_ref(
 
 template <typename T>
 struct rel_funcs_return;
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <>
 struct rel_funcs_return<sycl::half> {
   using type = int16_t;
 };
+#endif
 template <>
 struct rel_funcs_return<float> {
   using type = int32_t;

--- a/util/math_reference.cpp
+++ b/util/math_reference.cpp
@@ -71,9 +71,11 @@ float bitselect(float a, float b, float c) {
 double bitselect(double a, double b, double c) {
   return bitselect_f_t<int64_t>(a, b, c);
 }
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half bitselect(sycl::half a, sycl::half b, sycl::half c) {
   return bitselect_f_t<int16_t>(a, b, c);
 }
+#endif
 
 /* ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- DEGREES
  *
@@ -84,7 +86,9 @@ T degrees_t(T a) {
   return a * (180.0 / M_PI);
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half degrees(sycl::half a) { return degrees_t(a); }
+#endif
 
 float degrees(float a) { return degrees_t(a); }
 
@@ -99,7 +103,9 @@ T radians_t(T a) {
   return a * (M_PI / 180.0);
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half radians(sycl::half a) { return radians_t(a); }
+#endif
 
 float radians(float a) { return radians_t(a); }
 
@@ -114,7 +120,9 @@ T step_t(T a, T b) {
   return 1.0;
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half step(sycl::half a, sycl::half b) { return step_t(a, b); }
+#endif
 
 float step(float a, float b) { return step_t(a, b); }
 
@@ -131,10 +139,12 @@ sycl_cts::resultRef<T> smoothstep_t(T a, T b, T c) {
   return t * t * (3 - 2 * t);
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl_cts::resultRef<sycl::half> smoothstep(sycl::half a, sycl::half b,
                                            sycl::half c) {
   return smoothstep_t(a, b, c);
 }
+#endif
 sycl_cts::resultRef<float> smoothstep(float a, float b, float c) {
   return smoothstep_t(a, b, c);
 }
@@ -155,7 +165,9 @@ T sign_t(T a) {
   return +0.0;
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half sign(sycl::half a) { return sign_t(a); }
+#endif
 
 float sign(float a) { return sign_t(a); }
 
@@ -258,10 +270,12 @@ sycl_cts::resultRef<T> mix_t(T x, T y, T a) {
   return sycl_cts::resultRef<T>(T(), true);
 }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl_cts::resultRef<sycl::half> mix(const sycl::half a, const sycl::half b,
                                     const sycl::half c) {
   return mix_t(a, b, c);
 }
+#endif
 
 sycl_cts::resultRef<float> mix(const float a, const float b, const float c) {
   return mix_t(a, b, c);
@@ -458,37 +472,49 @@ sycl_cts::resultRef<uint32_t> mul24(uint32_t x, uint32_t y) {
  *
  */
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half acospi(sycl::half a) { return reference_acospi(a); }
+#endif
 float acospi(float a) { return reference_acospi(a); }
 double acospi(double a) { return reference_acospil(a); }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half asinpi(sycl::half a) { return reference_asinpi(a); }
+#endif
 float asinpi(float a) { return reference_asinpi(a); }
 double asinpi(double a) { return reference_asinpil(a); }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half atanpi(sycl::half a) { return reference_atanpi(a); }
+#endif
 float atanpi(float a) { return reference_atanpi(a); }
 double atanpi(double a) { return reference_atanpil(a); }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half atan2pi(sycl::half a, sycl::half b) {
   return reference_atan2pi(a, b);
 }
+#endif
 float atan2pi(float a, float b) { return reference_atan2pi(a, b); }
 double atan2pi(double a, double b) { return reference_atan2pil(a, b); }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half cospi(sycl::half a) { return reference_cospi(a); }
+#endif
 float cospi(float a) { return reference_cospi(a); }
 double cospi(double a) { return reference_cospil(a); }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fma(sycl::half a, sycl::half b, sycl::half c) {
   return reference_fma(a, b, c, 0);
 }
+#endif
 float fma(float a, float b, float c) { return reference_fma(a, b, c, 0); }
 double fma(double a, double b, double c) { return reference_fmal(a, b, c); }
 
 // AdaptiveCpp does not yet support sycl::bit_cast, which is used in
 // `nextafter`.
-#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+#if SYCL_CTS_ENABLE_HALF_TESTS && !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 sycl::half fdim(sycl::half a, sycl::half b) {
   if (a > b) {
     // to get rounding to nearest even
@@ -507,10 +533,12 @@ sycl::half fdim(sycl::half a, sycl::half b) {
 }
 #endif
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fract(sycl::half a, sycl::half *b) {
   *b = std::floor(a);
   return std::fmin(a - *b, nextafter(sycl::half(1.0), sycl::half(0.0)));
 }
+#endif
 float fract(float a, float *b) {
   *b = std::floor(a);
   return std::fmin(a - *b, nextafter(1.0f, 0.0f));
@@ -523,17 +551,21 @@ double fract(double a, double *b) {
 float nan(unsigned int a) { return std::nanf(std::to_string(a).c_str()); }
 double nan(unsigned long a) { return std::nan(std::to_string(a).c_str()); }
 double nan(unsigned long long a) { return std::nan(std::to_string(a).c_str()); }
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half nan(unsigned short a) { return nan(unsigned(a)); }
+#endif
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half modf(sycl::half a, sycl::half *b) {
   float resPtr;
   float res = modf(static_cast<float>(a), &resPtr);
   *b = static_cast<sycl::half>(resPtr);
   return res;
 }
+#endif
 
 // AdaptiveCpp does not yet support sycl::bit_cast
-#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+#if SYCL_CTS_ENABLE_HALF_TESTS && !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 sycl::half nextafter(sycl::half x, sycl::half y) {
   if (std::isnan(x)) return x;
 
@@ -561,11 +593,15 @@ sycl::half nextafter(sycl::half x, sycl::half y) {
 }
 #endif
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half sinpi(sycl::half a) { return reference_sinpi(a); }
+#endif
 float sinpi(float a) { return reference_sinpi(a); }
 double sinpi(double a) { return reference_sinpil(a); }
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half tanpi(sycl::half a) { return reference_tanpi(a); }
+#endif
 float tanpi(float a) { return reference_tanpi(a); }
 double tanpi(double a) { return reference_tanpil(a); }
 
@@ -625,6 +661,7 @@ sycl::mdouble3 cross(sycl::mdouble3 p0, sycl::mdouble3 p1) {
 }
 #endif  // SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fast_dot(float p0) { return std::pow(p0, 2); }
 sycl::half fast_dot(sycl::float2 p0) {
   return std::pow(p0.x(), 2) + std::pow(p0.y(), 2);
@@ -648,6 +685,7 @@ sycl::half fast_dot(sycl::mfloat4 p0) {
   return std::pow(p0[0], 2) + std::pow(p0[1], 2) + std::pow(p0[2], 2) +
          std::pow(p0[3], 2);
 }
+#endif
 #endif
 
 } /* namespace reference */

--- a/util/math_reference.cpp
+++ b/util/math_reference.cpp
@@ -35,11 +35,11 @@
 namespace {
 
 template <typename A, typename B>
-void type_punn(const A &from, B &to) {
+void type_punn(const A& from, B& to) {
   static_assert(sizeof(A) == sizeof(B),
                 "type punning of incompatible sized types");
-  std::memcpy(reinterpret_cast<void *>(&to),
-              reinterpret_cast<const void *>(&from), sizeof(A));
+  std::memcpy(reinterpret_cast<void*>(&to),
+              reinterpret_cast<const void*>(&from), sizeof(A));
 }
 
 #define MAX(_a, _b) ((_a) > (_b) ? (_a) : (_b))
@@ -68,14 +68,6 @@ T bitselect_f_t(T x, T y, T z) {
 float bitselect(float a, float b, float c) {
   return bitselect_f_t<int32_t>(a, b, c);
 }
-double bitselect(double a, double b, double c) {
-  return bitselect_f_t<int64_t>(a, b, c);
-}
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half bitselect(sycl::half a, sycl::half b, sycl::half c) {
-  return bitselect_f_t<int16_t>(a, b, c);
-}
-#endif
 
 /* ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- DEGREES
  *
@@ -86,13 +78,7 @@ T degrees_t(T a) {
   return a * (180.0 / M_PI);
 }
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half degrees(sycl::half a) { return degrees_t(a); }
-#endif
-
 float degrees(float a) { return degrees_t(a); }
-
-double degrees(double a) { return degrees_t(a); }
 
 /* ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- RADIANS
  *
@@ -103,13 +89,8 @@ T radians_t(T a) {
   return a * (M_PI / 180.0);
 }
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half radians(sycl::half a) { return radians_t(a); }
-#endif
-
 float radians(float a) { return radians_t(a); }
 
-double radians(double a) { return radians_t(a); }
 /* ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- STEP
  *
  */
@@ -120,13 +101,7 @@ T step_t(T a, T b) {
   return 1.0;
 }
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half step(sycl::half a, sycl::half b) { return step_t(a, b); }
-#endif
-
 float step(float a, float b) { return step_t(a, b); }
-
-double step(double a, double b) { return step_t(a, b); }
 
 /* ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- SMOOTHSTEP
  *
@@ -139,16 +114,7 @@ sycl_cts::resultRef<T> smoothstep_t(T a, T b, T c) {
   return t * t * (3 - 2 * t);
 }
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl_cts::resultRef<sycl::half> smoothstep(sycl::half a, sycl::half b,
-                                           sycl::half c) {
-  return smoothstep_t(a, b, c);
-}
-#endif
 sycl_cts::resultRef<float> smoothstep(float a, float b, float c) {
-  return smoothstep_t(a, b, c);
-}
-sycl_cts::resultRef<double> smoothstep(double a, double b, double c) {
   return smoothstep_t(a, b, c);
 }
 
@@ -165,13 +131,7 @@ T sign_t(T a) {
   return +0.0;
 }
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half sign(sycl::half a) { return sign_t(a); }
-#endif
-
 float sign(float a) { return sign_t(a); }
-
-double sign(double a) { return sign_t(a); }
 
 /* ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- MAD_SAT
  *
@@ -270,19 +230,7 @@ sycl_cts::resultRef<T> mix_t(T x, T y, T a) {
   return sycl_cts::resultRef<T>(T(), true);
 }
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl_cts::resultRef<sycl::half> mix(const sycl::half a, const sycl::half b,
-                                    const sycl::half c) {
-  return mix_t(a, b, c);
-}
-#endif
-
 sycl_cts::resultRef<float> mix(const float a, const float b, const float c) {
-  return mix_t(a, b, c);
-}
-
-sycl_cts::resultRef<double> mix(const double a, const double b,
-                                const double c) {
   return mix_t(a, b, c);
 }
 
@@ -472,49 +420,105 @@ sycl_cts::resultRef<uint32_t> mul24(uint32_t x, uint32_t y) {
  *
  */
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half acospi(sycl::half a) { return reference_acospi(a); }
-#endif
 float acospi(float a) { return reference_acospi(a); }
-double acospi(double a) { return reference_acospil(a); }
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half asinpi(sycl::half a) { return reference_asinpi(a); }
-#endif
 float asinpi(float a) { return reference_asinpi(a); }
-double asinpi(double a) { return reference_asinpil(a); }
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half atanpi(sycl::half a) { return reference_atanpi(a); }
-#endif
 float atanpi(float a) { return reference_atanpi(a); }
-double atanpi(double a) { return reference_atanpil(a); }
+float atan2pi(float a, float b) { return reference_atan2pi(a, b); }
+float cospi(float a) { return reference_cospi(a); }
+float fma(float a, float b, float c) { return reference_fma(a, b, c, 0); }
+
+float fract(float a, float* b) {
+  *b = std::floor(a);
+  return std::fmin(a - *b, nextafter(1.0f, 0.0f));
+}
+
+float nan(unsigned int a) { return std::nanf(std::to_string(a).c_str()); }
+float sinpi(float a) { return reference_sinpi(a); }
+float tanpi(float a) { return reference_tanpi(a); }
+
+// Geometric functions
+
+template <typename T, int N>
+sycl::vec<T, N> cross_t(sycl::vec<T, N> a, sycl::vec<T, N> b) {
+  sycl::vec<T, N> res;
+  std::vector<T> temp_res(4);
+  std::vector<T> av({a.x(), a.y(), a.z()});
+  std::vector<T> bv({b.x(), b.y(), b.z()});
+  temp_res[0] = av[1] * bv[2] - av[2] * bv[1];
+  temp_res[1] = av[2] * bv[0] - av[0] * bv[2];
+  temp_res[2] = av[0] * bv[1] - av[1] * bv[0];
+  temp_res[3] = 0.0;
+  for (int i = 0; i < N; i++) res[i] = temp_res[i];
+
+  return res;
+}
+
+sycl::float4 cross(sycl::float4 p0, sycl::float4 p1) { return cross_t(p0, p1); }
+sycl::float3 cross(sycl::float3 p0, sycl::float3 p1) { return cross_t(p0, p1); }
+
+// FIXME: AdaptiveCpp does not support marray
+#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+template <typename T, size_t N>
+sycl::marray<T, N> cross_t(sycl::marray<T, N> a, sycl::marray<T, N> b) {
+  sycl::marray<T, N> res;
+  std::vector<T> temp_res(4);
+  std::vector<T> av({a[0], a[1], a[2]});
+  std::vector<T> bv({b[0], b[1], b[2]});
+  temp_res[0] = av[1] * bv[2] - av[2] * bv[1];
+  temp_res[1] = av[2] * bv[0] - av[0] * bv[2];
+  temp_res[2] = av[0] * bv[1] - av[1] * bv[0];
+  temp_res[3] = 0.0;
+  for (size_t i = 0; i < N; i++) res[i] = temp_res[i];
+  return res;
+}
+
+sycl::mfloat4 cross(sycl::mfloat4 p0, sycl::mfloat4 p1) {
+  return cross_t(p0, p1);
+}
+sycl::mfloat3 cross(sycl::mfloat3 p0, sycl::mfloat3 p1) {
+  return cross_t(p0, p1);
+}
+#endif  // SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 
 #if SYCL_CTS_ENABLE_HALF_TESTS
+
+sycl::half bitselect(sycl::half a, sycl::half b, sycl::half c) {
+  return bitselect_f_t<int16_t>(a, b, c);
+}
+
+sycl::half degrees(sycl::half a) { return degrees_t(a); }
+sycl::half radians(sycl::half a) { return radians_t(a); }
+sycl::half step(sycl::half a, sycl::half b) { return step_t(a, b); }
+
+sycl_cts::resultRef<sycl::half> smoothstep(sycl::half a, sycl::half b,
+                                           sycl::half c) {
+  return smoothstep_t(a, b, c);
+}
+
+sycl::half sign(sycl::half a) { return sign_t(a); }
+
+sycl_cts::resultRef<sycl::half> mix(const sycl::half a, const sycl::half b,
+                                    const sycl::half c) {
+  return mix_t(a, b, c);
+}
+
+sycl::half acospi(sycl::half a) { return reference_acospi(a); }
+sycl::half asinpi(sycl::half a) { return reference_asinpi(a); }
+sycl::half atanpi(sycl::half a) { return reference_atanpi(a); }
+
 sycl::half atan2pi(sycl::half a, sycl::half b) {
   return reference_atan2pi(a, b);
 }
-#endif
-float atan2pi(float a, float b) { return reference_atan2pi(a, b); }
-double atan2pi(double a, double b) { return reference_atan2pil(a, b); }
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half cospi(sycl::half a) { return reference_cospi(a); }
-#endif
-float cospi(float a) { return reference_cospi(a); }
-double cospi(double a) { return reference_cospil(a); }
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fma(sycl::half a, sycl::half b, sycl::half c) {
   return reference_fma(a, b, c, 0);
 }
-#endif
-float fma(float a, float b, float c) { return reference_fma(a, b, c, 0); }
-double fma(double a, double b, double c) { return reference_fmal(a, b, c); }
 
 // AdaptiveCpp does not yet support sycl::bit_cast, which is used in
 // `nextafter`.
-#if SYCL_CTS_ENABLE_HALF_TESTS && !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 sycl::half fdim(sycl::half a, sycl::half b) {
   if (a > b) {
     // to get rounding to nearest even
@@ -533,39 +537,22 @@ sycl::half fdim(sycl::half a, sycl::half b) {
 }
 #endif
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half fract(sycl::half a, sycl::half *b) {
+sycl::half fract(sycl::half a, sycl::half* b) {
   *b = std::floor(a);
   return std::fmin(a - *b, nextafter(sycl::half(1.0), sycl::half(0.0)));
 }
-#endif
-float fract(float a, float *b) {
-  *b = std::floor(a);
-  return std::fmin(a - *b, nextafter(1.0f, 0.0f));
-}
-double fract(double a, double *b) {
-  *b = std::floor(a);
-  return std::fmin(a - *b, nextafter(1.0, 0.0));
-}
 
-float nan(unsigned int a) { return std::nanf(std::to_string(a).c_str()); }
-double nan(unsigned long a) { return std::nan(std::to_string(a).c_str()); }
-double nan(unsigned long long a) { return std::nan(std::to_string(a).c_str()); }
-#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half nan(unsigned short a) { return nan(unsigned(a)); }
-#endif
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half modf(sycl::half a, sycl::half *b) {
+sycl::half modf(sycl::half a, sycl::half* b) {
   float resPtr;
   float res = modf(static_cast<float>(a), &resPtr);
   *b = static_cast<sycl::half>(resPtr);
   return res;
 }
-#endif
 
 // AdaptiveCpp does not yet support sycl::bit_cast
-#if SYCL_CTS_ENABLE_HALF_TESTS && !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 sycl::half nextafter(sycl::half x, sycl::half y) {
   if (std::isnan(x)) return x;
 
@@ -593,75 +580,9 @@ sycl::half nextafter(sycl::half x, sycl::half y) {
 }
 #endif
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half sinpi(sycl::half a) { return reference_sinpi(a); }
-#endif
-float sinpi(float a) { return reference_sinpi(a); }
-double sinpi(double a) { return reference_sinpil(a); }
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half tanpi(sycl::half a) { return reference_tanpi(a); }
-#endif
-float tanpi(float a) { return reference_tanpi(a); }
-double tanpi(double a) { return reference_tanpil(a); }
 
-// Geometric functions
-
-template <typename T, int N>
-sycl::vec<T, N> cross_t(sycl::vec<T, N> a, sycl::vec<T, N> b) {
-  sycl::vec<T, N> res;
-  std::vector<T> temp_res(4);
-  std::vector<T> av({a.x(), a.y(), a.z()});
-  std::vector<T> bv({b.x(), b.y(), b.z()});
-  temp_res[0] = av[1] * bv[2] - av[2] * bv[1];
-  temp_res[1] = av[2] * bv[0] - av[0] * bv[2];
-  temp_res[2] = av[0] * bv[1] - av[1] * bv[0];
-  temp_res[3] = 0.0;
-  for (int i = 0; i < N; i++) res[i] = temp_res[i];
-
-  return res;
-}
-
-sycl::float4 cross(sycl::float4 p0, sycl::float4 p1) { return cross_t(p0, p1); }
-sycl::float3 cross(sycl::float3 p0, sycl::float3 p1) { return cross_t(p0, p1); }
-sycl::double4 cross(sycl::double4 p0, sycl::double4 p1) {
-  return cross_t(p0, p1);
-}
-sycl::double3 cross(sycl::double3 p0, sycl::double3 p1) {
-  return cross_t(p0, p1);
-}
-
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl::marray<T, N> cross_t(sycl::marray<T, N> a, sycl::marray<T, N> b) {
-  sycl::marray<T, N> res;
-  std::vector<T> temp_res(4);
-  std::vector<T> av({a[0], a[1], a[2]});
-  std::vector<T> bv({b[0], b[1], b[2]});
-  temp_res[0] = av[1] * bv[2] - av[2] * bv[1];
-  temp_res[1] = av[2] * bv[0] - av[0] * bv[2];
-  temp_res[2] = av[0] * bv[1] - av[1] * bv[0];
-  temp_res[3] = 0.0;
-  for (size_t i = 0; i < N; i++) res[i] = temp_res[i];
-  return res;
-}
-
-sycl::mfloat4 cross(sycl::mfloat4 p0, sycl::mfloat4 p1) {
-  return cross_t(p0, p1);
-}
-sycl::mfloat3 cross(sycl::mfloat3 p0, sycl::mfloat3 p1) {
-  return cross_t(p0, p1);
-}
-sycl::mdouble4 cross(sycl::mdouble4 p0, sycl::mdouble4 p1) {
-  return cross_t(p0, p1);
-}
-sycl::mdouble3 cross(sycl::mdouble3 p0, sycl::mdouble3 p1) {
-  return cross_t(p0, p1);
-}
-#endif  // SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fast_dot(float p0) { return std::pow(p0, 2); }
 sycl::half fast_dot(sycl::float2 p0) {
   return std::pow(p0.x(), 2) + std::pow(p0.y(), 2);
@@ -686,6 +607,64 @@ sycl::half fast_dot(sycl::mfloat4 p0) {
          std::pow(p0[3], 2);
 }
 #endif
+
+#endif  // SYCL_CTS_ENABLE_HALF_TESTS
+
+#if SYCL_CTS_ENABLE_DOUBLE_TESTS
+
+double bitselect(double a, double b, double c) {
+  return bitselect_f_t<int64_t>(a, b, c);
+}
+
+double degrees(double a) { return degrees_t(a); }
+double radians(double a) { return radians_t(a); }
+double step(double a, double b) { return step_t(a, b); }
+
+sycl_cts::resultRef<double> smoothstep(double a, double b, double c) {
+  return smoothstep_t(a, b, c);
+}
+
+double sign(double a) { return sign_t(a); }
+
+sycl_cts::resultRef<double> mix(const double a, const double b,
+                                const double c) {
+  return mix_t(a, b, c);
+}
+
+double acospi(double a) { return reference_acospil(a); }
+double asinpi(double a) { return reference_asinpil(a); }
+double atanpi(double a) { return reference_atanpil(a); }
+double atan2pi(double a, double b) { return reference_atan2pil(a, b); }
+double cospi(double a) { return reference_cospil(a); }
+double fma(double a, double b, double c) { return reference_fmal(a, b, c); }
+
+double fract(double a, double* b) {
+  *b = std::floor(a);
+  return std::fmin(a - *b, nextafter(1.0, 0.0));
+}
+
+double nan(unsigned long a) { return std::nan(std::to_string(a).c_str()); }
+double nan(unsigned long long a) { return std::nan(std::to_string(a).c_str()); }
+
+double sinpi(double a) { return reference_sinpil(a); }
+double tanpi(double a) { return reference_tanpil(a); }
+
+sycl::double4 cross(sycl::double4 p0, sycl::double4 p1) {
+  return cross_t(p0, p1);
+}
+sycl::double3 cross(sycl::double3 p0, sycl::double3 p1) {
+  return cross_t(p0, p1);
+}
+
+#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+sycl::mdouble4 cross(sycl::mdouble4 p0, sycl::mdouble4 p1) {
+  return cross_t(p0, p1);
+}
+sycl::mdouble3 cross(sycl::mdouble3 p0, sycl::mdouble3 p1) {
+  return cross_t(p0, p1);
+}
 #endif
+
+#endif  // SYCL_CTS_ENABLE_DOUBLE_TESTS
 
 } /* namespace reference */

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -249,7 +249,9 @@ template <typename T>
 T bitselect(T a, T b, T c) {
   return (c & b) | (~c & a);
 }
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half bitselect(sycl::half a, sycl::half b, sycl::half c);
+#endif
 float bitselect(float a, float b, float c);
 double bitselect(double a, double b, double c);
 MAKE_VEC_AND_MARRAY_VERSIONS_3ARGS(bitselect)
@@ -710,7 +712,9 @@ sycl_cts::resultRef<sycl::marray<T, N>> mul24(sycl::marray<T, N> a,
 // clamp is in Integer functions
 
 /* degrees */
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half degrees(sycl::half);
+#endif
 float degrees(float a);
 double degrees(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(degrees)
@@ -718,8 +722,10 @@ MAKE_VEC_AND_MARRAY_VERSIONS(degrees)
 // max and min are in Integer functions
 
 /* mix */
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl_cts::resultRef<sycl::half> mix(const sycl::half a, const sycl::half b,
                                     const sycl::half c);
+#endif
 sycl_cts::resultRef<float> mix(const float a, const float b, const float c);
 sycl_cts::resultRef<double> mix(const double a, const double b, const double c);
 
@@ -769,13 +775,17 @@ sycl_cts::resultRef<sycl::marray<T, N>> mix(sycl::marray<T, N> a,
 #endif
 
 /* radians */
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half radians(sycl::half);
+#endif
 float radians(float a);
 double radians(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(radians)
 
 /* step */
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half step(sycl::half a, sycl::half b);
+#endif
 float step(float a, float b);
 double step(double a, double b);
 MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(step)
@@ -801,8 +811,10 @@ sycl::marray<T, N> step(T a, sycl::marray<T, N> b) {
 #endif
 
 /* smoothstep */
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl_cts::resultRef<sycl::half> smoothstep(sycl::half a, sycl::half b,
                                            sycl::half c);
+#endif
 sycl_cts::resultRef<float> smoothstep(float a, float b, float c);
 sycl_cts::resultRef<double> smoothstep(double a, double b, double c);
 
@@ -852,7 +864,9 @@ sycl_cts::resultRef<sycl::marray<T, N>> smoothstep(T a, T b,
 #endif
 
 /* sign */
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half sign(sycl::half a);
+#endif
 float sign(float a);
 double sign(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(sign)
@@ -862,10 +876,12 @@ MAKE_VEC_AND_MARRAY_VERSIONS(sign)
 template <typename T>
 struct higher_accuracy;
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <>
 struct higher_accuracy<sycl::half> {
   using type = float;
 };
+#endif
 template <>
 struct higher_accuracy<float> {
   using type = double;
@@ -899,7 +915,9 @@ T acosh(T a) {
 }
 MAKE_VEC_AND_MARRAY_VERSIONS(acosh)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half acospi(sycl::half a);
+#endif
 float acospi(float a);
 double acospi(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(acospi)
@@ -916,7 +934,9 @@ T asinh(T a) {
 }
 MAKE_VEC_AND_MARRAY_VERSIONS(asinh)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half asinpi(sycl::half a);
+#endif
 float asinpi(float a);
 double asinpi(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(asinpi)
@@ -939,12 +959,16 @@ T atanh(T a) {
 }
 MAKE_VEC_AND_MARRAY_VERSIONS(atanh)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half atanpi(sycl::half a);
+#endif
 float atanpi(float a);
 double atanpi(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(atanpi)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half atan2pi(sycl::half a, sycl::half b);
+#endif
 float atan2pi(float a, float b);
 double atan2pi(double a, double b);
 MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(atan2pi)
@@ -973,7 +997,9 @@ T cosh(T a) {
 }
 MAKE_VEC_AND_MARRAY_VERSIONS(cosh)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half cospi(sycl::half a);
+#endif
 float cospi(float a);
 double cospi(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(cospi)
@@ -1019,13 +1045,17 @@ using std::fabs;
 MAKE_VEC_AND_MARRAY_VERSIONS(fabs)
 
 using std::fdim;
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fdim(sycl::half a, sycl::half b);
+#endif
 MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(fdim)
 
 using std::floor;
 MAKE_VEC_AND_MARRAY_VERSIONS(floor)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fma(sycl::half a, sycl::half b, sycl::half c);
+#endif
 float fma(float a, float b, float c);
 double fma(double a, double b, double c);
 
@@ -1042,7 +1072,9 @@ MAKE_VEC_AND_MARRAY_VERSIONS_WITH_SCALAR(fmin)
 using std::fmod;
 MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(fmod)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fract(sycl::half a, sycl::half *b);
+#endif
 float fract(float a, float *b);
 double fract(double a, double *b);
 
@@ -1261,7 +1293,9 @@ T minmag(T a, T b) {
 MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(minmag)
 
 using std::modf;
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half modf(sycl::half a, sycl::half *b);
+#endif
 template <typename T, int N>
 sycl::vec<T, N> modf(sycl::vec<T, N> a, sycl::vec<T, N> *b) {
   sycl::vec<T, N> res;
@@ -1290,15 +1324,19 @@ sycl::marray<T, N> modf(sycl::marray<T, N> a, sycl::marray<T, N> *b) {
 }
 #endif
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half nan(unsigned short a);
+#endif
 float nan(unsigned int a);
 double nan(unsigned long a);
 double nan(unsigned long long a);
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <int N>
 sycl::vec<sycl::half, N> nan(sycl::vec<unsigned short, N> a) {
   return sycl_cts::math::run_func_on_vector<sycl::half, unsigned short, N>(
       [](unsigned short x) { return nan(x); }, a);
 }
+#endif
 template <int N>
 sycl::vec<float, N> nan(sycl::vec<unsigned int, N> a) {
   return sycl_cts::math::run_func_on_vector<float, unsigned int, N>(
@@ -1314,11 +1352,13 @@ nan(sycl::vec<T, N> a) {
 }
 // FIXME: AdaptiveCpp does not support marray
 #ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+#if SYCL_CTS_ENABLE_HALF_TESTS
 template <size_t N>
 sycl::marray<sycl::half, N> nan(sycl::marray<unsigned short, N> a) {
   return sycl_cts::math::run_func_on_marray<sycl::half, unsigned short, N>(
       [](unsigned short x) { return nan(x); }, a);
 }
+#endif
 template <size_t N>
 sycl::marray<float, N> nan(sycl::marray<unsigned int, N> a) {
   return sycl_cts::math::run_func_on_marray<float, unsigned int, N>(
@@ -1335,7 +1375,9 @@ nan(sycl::marray<T, N> a) {
 #endif
 
 using std::nextafter;
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half nextafter(sycl::half a, sycl::half b);
+#endif
 MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(nextafter)
 
 template <typename T>
@@ -1512,7 +1554,9 @@ T sinh(T a) {
 }
 MAKE_VEC_AND_MARRAY_VERSIONS(sinh)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half sinpi(sycl::half a);
+#endif
 float sinpi(float a);
 double sinpi(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(sinpi)
@@ -1535,7 +1579,9 @@ T tanh(T a) {
 }
 MAKE_VEC_AND_MARRAY_VERSIONS(tanh)
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half tanpi(sycl::half a);
+#endif
 float tanpi(float a);
 double tanpi(double a);
 MAKE_VEC_AND_MARRAY_VERSIONS(tanpi)
@@ -1631,6 +1677,7 @@ sycl::marray<T, N> normalize(sycl::marray<T, N> a) {
 }
 #endif
 
+#if SYCL_CTS_ENABLE_HALF_TESTS
 sycl::half fast_dot(float p0);
 sycl::half fast_dot(sycl::float2 p0);
 sycl::half fast_dot(sycl::float3 p0);
@@ -1640,6 +1687,7 @@ sycl::half fast_dot(sycl::float4 p0);
 sycl::half fast_dot(sycl::mfloat2 p0);
 sycl::half fast_dot(sycl::mfloat3 p0);
 sycl::half fast_dot(sycl::mfloat4 p0);
+#endif
 #endif
 
 template <typename T>

--- a/util/math_reference.h
+++ b/util/math_reference.h
@@ -28,93 +28,8 @@
 #include "./math_helper.h"
 #include <cmath>
 
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-
-#define MAKE_VEC_AND_MARRAY_VERSIONS(func)              \
-  template <typename T, int N>                          \
-  sycl::vec<T, N> func(sycl::vec<T, N> a) {             \
-    return sycl_cts::math::run_func_on_vector<T, T, N>( \
-        [](T x) { return func(x); }, a);                \
-  }                                                     \
-  template <typename T, size_t N>                       \
-  sycl::marray<T, N> func(sycl::marray<T, N> a) {       \
-    return sycl_cts::math::run_func_on_marray<T, T, N>( \
-        [](T x) { return func(x); }, a);                \
-  }
-
-#define MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(func)                        \
-  template <typename T, int N>                                          \
-  sycl::vec<T, N> func(sycl::vec<T, N> a, sycl::vec<T, N> b) {          \
-    return sycl_cts::math::run_func_on_vector<T, T, N>(                 \
-        [](T x, T y) { return func(x, y); }, a, b);                     \
-  }                                                                     \
-  template <typename T, size_t N>                                       \
-  sycl::marray<T, N> func(sycl::marray<T, N> a, sycl::marray<T, N> b) { \
-    return sycl_cts::math::run_func_on_marray<T, T, N>(                 \
-        [](T x, T y) { return func(x, y); }, a, b);                     \
-  }
-
-#define MAKE_VEC_AND_MARRAY_VERSIONS_3ARGS(func)                      \
-  template <typename T, int N>                                        \
-  sycl::vec<T, N> func(sycl::vec<T, N> a, sycl::vec<T, N> b,          \
-                       sycl::vec<T, N> c) {                           \
-    return sycl_cts::math::run_func_on_vector<T, T, N>(               \
-        [](T x, T y, T z) { return func(x, y, z); }, a, b, c);        \
-  }                                                                   \
-  template <typename T, size_t N>                                     \
-  sycl::marray<T, N> func(sycl::marray<T, N> a, sycl::marray<T, N> b, \
-                          sycl::marray<T, N> c) {                     \
-    return sycl_cts::math::run_func_on_marray<T, T, N>(               \
-        [](T x, T y, T z) { return func(x, y, z); }, a, b, c);        \
-  }
-
-#define MAKE_VEC_AND_MARRAY_VERSIONS_WITH_SCALAR(func)  \
-  template <typename T, int N>                          \
-  sycl::vec<T, N> func(sycl::vec<T, N> a, T b) {        \
-    return sycl_cts::math::run_func_on_vector<T, T, N>( \
-        [](T x, T y) { return func(x, y); }, a, b);     \
-  }                                                     \
-  template <typename T, size_t N>                       \
-  sycl::marray<T, N> func(sycl::marray<T, N> a, T b) {  \
-    return sycl_cts::math::run_func_on_marray<T, T, N>( \
-        [](T x, T y) { return func(x, y); }, a, b);     \
-  }
-
-#else  // definitions without marray for AdaptiveCpp
-
-#define MAKE_VEC_AND_MARRAY_VERSIONS(func)              \
-  template <typename T, int N>                          \
-  sycl::vec<T, N> func(sycl::vec<T, N> a) {             \
-    return sycl_cts::math::run_func_on_vector<T, T, N>( \
-        [](T x) { return func(x); }, a);                \
-  }
-
-#define MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(func)               \
-  template <typename T, int N>                                 \
-  sycl::vec<T, N> func(sycl::vec<T, N> a, sycl::vec<T, N> b) { \
-    return sycl_cts::math::run_func_on_vector<T, T, N>(        \
-        [](T x, T y) { return func(x, y); }, a, b);            \
-  }
-
-#define MAKE_VEC_AND_MARRAY_VERSIONS_3ARGS(func)               \
-  template <typename T, int N>                                 \
-  sycl::vec<T, N> func(sycl::vec<T, N> a, sycl::vec<T, N> b,   \
-                       sycl::vec<T, N> c) {                    \
-    return sycl_cts::math::run_func_on_vector<T, T, N>(        \
-        [](T x, T y, T z) { return func(x, y, z); }, a, b, c); \
-  }
-
-#define MAKE_VEC_AND_MARRAY_VERSIONS_WITH_SCALAR(func)  \
-  template <typename T, int N>                          \
-  sycl::vec<T, N> func(sycl::vec<T, N> a, T b) {        \
-    return sycl_cts::math::run_func_on_vector<T, T, N>( \
-        [](T x, T y) { return func(x, y); }, a, b);     \
-  }
-
-#endif
-
 namespace reference {
+
 /* two argument relational reference */
 template <typename T>
 auto isequal(T a, T b) {
@@ -146,7 +61,7 @@ auto islessequal(T a, T b) {
   return sycl_cts::math::rel_func_dispatcher<std::less_equal>(a, b);
 }
 
-auto constexpr islessgreater_func = [](const auto &x, const auto &y) {
+auto constexpr islessgreater_func = [](const auto& x, const auto& y) {
   return (x < y) || (x > y);
 };
 template <typename T>
@@ -154,7 +69,7 @@ auto islessgreater(T a, T b) {
   return sycl_cts::math::rel_func_dispatcher(islessgreater_func, a, b);
 }
 
-auto constexpr isordered_func = [](const auto &x, const auto &y) {
+auto constexpr isordered_func = [](const auto& x, const auto& y) {
   return (x == x) && (y == y);
 };
 template <typename T>
@@ -162,7 +77,7 @@ auto isordered(T a, T b) {
   return sycl_cts::math::rel_func_dispatcher(isordered_func, a, b);
 }
 
-auto constexpr isunordered_func = [](const auto &x, const auto &y) {
+auto constexpr isunordered_func = [](const auto& x, const auto& y) {
   return !((x == x) && (y == y));
 };
 template <typename T>
@@ -171,31 +86,31 @@ auto isunordered(T a, T b) {
 }
 
 /* one argument relational reference */
-auto constexpr isfinite_func = [](const auto &x) { return std::isfinite(x); };
+auto constexpr isfinite_func = [](const auto& x) { return std::isfinite(x); };
 template <typename T>
 auto isfinite(T a) {
   return sycl_cts::math::rel_func_dispatcher(isfinite_func, a);
 }
 
-auto constexpr isinf_func = [](const auto &x) { return std::isinf(x); };
+auto constexpr isinf_func = [](const auto& x) { return std::isinf(x); };
 template <typename T>
 auto isinf(T a) {
   return sycl_cts::math::rel_func_dispatcher(isinf_func, a);
 }
 
-auto constexpr isnan_func = [](const auto &x) { return std::isnan(x); };
+auto constexpr isnan_func = [](const auto& x) { return std::isnan(x); };
 template <typename T>
 auto isnan(T a) {
   return sycl_cts::math::rel_func_dispatcher(isnan_func, a);
 }
 
-auto constexpr isnormal_func = [](const auto &x) { return std::isnormal(x); };
+auto constexpr isnormal_func = [](const auto& x) { return std::isnormal(x); };
 template <typename T>
 auto isnormal(T a) {
   return sycl_cts::math::rel_func_dispatcher(isnormal_func, a);
 }
 
-auto constexpr signbit_func = [](const auto &x) { return std::signbit(x); };
+auto constexpr signbit_func = [](const auto& x) { return std::signbit(x); };
 template <typename T>
 auto signbit(T a) {
   return sycl_cts::math::rel_func_dispatcher(signbit_func, a);
@@ -205,85 +120,22 @@ template <typename T>
 bool any(T x) {
   return sycl_cts::math::if_msb_set(x);
 }
-template <typename T, int N>
-int any(sycl::vec<T, N> a) {
-  for (int i = 0; i < N; i++) {
-    if (any(a[i]) == 1) return true;
-  }
-  return false;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-bool any(sycl::marray<T, N> a) {
-  for (size_t i = 0; i < N; i++) {
-    if (any(a[i]) == 1) return true;
-  }
-  return false;
-}
-#endif
 
 template <typename T>
 bool all(T x) {
   return sycl_cts::math::if_msb_set(x);
 }
-template <typename T, int N>
-int all(sycl::vec<T, N> a) {
-  for (int i = 0; i < N; i++) {
-    if (all(a[i]) == 0) return false;
-  }
-  return true;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-bool all(sycl::marray<T, N> a) {
-  for (size_t i = 0; i < N; i++) {
-    if (all(a[i]) == 0) return false;
-  }
-  return true;
-}
-#endif
 
 template <typename T>
 T bitselect(T a, T b, T c) {
   return (c & b) | (~c & a);
 }
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half bitselect(sycl::half a, sycl::half b, sycl::half c);
-#endif
 float bitselect(float a, float b, float c);
-double bitselect(double a, double b, double c);
-MAKE_VEC_AND_MARRAY_VERSIONS_3ARGS(bitselect)
 
 template <typename T>
 T select(T a, T b, bool c) {
   return c ? b : a;
 }
-template <typename T, typename K, int N>
-sycl::vec<T, N> select(sycl::vec<T, N> a, sycl::vec<T, N> b,
-                       sycl::vec<K, N> c) {
-  sycl::vec<T, N> res;
-  for (int i = 0; i < N; i++) {
-    if (any(c[i]) == 1)
-      res[i] = b[i];
-    else
-      res[i] = a[i];
-  }
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl::marray<T, N> select(sycl::marray<T, N> a, sycl::marray<T, N> b,
-                          sycl::marray<bool, N> c) {
-  sycl::marray<T, N> res;
-  for (size_t i = 0; i < N; i++) {
-    res[i] = c[i] ? b[i] : a[i];
-  }
-  return res;
-}
-#endif
 
 /* absolute value */
 template <typename T>
@@ -292,18 +144,6 @@ sycl_cts::resultRef<T> abs(T x) {
   T result = x < 0 ? T(-U(x)) : x;
   return result < 0 ? sycl_cts::resultRef<T>(0, true) : result;
 }
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> abs(sycl::vec<T, N> a) {
-  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
-      [](T x) { return abs(x); }, a);
-}
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> abs(sycl::marray<T, N> a) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x) { return abs(x); }, a);
-}
-#endif
 
 /* absolute difference */
 template <typename T>
@@ -319,21 +159,6 @@ sycl_cts::resultRef<T> abs_diff(T a, T b) {
              ? sycl_cts::resultRef<T>(0, true)
              : T(result);
 }
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> abs_diff(sycl::vec<T, N> a,
-                                              sycl::vec<T, N> b) {
-  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
-      [](T x, T y) { return abs_diff(x, y); }, a, b);
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> abs_diff(sycl::marray<T, N> a,
-                                                 sycl::marray<T, N> b) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y) { return abs_diff(x, y); }, a, b);
-}
-#endif
 
 /* add with saturation */
 template <typename T>
@@ -353,7 +178,6 @@ T add_sat(T a, T b) {
     return r;
   }
 }
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(add_sat)
 
 /* half add */
 template <typename T>
@@ -361,14 +185,12 @@ T hadd(T a, T b) {
   if (std::is_unsigned<T>::value) return (a >> 1) + (b >> 1) + ((a & b) & 0x1);
   return (a >> 1) + (b >> 1) + (a & b & 1);
 }
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(hadd)
 
 /* round up half add */
 template <typename T>
 T rhadd(T a, T b) {
   return (a >> 1) + (b >> 1) + ((a & 1) | (b & 1));
 }
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(rhadd)
 
 /* clamp */
 template <typename T>
@@ -376,48 +198,6 @@ sycl_cts::resultRef<T> clamp(T v, T minv, T maxv) {
   if (minv > maxv) return sycl_cts::resultRef<T>(T(), true);
   return (v < minv) ? minv : ((v > maxv) ? maxv : v);
 }
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> clamp(sycl::vec<T, N> a, sycl::vec<T, N> b,
-                                           sycl::vec<T, N> c) {
-  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
-      [](T x, T y, T z) { return clamp(x, y, z); }, a, b, c);
-}
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> clamp(sycl::vec<T, N> a, T b, T c) {
-  sycl::vec<T, N> res;
-  std::map<int, bool> undefined;
-  for (int i = 0; i < N; i++) {
-    sycl_cts::resultRef<T> element = clamp(a[i], b, c);
-    if (element.undefined.empty())
-      res[i] = element.res;
-    else
-      undefined[i] = true;
-  }
-  return sycl_cts::resultRef<sycl::vec<T, N>>(res, undefined);
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> clamp(sycl::marray<T, N> a,
-                                              sycl::marray<T, N> b,
-                                              sycl::marray<T, N> c) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y, T z) { return clamp(x, y, z); }, a, b, c);
-}
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> clamp(sycl::marray<T, N> a, T b, T c) {
-  sycl::marray<T, N> res;
-  std::map<int, bool> undefined;
-  for (size_t i = 0; i < N; i++) {
-    sycl_cts::resultRef<T> element = clamp(a[i], b, c);
-    if (element.undefined.empty())
-      res[i] = element.res;
-    else
-      undefined[i] = true;
-  }
-  return sycl_cts::resultRef<sycl::marray<T, N>>(res, undefined);
-}
-#endif
 
 /* count leading zeros */
 template <typename T>
@@ -430,7 +210,6 @@ T clz(T x) {
       lz++;
   return static_cast<T>(lz);
 }
-MAKE_VEC_AND_MARRAY_VERSIONS(clz)
 
 /* count trailing zeros */
 template <typename T>
@@ -445,7 +224,6 @@ T ctz(T x) {
       tz++;
   return static_cast<T>(tz);
 }
-MAKE_VEC_AND_MARRAY_VERSIONS(ctz)
 
 // mad_hi is after mul_hi
 
@@ -463,8 +241,6 @@ int mad_sat(int, int, int);
 long mad_sat(long, long, long);
 long long mad_sat(long long, long long, long long);
 
-MAKE_VEC_AND_MARRAY_VERSIONS_3ARGS(mad_sat)
-
 /* maximum value */
 template <typename T>
 sycl_cts::resultRef<T> max(T a, T b) {
@@ -474,30 +250,6 @@ sycl_cts::resultRef<T> max(T a, T b) {
     return (a < b) ? b : a;
   return sycl_cts::resultRef<T>(T(), true);
 }
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> max(sycl::vec<T, N> a, sycl::vec<T, N> b) {
-  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
-      [](T x, T y) { return max(x, y); }, a, b);
-}
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> max(sycl::vec<T, N> a, T b) {
-  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
-      [](T x, T y) { return max(x, y); }, a, b);
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> max(sycl::marray<T, N> a,
-                                            sycl::marray<T, N> b) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y) { return max(x, y); }, a, b);
-}
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> max(sycl::marray<T, N> a, T b) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y) { return max(x, y); }, a, b);
-}
-#endif
 
 /* minimum value */
 template <typename T>
@@ -508,30 +260,6 @@ sycl_cts::resultRef<T> min(T a, T b) {
     return (b < a) ? b : a;
   return sycl_cts::resultRef<T>(T(), true);
 }
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> min(sycl::vec<T, N> a, sycl::vec<T, N> b) {
-  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
-      [](T x, T y) { return min(x, y); }, a, b);
-}
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> min(sycl::vec<T, N> a, T b) {
-  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
-      [](T x, T y) { return min(x, y); }, a, b);
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> min(sycl::marray<T, N> a,
-                                            sycl::marray<T, N> b) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y) { return min(x, y); }, a, b);
-}
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> min(sycl::marray<T, N> a, T b) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y) { return min(x, y); }, a, b);
-}
-#endif
 
 /* multiply and return high part */
 unsigned char mul_hi(unsigned char, unsigned char);
@@ -545,14 +273,12 @@ short mul_hi(short, short);
 int mul_hi(int, int);
 long mul_hi(long, long);
 long long mul_hi(long long, long long);
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(mul_hi)
 
 /* multiply add, get high part */
 template <typename T>
 T mad_hi(T x, T y, T z) {
   return mul_hi(x, y) + z;
 }
-MAKE_VEC_AND_MARRAY_VERSIONS_3ARGS(mad_hi)
 
 /* bitwise rotate */
 template <typename T>
@@ -570,7 +296,6 @@ T rotate(T v, T i) {
   size_t nBits = sycl_cts::math::num_bits(v) - size_t(i_mod);
   return T((v << i_mod) | ((v >> nBits) & mask));
 }
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(rotate)
 
 /* substract with saturation */
 template <typename T>
@@ -596,7 +321,6 @@ T sub_sat(T x, T y) {
     }
   }
 }
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(sub_sat)
 
 /* upsample */
 uint16_t upsample(uint8_t h, uint8_t l);
@@ -639,23 +363,6 @@ struct upsample_t<int32_t> {
   using type = int64_t;
 };
 
-template <typename T, int N>
-sycl::vec<typename upsample_t<T>::type, N> upsample(
-    sycl::vec<T, N> a, sycl::vec<typename std::make_unsigned<T>::type, N> b) {
-  return sycl_cts::math::run_func_on_vector<typename upsample_t<T>::type, T, N>(
-      [](T x, T y) { return upsample(x, y); }, a, b);
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl::marray<typename upsample_t<T>::type, N> upsample(
-    sycl::marray<T, N> a,
-    sycl::marray<typename std::make_unsigned<T>::type, N> b) {
-  return sycl_cts::math::run_func_on_marray<typename upsample_t<T>::type, T, N>(
-      [](T x, T y) { return upsample(x, y); }, a, b);
-}
-#endif
-
 /* return number of non zero bits in x */
 template <typename T>
 T popcount(T x) {
@@ -664,11 +371,580 @@ T popcount(T x) {
     if (x & (1ull << i)) lz++;
   return lz;
 }
-MAKE_VEC_AND_MARRAY_VERSIONS(popcount)
 
 /* fast multiply add 24bits */
 sycl_cts::resultRef<int32_t> mad24(int32_t x, int32_t y, int32_t z);
 sycl_cts::resultRef<uint32_t> mad24(uint32_t x, uint32_t y, uint32_t z);
+
+/* fast multiply 24bits */
+sycl_cts::resultRef<int32_t> mul24(int32_t x, int32_t y);
+sycl_cts::resultRef<uint32_t> mul24(uint32_t x, uint32_t y);
+
+// Common functions
+
+float degrees(float a);
+sycl_cts::resultRef<float> mix(const float a, const float b, const float c);
+float radians(float a);
+float step(float a, float b);
+sycl_cts::resultRef<float> smoothstep(float a, float b, float c);
+float sign(float a);
+
+// Math Functions
+
+template <typename T>
+struct higher_accuracy;
+
+template <>
+struct higher_accuracy<float> {
+  using type = double;
+};
+
+template <typename T>
+T acos(T a) {
+  return std::acos(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T acosh(T a) {
+  return std::acosh(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+float acospi(float a);
+
+template <typename T>
+T asin(T a) {
+  return std::asin(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T asinh(T a) {
+  return std::asinh(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+float asinpi(float a);
+
+template <typename T>
+T atan(T a) {
+  return std::atan(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T atan2(T a, T b) {
+  return std::atan2(static_cast<typename higher_accuracy<T>::type>(a), b);
+}
+
+template <typename T>
+T atanh(T a) {
+  return std::atanh(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+float atanpi(float a);
+
+float atan2pi(float a, float b);
+
+template <typename T>
+T cbrt(T a) {
+  return std::cbrt(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+using std::ceil;
+using std::copysign;
+
+template <typename T>
+T cos(T a) {
+  return std::cos(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T cosh(T a) {
+  return std::cosh(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+float cospi(float a);
+
+template <typename T>
+T erfc(T a) {
+  return std::erfc(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T erf(T a) {
+  return std::erf(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T exp(T a) {
+  return std::exp(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T exp2(T a) {
+  return std::exp2(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T exp10(T a) {
+  return std::pow(static_cast<typename higher_accuracy<T>::type>(10),
+                  static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T expm1(T a) {
+  return std::expm1(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+using std::fabs;
+using std::fdim;
+using std::floor;
+float fma(float a, float b, float c);
+using std::fmax;
+using std::fmin;
+using std::fmod;
+float fract(float a, float* b);
+using std::frexp;
+
+template <typename T>
+T hypot(T a, T b) {
+  return std::hypot(static_cast<typename higher_accuracy<T>::type>(a), b);
+}
+
+using std::ilogb;
+using std::ldexp;
+using std::lgamma;
+
+template <typename T>
+T lgamma_r(T a, int* b) {
+  *b = (std::tgamma(a) > 0) ? 1 : -1;
+  return std::lgamma(a);
+}
+
+template <typename T>
+T log(T a) {
+  return std::log(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T log2(T a) {
+  return std::log2(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T log10(T a) {
+  return std::log10(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T log1p(T a) {
+  return std::log1p(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+using std::logb;
+
+template <typename T>
+T mad(T a, T b, T c) {
+  return a * b + c;
+}
+
+template <typename T>
+T maxmag(T a, T b) {
+  if (fabs(a) > fabs(b))
+    return a;
+  else if (fabs(b) > fabs(a))
+    return b;
+  return fmax(a, b);
+}
+
+template <typename T>
+T minmag(T a, T b) {
+  if (fabs(a) < fabs(b))
+    return a;
+  else if (fabs(b) < fabs(a))
+    return b;
+  return fmin(a, b);
+}
+
+using std::modf;
+float nan(unsigned int a);
+using std::nextafter;
+
+template <typename T>
+T pow(T a, T b) {
+  return std::pow(static_cast<typename higher_accuracy<T>::type>(a),
+                  static_cast<typename higher_accuracy<T>::type>(b));
+}
+
+template <typename T>
+T pown(T a, int b) {
+  return std::pow(static_cast<typename higher_accuracy<T>::type>(a),
+                  static_cast<typename higher_accuracy<T>::type>(b));
+}
+
+template <typename T>
+sycl_cts::resultRef<T> powr(T a, T b) {
+  if (a < 0) return sycl_cts::resultRef<T>(T(), true);
+  return std::pow(static_cast<typename higher_accuracy<T>::type>(a),
+                  static_cast<typename higher_accuracy<T>::type>(b));
+}
+
+using std::remainder;
+
+template <typename T>
+T remquo(T x, T y, int* quo) {
+  return reference_remquol(x, y, quo);
+}
+
+using std::rint;
+
+template <typename T>
+T rootn(T a, int b) {
+  return std::pow(static_cast<typename higher_accuracy<T>::type>(a),
+                  static_cast<typename higher_accuracy<T>::type>(1.0 / b));
+}
+
+using std::round;
+
+template <typename T>
+T rsqrt(T a) {
+  return 1 / std::sqrt(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T sincos(T a, T* b) {
+  *b = std::cos(static_cast<typename higher_accuracy<T>::type>(a));
+  return std::sin(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T sin(T a) {
+  return std::sin(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T sinh(T a) {
+  return std::sinh(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+float sinpi(float a);
+
+template <typename T>
+T sqrt(T a) {
+  return std::sqrt(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T tan(T a) {
+  return std::tan(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+template <typename T>
+T tanh(T a) {
+  return std::tanh(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+float tanpi(float a);
+
+template <typename T>
+T tgamma(T a) {
+  return std::tgamma(static_cast<typename higher_accuracy<T>::type>(a));
+}
+
+using std::trunc;
+
+template <typename T>
+T recip(T a) {
+  return 1.0 / a;
+}
+
+template <typename T>
+T divide(T a, T b) {
+  return a / b;
+}
+
+// Geometric functions
+
+sycl::float4 cross(sycl::float4 p0, sycl::float4 p1);
+sycl::float3 cross(sycl::float3 p0, sycl::float3 p1);
+
+// FIXME: AdaptiveCpp does not support marray
+#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+sycl::mfloat4 cross(sycl::mfloat4 p0, sycl::mfloat4 p1);
+sycl::mfloat3 cross(sycl::mfloat3 p0, sycl::mfloat3 p1);
+#endif
+
+template <typename T>
+T dot(T p0, T p1) {
+  return p0 * p1;
+}
+
+template <typename T>
+T normalize(T p) {
+  if (p < 0) return -1;
+  return 1;
+}
+
+#if SYCL_CTS_ENABLE_HALF_TESTS
+
+template <>
+struct higher_accuracy<sycl::half> {
+  using type = float;
+};
+
+sycl::half bitselect(sycl::half a, sycl::half b, sycl::half c);
+sycl::half degrees(sycl::half);
+sycl_cts::resultRef<sycl::half> mix(const sycl::half a, const sycl::half b,
+                                    const sycl::half c);
+sycl::half radians(sycl::half);
+sycl::half step(sycl::half a, sycl::half b);
+sycl_cts::resultRef<sycl::half> smoothstep(sycl::half a, sycl::half b,
+                                           sycl::half c);
+sycl::half sign(sycl::half a);
+sycl::half acospi(sycl::half a);
+sycl::half asinpi(sycl::half a);
+sycl::half atanpi(sycl::half a);
+sycl::half atan2pi(sycl::half a, sycl::half b);
+sycl::half cospi(sycl::half a);
+sycl::half fdim(sycl::half a, sycl::half b);
+sycl::half fma(sycl::half a, sycl::half b, sycl::half c);
+sycl::half fract(sycl::half a, sycl::half* b);
+sycl::half modf(sycl::half a, sycl::half* b);
+sycl::half nan(unsigned short a);
+
+template <int N>
+sycl::vec<sycl::half, N> nan(sycl::vec<unsigned short, N> a) {
+  return sycl_cts::math::run_func_on_vector<sycl::half, unsigned short, N>(
+      [](unsigned short x) { return nan(x); }, a);
+}
+
+// FIXME: AdaptiveCpp does not support marray
+#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+template <size_t N>
+sycl::marray<sycl::half, N> nan(sycl::marray<unsigned short, N> a) {
+  return sycl_cts::math::run_func_on_marray<sycl::half, unsigned short, N>(
+      [](unsigned short x) { return nan(x); }, a);
+}
+#endif
+
+sycl::half nextafter(sycl::half a, sycl::half b);
+sycl::half sinpi(sycl::half a);
+sycl::half tanpi(sycl::half a);
+
+sycl::half fast_dot(float p0);
+sycl::half fast_dot(sycl::float2 p0);
+sycl::half fast_dot(sycl::float3 p0);
+sycl::half fast_dot(sycl::float4 p0);
+
+// FIXME: AdaptiveCpp does not support marray
+#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+sycl::half fast_dot(sycl::mfloat2 p0);
+sycl::half fast_dot(sycl::mfloat3 p0);
+sycl::half fast_dot(sycl::mfloat4 p0);
+#endif
+
+#endif  // SYCL_CTS_ENABLE_HALF_TESTS
+
+#if SYCL_CTS_ENABLE_DOUBLE_TESTS
+
+template <>
+struct higher_accuracy<double> {
+  using type = long double;
+};
+
+double bitselect(double a, double b, double c);
+double degrees(double a);
+sycl_cts::resultRef<double> mix(const double a, const double b, const double c);
+double radians(double a);
+double step(double a, double b);
+sycl_cts::resultRef<double> smoothstep(double a, double b, double c);
+double sign(double a);
+
+double acospi(double a);
+double asinpi(double a);
+double atanpi(double a);
+double atan2pi(double a, double b);
+double cospi(double a);
+double fma(double a, double b, double c);
+double fract(double a, double* b);
+double nan(unsigned long a);
+double nan(unsigned long long a);
+
+template <typename T, int N>
+std::enable_if_t<std::is_same_v<unsigned long, T> ||
+                     std::is_same_v<unsigned long long, T>,
+                 sycl::vec<double, N>>
+nan(sycl::vec<T, N> a) {
+  return sycl_cts::math::run_func_on_vector<double, T, N>(
+      [](T x) { return nan(x); }, a);
+}
+
+// FIXME: AdaptiveCpp does not support marray
+#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+template <typename T, size_t N>
+std::enable_if_t<std::is_same_v<unsigned long, T> ||
+                     std::is_same_v<unsigned long long, T>,
+                 sycl::marray<double, N>>
+nan(sycl::marray<T, N> a) {
+  return sycl_cts::math::run_func_on_marray<double, T, N>(
+      [](T x) { return nan(x); }, a);
+}
+#endif
+
+double sinpi(double a);
+double tanpi(double a);
+
+sycl::double4 cross(sycl::double4 p0, sycl::double4 p1);
+sycl::double3 cross(sycl::double3 p0, sycl::double3 p1);
+
+// FIXME: AdaptiveCpp does not support marray
+#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+sycl::mdouble4 cross(sycl::mdouble4 p0, sycl::mdouble4 p1);
+sycl::mdouble3 cross(sycl::mdouble3 p0, sycl::mdouble3 p1);
+#endif
+
+#endif  // SYCL_CTS_ENABLE_DOUBLE_TESTS
+
+// sycl::vec overloads of the above. Some vector functions reference their
+// scalar counterparts, so all scalar overloads (float, half, double) must have
+// been declared previously - otherwise they will not participate in overload
+// resolution, even if the point of template instantiation is outside this file.
+#define MAKE_VEC_VERSION(func)                          \
+  template <typename T, int N>                          \
+  sycl::vec<T, N> func(sycl::vec<T, N> a) {             \
+    return sycl_cts::math::run_func_on_vector<T, T, N>( \
+        [](T x) { return func(x); }, a);                \
+  }
+
+#define MAKE_VEC_VERSION_2ARGS(func)                           \
+  template <typename T, int N>                                 \
+  sycl::vec<T, N> func(sycl::vec<T, N> a, sycl::vec<T, N> b) { \
+    return sycl_cts::math::run_func_on_vector<T, T, N>(        \
+        [](T x, T y) { return func(x, y); }, a, b);            \
+  }
+
+#define MAKE_VEC_VERSION_3ARGS(func)                           \
+  template <typename T, int N>                                 \
+  sycl::vec<T, N> func(sycl::vec<T, N> a, sycl::vec<T, N> b,   \
+                       sycl::vec<T, N> c) {                    \
+    return sycl_cts::math::run_func_on_vector<T, T, N>(        \
+        [](T x, T y, T z) { return func(x, y, z); }, a, b, c); \
+  }
+
+#define MAKE_VEC_VERSION_WITH_SCALAR(func)              \
+  template <typename T, int N>                          \
+  sycl::vec<T, N> func(sycl::vec<T, N> a, T b) {        \
+    return sycl_cts::math::run_func_on_vector<T, T, N>( \
+        [](T x, T y) { return func(x, y); }, a, b);     \
+  }
+
+// Common functions
+
+template <typename T, int N>
+int any(sycl::vec<T, N> a) {
+  for (int i = 0; i < N; i++) {
+    if (any(a[i]) == 1) return true;
+  }
+  return false;
+}
+
+template <typename T, int N>
+int all(sycl::vec<T, N> a) {
+  for (int i = 0; i < N; i++) {
+    if (all(a[i]) == 0) return false;
+  }
+  return true;
+}
+
+MAKE_VEC_VERSION_3ARGS(bitselect)
+
+template <typename T, typename K, int N>
+sycl::vec<T, N> select(sycl::vec<T, N> a, sycl::vec<T, N> b,
+                       sycl::vec<K, N> c) {
+  sycl::vec<T, N> res;
+  for (int i = 0; i < N; i++) {
+    if (any(c[i]) == 1)
+      res[i] = b[i];
+    else
+      res[i] = a[i];
+  }
+  return res;
+}
+
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> abs(sycl::vec<T, N> a) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x) { return abs(x); }, a);
+}
+
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> abs_diff(sycl::vec<T, N> a,
+                                              sycl::vec<T, N> b) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x, T y) { return abs_diff(x, y); }, a, b);
+}
+
+MAKE_VEC_VERSION_2ARGS(add_sat)
+MAKE_VEC_VERSION_2ARGS(hadd)
+MAKE_VEC_VERSION_2ARGS(rhadd)
+
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> clamp(sycl::vec<T, N> a, sycl::vec<T, N> b,
+                                           sycl::vec<T, N> c) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x, T y, T z) { return clamp(x, y, z); }, a, b, c);
+}
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> clamp(sycl::vec<T, N> a, T b, T c) {
+  sycl::vec<T, N> res;
+  std::map<int, bool> undefined;
+  for (int i = 0; i < N; i++) {
+    sycl_cts::resultRef<T> element = clamp(a[i], b, c);
+    if (element.undefined.empty())
+      res[i] = element.res;
+    else
+      undefined[i] = true;
+  }
+  return sycl_cts::resultRef<sycl::vec<T, N>>(res, undefined);
+}
+
+MAKE_VEC_VERSION(clz)
+MAKE_VEC_VERSION(ctz)
+
+MAKE_VEC_VERSION_3ARGS(mad_sat)
+
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> max(sycl::vec<T, N> a, sycl::vec<T, N> b) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x, T y) { return max(x, y); }, a, b);
+}
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> max(sycl::vec<T, N> a, T b) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x, T y) { return max(x, y); }, a, b);
+}
+
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> min(sycl::vec<T, N> a, sycl::vec<T, N> b) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x, T y) { return min(x, y); }, a, b);
+}
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> min(sycl::vec<T, N> a, T b) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x, T y) { return min(x, y); }, a, b);
+}
+
+MAKE_VEC_VERSION_2ARGS(mul_hi)
+MAKE_VEC_VERSION_3ARGS(mad_hi)
+MAKE_VEC_VERSION_2ARGS(rotate)
+MAKE_VEC_VERSION_2ARGS(sub_sat)
+
+template <typename T, int N>
+sycl::vec<typename upsample_t<T>::type, N> upsample(
+    sycl::vec<T, N> a, sycl::vec<typename std::make_unsigned<T>::type, N> b) {
+  return sycl_cts::math::run_func_on_vector<typename upsample_t<T>::type, T, N>(
+      [](T x, T y) { return upsample(x, y); }, a, b);
+}
+
+MAKE_VEC_VERSION(popcount)
 
 template <typename T, int N>
 sycl_cts::resultRef<sycl::vec<T, N>> mad24(sycl::vec<T, N> a, sycl::vec<T, N> b,
@@ -676,20 +952,6 @@ sycl_cts::resultRef<sycl::vec<T, N>> mad24(sycl::vec<T, N> a, sycl::vec<T, N> b,
   return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
       [](T x, T y, T z) { return mad24(x, y, z); }, a, b, c);
 }
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> mad24(sycl::marray<T, N> a,
-                                              sycl::marray<T, N> b,
-                                              sycl::marray<T, N> c) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y, T z) { return mad24(x, y, z); }, a, b, c);
-}
-#endif
-
-/* fast multiply 24bits */
-sycl_cts::resultRef<int32_t> mul24(int32_t x, int32_t y);
-sycl_cts::resultRef<uint32_t> mul24(uint32_t x, uint32_t y);
 
 template <typename T, int N>
 sycl_cts::resultRef<sycl::vec<T, N>> mul24(sycl::vec<T, N> a,
@@ -697,37 +959,8 @@ sycl_cts::resultRef<sycl::vec<T, N>> mul24(sycl::vec<T, N> a,
   return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
       [](T x, T y) { return mul24(x, y); }, a, b);
 }
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> mul24(sycl::marray<T, N> a,
-                                              sycl::marray<T, N> b) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y) { return mul24(x, y); }, a, b);
-}
-#endif
 
-// Common functions
-
-// clamp is in Integer functions
-
-/* degrees */
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half degrees(sycl::half);
-#endif
-float degrees(float a);
-double degrees(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(degrees)
-
-// max and min are in Integer functions
-
-/* mix */
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl_cts::resultRef<sycl::half> mix(const sycl::half a, const sycl::half b,
-                                    const sycl::half c);
-#endif
-sycl_cts::resultRef<float> mix(const float a, const float b, const float c);
-sycl_cts::resultRef<double> mix(const double a, const double b, const double c);
+MAKE_VEC_VERSION(degrees)
 
 template <typename T, int N>
 sycl_cts::resultRef<sycl::vec<T, N>> mix(sycl::vec<T, N> a, sycl::vec<T, N> b,
@@ -749,46 +982,8 @@ sycl_cts::resultRef<sycl::vec<T, N>> mix(sycl::vec<T, N> a, sycl::vec<T, N> b,
   }
   return sycl_cts::resultRef<sycl::vec<T, N>>(res, undefined);
 }
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> mix(sycl::marray<T, N> a,
-                                            sycl::marray<T, N> b,
-                                            sycl::marray<T, N> c) {
-  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y, T z) { return mix(x, y, z); }, a, b, c);
-}
-template <typename T, size_t N>
-sycl_cts::resultRef<sycl::marray<T, N>> mix(sycl::marray<T, N> a,
-                                            sycl::marray<T, N> b, T c) {
-  sycl::marray<T, N> res;
-  std::map<int, bool> undefined;
-  for (size_t i = 0; i < N; i++) {
-    sycl_cts::resultRef<T> element = mix(a[i], b[i], c);
-    if (element.undefined.empty())
-      res[i] = element.res;
-    else
-      undefined[i] = true;
-  }
-  return sycl_cts::resultRef<sycl::marray<T, N>>(res, undefined);
-}
-#endif
 
-/* radians */
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half radians(sycl::half);
-#endif
-float radians(float a);
-double radians(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(radians)
-
-/* step */
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half step(sycl::half a, sycl::half b);
-#endif
-float step(float a, float b);
-double step(double a, double b);
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(step)
+MAKE_VEC_VERSION(radians)
 
 template <typename T, int N>
 sycl::vec<T, N> step(T a, sycl::vec<T, N> b) {
@@ -798,25 +993,6 @@ sycl::vec<T, N> step(T a, sycl::vec<T, N> b) {
   }
   return res;
 }
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <typename T, size_t N>
-sycl::marray<T, N> step(T a, sycl::marray<T, N> b) {
-  sycl::marray<T, N> res;
-  for (size_t i = 0; i < N; i++) {
-    res[i] = step(a, b[i]);
-  }
-  return res;
-}
-#endif
-
-/* smoothstep */
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl_cts::resultRef<sycl::half> smoothstep(sycl::half a, sycl::half b,
-                                           sycl::half c);
-#endif
-sycl_cts::resultRef<float> smoothstep(float a, float b, float c);
-sycl_cts::resultRef<double> smoothstep(double a, double b, double c);
 
 template <typename T, int N>
 sycl_cts::resultRef<sycl::vec<T, N>> smoothstep(sycl::vec<T, N> a,
@@ -838,8 +1014,425 @@ sycl_cts::resultRef<sycl::vec<T, N>> smoothstep(T a, T b, sycl::vec<T, N> c) {
   }
   return sycl_cts::resultRef<sycl::vec<T, N>>(res, undefined);
 }
-// FIXME: AdaptiveCpp does not support marray
+
+// Math functions
+
+template <typename T, int N>
+struct higher_accuracy<sycl::vec<T, N>> {
+  using type = sycl::vec<typename higher_accuracy<T>::type, N>;
+};
+
+MAKE_VEC_VERSION(acos)
+MAKE_VEC_VERSION(acosh)
+MAKE_VEC_VERSION(acospi)
+MAKE_VEC_VERSION(asin)
+MAKE_VEC_VERSION(asinh)
+MAKE_VEC_VERSION(asinpi)
+MAKE_VEC_VERSION(atan)
+MAKE_VEC_VERSION_2ARGS(atan2)
+MAKE_VEC_VERSION(atanh)
+MAKE_VEC_VERSION(atanpi)
+MAKE_VEC_VERSION_2ARGS(atan2pi)
+MAKE_VEC_VERSION(cbrt)
+MAKE_VEC_VERSION(ceil)
+MAKE_VEC_VERSION_2ARGS(copysign)
+MAKE_VEC_VERSION(cos)
+MAKE_VEC_VERSION(cosh)
+MAKE_VEC_VERSION(cospi)
+MAKE_VEC_VERSION(erfc)
+MAKE_VEC_VERSION(erf)
+MAKE_VEC_VERSION(exp)
+MAKE_VEC_VERSION(exp2)
+MAKE_VEC_VERSION(exp10)
+MAKE_VEC_VERSION(expm1)
+MAKE_VEC_VERSION(fabs)
+MAKE_VEC_VERSION_2ARGS(fdim)
+MAKE_VEC_VERSION(floor)
+MAKE_VEC_VERSION_3ARGS(fma)
+MAKE_VEC_VERSION_2ARGS(fmax)
+MAKE_VEC_VERSION_WITH_SCALAR(fmax)
+MAKE_VEC_VERSION_2ARGS(fmin)
+MAKE_VEC_VERSION_WITH_SCALAR(fmin)
+MAKE_VEC_VERSION_2ARGS(fmod)
+
+template <typename T, int N>
+sycl::vec<T, N> fract(sycl::vec<T, N> a, sycl::vec<T, N>* b) {
+  sycl::vec<T, N> res;
+  sycl::vec<T, N> resPtr;
+  for (int i = 0; i < N; i++) {
+    T value;
+    res[i] = reference::fract(a[i], &value);
+    resPtr[i] = value;
+  }
+  *b = resPtr;
+  return res;
+}
+
+template <typename T, int N>
+sycl::vec<T, N> frexp(sycl::vec<T, N> a, sycl::vec<int, N>* b) {
+  sycl::vec<T, N> res;
+  sycl::vec<int, N> resPtr;
+  for (int i = 0; i < N; i++) {
+    int value;
+    res[i] = reference::frexp(a[i], &value);
+    resPtr[i] = value;
+  }
+  *b = resPtr;
+  return res;
+}
+
+MAKE_VEC_VERSION_2ARGS(hypot)
+
+template <typename T, int N>
+sycl::vec<int, N> ilogb(sycl::vec<T, N> a) {
+  sycl::vec<int, N> res;
+  for (int i = 0; i < N; i++) {
+    res[i] = reference::ilogb(a[i]);
+  }
+  return res;
+}
+
+template <typename T, int N>
+sycl::vec<T, N> ldexp(sycl::vec<T, N> a, sycl::vec<int, N> b) {
+  sycl::vec<T, N> res;
+  for (int i = 0; i < N; i++) {
+    res[i] = reference::ldexp(a[i], b[i]);
+  }
+  return res;
+}
+template <typename T, int N>
+sycl::vec<T, N> ldexp(sycl::vec<T, N> a, int b) {
+  sycl::vec<T, N> res;
+  for (int i = 0; i < N; i++) {
+    res[i] = reference::ldexp(a[i], b);
+  }
+  return res;
+}
+
+MAKE_VEC_VERSION(lgamma)
+
+template <typename T, int N>
+sycl::vec<T, N> lgamma_r(sycl::vec<T, N> a, sycl::vec<int, N>* b) {
+  sycl::vec<T, N> res;
+  sycl::vec<int, N> resPtr;
+  for (int i = 0; i < N; i++) {
+    int value;
+    res[i] = reference::lgamma_r(a[i], &value);
+    resPtr[i] = value;
+  }
+  *b = resPtr;
+  return res;
+}
+
+MAKE_VEC_VERSION(log)
+MAKE_VEC_VERSION(log2)
+MAKE_VEC_VERSION(log10)
+MAKE_VEC_VERSION(log1p)
+MAKE_VEC_VERSION(logb)
+
+MAKE_VEC_VERSION_3ARGS(mad)
+MAKE_VEC_VERSION_2ARGS(maxmag)
+MAKE_VEC_VERSION_2ARGS(minmag)
+
+template <typename T, int N>
+sycl::vec<T, N> modf(sycl::vec<T, N> a, sycl::vec<T, N>* b) {
+  sycl::vec<T, N> res;
+  sycl::vec<T, N> resPtr;
+  for (int i = 0; i < N; i++) {
+    T value;
+    res[i] = reference::modf(a[i], &value);
+    resPtr[i] = value;
+  }
+  *b = resPtr;
+  return res;
+}
+
+template <int N>
+sycl::vec<float, N> nan(sycl::vec<unsigned int, N> a) {
+  return sycl_cts::math::run_func_on_vector<float, unsigned int, N>(
+      [](unsigned int x) { return nan(x); }, a);
+}
+
+MAKE_VEC_VERSION_2ARGS(nextafter)
+MAKE_VEC_VERSION_2ARGS(pow)
+
+template <typename T, int N>
+sycl::vec<T, N> pown(sycl::vec<T, N> a, sycl::vec<int, N> b) {
+  sycl::vec<T, N> res;
+  for (int i = 0; i < N; i++) {
+    res[i] = reference::pown(a[i], b[i]);
+  }
+  return res;
+}
+
+template <typename T, int N>
+sycl_cts::resultRef<sycl::vec<T, N>> powr(sycl::vec<T, N> a,
+                                          sycl::vec<T, N> b) {
+  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
+      [](T x, T y) { return reference::powr(x, y); }, a, b);
+}
+
+MAKE_VEC_VERSION_2ARGS(remainder)
+
+template <typename T, int N>
+sycl::vec<T, N> remquo(sycl::vec<T, N> a, sycl::vec<T, N> b,
+                       sycl::vec<int, N>* c) {
+  sycl::vec<T, N> res;
+  sycl::vec<int, N> resPtr;
+  for (int i = 0; i < N; i++) {
+    int value;
+    res[i] = reference::remquo(a[i], b[i], &value);
+    resPtr[i] = value;
+  }
+  *c = resPtr;
+  return res;
+}
+
+MAKE_VEC_VERSION(rint)
+
+template <typename T, int N>
+sycl::vec<T, N> rootn(sycl::vec<T, N> a, sycl::vec<int, N> b) {
+  sycl::vec<T, N> res;
+  for (int i = 0; i < N; i++) {
+    res[i] = reference::rootn(a[i], b[i]);
+  }
+  return res;
+}
+
+MAKE_VEC_VERSION(round)
+MAKE_VEC_VERSION(rsqrt)
+MAKE_VEC_VERSION(sign)
+
+template <typename T, int N>
+sycl::vec<T, N> sincos(sycl::vec<T, N> a, sycl::vec<T, N>* b) {
+  sycl::vec<T, N> res;
+  sycl::vec<T, N> resPtr;
+  for (int i = 0; i < N; i++) {
+    T value;
+    res[i] = reference::sincos(a[i], &value);
+    resPtr[i] = value;
+  }
+  *b = resPtr;
+  return res;
+}
+
+MAKE_VEC_VERSION(sin)
+MAKE_VEC_VERSION(sinh)
+MAKE_VEC_VERSION(sinpi)
+MAKE_VEC_VERSION(sqrt)
+MAKE_VEC_VERSION_2ARGS(step)
+MAKE_VEC_VERSION(tan)
+MAKE_VEC_VERSION(tanh)
+MAKE_VEC_VERSION(tanpi)
+MAKE_VEC_VERSION(tgamma)
+MAKE_VEC_VERSION(trunc)
+MAKE_VEC_VERSION(recip)
+MAKE_VEC_VERSION_2ARGS(divide)
+
+// Geometric functions
+
+template <typename T, int N>
+T dot(sycl::vec<T, N> a, sycl::vec<T, N> b) {
+  T res = 0;
+  for (int i = 0; i < N; i++) res += a[i] * b[i];
+  return res;
+}
+
+// sycl::marray overloads of the above. Not supported by AdaptiveCpp.
+// Again, like for sycl::vec, these must be defined after all scalar overloads.
 #ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+
+#define MAKE_MARRAY_VERSION(func)                       \
+  template <typename T, size_t N>                       \
+  sycl::marray<T, N> func(sycl::marray<T, N> a) {       \
+    return sycl_cts::math::run_func_on_marray<T, T, N>( \
+        [](T x) { return func(x); }, a);                \
+  }
+
+#define MAKE_MARRAY_VERSION_2ARGS(func)                                 \
+  template <typename T, size_t N>                                       \
+  sycl::marray<T, N> func(sycl::marray<T, N> a, sycl::marray<T, N> b) { \
+    return sycl_cts::math::run_func_on_marray<T, T, N>(                 \
+        [](T x, T y) { return func(x, y); }, a, b);                     \
+  }
+
+#define MAKE_MARRAY_VERSION_3ARGS(func)                               \
+  template <typename T, size_t N>                                     \
+  sycl::marray<T, N> func(sycl::marray<T, N> a, sycl::marray<T, N> b, \
+                          sycl::marray<T, N> c) {                     \
+    return sycl_cts::math::run_func_on_marray<T, T, N>(               \
+        [](T x, T y, T z) { return func(x, y, z); }, a, b, c);        \
+  }
+
+#define MAKE_MARRAY_VERSION_WITH_SCALAR(func)           \
+  template <typename T, size_t N>                       \
+  sycl::marray<T, N> func(sycl::marray<T, N> a, T b) {  \
+    return sycl_cts::math::run_func_on_marray<T, T, N>( \
+        [](T x, T y) { return func(x, y); }, a, b);     \
+  }
+
+// Common functions.
+
+template <typename T, size_t N>
+bool any(sycl::marray<T, N> a) {
+  for (size_t i = 0; i < N; i++) {
+    if (any(a[i]) == 1) return true;
+  }
+  return false;
+}
+
+template <typename T, size_t N>
+bool all(sycl::marray<T, N> a) {
+  for (size_t i = 0; i < N; i++) {
+    if (all(a[i]) == 0) return false;
+  }
+  return true;
+}
+
+MAKE_MARRAY_VERSION_3ARGS(bitselect)
+
+template <typename T, size_t N>
+sycl::marray<T, N> select(sycl::marray<T, N> a, sycl::marray<T, N> b,
+                          sycl::marray<bool, N> c) {
+  sycl::marray<T, N> res;
+  for (size_t i = 0; i < N; i++) {
+    res[i] = c[i] ? b[i] : a[i];
+  }
+  return res;
+}
+
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> abs(sycl::marray<T, N> a) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x) { return abs(x); }, a);
+}
+
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> abs_diff(sycl::marray<T, N> a,
+                                                 sycl::marray<T, N> b) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y) { return abs_diff(x, y); }, a, b);
+}
+
+MAKE_MARRAY_VERSION_2ARGS(add_sat)
+MAKE_MARRAY_VERSION_2ARGS(hadd)
+MAKE_MARRAY_VERSION_2ARGS(rhadd)
+
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> clamp(sycl::marray<T, N> a,
+                                              sycl::marray<T, N> b,
+                                              sycl::marray<T, N> c) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y, T z) { return clamp(x, y, z); }, a, b, c);
+}
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> clamp(sycl::marray<T, N> a, T b, T c) {
+  sycl::marray<T, N> res;
+  std::map<int, bool> undefined;
+  for (size_t i = 0; i < N; i++) {
+    sycl_cts::resultRef<T> element = clamp(a[i], b, c);
+    if (element.undefined.empty())
+      res[i] = element.res;
+    else
+      undefined[i] = true;
+  }
+  return sycl_cts::resultRef<sycl::marray<T, N>>(res, undefined);
+}
+
+MAKE_MARRAY_VERSION(clz)
+MAKE_MARRAY_VERSION(ctz)
+
+MAKE_MARRAY_VERSION_3ARGS(mad_sat)
+
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> max(sycl::marray<T, N> a,
+                                            sycl::marray<T, N> b) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y) { return max(x, y); }, a, b);
+}
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> max(sycl::marray<T, N> a, T b) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y) { return max(x, y); }, a, b);
+}
+
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> min(sycl::marray<T, N> a,
+                                            sycl::marray<T, N> b) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y) { return min(x, y); }, a, b);
+}
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> min(sycl::marray<T, N> a, T b) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y) { return min(x, y); }, a, b);
+}
+
+MAKE_MARRAY_VERSION_2ARGS(mul_hi)
+MAKE_MARRAY_VERSION_3ARGS(mad_hi)
+MAKE_MARRAY_VERSION_2ARGS(rotate)
+MAKE_MARRAY_VERSION_2ARGS(sub_sat)
+
+template <typename T, size_t N>
+sycl::marray<typename upsample_t<T>::type, N> upsample(
+    sycl::marray<T, N> a,
+    sycl::marray<typename std::make_unsigned<T>::type, N> b) {
+  return sycl_cts::math::run_func_on_marray<typename upsample_t<T>::type, T, N>(
+      [](T x, T y) { return upsample(x, y); }, a, b);
+}
+
+MAKE_MARRAY_VERSION(popcount)
+
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> mad24(sycl::marray<T, N> a,
+                                              sycl::marray<T, N> b,
+                                              sycl::marray<T, N> c) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y, T z) { return mad24(x, y, z); }, a, b, c);
+}
+
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> mul24(sycl::marray<T, N> a,
+                                              sycl::marray<T, N> b) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y) { return mul24(x, y); }, a, b);
+}
+
+MAKE_MARRAY_VERSION(degrees)
+
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> mix(sycl::marray<T, N> a,
+                                            sycl::marray<T, N> b,
+                                            sycl::marray<T, N> c) {
+  return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
+      [](T x, T y, T z) { return mix(x, y, z); }, a, b, c);
+}
+template <typename T, size_t N>
+sycl_cts::resultRef<sycl::marray<T, N>> mix(sycl::marray<T, N> a,
+                                            sycl::marray<T, N> b, T c) {
+  sycl::marray<T, N> res;
+  std::map<int, bool> undefined;
+  for (size_t i = 0; i < N; i++) {
+    sycl_cts::resultRef<T> element = mix(a[i], b[i], c);
+    if (element.undefined.empty())
+      res[i] = element.res;
+    else
+      undefined[i] = true;
+  }
+  return sycl_cts::resultRef<sycl::marray<T, N>>(res, undefined);
+}
+
+MAKE_MARRAY_VERSION(radians)
+
+template <typename T, size_t N>
+sycl::marray<T, N> step(T a, sycl::marray<T, N> b) {
+  sycl::marray<T, N> res;
+  for (size_t i = 0; i < N; i++) {
+    res[i] = step(a, b[i]);
+  }
+  return res;
+}
+
 template <typename T, size_t N>
 sycl_cts::resultRef<sycl::marray<T, N>> smoothstep(sycl::marray<T, N> a,
                                                    sycl::marray<T, N> b,
@@ -861,790 +1454,236 @@ sycl_cts::resultRef<sycl::marray<T, N>> smoothstep(T a, T b,
   }
   return sycl_cts::resultRef<sycl::marray<T, N>>(res, undefined);
 }
-#endif
 
-/* sign */
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half sign(sycl::half a);
-#endif
-float sign(float a);
-double sign(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(sign)
+// Math functions
 
-// Math Functions
-
-template <typename T>
-struct higher_accuracy;
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-template <>
-struct higher_accuracy<sycl::half> {
-  using type = float;
-};
-#endif
-template <>
-struct higher_accuracy<float> {
-  using type = double;
-};
-template <>
-struct higher_accuracy<double> {
-  using type = long double;
-};
-
-template <typename T, int N>
-struct higher_accuracy<sycl::vec<T, N>> {
-  using type = sycl::vec<typename higher_accuracy<T>::type, N>;
-};
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
 struct higher_accuracy<sycl::marray<T, N>> {
   using type = sycl::marray<typename higher_accuracy<T>::type, N>;
 };
-#endif
 
-template <typename T>
-T acos(T a) {
-  return std::acos(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(acos)
+MAKE_MARRAY_VERSION(acos)
+MAKE_MARRAY_VERSION(acosh)
+MAKE_MARRAY_VERSION(acospi)
+MAKE_MARRAY_VERSION(asin)
+MAKE_MARRAY_VERSION(asinh)
+MAKE_MARRAY_VERSION(asinpi)
+MAKE_MARRAY_VERSION(atan)
+MAKE_MARRAY_VERSION_2ARGS(atan2)
+MAKE_MARRAY_VERSION(atanh)
+MAKE_MARRAY_VERSION(atanpi)
+MAKE_MARRAY_VERSION_2ARGS(atan2pi)
+MAKE_MARRAY_VERSION(cbrt)
+MAKE_MARRAY_VERSION(ceil)
+MAKE_MARRAY_VERSION_2ARGS(copysign)
+MAKE_MARRAY_VERSION(cos)
+MAKE_MARRAY_VERSION(cosh)
+MAKE_MARRAY_VERSION(cospi)
+MAKE_MARRAY_VERSION(erfc)
+MAKE_MARRAY_VERSION(erf)
+MAKE_MARRAY_VERSION(exp)
+MAKE_MARRAY_VERSION(exp2)
+MAKE_MARRAY_VERSION(exp10)
+MAKE_MARRAY_VERSION(expm1)
+MAKE_MARRAY_VERSION(fabs)
+MAKE_MARRAY_VERSION_2ARGS(fdim)
+MAKE_MARRAY_VERSION(floor)
+MAKE_MARRAY_VERSION_3ARGS(fma)
+MAKE_MARRAY_VERSION_2ARGS(fmax)
+MAKE_MARRAY_VERSION_WITH_SCALAR(fmax)
+MAKE_MARRAY_VERSION_2ARGS(fmin)
+MAKE_MARRAY_VERSION_WITH_SCALAR(fmin)
+MAKE_MARRAY_VERSION_2ARGS(fmod)
 
-template <typename T>
-T acosh(T a) {
-  return std::acosh(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(acosh)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half acospi(sycl::half a);
-#endif
-float acospi(float a);
-double acospi(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(acospi)
-
-template <typename T>
-T asin(T a) {
-  return std::asin(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(asin)
-
-template <typename T>
-T asinh(T a) {
-  return std::asinh(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(asinh)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half asinpi(sycl::half a);
-#endif
-float asinpi(float a);
-double asinpi(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(asinpi)
-
-template <typename T>
-T atan(T a) {
-  return std::atan(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(atan)
-
-template <typename T>
-T atan2(T a, T b) {
-  return std::atan2(static_cast<typename higher_accuracy<T>::type>(a), b);
-}
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(atan2)
-
-template <typename T>
-T atanh(T a) {
-  return std::atanh(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(atanh)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half atanpi(sycl::half a);
-#endif
-float atanpi(float a);
-double atanpi(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(atanpi)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half atan2pi(sycl::half a, sycl::half b);
-#endif
-float atan2pi(float a, float b);
-double atan2pi(double a, double b);
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(atan2pi)
-
-template <typename T>
-T cbrt(T a) {
-  return std::cbrt(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(cbrt)
-
-using std::ceil;
-MAKE_VEC_AND_MARRAY_VERSIONS(ceil)
-
-using std::copysign;
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(copysign)
-
-template <typename T>
-T cos(T a) {
-  return std::cos(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(cos)
-
-template <typename T>
-T cosh(T a) {
-  return std::cosh(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(cosh)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half cospi(sycl::half a);
-#endif
-float cospi(float a);
-double cospi(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(cospi)
-
-template <typename T>
-T erfc(T a) {
-  return std::erfc(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(erfc)
-
-template <typename T>
-T erf(T a) {
-  return std::erf(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(erf)
-
-template <typename T>
-T exp(T a) {
-  return std::exp(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(exp)
-
-template <typename T>
-T exp2(T a) {
-  return std::exp2(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(exp2)
-
-template <typename T>
-T exp10(T a) {
-  return std::pow(static_cast<typename higher_accuracy<T>::type>(10),
-                  static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(exp10)
-
-template <typename T>
-T expm1(T a) {
-  return std::expm1(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(expm1)
-
-using std::fabs;
-MAKE_VEC_AND_MARRAY_VERSIONS(fabs)
-
-using std::fdim;
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half fdim(sycl::half a, sycl::half b);
-#endif
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(fdim)
-
-using std::floor;
-MAKE_VEC_AND_MARRAY_VERSIONS(floor)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half fma(sycl::half a, sycl::half b, sycl::half c);
-#endif
-float fma(float a, float b, float c);
-double fma(double a, double b, double c);
-
-MAKE_VEC_AND_MARRAY_VERSIONS_3ARGS(fma)
-
-using std::fmax;
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(fmax)
-MAKE_VEC_AND_MARRAY_VERSIONS_WITH_SCALAR(fmax)
-
-using std::fmin;
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(fmin)
-MAKE_VEC_AND_MARRAY_VERSIONS_WITH_SCALAR(fmin)
-
-using std::fmod;
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(fmod)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half fract(sycl::half a, sycl::half *b);
-#endif
-float fract(float a, float *b);
-double fract(double a, double *b);
-
-template <typename T, int N>
-sycl::vec<T, N> fract(sycl::vec<T, N> a, sycl::vec<T, N> *b) {
-  sycl::vec<T, N> res;
-  sycl::vec<T, N> resPtr;
-  for (int i = 0; i < N; i++) {
-    T value;
-    res[i] = fract(a[i], &value);
-    resPtr[i] = value;
-  }
-  *b = resPtr;
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
-sycl::marray<T, N> fract(sycl::marray<T, N> a, sycl::marray<T, N> *b) {
+sycl::marray<T, N> fract(sycl::marray<T, N> a, sycl::marray<T, N>* b) {
   sycl::marray<T, N> res;
   sycl::marray<T, N> resPtr;
   for (size_t i = 0; i < N; i++) {
     T value;
-    res[i] = fract(a[i], &value);
+    res[i] = reference::fract(a[i], &value);
     resPtr[i] = value;
   }
   *b = resPtr;
   return res;
 }
-#endif
 
-using std::frexp;
-template <typename T, int N>
-sycl::vec<T, N> frexp(sycl::vec<T, N> a, sycl::vec<int, N> *b) {
-  sycl::vec<T, N> res;
-  sycl::vec<int, N> resPtr;
-  for (int i = 0; i < N; i++) {
-    int value;
-    res[i] = frexp(a[i], &value);
-    resPtr[i] = value;
-  }
-  *b = resPtr;
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
-sycl::marray<T, N> frexp(sycl::marray<T, N> a, sycl::marray<int, N> *b) {
+sycl::marray<T, N> frexp(sycl::marray<T, N> a, sycl::marray<int, N>* b) {
   sycl::marray<T, N> res;
   sycl::marray<int, N> resPtr;
   for (size_t i = 0; i < N; i++) {
     int value;
-    res[i] = frexp(a[i], &value);
-    ;
+    res[i] = reference::frexp(a[i], &value);
     resPtr[i] = value;
   }
   *b = resPtr;
   return res;
 }
-#endif
 
-template <typename T>
-T hypot(T a, T b) {
-  return std::hypot(static_cast<typename higher_accuracy<T>::type>(a), b);
-}
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(hypot)
+MAKE_MARRAY_VERSION_2ARGS(hypot)
 
-using std::ilogb;
-template <typename T, int N>
-sycl::vec<int, N> ilogb(sycl::vec<T, N> a) {
-  sycl::vec<int, N> res;
-  for (int i = 0; i < N; i++) {
-    res[i] = ilogb(a[i]);
-  }
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
 sycl::marray<int, N> ilogb(sycl::marray<T, N> a) {
   sycl::marray<int, N> res;
   for (size_t i = 0; i < N; i++) {
-    res[i] = ilogb(a[i]);
+    res[i] = reference::ilogb(a[i]);
   }
   return res;
 }
-#endif
 
-using std::ldexp;
-template <typename T, int N>
-sycl::vec<T, N> ldexp(sycl::vec<T, N> a, sycl::vec<int, N> b) {
-  sycl::vec<T, N> res;
-  for (int i = 0; i < N; i++) {
-    res[i] = ldexp(a[i], b[i]);
-  }
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
 sycl::marray<T, N> ldexp(sycl::marray<T, N> a, sycl::marray<int, N> b) {
   sycl::marray<T, N> res;
   for (size_t i = 0; i < N; i++) {
-    res[i] = ldexp(a[i], b[i]);
+    res[i] = reference::ldexp(a[i], b[i]);
   }
   return res;
 }
-#endif
-template <typename T, int N>
-sycl::vec<T, N> ldexp(sycl::vec<T, N> a, int b) {
-  sycl::vec<T, N> res;
-  for (int i = 0; i < N; i++) {
-    res[i] = ldexp(a[i], b);
-  }
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
 sycl::marray<T, N> ldexp(sycl::marray<T, N> a, int b) {
   sycl::marray<T, N> res;
   for (size_t i = 0; i < N; i++) {
-    res[i] = ldexp(a[i], b);
+    res[i] = reference::ldexp(a[i], b);
   }
   return res;
 }
-#endif
 
-using std::lgamma;
-MAKE_VEC_AND_MARRAY_VERSIONS(lgamma)
+MAKE_MARRAY_VERSION(lgamma)
 
-template <typename T>
-T lgamma_r(T a, int *b) {
-  *b = (std::tgamma(a) > 0) ? 1 : -1;
-  return std::lgamma(a);
-}
-template <typename T, int N>
-sycl::vec<T, N> lgamma_r(sycl::vec<T, N> a, sycl::vec<int, N> *b) {
-  sycl::vec<T, N> res;
-  sycl::vec<int, N> resPtr;
-  for (int i = 0; i < N; i++) {
-    int value;
-    res[i] = lgamma_r(a[i], &value);
-    resPtr[i] = value;
-  }
-  *b = resPtr;
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
-sycl::marray<T, N> lgamma_r(sycl::marray<T, N> a, sycl::marray<int, N> *b) {
+sycl::marray<T, N> lgamma_r(sycl::marray<T, N> a, sycl::marray<int, N>* b) {
   sycl::marray<T, N> res;
   sycl::marray<int, N> resPtr;
   for (size_t i = 0; i < N; i++) {
     int value;
-    res[i] = lgamma_r(a[i], &value);
+    res[i] = reference::lgamma_r(a[i], &value);
     resPtr[i] = value;
   }
   *b = resPtr;
   return res;
 }
-#endif
 
-template <typename T>
-T log(T a) {
-  return std::log(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(log)
+MAKE_MARRAY_VERSION(log)
+MAKE_MARRAY_VERSION(log2)
+MAKE_MARRAY_VERSION(log10)
+MAKE_MARRAY_VERSION(log1p)
+MAKE_MARRAY_VERSION(logb)
 
-template <typename T>
-T log2(T a) {
-  return std::log2(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(log2)
+MAKE_MARRAY_VERSION_3ARGS(mad)
+MAKE_MARRAY_VERSION_2ARGS(maxmag)
+MAKE_MARRAY_VERSION_2ARGS(minmag)
 
-template <typename T>
-T log10(T a) {
-  return std::log10(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(log10)
-
-template <typename T>
-T log1p(T a) {
-  return std::log1p(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(log1p)
-
-using std::logb;
-MAKE_VEC_AND_MARRAY_VERSIONS(logb)
-
-template <typename T>
-T mad(T a, T b, T c) {
-  return a * b + c;
-}
-MAKE_VEC_AND_MARRAY_VERSIONS_3ARGS(mad)
-
-template <typename T>
-T maxmag(T a, T b) {
-  if (fabs(a) > fabs(b))
-    return a;
-  else if (fabs(b) > fabs(a))
-    return b;
-  return fmax(a, b);
-}
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(maxmag)
-
-template <typename T>
-T minmag(T a, T b) {
-  if (fabs(a) < fabs(b))
-    return a;
-  else if (fabs(b) < fabs(a))
-    return b;
-  return fmin(a, b);
-}
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(minmag)
-
-using std::modf;
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half modf(sycl::half a, sycl::half *b);
-#endif
-template <typename T, int N>
-sycl::vec<T, N> modf(sycl::vec<T, N> a, sycl::vec<T, N> *b) {
-  sycl::vec<T, N> res;
-  sycl::vec<T, N> resPtr;
-  for (int i = 0; i < N; i++) {
-    T value;
-    res[i] = modf(a[i], &value);
-    resPtr[i] = value;
-  }
-  *b = resPtr;
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
-sycl::marray<T, N> modf(sycl::marray<T, N> a, sycl::marray<T, N> *b) {
+sycl::marray<T, N> modf(sycl::marray<T, N> a, sycl::marray<T, N>* b) {
   sycl::marray<T, N> res;
   sycl::marray<T, N> resPtr;
   for (int i = 0; i < N; i++) {
     T value;
-    res[i] = modf(a[i], &value);
+    res[i] = reference::modf(a[i], &value);
     resPtr[i] = value;
   }
   *b = resPtr;
   return res;
 }
-#endif
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half nan(unsigned short a);
-#endif
-float nan(unsigned int a);
-double nan(unsigned long a);
-double nan(unsigned long long a);
-#if SYCL_CTS_ENABLE_HALF_TESTS
-template <int N>
-sycl::vec<sycl::half, N> nan(sycl::vec<unsigned short, N> a) {
-  return sycl_cts::math::run_func_on_vector<sycl::half, unsigned short, N>(
-      [](unsigned short x) { return nan(x); }, a);
-}
-#endif
-template <int N>
-sycl::vec<float, N> nan(sycl::vec<unsigned int, N> a) {
-  return sycl_cts::math::run_func_on_vector<float, unsigned int, N>(
-      [](unsigned int x) { return nan(x); }, a);
-}
-template <typename T, int N>
-std::enable_if_t<std::is_same_v<unsigned long, T> ||
-                     std::is_same_v<unsigned long long, T>,
-                 sycl::vec<double, N>>
-nan(sycl::vec<T, N> a) {
-  return sycl_cts::math::run_func_on_vector<double, T, N>(
-      [](T x) { return nan(x); }, a);
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-#if SYCL_CTS_ENABLE_HALF_TESTS
-template <size_t N>
-sycl::marray<sycl::half, N> nan(sycl::marray<unsigned short, N> a) {
-  return sycl_cts::math::run_func_on_marray<sycl::half, unsigned short, N>(
-      [](unsigned short x) { return nan(x); }, a);
-}
-#endif
 template <size_t N>
 sycl::marray<float, N> nan(sycl::marray<unsigned int, N> a) {
   return sycl_cts::math::run_func_on_marray<float, unsigned int, N>(
       [](unsigned int x) { return nan(x); }, a);
 }
-template <typename T, size_t N>
-std::enable_if_t<std::is_same_v<unsigned long, T> ||
-                     std::is_same_v<unsigned long long, T>,
-                 sycl::marray<double, N>>
-nan(sycl::marray<T, N> a) {
-  return sycl_cts::math::run_func_on_marray<double, T, N>(
-      [](T x) { return nan(x); }, a);
-}
-#endif
 
-using std::nextafter;
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half nextafter(sycl::half a, sycl::half b);
-#endif
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(nextafter)
+MAKE_MARRAY_VERSION_2ARGS(nextafter)
+MAKE_MARRAY_VERSION_2ARGS(pow)
 
-template <typename T>
-T pow(T a, T b) {
-  return std::pow(static_cast<typename higher_accuracy<T>::type>(a),
-                  static_cast<typename higher_accuracy<T>::type>(b));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(pow)
-
-template <typename T>
-T pown(T a, int b) {
-  return std::pow(static_cast<typename higher_accuracy<T>::type>(a),
-                  static_cast<typename higher_accuracy<T>::type>(b));
-}
-template <typename T, int N>
-sycl::vec<T, N> pown(sycl::vec<T, N> a, sycl::vec<int, N> b) {
-  sycl::vec<T, N> res;
-  for (int i = 0; i < N; i++) {
-    res[i] = pown(a[i], b[i]);
-  }
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
 sycl::marray<T, N> pown(sycl::marray<T, N> a, sycl::marray<int, N> b) {
   sycl::marray<T, N> res;
   for (size_t i = 0; i < N; i++) {
-    res[i] = pown(a[i], b[i]);
+    res[i] = reference::pown(a[i], b[i]);
   }
   return res;
 }
-#endif
 
-template <typename T>
-sycl_cts::resultRef<T> powr(T a, T b) {
-  if (a < 0) return sycl_cts::resultRef<T>(T(), true);
-  return std::pow(static_cast<typename higher_accuracy<T>::type>(a),
-                  static_cast<typename higher_accuracy<T>::type>(b));
-}
-template <typename T, int N>
-sycl_cts::resultRef<sycl::vec<T, N>> powr(sycl::vec<T, N> a,
-                                          sycl::vec<T, N> b) {
-  return sycl_cts::math::run_func_on_vector_result_ref<T, N>(
-      [](T x, T y) { return powr(x, y); }, a, b);
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
 sycl_cts::resultRef<sycl::marray<T, N>> powr(sycl::marray<T, N> a,
                                              sycl::marray<T, N> b) {
   return sycl_cts::math::run_func_on_marray_result_ref<T, N>(
-      [](T x, T y) { return powr(x, y); }, a, b);
-}
-#endif
-
-using std::remainder;
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(remainder)
-
-template <typename T>
-T remquo(T x, T y, int *quo) {
-  return reference_remquol(x, y, quo);
+      [](T x, T y) { return reference::powr(x, y); }, a, b);
 }
 
-template <typename T, int N>
-sycl::vec<T, N> remquo(sycl::vec<T, N> a, sycl::vec<T, N> b,
-                       sycl::vec<int, N> *c) {
-  sycl::vec<T, N> res;
-  sycl::vec<int, N> resPtr;
-  for (int i = 0; i < N; i++) {
-    int value;
-    res[i] = remquo(a[i], b[i], &value);
-    resPtr[i] = value;
-  }
-  *c = resPtr;
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+MAKE_MARRAY_VERSION_2ARGS(remainder)
+
 template <typename T, size_t N>
 sycl::marray<T, N> remquo(sycl::marray<T, N> a, sycl::marray<T, N> b,
-                          sycl::marray<int, N> *c) {
+                          sycl::marray<int, N>* c) {
   sycl::marray<T, N> res;
   sycl::marray<int, N> resPtr;
   for (size_t i = 0; i < N; i++) {
     int value;
-    res[i] = remquo(a[i], b[i], &value);
+    res[i] = reference::remquo(a[i], b[i], &value);
     resPtr[i] = value;
   }
   *c = resPtr;
   return res;
 }
-#endif
 
-using std::rint;
-MAKE_VEC_AND_MARRAY_VERSIONS(rint)
+MAKE_MARRAY_VERSION(rint)
 
-template <typename T>
-T rootn(T a, int b) {
-  return std::pow(static_cast<typename higher_accuracy<T>::type>(a),
-                  static_cast<typename higher_accuracy<T>::type>(1.0 / b));
-}
-template <typename T, int N>
-sycl::vec<T, N> rootn(sycl::vec<T, N> a, sycl::vec<int, N> b) {
-  sycl::vec<T, N> res;
-  for (int i = 0; i < N; i++) {
-    res[i] = rootn(a[i], b[i]);
-  }
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
 sycl::marray<T, N> rootn(sycl::marray<T, N> a, sycl::marray<int, N> b) {
   sycl::marray<T, N> res;
   for (size_t i = 0; i < N; i++) {
-    res[i] = rootn(a[i], b[i]);
+    res[i] = reference::rootn(a[i], b[i]);
   }
   return res;
 }
-#endif
 
-using std::round;
-MAKE_VEC_AND_MARRAY_VERSIONS(round)
+MAKE_MARRAY_VERSION(round)
+MAKE_MARRAY_VERSION(rsqrt)
+MAKE_MARRAY_VERSION(sign)
 
-template <typename T>
-T rsqrt(T a) {
-  return 1 / std::sqrt(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(rsqrt)
-
-template <typename T>
-T sincos(T a, T *b) {
-  *b = std::cos(static_cast<typename higher_accuracy<T>::type>(a));
-  return std::sin(static_cast<typename higher_accuracy<T>::type>(a));
-}
-template <typename T, int N>
-sycl::vec<T, N> sincos(sycl::vec<T, N> a, sycl::vec<T, N> *b) {
-  sycl::vec<T, N> res;
-  sycl::vec<T, N> resPtr;
-  for (int i = 0; i < N; i++) {
-    T value;
-    res[i] = sincos(a[i], &value);
-    resPtr[i] = value;
-  }
-  *b = resPtr;
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
-sycl::marray<T, N> sincos(sycl::marray<T, N> a, sycl::marray<T, N> *b) {
+sycl::marray<T, N> sincos(sycl::marray<T, N> a, sycl::marray<T, N>* b) {
   sycl::marray<T, N> res;
   sycl::marray<T, N> resPtr;
   for (size_t i = 0; i < N; i++) {
     T value;
-    res[i] = sincos(a[i], &value);
+    res[i] = reference::sincos(a[i], &value);
     resPtr[i] = value;
   }
   *b = resPtr;
   return res;
 }
-#endif
 
-template <typename T>
-T sin(T a) {
-  return std::sin(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(sin)
+MAKE_MARRAY_VERSION(sin)
+MAKE_MARRAY_VERSION(sinh)
+MAKE_MARRAY_VERSION(sinpi)
+MAKE_MARRAY_VERSION(sqrt)
+MAKE_MARRAY_VERSION_2ARGS(step)
+MAKE_MARRAY_VERSION(tan)
+MAKE_MARRAY_VERSION(tanh)
+MAKE_MARRAY_VERSION(tanpi)
+MAKE_MARRAY_VERSION(tgamma)
+MAKE_MARRAY_VERSION(trunc)
+MAKE_MARRAY_VERSION(recip)
+MAKE_MARRAY_VERSION_2ARGS(divide)
 
-template <typename T>
-T sinh(T a) {
-  return std::sinh(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(sinh)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half sinpi(sycl::half a);
-#endif
-float sinpi(float a);
-double sinpi(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(sinpi)
-
-template <typename T>
-T sqrt(T a) {
-  return std::sqrt(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(sqrt)
-
-template <typename T>
-T tan(T a) {
-  return std::tan(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(tan)
-
-template <typename T>
-T tanh(T a) {
-  return std::tanh(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(tanh)
-
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half tanpi(sycl::half a);
-#endif
-float tanpi(float a);
-double tanpi(double a);
-MAKE_VEC_AND_MARRAY_VERSIONS(tanpi)
-
-template <typename T>
-T tgamma(T a) {
-  return std::tgamma(static_cast<typename higher_accuracy<T>::type>(a));
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(tgamma)
-
-using std::trunc;
-MAKE_VEC_AND_MARRAY_VERSIONS(trunc)
-
-template <typename T>
-T recip(T a) {
-  return 1.0 / a;
-}
-MAKE_VEC_AND_MARRAY_VERSIONS(recip)
-
-template <typename T>
-T divide(T a, T b) {
-  return a / b;
-}
-MAKE_VEC_AND_MARRAY_VERSIONS_2ARGS(divide)
-
-// Geometric functions
-
-sycl::float4 cross(sycl::float4 p0, sycl::float4 p1);
-sycl::float3 cross(sycl::float3 p0, sycl::float3 p1);
-sycl::double4 cross(sycl::double4 p0, sycl::double4 p1);
-sycl::double3 cross(sycl::double3 p0, sycl::double3 p1);
-
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-sycl::mfloat4 cross(sycl::mfloat4 p0, sycl::mfloat4 p1);
-sycl::mfloat3 cross(sycl::mfloat3 p0, sycl::mfloat3 p1);
-sycl::mdouble4 cross(sycl::mdouble4 p0, sycl::mdouble4 p1);
-sycl::mdouble3 cross(sycl::mdouble3 p0, sycl::mdouble3 p1);
-#endif
-
-template <typename T>
-T dot(T p0, T p1) {
-  return p0 * p1;
-}
-template <typename T, int N>
-T dot(sycl::vec<T, N> a, sycl::vec<T, N> b) {
-  T res = 0;
-  for (int i = 0; i < N; i++) res += a[i] * b[i];
-  return res;
-}
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <typename T, size_t N>
 T dot(sycl::marray<T, N> a, sycl::marray<T, N> b) {
   T res = 0;
   for (size_t i = 0; i < N; i++) res += a[i] * b[i];
   return res;
 }
-#endif
+
+#endif  // SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+
+// Generic functions over both scalars and vec / marray types.
+// These need to be defined last.
 
 template <typename T>
 auto length(T p) {
-  return sqrt(reference::dot(p, p));
+  return reference::sqrt(reference::dot(p, p));
 }
 
 template <typename T>
@@ -1652,11 +1691,6 @@ auto distance(T p0, T p1) {
   return reference::length(p0 - p1);
 }
 
-template <typename T>
-T normalize(T p) {
-  if (p < 0) return -1;
-  return 1;
-}
 template <typename T, int N>
 sycl::vec<T, N> normalize(sycl::vec<T, N> a) {
   sycl::vec<T, N> res;
@@ -1677,22 +1711,9 @@ sycl::marray<T, N> normalize(sycl::marray<T, N> a) {
 }
 #endif
 
-#if SYCL_CTS_ENABLE_HALF_TESTS
-sycl::half fast_dot(float p0);
-sycl::half fast_dot(sycl::float2 p0);
-sycl::half fast_dot(sycl::float3 p0);
-sycl::half fast_dot(sycl::float4 p0);
-// FIXME: AdaptiveCpp does not support marray
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-sycl::half fast_dot(sycl::mfloat2 p0);
-sycl::half fast_dot(sycl::mfloat3 p0);
-sycl::half fast_dot(sycl::mfloat4 p0);
-#endif
-#endif
-
 template <typename T>
 float fast_length(T p0) {
-  return sqrt(fast_dot(p0));
+  return reference::sqrt(fast_dot(p0));
 }
 
 template <typename T>
@@ -1702,7 +1723,7 @@ float fast_distance(T p0, T p1) {
 
 template <typename T>
 T fast_normalize(T p0) {
-  return p0 * rsqrt(fast_dot(p0));
+  return p0 * reference::rsqrt(fast_dot(p0));
 }
 
 }  // namespace reference

--- a/util/type_names.h
+++ b/util/type_names.h
@@ -48,7 +48,9 @@ std::string type_name() {
   /* float types */
   MAKENAME(float);
   MAKENAME(double);
+#if SYCL_CTS_ENABLE_HALF_TESTS
   MAKESYCLNAME(half);
+#endif
 
   /* scalar types */
   MAKESTDNAME(int8_t);

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -50,7 +50,7 @@ using has_atomic_support = contains<T, int, unsigned int, long, unsigned long,
  * @brief Checks whether T is a floating-point sycl type
  */
 template <typename T>
-using is_sycl_floating_point =
+using is_sycl_scalar_floating_point =
 #if SYCL_CTS_ENABLE_HALF_TESTS
     std::bool_constant<std::is_floating_point_v<T> ||
                        std::is_same_v<std::remove_cv_t<T>, sycl::half>>;
@@ -59,8 +59,8 @@ using is_sycl_floating_point =
 #endif
 
 template <typename T>
-inline constexpr bool is_sycl_floating_point_v{
-    is_sycl_floating_point<T>::value};
+inline constexpr bool is_sycl_scalar_floating_point_v{
+    is_sycl_scalar_floating_point<T>::value};
 
 template <typename T>
 using is_nonconst_rvalue_reference =
@@ -410,10 +410,10 @@ using is_legal_operator = std::bool_constant<
      std::is_same_v<std::remove_cv_t<T>, bool>) ||
     (std::is_same_v<OperatorT, sycl::minimum<T>> && std::is_integral_v<T>) ||
     (std::is_same_v<OperatorT, sycl::minimum<T>> &&
-     is_sycl_floating_point_v<T>) ||
+     is_sycl_scalar_floating_point_v<T>) ||
     (std::is_same_v<OperatorT, sycl::maximum<T>> && std::is_integral_v<T>) ||
     (std::is_same_v<OperatorT, sycl::maximum<T>> &&
-     is_sycl_floating_point_v<T>)>;
+     is_sycl_scalar_floating_point_v<T>)>;
 
 /**
  Checks whether \p T and \p OperatorT form a valid SYCL operator. */

--- a/util/type_traits.h
+++ b/util/type_traits.h
@@ -51,8 +51,12 @@ using has_atomic_support = contains<T, int, unsigned int, long, unsigned long,
  */
 template <typename T>
 using is_sycl_floating_point =
+#if SYCL_CTS_ENABLE_HALF_TESTS
     std::bool_constant<std::is_floating_point_v<T> ||
-                       std::is_same_v<T, sycl::half>>;
+                       std::is_same_v<std::remove_cv_t<T>, sycl::half>>;
+#else
+    std::is_floating_point<T>;
+#endif
 
 template <typename T>
 inline constexpr bool is_sycl_floating_point_v{
@@ -406,12 +410,10 @@ using is_legal_operator = std::bool_constant<
      std::is_same_v<std::remove_cv_t<T>, bool>) ||
     (std::is_same_v<OperatorT, sycl::minimum<T>> && std::is_integral_v<T>) ||
     (std::is_same_v<OperatorT, sycl::minimum<T>> &&
-     (std::is_floating_point_v<T> ||
-      std::is_same_v<std::remove_cv_t<T>, sycl::half>)) ||
+     is_sycl_floating_point_v<T>) ||
     (std::is_same_v<OperatorT, sycl::maximum<T>> && std::is_integral_v<T>) ||
     (std::is_same_v<OperatorT, sycl::maximum<T>> &&
-     (std::is_floating_point_v<T> ||
-      std::is_same_v<std::remove_cv_t<T>, sycl::half>))>;
+     is_sycl_floating_point_v<T>)>;
 
 /**
  Checks whether \p T and \p OperatorT form a valid SYCL operator. */


### PR DESCRIPTION
This PR improves compatibility with implementations that do not expose the `sycl::half` type (notably, [SimSYCL](https://github.com/celerity/SimSYCL) built with GCC).

There might be additional usages I missed, in tests that SimSYCL is currently unable to compile for other reasons.

**Question** to the reviewers: Is it necessary to exclude some translation units in CMake when the file names are `*fp16.cpp` or are these handled automatically?