### PR TITLE
Compatibility: Only use `cl_*` types if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS is set

### DIFF
--- a/tests/accessor_legacy/accessor_constructors_buffer_utility.h
+++ b/tests/accessor_legacy/accessor_constructors_buffer_utility.h
@@ -341,7 +341,7 @@ public:
 
   using range_t = sycl::range<dataDims>;
   using offset_t = sycl::id<dataDims>;
-  using data_t = std::vector<sycl::cl_uchar>;
+  using data_t = std::vector<sycl::opencl::cl_uchar>;
   using buffer_t = sycl::buffer<T, dataDims, allocatorT...>;
 
 public:
@@ -384,7 +384,7 @@ public:
 
   using range_t = sycl::range<dataDims>;
   using offset_t = sycl::id<dataDims>;
-  using data_t = std::vector<sycl::cl_uchar>;
+  using data_t = std::vector<sycl::opencl::cl_uchar>;
   using buffer_t = sycl::buffer<T, dataDims, allocatorT...>;
 
 public:

--- a/tests/accessor_legacy/accessor_types_core.h
+++ b/tests/accessor_legacy/accessor_types_core.h
@@ -82,49 +82,49 @@ public:
                         "user alias");
 
 #ifdef INT8_MAX
-    if (!std::is_same<std::int8_t, sycl::cl_char>::value) {
+    if (!std::is_same<std::int8_t, sycl::opencl::cl_char>::value) {
       for_type_and_vectors<check_type, std::int8_t>(
           log, queue, "std::int8_t");
     }
 #endif
 #ifdef UINT8_MAX
-    if (!std::is_same<std::uint8_t, sycl::cl_uchar>::value) {
+    if (!std::is_same<std::uint8_t, sycl::opencl::cl_uchar>::value) {
       for_type_and_vectors<check_type, std::uint8_t>(
           log, queue, "std::uint8_t");
     }
 #endif
 #ifdef INT16_MAX
-    if (!std::is_same<std::int16_t, sycl::cl_short>::value) {
+    if (!std::is_same<std::int16_t, sycl::opencl::cl_short>::value) {
       for_type_and_vectors<check_type, std::int16_t>(
           log, queue, "std::int16_t");
     }
 #endif
 #ifdef UINT16_MAX
-    if (!std::is_same<std::uint16_t, sycl::cl_ushort>::value) {
+    if (!std::is_same<std::uint16_t, sycl::opencl::cl_ushort>::value) {
       for_type_and_vectors<check_type, std::uint16_t>(
           log, queue, "std::uint16_t");
     }
 #endif
 #ifdef INT32_MAX
-    if (!std::is_same<std::int32_t, sycl::cl_int>::value) {
+    if (!std::is_same<std::int32_t, sycl::opencl::cl_int>::value) {
       for_type_and_vectors<check_type, std::int32_t>(
           log, queue, "std::int32_t");
     }
 #endif
 #ifdef UINT32_MAX
-    if (!std::is_same<std::uint32_t, sycl::cl_uint>::value) {
+    if (!std::is_same<std::uint32_t, sycl::opencl::cl_uint>::value) {
       for_type_and_vectors<check_type, std::uint32_t>(
           log, queue, "std::uint32_t");
     }
 #endif
 #ifdef INT64_MAX
-    if (!std::is_same<std::int64_t, sycl::cl_long>::value) {
+    if (!std::is_same<std::int64_t, sycl::opencl::cl_long>::value) {
       for_type_and_vectors<check_type, std::int64_t>(
           log, queue, "std::int64_t");
     }
 #endif
 #ifdef UINT64_MAX
-    if (!std::is_same<std::uint64_t, sycl::cl_ulong>::value) {
+    if (!std::is_same<std::uint64_t, sycl::opencl::cl_ulong>::value) {
       for_type_and_vectors<check_type, std::uint64_t>(
           log, queue, "std::uint64_t");
     }

--- a/tests/accessor_legacy/accessor_types_fp16.h
+++ b/tests/accessor_legacy/accessor_types_fp16.h
@@ -55,8 +55,8 @@ public:
     // Extended type coverage
     for_type_and_vectors<check_type, sycl::half>(
         log, queue, "sycl::half");
-    for_type_and_vectors<check_type, sycl::cl_half>(
-        log, queue, "sycl::cl_half");
+    for_type_and_vectors<check_type, sycl::opencl::cl_half>(
+        log, queue, "sycl::opencl::cl_half");
 
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 

--- a/tests/accessor_legacy/accessor_types_fp64.h
+++ b/tests/accessor_legacy/accessor_types_fp64.h
@@ -60,8 +60,8 @@ public:
     // Extended type coverage
     for_type_and_vectors<check_type, double>(
         log, queue, "double");
-    for_type_and_vectors<check_type, sycl::cl_double>(
-        log, queue, "sycl::cl_double");
+    for_type_and_vectors<check_type, sycl::opencl::cl_double>(
+        log, queue, "sycl::opencl::cl_double");
 
 #endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
 

--- a/tests/accessor_legacy/accessor_types_image_core.h
+++ b/tests/accessor_legacy/accessor_types_image_core.h
@@ -19,7 +19,7 @@
 
 namespace TEST_NAMESPACE {
 
-using user_alias = sycl::vec<sycl::cl_int, 4>;
+using user_alias = sycl::vec<sycl::opencl::cl_int, 4>;
 
 /**
  *  @brief Run specific image accessors' tests for core type set
@@ -50,9 +50,9 @@ public:
                         sycl::cl_uint4,
                         sycl::cl_float4,
                         user_alias>::generate(
-                        "sycl::cl_int",
-                        "sycl::cl_uint",
-                        "sycl::cl_float",
+                        "sycl::opencl::cl_int",
+                        "sycl::opencl::cl_uint",
+                        "sycl::opencl::cl_float",
                         "user_alias");
 
     for_all_types<check_type>(types, log, queue);

--- a/tests/accessor_legacy/accessor_types_image_core.h
+++ b/tests/accessor_legacy/accessor_types_image_core.h
@@ -24,16 +24,13 @@ using user_alias = sycl::vec<sycl::opencl::cl_int, 4>;
 /**
  *  @brief Run specific image accessors' tests for core type set
  */
-template <template <typename, typename> class action,
-          typename extensionTagT>
+template <template <typename, typename> class action, typename extensionTagT>
 class check_all_types_image_core {
-
   template <typename T>
   using check_type = action<T, extensionTagT>;
 
-public:
-  static void run(sycl::queue& queue, sycl_cts::util::logger &log) {
-
+ public:
+  static void run(sycl::queue& queue, sycl_cts::util::logger& log) {
     if (!queue.get_device().get_info<sycl::info::device::image_support>()) {
       log.note("Device does not support images -- skipping check");
       return;
@@ -42,18 +39,14 @@ public:
     // Skip tests in case extension not available
     using availability =
         sycl_cts::util::extensions::availability<extensionTagT>;
-    if (!availability::check(queue, log))
-      return;
+    if (!availability::check(queue, log)) return;
 
     const auto types =
-        named_type_pack<sycl::cl_int4,
-                        sycl::cl_uint4,
-                        sycl::cl_float4,
-                        user_alias>::generate(
-                        "sycl::opencl::cl_int",
-                        "sycl::opencl::cl_uint",
-                        "sycl::opencl::cl_float",
-                        "user_alias");
+        named_type_pack<sycl::cl_int4, sycl::cl_uint4, sycl::cl_float4,
+                        user_alias>::generate("sycl::opencl::cl_int",
+                                              "sycl::opencl::cl_uint",
+                                              "sycl::opencl::cl_float",
+                                              "user_alias");
 
     for_all_types<check_type>(types, log, queue);
 
@@ -63,4 +56,4 @@ public:
 
 }  // namespace TEST_NAMESPACE
 
-#endif // SYCL_1_2_1_TESTS_ACCESSOR_ACCESSOR_TYPES_IMAGE_CORE_H
+#endif  // SYCL_1_2_1_TESTS_ACCESSOR_ACCESSOR_TYPES_IMAGE_CORE_H

--- a/tests/accessor_legacy/accessor_types_image_fp16.h
+++ b/tests/accessor_legacy/accessor_types_image_fp16.h
@@ -44,7 +44,7 @@ public:
     if (!availability::check(queue, log))
       return;
 
-    check_type<sycl::cl_half4>()(log, queue, "sycl::cl_half");
+    check_type<sycl::cl_half4>()(log, queue, "sycl::opencl::cl_half");
 
     queue.wait_and_throw();
   }

--- a/tests/buffer/buffer_api_fp16.cpp
+++ b/tests/buffer/buffer_api_fp16.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-// Provides buffer api tests for sycl::half and sycl::cl_half
+// Provides buffer api tests for sycl::half and sycl::opencl::cl_half
 //
 *******************************************************************************/
 
@@ -38,7 +38,7 @@ public:
                          sycl::half>(log, "sycl::half");
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_api_common::check_buffer_api_for_type,
-                         sycl::cl_half>(log, "sycl::cl_half");
+                         sycl::opencl::cl_half>(log, "sycl::opencl::cl_half");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   }
 };

--- a/tests/buffer/buffer_api_fp64.cpp
+++ b/tests/buffer/buffer_api_fp64.cpp
@@ -18,16 +18,16 @@ using namespace sycl_cts;
 /** test sycl::buffer API
  */
 class TEST_NAME : public util::test_base {
-public:
+ public:
   /** return information about this test
    */
-  void get_info(test_base::info &out) const override {
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
    */
-  void run(util::logger &log) override {
+  void run(util::logger& log) override {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp64)) {
       log.note(
@@ -38,12 +38,13 @@ public:
         log, "double");
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_api_common::check_buffer_api_for_type,
-                         sycl::opencl::cl_double>(log, "sycl::opencl::cl_double");
-#endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+                         sycl::opencl::cl_double>(log,
+                                                  "sycl::opencl::cl_double");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   }
 };
 
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-} // namespace TEST_NAMESPACE
+}  // namespace TEST_NAMESPACE

--- a/tests/buffer/buffer_api_fp64.cpp
+++ b/tests/buffer/buffer_api_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-// Provides buffer api tests for double and sycl::cl_double
+// Provides buffer api tests for double and sycl::opencl::cl_double
 //
 *******************************************************************************/
 
@@ -38,7 +38,7 @@ public:
         log, "double");
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_api_common::check_buffer_api_for_type,
-                         sycl::cl_double>(log, "sycl::cl_double");
+                         sycl::opencl::cl_double>(log, "sycl::opencl::cl_double");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   }
 };

--- a/tests/buffer/buffer_constructors_fp16.cpp
+++ b/tests/buffer/buffer_constructors_fp16.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-// Provides buffer constructors tests for sycl::half and sycl::cl_half
+// Provides buffer constructors tests for sycl::half and sycl::opencl::cl_half
 //
 *******************************************************************************/
 
@@ -40,7 +40,7 @@ public:
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<
         buffer_constructors_common::check_buffer_ctors_for_type,
-        sycl::cl_half>(log, "sycl::cl_half");
+        sycl::opencl::cl_half>(log, "sycl::opencl::cl_half");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   }
 };

--- a/tests/buffer/buffer_constructors_fp64.cpp
+++ b/tests/buffer/buffer_constructors_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-// Provides buffer constructors tests for double and sycl::cl_double
+// Provides buffer constructors tests for double and sycl::opencl::cl_double
 //
 *******************************************************************************/
 
@@ -40,7 +40,7 @@ public:
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<
         buffer_constructors_common::check_buffer_ctors_for_type,
-        sycl::cl_double>(log, "sycl::cl_double");
+        sycl::opencl::cl_double>(log, "sycl::opencl::cl_double");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   }
 };

--- a/tests/buffer/buffer_storage_fp16.cpp
+++ b/tests/buffer/buffer_storage_fp16.cpp
@@ -3,7 +3,7 @@
 //  SYCL 2020 Conformance Test Suite
 //
 // Provides buffer storage methods tests for sycl::half and
-sycl::cl_half
+sycl::opencl::cl_half
 //
 *******************************************************************************/
 
@@ -39,7 +39,7 @@ public:
                          sycl::half>(log, "sycl::half");
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_storage_common::check_buffer_storage_for_type,
-                         sycl::cl_half>(log, "sycl::cl_half");
+                         sycl::opencl::cl_half>(log, "sycl::opencl::cl_half");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   }
 };

--- a/tests/buffer/buffer_storage_fp64.cpp
+++ b/tests/buffer/buffer_storage_fp64.cpp
@@ -18,16 +18,16 @@ using namespace sycl_cts;
 /** test sycl::buffer storage methods
  */
 class TEST_NAME : public util::test_base {
-public:
+ public:
   /** return information about this test
    */
-  void get_info(test_base::info &out) const override {
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
    */
-  void run(util::logger &log) override {
+  void run(util::logger& log) override {
     auto queue = util::get_cts_object::queue();
     if (!queue.get_device().has(sycl::aspect::fp64)) {
       log.note(
@@ -38,12 +38,13 @@ public:
                          double>(log, "double");
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_storage_common::check_buffer_storage_for_type,
-                         sycl::opencl::cl_double>(log, "sycl::opencl::cl_double");
-#endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
+                         sycl::opencl::cl_double>(log,
+                                                  "sycl::opencl::cl_double");
+#endif  // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   }
 };
 
 // construction of this proxy will register the above test
 util::test_proxy<TEST_NAME> proxy;
 
-} // namespace TEST_NAMESPACE
+}  // namespace TEST_NAMESPACE

--- a/tests/buffer/buffer_storage_fp64.cpp
+++ b/tests/buffer/buffer_storage_fp64.cpp
@@ -2,7 +2,7 @@
 //
 //  SYCL 2020 Conformance Test Suite
 //
-// Provides buffer storage methods tests for double and sycl::cl_double
+// Provides buffer storage methods tests for double and sycl::opencl::cl_double
 //
 *******************************************************************************/
 
@@ -38,7 +38,7 @@ public:
                          double>(log, "double");
 #if SYCL_CTS_ENABLE_FULL_CONFORMANCE
     for_type_and_vectors<buffer_storage_common::check_buffer_storage_for_type,
-                         sycl::cl_double>(log, "sycl::cl_double");
+                         sycl::opencl::cl_double>(log, "sycl::opencl::cl_double");
 #endif // SYCL_CTS_ENABLE_FULL_CONFORMANCE
   }
 };

--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -430,8 +430,8 @@ struct image_access;
  */
 template <>
 struct image_access<1> {
-  using int_type = sycl::cl_int;
-  using float_type = sycl::cl_float;
+  using int_type = sycl::opencl::cl_int;
+  using float_type = sycl::opencl::cl_float;
   static int_type get_int(const sycl::id<1>& i) {
     return int_type(i.get(0));
   }

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -219,22 +219,22 @@ inline auto get_vector_types() {
   static const auto pack = named_type_pack<
       bool, char, signed char, unsigned char, short, unsigned short, int,
       unsigned int, long, unsigned long, long long, unsigned long long, float,
-      sycl::cl_float, sycl::byte, sycl::cl_bool, sycl::cl_char, sycl::cl_uchar,
-      sycl::cl_short, sycl::cl_ushort, sycl::cl_int, sycl::cl_uint,
-      sycl::cl_long, sycl::cl_ulong>::generate("bool", "char", "signed char",
+      sycl::opencl::cl_float, sycl::byte, sycl::opencl::cl_bool, sycl::opencl::cl_char, sycl::opencl::cl_uchar,
+      sycl::opencl::cl_short, sycl::opencl::cl_ushort, sycl::opencl::cl_int, sycl::opencl::cl_uint,
+      sycl::opencl::cl_long, sycl::opencl::cl_ulong>::generate("bool", "char", "signed char",
                                                "unsigned char", "short",
                                                "unsigned short", "int",
                                                "unsigned int", "long",
                                                "unsigned long", "long long",
                                                "unsigned long long", "float",
-                                               "sycl::cl_float", "sycl::byte",
-                                               "sycl::cl_bool", "sycl::cl_char",
-                                               "sycl::cl_uchar",
-                                               "sycl::cl_short",
-                                               "sycl::cl_ushort",
-                                               "sycl::cl_int", "sycl::cl_uint",
-                                               "sycl::cl_long",
-                                               "sycl::cl_ulong");
+                                               "sycl::opencl::cl_float", "sycl::byte",
+                                               "sycl::opencl::cl_bool", "sycl::opencl::cl_char",
+                                               "sycl::opencl::cl_uchar",
+                                               "sycl::opencl::cl_short",
+                                               "sycl::opencl::cl_ushort",
+                                               "sycl::opencl::cl_int", "sycl::opencl::cl_uint",
+                                               "sycl::opencl::cl_long",
+                                               "sycl::opencl::cl_ulong");
 #else
   static const auto pack =
       named_type_pack<bool, char, signed char, unsigned char, short,

--- a/tests/common/type_list.h
+++ b/tests/common/type_list.h
@@ -27,12 +27,12 @@ struct user_struct {
 
   element_type operator[](size_t) const { return b; }
 
-  friend bool operator==(const user_struct &lhs, const user_struct &rhs) {
+  friend bool operator==(const user_struct& lhs, const user_struct& rhs) {
     static constexpr auto eps = 1e-4f;
     return (((lhs.a + eps > rhs.a) && (lhs.a < rhs.a + eps)) &&
             (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
-  friend bool operator!=(const user_struct &lhs, const user_struct &rhs) {
+  friend bool operator!=(const user_struct& lhs, const user_struct& rhs) {
     return !(lhs == rhs);
   }
 };
@@ -45,7 +45,7 @@ class Base {
   PrimaryType member;
   Base() = default;
   Base(int value) { value_operations::assign(member, value); }
-  bool operator==(const Base &rhs) const { return member == rhs.member; }
+  bool operator==(const Base& rhs) const { return member == rhs.member; }
 };
 
 template <typename PrimaryType>
@@ -63,22 +63,22 @@ struct no_cnstr {
   int b;
   char c;
 
-  constexpr auto &operator=(const int &v) {
+  constexpr auto& operator=(const int& v) {
     a = v;
     b = v;
     c = v;
     return *this;
   }
 
-  friend bool operator==(const no_cnstr &lhs, const no_cnstr &rhs) {
+  friend bool operator==(const no_cnstr& lhs, const no_cnstr& rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
 
-  friend bool operator!=(const no_cnstr &lhs, const no_cnstr &rhs) {
+  friend bool operator!=(const no_cnstr& lhs, const no_cnstr& rhs) {
     return !(lhs == rhs);
   }
 
-  friend no_cnstr operator+(const no_cnstr &lhs, int i) {
+  friend no_cnstr operator+(const no_cnstr& lhs, int i) {
     return {lhs.a + static_cast<float>(i), lhs.b + i,
             static_cast<char>(lhs.c + i)};
   }
@@ -101,16 +101,16 @@ struct def_cnstr {
     c = val;
   }
 
-  constexpr auto &operator=(const int &v) {
+  constexpr auto& operator=(const int& v) {
     assign(v);
     return *this;
   }
 
-  inline friend bool operator==(const def_cnstr &lhs, const def_cnstr &rhs) {
+  inline friend bool operator==(const def_cnstr& lhs, const def_cnstr& rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
 
-  friend bool operator!=(const def_cnstr &lhs, const def_cnstr &rhs) {
+  friend bool operator!=(const def_cnstr& lhs, const def_cnstr& rhs) {
     return !(lhs == rhs);
   }
 };
@@ -127,11 +127,11 @@ class no_def_cnstr {
 
   constexpr no_def_cnstr(int val) : a(val * 3.0f), b(val * 2), c(val) {}
 
-  friend bool operator==(const no_def_cnstr &lhs, const no_def_cnstr &rhs) {
+  friend bool operator==(const no_def_cnstr& lhs, const no_def_cnstr& rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
 
-  friend bool operator!=(const no_def_cnstr &lhs, const no_def_cnstr &rhs) {
+  friend bool operator!=(const no_def_cnstr& lhs, const no_def_cnstr& rhs) {
     return !(lhs == rhs);
   }
 };
@@ -143,21 +143,21 @@ struct arrow_operator_overloaded {
   int b;
   char c;
 
-  void operator=(const int &v) {
+  void operator=(const int& v) {
     this->a = v;
     this->b = v;
     this->c = v;
   }
 
-  arrow_operator_overloaded *operator->() { return this; }
-  const arrow_operator_overloaded *operator->() const { return this; }
+  arrow_operator_overloaded* operator->() { return this; }
+  const arrow_operator_overloaded* operator->() const { return this; }
 
-  friend bool operator==(const arrow_operator_overloaded &lhs,
-                         const arrow_operator_overloaded &rhs) {
+  friend bool operator==(const arrow_operator_overloaded& lhs,
+                         const arrow_operator_overloaded& rhs) {
     return ((lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c));
   }
-  friend bool operator!=(const arrow_operator_overloaded &lhs,
-                         const arrow_operator_overloaded &rhs) {
+  friend bool operator!=(const arrow_operator_overloaded& lhs,
+                         const arrow_operator_overloaded& rhs) {
     return !(lhs == rhs);
   }
 };
@@ -219,22 +219,18 @@ inline auto get_vector_types() {
   static const auto pack = named_type_pack<
       bool, char, signed char, unsigned char, short, unsigned short, int,
       unsigned int, long, unsigned long, long long, unsigned long long, float,
-      sycl::opencl::cl_float, sycl::byte, sycl::opencl::cl_bool, sycl::opencl::cl_char, sycl::opencl::cl_uchar,
-      sycl::opencl::cl_short, sycl::opencl::cl_ushort, sycl::opencl::cl_int, sycl::opencl::cl_uint,
-      sycl::opencl::cl_long, sycl::opencl::cl_ulong>::generate("bool", "char", "signed char",
-                                               "unsigned char", "short",
-                                               "unsigned short", "int",
-                                               "unsigned int", "long",
-                                               "unsigned long", "long long",
-                                               "unsigned long long", "float",
-                                               "sycl::opencl::cl_float", "sycl::byte",
-                                               "sycl::opencl::cl_bool", "sycl::opencl::cl_char",
-                                               "sycl::opencl::cl_uchar",
-                                               "sycl::opencl::cl_short",
-                                               "sycl::opencl::cl_ushort",
-                                               "sycl::opencl::cl_int", "sycl::opencl::cl_uint",
-                                               "sycl::opencl::cl_long",
-                                               "sycl::opencl::cl_ulong");
+      sycl::opencl::cl_float, sycl::byte, sycl::opencl::cl_bool,
+      sycl::opencl::cl_char, sycl::opencl::cl_uchar, sycl::opencl::cl_short,
+      sycl::opencl::cl_ushort, sycl::opencl::cl_int, sycl::opencl::cl_uint,
+      sycl::opencl::cl_long, sycl::opencl::cl_ulong>::
+      generate("bool", "char", "signed char", "unsigned char", "short",
+               "unsigned short", "int", "unsigned int", "long", "unsigned long",
+               "long long", "unsigned long long", "float",
+               "sycl::opencl::cl_float", "sycl::byte", "sycl::opencl::cl_bool",
+               "sycl::opencl::cl_char", "sycl::opencl::cl_uchar",
+               "sycl::opencl::cl_short", "sycl::opencl::cl_ushort",
+               "sycl::opencl::cl_int", "sycl::opencl::cl_uint",
+               "sycl::opencl::cl_long", "sycl::opencl::cl_ulong");
 #else
   static const auto pack =
       named_type_pack<bool, char, signed char, unsigned char, short,

--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -93,28 +93,59 @@ class TEST_NAME : public util::test_base {
 #endif
 
 #ifdef INT8_MAX
-    for_type_and_vectors<check_type, std::int8_t>(log, "std::int8_t");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    if (!std::is_same<sycl::cl_char, std::int8_t>::value)
 #endif
+      for_type_and_vectors<check_type, std::int8_t>(log, "std::int8_t");
+#endif
+
 #ifdef INT16_MAX
-    for_type_and_vectors<check_type, std::int16_t>(log, "std::int16_t");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    if (!std::is_same<sycl::cl_short, std::int16_t>::value)
 #endif
+      for_type_and_vectors<check_type, std::int16_t>(log, "std::int16_t");
+#endif
+
 #ifdef INT32_MAX
-    for_type_and_vectors<check_type, std::int32_t>(log, "std::int32_t");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    if (!std::is_same<sycl::cl_int, std::int32_t>::value)
 #endif
+      for_type_and_vectors<check_type, std::int32_t>(log, "std::int32_t");
+#endif
+
 #ifdef INT64_MAX
-    for_type_and_vectors<check_type, std::int64_t>(log, "std::int64_t");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    if (!std::is_same<sycl::cl_long, std::int64_t>::value)
 #endif
+      for_type_and_vectors<check_type, std::int64_t>(log, "std::int64_t");
+#endif
+
 #ifdef UINT8_MAX
-    for_type_and_vectors<check_type, std::uint8_t>(log, "std::uint8_t");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    if (!std::is_same<sycl::cl_uchar, std::uint8_t>::value)
 #endif
+      for_type_and_vectors<check_type, std::uint8_t>(log, "std::uint8_t");
+#endif
+
 #ifdef UINT16_MAX
-    for_type_and_vectors<check_type, std::uint16_t>(log, "std::uint16_t");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    if (!std::is_same<sycl::cl_ushort, std::uint16_t>::value)
 #endif
+      for_type_and_vectors<check_type, std::uint16_t>(log, "std::uint16_t");
+#endif
+
 #ifdef UINT32_MAX
-    for_type_and_vectors<check_type, std::uint32_t>(log, "std::uint32_t");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    if (!std::is_same<sycl::cl_uint, std::uint32_t>::value)
 #endif
+      for_type_and_vectors<check_type, std::uint32_t>(log, "std::uint32_t");
+#endif
+
 #ifdef UINT64_MAX
-    for_type_and_vectors<check_type, std::uint64_t>(log, "std::uint64_t");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
+    if (!std::is_same<sycl::cl_ulong, std::uint64_t>::value)
+#endif
+      for_type_and_vectors<check_type, std::uint64_t>(log, "std::uint64_t");
 #endif
   }
 };

--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -57,16 +57,26 @@ class TEST_NAME : public util::test_base {
     for_type_and_vectors<check_type, sycl::byte>(log, "sycl::byte");
 
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    for_type_and_vectors<check_type, sycl::opencl::cl_bool>(log, "sycl::opencl::cl_bool");
-    for_type_and_vectors<check_type, sycl::opencl::cl_char>(log, "sycl::opencl::cl_char");
-    for_type_and_vectors<check_type, sycl::opencl::cl_uchar>(log, "sycl::opencl::cl_uchar");
-    for_type_and_vectors<check_type, sycl::opencl::cl_short>(log, "sycl::opencl::cl_short");
-    for_type_and_vectors<check_type, sycl::opencl::cl_ushort>(log, "sycl::opencl::cl_ushort");
-    for_type_and_vectors<check_type, sycl::opencl::cl_int>(log, "sycl::opencl::cl_int");
-    for_type_and_vectors<check_type, sycl::opencl::cl_uint>(log, "sycl::opencl::cl_uint");
-    for_type_and_vectors<check_type, sycl::opencl::cl_long>(log, "sycl::opencl::cl_long");
-    for_type_and_vectors<check_type, sycl::opencl::cl_ulong>(log, "sycl::opencl::cl_ulong");
-    for_type_and_vectors<check_type, sycl::opencl::cl_float>(log, "sycl::opencl::cl_float");
+    for_type_and_vectors<check_type, sycl::opencl::cl_bool>(
+        log, "sycl::opencl::cl_bool");
+    for_type_and_vectors<check_type, sycl::opencl::cl_char>(
+        log, "sycl::opencl::cl_char");
+    for_type_and_vectors<check_type, sycl::opencl::cl_uchar>(
+        log, "sycl::opencl::cl_uchar");
+    for_type_and_vectors<check_type, sycl::opencl::cl_short>(
+        log, "sycl::opencl::cl_short");
+    for_type_and_vectors<check_type, sycl::opencl::cl_ushort>(
+        log, "sycl::opencl::cl_ushort");
+    for_type_and_vectors<check_type, sycl::opencl::cl_int>(
+        log, "sycl::opencl::cl_int");
+    for_type_and_vectors<check_type, sycl::opencl::cl_uint>(
+        log, "sycl::opencl::cl_uint");
+    for_type_and_vectors<check_type, sycl::opencl::cl_long>(
+        log, "sycl::opencl::cl_long");
+    for_type_and_vectors<check_type, sycl::opencl::cl_ulong>(
+        log, "sycl::opencl::cl_ulong");
+    for_type_and_vectors<check_type, sycl::opencl::cl_float>(
+        log, "sycl::opencl::cl_float");
 #endif
 
 #ifdef INT8_MAX

--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -32,64 +32,41 @@ class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
    */
-  void get_info(test_base::info &out) const override {
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
    */
-  void run(util::logger &log) override {
+  void run(util::logger& log) override {
     check_type<size_t>{}(log, "size_t");
-    for_type_and_vectors<check_type, bool>(log,
-        "bool");
-    for_type_and_vectors<check_type, char>(log,
-        "char");
-    for_type_and_vectors<check_type, signed char>(log,
-        "signed char");
-    for_type_and_vectors<check_type, unsigned char>(log,
-        "unsigned char");
-    for_type_and_vectors<check_type, short int>(log,
-        "short");
-    for_type_and_vectors<check_type, unsigned short int>(log,
-        "unsigned short");
-    for_type_and_vectors<check_type, int>(log,
-        "int");
-    for_type_and_vectors<check_type, unsigned int>(log,
-        "unsigned int");
-    for_type_and_vectors<check_type, long int>(log,
-        "long");
-    for_type_and_vectors<check_type, unsigned long int>(log,
-        "unsigned long");
-    for_type_and_vectors<check_type, long long int>(log,
-        "long long");
-    for_type_and_vectors<check_type, unsigned long long int>(log,
-        "unsigned long long");
-    for_type_and_vectors<check_type, float>(log,
-        "float");
-    for_type_and_vectors<check_type, sycl::byte>(log,
-        "sycl::byte");
+    for_type_and_vectors<check_type, bool>(log, "bool");
+    for_type_and_vectors<check_type, char>(log, "char");
+    for_type_and_vectors<check_type, signed char>(log, "signed char");
+    for_type_and_vectors<check_type, unsigned char>(log, "unsigned char");
+    for_type_and_vectors<check_type, short int>(log, "short");
+    for_type_and_vectors<check_type, unsigned short int>(log, "unsigned short");
+    for_type_and_vectors<check_type, int>(log, "int");
+    for_type_and_vectors<check_type, unsigned int>(log, "unsigned int");
+    for_type_and_vectors<check_type, long int>(log, "long");
+    for_type_and_vectors<check_type, unsigned long int>(log, "unsigned long");
+    for_type_and_vectors<check_type, long long int>(log, "long long");
+    for_type_and_vectors<check_type, unsigned long long int>(
+        log, "unsigned long long");
+    for_type_and_vectors<check_type, float>(log, "float");
+    for_type_and_vectors<check_type, sycl::byte>(log, "sycl::byte");
 
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    for_type_and_vectors<check_type, sycl::cl_bool>(log,
-        "sycl::cl_bool");
-    for_type_and_vectors<check_type, sycl::cl_char>(log,
-        "sycl::cl_char");
-    for_type_and_vectors<check_type, sycl::cl_uchar>(log,
-        "sycl::cl_uchar");
-    for_type_and_vectors<check_type, sycl::cl_short>(log,
-        "sycl::cl_short");
-    for_type_and_vectors<check_type, sycl::cl_ushort>(log,
-        "sycl::cl_ushort");
-    for_type_and_vectors<check_type, sycl::cl_int>(log,
-        "sycl::cl_int");
-    for_type_and_vectors<check_type, sycl::cl_uint>(log,
-        "sycl::cl_uint");
-    for_type_and_vectors<check_type, sycl::cl_long>(log,
-        "sycl::cl_long");
-    for_type_and_vectors<check_type, sycl::cl_ulong>(log,
-        "sycl::cl_ulong");
-    for_type_and_vectors<check_type, sycl::cl_float>(log,
-        "sycl::cl_float");
+    for_type_and_vectors<check_type, sycl::cl_bool>(log, "sycl::cl_bool");
+    for_type_and_vectors<check_type, sycl::cl_char>(log, "sycl::cl_char");
+    for_type_and_vectors<check_type, sycl::cl_uchar>(log, "sycl::cl_uchar");
+    for_type_and_vectors<check_type, sycl::cl_short>(log, "sycl::cl_short");
+    for_type_and_vectors<check_type, sycl::cl_ushort>(log, "sycl::cl_ushort");
+    for_type_and_vectors<check_type, sycl::cl_int>(log, "sycl::cl_int");
+    for_type_and_vectors<check_type, sycl::cl_uint>(log, "sycl::cl_uint");
+    for_type_and_vectors<check_type, sycl::cl_long>(log, "sycl::cl_long");
+    for_type_and_vectors<check_type, sycl::cl_ulong>(log, "sycl::cl_ulong");
+    for_type_and_vectors<check_type, sycl::cl_float>(log, "sycl::cl_float");
 #endif
 
 #ifdef INT8_MAX

--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -57,70 +57,70 @@ class TEST_NAME : public util::test_base {
     for_type_and_vectors<check_type, sycl::byte>(log, "sycl::byte");
 
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    for_type_and_vectors<check_type, sycl::cl_bool>(log, "sycl::cl_bool");
-    for_type_and_vectors<check_type, sycl::cl_char>(log, "sycl::cl_char");
-    for_type_and_vectors<check_type, sycl::cl_uchar>(log, "sycl::cl_uchar");
-    for_type_and_vectors<check_type, sycl::cl_short>(log, "sycl::cl_short");
-    for_type_and_vectors<check_type, sycl::cl_ushort>(log, "sycl::cl_ushort");
-    for_type_and_vectors<check_type, sycl::cl_int>(log, "sycl::cl_int");
-    for_type_and_vectors<check_type, sycl::cl_uint>(log, "sycl::cl_uint");
-    for_type_and_vectors<check_type, sycl::cl_long>(log, "sycl::cl_long");
-    for_type_and_vectors<check_type, sycl::cl_ulong>(log, "sycl::cl_ulong");
-    for_type_and_vectors<check_type, sycl::cl_float>(log, "sycl::cl_float");
+    for_type_and_vectors<check_type, sycl::opencl::cl_bool>(log, "sycl::opencl::cl_bool");
+    for_type_and_vectors<check_type, sycl::opencl::cl_char>(log, "sycl::opencl::cl_char");
+    for_type_and_vectors<check_type, sycl::opencl::cl_uchar>(log, "sycl::opencl::cl_uchar");
+    for_type_and_vectors<check_type, sycl::opencl::cl_short>(log, "sycl::opencl::cl_short");
+    for_type_and_vectors<check_type, sycl::opencl::cl_ushort>(log, "sycl::opencl::cl_ushort");
+    for_type_and_vectors<check_type, sycl::opencl::cl_int>(log, "sycl::opencl::cl_int");
+    for_type_and_vectors<check_type, sycl::opencl::cl_uint>(log, "sycl::opencl::cl_uint");
+    for_type_and_vectors<check_type, sycl::opencl::cl_long>(log, "sycl::opencl::cl_long");
+    for_type_and_vectors<check_type, sycl::opencl::cl_ulong>(log, "sycl::opencl::cl_ulong");
+    for_type_and_vectors<check_type, sycl::opencl::cl_float>(log, "sycl::opencl::cl_float");
 #endif
 
 #ifdef INT8_MAX
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    if (!std::is_same<sycl::cl_char, std::int8_t>::value)
+    if (!std::is_same<sycl::opencl::cl_char, std::int8_t>::value)
 #endif
       for_type_and_vectors<check_type, std::int8_t>(log, "std::int8_t");
 #endif
 
 #ifdef INT16_MAX
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    if (!std::is_same<sycl::cl_short, std::int16_t>::value)
+    if (!std::is_same<sycl::opencl::cl_short, std::int16_t>::value)
 #endif
       for_type_and_vectors<check_type, std::int16_t>(log, "std::int16_t");
 #endif
 
 #ifdef INT32_MAX
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    if (!std::is_same<sycl::cl_int, std::int32_t>::value)
+    if (!std::is_same<sycl::opencl::cl_int, std::int32_t>::value)
 #endif
       for_type_and_vectors<check_type, std::int32_t>(log, "std::int32_t");
 #endif
 
 #ifdef INT64_MAX
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    if (!std::is_same<sycl::cl_long, std::int64_t>::value)
+    if (!std::is_same<sycl::opencl::cl_long, std::int64_t>::value)
 #endif
       for_type_and_vectors<check_type, std::int64_t>(log, "std::int64_t");
 #endif
 
 #ifdef UINT8_MAX
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    if (!std::is_same<sycl::cl_uchar, std::uint8_t>::value)
+    if (!std::is_same<sycl::opencl::cl_uchar, std::uint8_t>::value)
 #endif
       for_type_and_vectors<check_type, std::uint8_t>(log, "std::uint8_t");
 #endif
 
 #ifdef UINT16_MAX
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    if (!std::is_same<sycl::cl_ushort, std::uint16_t>::value)
+    if (!std::is_same<sycl::opencl::cl_ushort, std::uint16_t>::value)
 #endif
       for_type_and_vectors<check_type, std::uint16_t>(log, "std::uint16_t");
 #endif
 
 #ifdef UINT32_MAX
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    if (!std::is_same<sycl::cl_uint, std::uint32_t>::value)
+    if (!std::is_same<sycl::opencl::cl_uint, std::uint32_t>::value)
 #endif
       for_type_and_vectors<check_type, std::uint32_t>(log, "std::uint32_t");
 #endif
 
 #ifdef UINT64_MAX
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-    if (!std::is_same<sycl::cl_ulong, std::uint64_t>::value)
+    if (!std::is_same<sycl::opencl::cl_ulong, std::uint64_t>::value)
 #endif
       for_type_and_vectors<check_type, std::uint64_t>(log, "std::uint64_t");
 #endif

--- a/tests/group/group_async_work_group_copy.cpp
+++ b/tests/group/group_async_work_group_copy.cpp
@@ -66,9 +66,10 @@ class TEST_NAME : public util::test_base {
         "unsigned long long");
     for_type_and_vectors<check_type, float>(log,
         "float");
-
     for_type_and_vectors<check_type, sycl::byte>(log,
         "sycl::byte");
+
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
     for_type_and_vectors<check_type, sycl::cl_bool>(log,
         "sycl::cl_bool");
     for_type_and_vectors<check_type, sycl::cl_char>(log,
@@ -89,38 +90,31 @@ class TEST_NAME : public util::test_base {
         "sycl::cl_ulong");
     for_type_and_vectors<check_type, sycl::cl_float>(log,
         "sycl::cl_float");
+#endif
 
 #ifdef INT8_MAX
-    if (!std::is_same<sycl::cl_char, std::int8_t>::value)
-      for_type_and_vectors<check_type, std::int8_t>(log, "std::int8_t");
+    for_type_and_vectors<check_type, std::int8_t>(log, "std::int8_t");
 #endif
 #ifdef INT16_MAX
-    if (!std::is_same<sycl::cl_short, std::int16_t>::value)
-      for_type_and_vectors<check_type, std::int16_t>(log, "std::int16_t");
+    for_type_and_vectors<check_type, std::int16_t>(log, "std::int16_t");
 #endif
 #ifdef INT32_MAX
-    if (!std::is_same<sycl::cl_int, std::int32_t>::value)
-      for_type_and_vectors<check_type, std::int32_t>(log, "std::int32_t");
+    for_type_and_vectors<check_type, std::int32_t>(log, "std::int32_t");
 #endif
 #ifdef INT64_MAX
-    if (!std::is_same<sycl::cl_long, std::int64_t>::value)
-      for_type_and_vectors<check_type, std::int64_t>(log, "std::int64_t");
+    for_type_and_vectors<check_type, std::int64_t>(log, "std::int64_t");
 #endif
 #ifdef UINT8_MAX
-    if (!std::is_same<sycl::cl_uchar, std::uint8_t>::value)
-      for_type_and_vectors<check_type, std::uint8_t>(log, "std::uint8_t");
+    for_type_and_vectors<check_type, std::uint8_t>(log, "std::uint8_t");
 #endif
 #ifdef UINT16_MAX
-    if (!std::is_same<sycl::cl_ushort, std::uint16_t>::value)
-      for_type_and_vectors<check_type, std::uint16_t>(log, "std::uint16_t");
+    for_type_and_vectors<check_type, std::uint16_t>(log, "std::uint16_t");
 #endif
 #ifdef UINT32_MAX
-    if (!std::is_same<sycl::cl_uint, std::uint32_t>::value)
-      for_type_and_vectors<check_type, std::uint32_t>(log, "std::uint32_t");
+    for_type_and_vectors<check_type, std::uint32_t>(log, "std::uint32_t");
 #endif
 #ifdef UINT64_MAX
-    if (!std::is_same<sycl::cl_ulong, std::uint64_t>::value)
-      for_type_and_vectors<check_type, std::uint64_t>(log, "std::uint64_t");
+    for_type_and_vectors<check_type, std::uint64_t>(log, "std::uint64_t");
 #endif
   }
 };

--- a/tests/group/group_async_work_group_copy_fp16.cpp
+++ b/tests/group/group_async_work_group_copy_fp16.cpp
@@ -37,8 +37,8 @@ class TEST_NAME : public util::test_base {
       // Test using queue constructed already
       for_type_and_vectors<check_type, sycl::half>(queue, log,
           "sycl::half");
-      for_type_and_vectors<check_type, sycl::cl_half>(queue, log,
-          "sycl::cl_half");
+      for_type_and_vectors<check_type, sycl::opencl::cl_half>(queue, log,
+          "sycl::opencl::cl_half");
     }
   }
 };

--- a/tests/group/group_async_work_group_copy_fp16.cpp
+++ b/tests/group/group_async_work_group_copy_fp16.cpp
@@ -18,14 +18,14 @@ namespace TEST_NAMESPACE {
 class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
-  */
-  void get_info(test_base::info &out) const override {
+   */
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
-  */
-  void run(util::logger &log) override {
+   */
+  void run(util::logger& log) override {
     {
       auto queue = util::get_cts_object::queue();
 
@@ -35,10 +35,9 @@ class TEST_NAME : public util::test_base {
         return;
       }
       // Test using queue constructed already
-      for_type_and_vectors<check_type, sycl::half>(queue, log,
-          "sycl::half");
-      for_type_and_vectors<check_type, sycl::opencl::cl_half>(queue, log,
-          "sycl::opencl::cl_half");
+      for_type_and_vectors<check_type, sycl::half>(queue, log, "sycl::half");
+      for_type_and_vectors<check_type, sycl::opencl::cl_half>(
+          queue, log, "sycl::opencl::cl_half");
     }
   }
 };

--- a/tests/group/group_async_work_group_copy_fp64.cpp
+++ b/tests/group/group_async_work_group_copy_fp64.cpp
@@ -37,8 +37,10 @@ class TEST_NAME : public util::test_base {
       // Test using queue constructed already
       for_type_and_vectors<check_type, double>(queue, log,
           "double");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
       for_type_and_vectors<check_type, sycl::cl_double>(queue, log,
           "sycl::cl_double");
+#endif
     }
   }
 };

--- a/tests/group/group_async_work_group_copy_fp64.cpp
+++ b/tests/group/group_async_work_group_copy_fp64.cpp
@@ -38,8 +38,8 @@ class TEST_NAME : public util::test_base {
       for_type_and_vectors<check_type, double>(queue, log,
           "double");
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-      for_type_and_vectors<check_type, sycl::cl_double>(queue, log,
-          "sycl::cl_double");
+      for_type_and_vectors<check_type, sycl::opencl::cl_double>(queue, log,
+          "sycl::opencl::cl_double");
 #endif
     }
   }

--- a/tests/group/group_async_work_group_copy_fp64.cpp
+++ b/tests/group/group_async_work_group_copy_fp64.cpp
@@ -18,28 +18,28 @@ namespace TEST_NAMESPACE {
 class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
-  */
-  void get_info(test_base::info &out) const override {
+   */
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
-  */
-  void run(util::logger &log) override {
+   */
+  void run(util::logger& log) override {
     {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp64)) {
         log.note(
-          "Device does not support double precision floating point operations");
+            "Device does not support double precision floating point "
+            "operations");
         return;
       }
       // Test using queue constructed already
-      for_type_and_vectors<check_type, double>(queue, log,
-          "double");
+      for_type_and_vectors<check_type, double>(queue, log, "double");
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-      for_type_and_vectors<check_type, sycl::opencl::cl_double>(queue, log,
-          "sycl::opencl::cl_double");
+      for_type_and_vectors<check_type, sycl::opencl::cl_double>(
+          queue, log, "sycl::opencl::cl_double");
 #endif
     }
   }

--- a/tests/nd_item/nd_item_async_work_group_copy.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy.cpp
@@ -80,36 +80,28 @@ class TEST_NAME : public util::test_base {
 #endif
 
 #ifdef INT8_MAX
-    if (!std::is_same<sycl::cl_char, std::int8_t>::value)
-      for_type_and_vectors<check_type, std::int8_t>(log, "std::int8_t");
+    for_type_and_vectors<check_type, std::int8_t>(log, "std::int8_t");
 #endif
 #ifdef INT16_MAX
-    if (!std::is_same<sycl::cl_short, std::int16_t>::value)
-      for_type_and_vectors<check_type, std::int16_t>(log, "std::int16_t");
+    for_type_and_vectors<check_type, std::int16_t>(log, "std::int16_t");
 #endif
 #ifdef INT32_MAX
-    if (!std::is_same<sycl::cl_int, std::int32_t>::value)
-      for_type_and_vectors<check_type, std::int32_t>(log, "std::int32_t");
+    for_type_and_vectors<check_type, std::int32_t>(log, "std::int32_t");
 #endif
 #ifdef INT64_MAX
-    if (!std::is_same<sycl::cl_long, std::int64_t>::value)
-      for_type_and_vectors<check_type, std::int64_t>(log, "std::int64_t");
+    for_type_and_vectors<check_type, std::int64_t>(log, "std::int64_t");
 #endif
 #ifdef UINT8_MAX
-    if (!std::is_same<sycl::cl_uchar, std::uint8_t>::value)
-      for_type_and_vectors<check_type, std::uint8_t>(log, "std::uint8_t");
+    for_type_and_vectors<check_type, std::uint8_t>(log, "std::uint8_t");
 #endif
 #ifdef UINT16_MAX
-    if (!std::is_same<sycl::cl_ushort, std::uint16_t>::value)
-      for_type_and_vectors<check_type, std::uint16_t>(log, "std::uint16_t");
+    for_type_and_vectors<check_type, std::uint16_t>(log, "std::uint16_t");
 #endif
 #ifdef UINT32_MAX
-    if (!std::is_same<sycl::cl_uint, std::uint32_t>::value)
-      for_type_and_vectors<check_type, std::uint32_t>(log, "std::uint32_t");
+    for_type_and_vectors<check_type, std::uint32_t>(log, "std::uint32_t");
 #endif
 #ifdef UINT64_MAX
-    if (!std::is_same<sycl::cl_ulong, std::uint64_t>::value)
-      for_type_and_vectors<check_type, std::uint64_t>(log, "std::uint64_t");
+    for_type_and_vectors<check_type, std::uint64_t>(log, "std::uint64_t");
 #endif
   }
 };

--- a/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
@@ -18,28 +18,27 @@ namespace TEST_NAMESPACE {
 class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
-  */
-  void get_info(test_base::info &out) const override {
+   */
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
-  */
-  void run(util::logger &log) override {
+   */
+  void run(util::logger& log) override {
     {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp16)) {
         log.note(
-          "Device does not support half precision floating point operations");
+            "Device does not support half precision floating point operations");
         return;
       }
       // Test using queue constructed already
-      for_type_and_vectors<check_type, sycl::half>(queue, log,
-          "sycl::half");
+      for_type_and_vectors<check_type, sycl::half>(queue, log, "sycl::half");
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-      for_type_and_vectors<check_type, sycl::opencl::cl_half>(queue, log,
-          "sycl::opencl::cl_half");
+      for_type_and_vectors<check_type, sycl::opencl::cl_half>(
+          queue, log, "sycl::opencl::cl_half");
 #endif
     }
   }

--- a/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
@@ -38,8 +38,8 @@ class TEST_NAME : public util::test_base {
       for_type_and_vectors<check_type, sycl::half>(queue, log,
           "sycl::half");
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-      for_type_and_vectors<check_type, sycl::cl_half>(queue, log,
-          "sycl::cl_half");
+      for_type_and_vectors<check_type, sycl::opencl::cl_half>(queue, log,
+          "sycl::opencl::cl_half");
 #endif
     }
   }

--- a/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp16.cpp
@@ -37,8 +37,10 @@ class TEST_NAME : public util::test_base {
       // Test using queue constructed already
       for_type_and_vectors<check_type, sycl::half>(queue, log,
           "sycl::half");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
       for_type_and_vectors<check_type, sycl::cl_half>(queue, log,
           "sycl::cl_half");
+#endif
     }
   }
 };

--- a/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
@@ -37,8 +37,10 @@ class TEST_NAME : public util::test_base {
       // Test using queue constructed already
       for_type_and_vectors<check_type, double>(queue, log,
           "double");
+#if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
       for_type_and_vectors<check_type, sycl::cl_double>(queue, log,
           "sycl::cl_double");
+#endif
     }
   }
 };

--- a/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
@@ -38,8 +38,8 @@ class TEST_NAME : public util::test_base {
       for_type_and_vectors<check_type, double>(queue, log,
           "double");
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-      for_type_and_vectors<check_type, sycl::cl_double>(queue, log,
-          "sycl::cl_double");
+      for_type_and_vectors<check_type, sycl::opencl::cl_double>(queue, log,
+          "sycl::opencl::cl_double");
 #endif
     }
   }

--- a/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
+++ b/tests/nd_item/nd_item_async_work_group_copy_fp64.cpp
@@ -18,28 +18,28 @@ namespace TEST_NAMESPACE {
 class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
-  */
-  void get_info(test_base::info &out) const override {
+   */
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
   /** execute the test
-  */
-  void run(util::logger &log) override {
+   */
+  void run(util::logger& log) override {
     {
       auto queue = util::get_cts_object::queue();
 
       if (!queue.get_device().has(sycl::aspect::fp64)) {
         log.note(
-          "Device does not support double precision floating point operations");
+            "Device does not support double precision floating point "
+            "operations");
         return;
       }
       // Test using queue constructed already
-      for_type_and_vectors<check_type, double>(queue, log,
-          "double");
+      for_type_and_vectors<check_type, double>(queue, log, "double");
 #if SYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS
-      for_type_and_vectors<check_type, sycl::opencl::cl_double>(queue, log,
-          "sycl::opencl::cl_double");
+      for_type_and_vectors<check_type, sycl::opencl::cl_double>(
+          queue, log, "sycl::opencl::cl_double");
 #endif
     }
   }

--- a/tests/scalars/scalars_interoperability_types.cpp
+++ b/tests/scalars/scalars_interoperability_types.cpp
@@ -38,16 +38,16 @@ class TEST_NAME : public util::test_base {
  public:
   /** return information about this test
    */
-  void get_info(test_base::info &out) const override {
+  void get_info(test_base::info& out) const override {
     set_test_info(out, TOSTRING(TEST_NAME), TEST_FILE);
   }
 
-  std::string errorStr = std::string(
-      "The following device type does not have the correct ");
+  std::string errorStr =
+      std::string("The following device type does not have the correct ");
 
   /** execute the test
    */
-  void run(util::logger &log) override {
+  void run(util::logger& log) override {
     {
       auto myQueue = util::get_cts_object::queue();
 
@@ -60,42 +60,40 @@ class TEST_NAME : public util::test_base {
         FAIL(log,
              "The following host type does not have the correct size: cl_bool");
       }
-      check_type_min_size_sign_log<sycl::opencl::cl_bool>(log, 1, false,
-                                                      "sycl::opencl::cl_bool");
-      check_type_min_size_sign_log<sycl::opencl::cl_char>(log, 1, true,
-                                                      "sycl::opencl::cl_char");
-      check_type_min_size_sign_log<sycl::opencl::cl_uchar>(log, 1, false,
-                                                       "sycl::opencl::cl_uchar");
-      check_type_min_size_sign_log<sycl::opencl::cl_short>(log, 2, true,
-                                                       "sycl::opencl::cl_short");
-      check_type_min_size_sign_log<sycl::opencl::cl_ushort>(log, 2, false,
-                                                        "sycl::opencl::cl_ushort");
-      check_type_min_size_sign_log<sycl::opencl::cl_int>(log, 4, true,
-                                                     "sycl::opencl::cl_int");
-      check_type_min_size_sign_log<sycl::opencl::cl_uint>(log, 4, false,
-                                                      "sycl::opencl::cl_uint");
-      check_type_min_size_sign_log<sycl::opencl::cl_long>(log, 8, true,
-                                                      "sycl::opencl::cl_long");
-      check_type_min_size_sign_log<sycl::opencl::cl_ulong>(log, 8, false,
-                                                       "sycl::opencl::cl_ulong");
+      check_type_min_size_sign_log<sycl::opencl::cl_bool>(
+          log, 1, false, "sycl::opencl::cl_bool");
+      check_type_min_size_sign_log<sycl::opencl::cl_char>(
+          log, 1, true, "sycl::opencl::cl_char");
+      check_type_min_size_sign_log<sycl::opencl::cl_uchar>(
+          log, 1, false, "sycl::opencl::cl_uchar");
+      check_type_min_size_sign_log<sycl::opencl::cl_short>(
+          log, 2, true, "sycl::opencl::cl_short");
+      check_type_min_size_sign_log<sycl::opencl::cl_ushort>(
+          log, 2, false, "sycl::opencl::cl_ushort");
+      check_type_min_size_sign_log<sycl::opencl::cl_int>(
+          log, 4, true, "sycl::opencl::cl_int");
+      check_type_min_size_sign_log<sycl::opencl::cl_uint>(
+          log, 4, false, "sycl::opencl::cl_uint");
+      check_type_min_size_sign_log<sycl::opencl::cl_long>(
+          log, 8, true, "sycl::opencl::cl_long");
+      check_type_min_size_sign_log<sycl::opencl::cl_ulong>(
+          log, 8, false, "sycl::opencl::cl_ulong");
 
       // Floating Point Interop Data Types
-      check_type_min_size_sign_log<sycl::opencl::cl_half>(log, 2, true,
-                                                      "sycl::opencl::cl_half");
-      check_type_min_size_sign_log<sycl::opencl::cl_float>(log, 4, true,
-                                                       "sycl::opencl::cl_float");
-      check_type_min_size_sign_log<sycl::opencl::cl_double>(log, 8, true,
-                                                        "sycl::opencl::cl_double");
+      check_type_min_size_sign_log<sycl::opencl::cl_half>(
+          log, 2, true, "sycl::opencl::cl_half");
+      check_type_min_size_sign_log<sycl::opencl::cl_float>(
+          log, 4, true, "sycl::opencl::cl_float");
+      check_type_min_size_sign_log<sycl::opencl::cl_double>(
+          log, 8, true, "sycl::opencl::cl_double");
 
       bool signResults[11];
       bool sizeResults[12];
       {
-        sycl::buffer<bool, 1> bufSignResult(signResults,
-                                                sycl::range<1>(11));
-        sycl::buffer<bool, 1> bufSizeResult(sizeResults,
-                                                sycl::range<1>(12));
+        sycl::buffer<bool, 1> bufSignResult(signResults, sycl::range<1>(11));
+        sycl::buffer<bool, 1> bufSizeResult(sizeResults, sycl::range<1>(12));
 
-        myQueue.submit([&](sycl::handler &cgh) {
+        myQueue.submit([&](sycl::handler& cgh) {
           auto accSignResult =
               bufSignResult.get_access<sycl::access_mode::read_write>(cgh);
           auto accSizeResult =
@@ -134,7 +132,7 @@ class TEST_NAME : public util::test_base {
         });
 
         if (device_supports_fp16) {
-          myQueue.submit([&](sycl::handler &cgh) {
+          myQueue.submit([&](sycl::handler& cgh) {
             auto accSignResult =
                 bufSignResult.get_access<sycl::access_mode::read_write>(cgh);
             auto accSizeResult =
@@ -153,7 +151,7 @@ class TEST_NAME : public util::test_base {
 
         if (device_supports_fp64) {
           myQueue
-              .submit([&](sycl::handler &cgh) {
+              .submit([&](sycl::handler& cgh) {
                 auto accSignResult =
                     bufSignResult.get_access<sycl::access_mode::read_write>(
                         cgh);
@@ -164,10 +162,12 @@ class TEST_NAME : public util::test_base {
                 cgh.single_task<scalars_interopability_fp64>([=] {
                   // Floating Point 64 Interop Data Type
                   // sign
-                  accSignResult[10] = check_type_sign<sycl::opencl::cl_double>(true);
+                  accSignResult[10] =
+                      check_type_sign<sycl::opencl::cl_double>(true);
 
                   // size
-                  accSizeResult[11] = check_type_min_size<sycl::opencl::cl_double>(8);
+                  accSizeResult[11] =
+                      check_type_min_size<sycl::opencl::cl_double>(8);
                 });
               })
               .wait_and_throw();

--- a/tests/scalars/scalars_interoperability_types.cpp
+++ b/tests/scalars/scalars_interoperability_types.cpp
@@ -60,32 +60,32 @@ class TEST_NAME : public util::test_base {
         FAIL(log,
              "The following host type does not have the correct size: cl_bool");
       }
-      check_type_min_size_sign_log<sycl::cl_bool>(log, 1, false,
-                                                      "sycl::cl_bool");
-      check_type_min_size_sign_log<sycl::cl_char>(log, 1, true,
-                                                      "sycl::cl_char");
-      check_type_min_size_sign_log<sycl::cl_uchar>(log, 1, false,
-                                                       "sycl::cl_uchar");
-      check_type_min_size_sign_log<sycl::cl_short>(log, 2, true,
-                                                       "sycl::cl_short");
-      check_type_min_size_sign_log<sycl::cl_ushort>(log, 2, false,
-                                                        "sycl::cl_ushort");
-      check_type_min_size_sign_log<sycl::cl_int>(log, 4, true,
-                                                     "sycl::cl_int");
-      check_type_min_size_sign_log<sycl::cl_uint>(log, 4, false,
-                                                      "sycl::cl_uint");
-      check_type_min_size_sign_log<sycl::cl_long>(log, 8, true,
-                                                      "sycl::cl_long");
-      check_type_min_size_sign_log<sycl::cl_ulong>(log, 8, false,
-                                                       "sycl::cl_ulong");
+      check_type_min_size_sign_log<sycl::opencl::cl_bool>(log, 1, false,
+                                                      "sycl::opencl::cl_bool");
+      check_type_min_size_sign_log<sycl::opencl::cl_char>(log, 1, true,
+                                                      "sycl::opencl::cl_char");
+      check_type_min_size_sign_log<sycl::opencl::cl_uchar>(log, 1, false,
+                                                       "sycl::opencl::cl_uchar");
+      check_type_min_size_sign_log<sycl::opencl::cl_short>(log, 2, true,
+                                                       "sycl::opencl::cl_short");
+      check_type_min_size_sign_log<sycl::opencl::cl_ushort>(log, 2, false,
+                                                        "sycl::opencl::cl_ushort");
+      check_type_min_size_sign_log<sycl::opencl::cl_int>(log, 4, true,
+                                                     "sycl::opencl::cl_int");
+      check_type_min_size_sign_log<sycl::opencl::cl_uint>(log, 4, false,
+                                                      "sycl::opencl::cl_uint");
+      check_type_min_size_sign_log<sycl::opencl::cl_long>(log, 8, true,
+                                                      "sycl::opencl::cl_long");
+      check_type_min_size_sign_log<sycl::opencl::cl_ulong>(log, 8, false,
+                                                       "sycl::opencl::cl_ulong");
 
       // Floating Point Interop Data Types
-      check_type_min_size_sign_log<sycl::cl_half>(log, 2, true,
-                                                      "sycl::cl_half");
-      check_type_min_size_sign_log<sycl::cl_float>(log, 4, true,
-                                                       "sycl::cl_float");
-      check_type_min_size_sign_log<sycl::cl_double>(log, 8, true,
-                                                        "sycl::cl_double");
+      check_type_min_size_sign_log<sycl::opencl::cl_half>(log, 2, true,
+                                                      "sycl::opencl::cl_half");
+      check_type_min_size_sign_log<sycl::opencl::cl_float>(log, 4, true,
+                                                       "sycl::opencl::cl_float");
+      check_type_min_size_sign_log<sycl::opencl::cl_double>(log, 8, true,
+                                                        "sycl::opencl::cl_double");
 
       bool signResults[11];
       bool sizeResults[12];
@@ -104,32 +104,32 @@ class TEST_NAME : public util::test_base {
           cgh.single_task<TEST_NAME>([=] {
             // Integral Interop Data Types
             // signs
-            accSignResult[0] = check_type_sign<sycl::cl_char>(true);
-            accSignResult[1] = check_type_sign<sycl::cl_uchar>(false);
-            accSignResult[2] = check_type_sign<sycl::cl_short>(true);
-            accSignResult[3] = check_type_sign<sycl::cl_ushort>(false);
-            accSignResult[4] = check_type_sign<sycl::cl_int>(true);
-            accSignResult[5] = check_type_sign<sycl::cl_uint>(false);
-            accSignResult[6] = check_type_sign<sycl::cl_long>(true);
-            accSignResult[7] = check_type_sign<sycl::cl_ulong>(false);
+            accSignResult[0] = check_type_sign<sycl::opencl::cl_char>(true);
+            accSignResult[1] = check_type_sign<sycl::opencl::cl_uchar>(false);
+            accSignResult[2] = check_type_sign<sycl::opencl::cl_short>(true);
+            accSignResult[3] = check_type_sign<sycl::opencl::cl_ushort>(false);
+            accSignResult[4] = check_type_sign<sycl::opencl::cl_int>(true);
+            accSignResult[5] = check_type_sign<sycl::opencl::cl_uint>(false);
+            accSignResult[6] = check_type_sign<sycl::opencl::cl_long>(true);
+            accSignResult[7] = check_type_sign<sycl::opencl::cl_ulong>(false);
 
             // sizes
-            accSizeResult[0] = check_type_min_size<sycl::cl_bool>(1);
-            accSizeResult[1] = check_type_min_size<sycl::cl_char>(1);
-            accSizeResult[2] = check_type_min_size<sycl::cl_uchar>(1);
-            accSizeResult[3] = check_type_min_size<sycl::cl_short>(2);
-            accSizeResult[4] = check_type_min_size<sycl::cl_ushort>(2);
-            accSizeResult[5] = check_type_min_size<sycl::cl_int>(4);
-            accSizeResult[6] = check_type_min_size<sycl::cl_uint>(4);
-            accSizeResult[7] = check_type_min_size<sycl::cl_long>(8);
-            accSizeResult[8] = check_type_min_size<sycl::cl_ulong>(8);
+            accSizeResult[0] = check_type_min_size<sycl::opencl::cl_bool>(1);
+            accSizeResult[1] = check_type_min_size<sycl::opencl::cl_char>(1);
+            accSizeResult[2] = check_type_min_size<sycl::opencl::cl_uchar>(1);
+            accSizeResult[3] = check_type_min_size<sycl::opencl::cl_short>(2);
+            accSizeResult[4] = check_type_min_size<sycl::opencl::cl_ushort>(2);
+            accSizeResult[5] = check_type_min_size<sycl::opencl::cl_int>(4);
+            accSizeResult[6] = check_type_min_size<sycl::opencl::cl_uint>(4);
+            accSizeResult[7] = check_type_min_size<sycl::opencl::cl_long>(8);
+            accSizeResult[8] = check_type_min_size<sycl::opencl::cl_ulong>(8);
 
             // Floating Point Interop Data Type
             // sign
-            accSignResult[9] = check_type_sign<sycl::cl_float>(true);
+            accSignResult[9] = check_type_sign<sycl::opencl::cl_float>(true);
 
             // size
-            accSizeResult[10] = check_type_min_size<sycl::cl_float>(4);
+            accSizeResult[10] = check_type_min_size<sycl::opencl::cl_float>(4);
           });
         });
 
@@ -143,10 +143,10 @@ class TEST_NAME : public util::test_base {
             cgh.single_task<scalars_interopability_fp16>([=] {
               // Floating Point 16 Interop Data Type
               // sign
-              accSignResult[8] = check_type_sign<sycl::cl_half>(true);
+              accSignResult[8] = check_type_sign<sycl::opencl::cl_half>(true);
 
               // size
-              accSizeResult[9] = check_type_min_size<sycl::cl_half>(2);
+              accSizeResult[9] = check_type_min_size<sycl::opencl::cl_half>(2);
             });
           });
         }
@@ -164,10 +164,10 @@ class TEST_NAME : public util::test_base {
                 cgh.single_task<scalars_interopability_fp64>([=] {
                   // Floating Point 64 Interop Data Type
                   // sign
-                  accSignResult[10] = check_type_sign<sycl::cl_double>(true);
+                  accSignResult[10] = check_type_sign<sycl::opencl::cl_double>(true);
 
                   // size
-                  accSizeResult[11] = check_type_min_size<sycl::cl_double>(8);
+                  accSizeResult[11] = check_type_min_size<sycl::opencl::cl_double>(8);
                 });
               })
               .wait_and_throw();
@@ -176,75 +176,75 @@ class TEST_NAME : public util::test_base {
 
       // signs
       if (!signResults[0]) {
-        FAIL(log, errorStr + "sign: sycl::cl_char");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_char");
       }
       if (!signResults[1]) {
-        FAIL(log, errorStr + "sign: sycl::cl_uchar");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_uchar");
       }
       if (!signResults[2]) {
-        FAIL(log, errorStr + "sign: sycl::cl_short");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_short");
       }
       if (!signResults[3]) {
-        FAIL(log, errorStr + "sign: sycl::cl_ushort");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_ushort");
       }
       if (!signResults[4]) {
-        FAIL(log, errorStr + "sign: sycl::cl_int");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_int");
       }
       if (!signResults[5]) {
-        FAIL(log, errorStr + "sign: sycl::cl_uint");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_uint");
       }
       if (!signResults[6]) {
-        FAIL(log, errorStr + "sign: sycl::cl_long");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_long");
       }
       if (!signResults[7]) {
-        FAIL(log, errorStr + "sign: sycl::cl_ulong");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_ulong");
       }
       if (!signResults[8] && device_supports_fp16) {
-        FAIL(log, errorStr + "sign: sycl::cl_half");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_half");
       }
       if (!signResults[9]) {
-        FAIL(log, errorStr + "sign: sycl::cl_float");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_float");
       }
       if (!signResults[10] && device_supports_fp64) {
-        FAIL(log, errorStr + "sign: sycl::cl_double");
+        FAIL(log, errorStr + "sign: sycl::opencl::cl_double");
       }
 
       // sizes
       if (!sizeResults[0]) {
-        FAIL(log, errorStr + "size: sycl::cl_bool");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_bool");
       }
       if (!sizeResults[1]) {
-        FAIL(log, errorStr + "size: sycl::cl_char");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_char");
       }
       if (!sizeResults[2]) {
-        FAIL(log, errorStr + "size: sycl::cl_uchar");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_uchar");
       }
       if (!sizeResults[3]) {
-        FAIL(log, errorStr + "size: sycl::cl_short");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_short");
       }
       if (!sizeResults[4]) {
-        FAIL(log, errorStr + "size: sycl::cl_ushort");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_ushort");
       }
       if (!sizeResults[5]) {
-        FAIL(log, errorStr + "size: sycl::cl_int");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_int");
       }
       if (!sizeResults[6]) {
-        FAIL(log, errorStr + "size: sycl::cl_uint");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_uint");
       }
       if (!sizeResults[7]) {
-        FAIL(log, errorStr + "size: sycl::cl_long");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_long");
       }
       if (!sizeResults[8]) {
-        FAIL(log, errorStr + "size: sycl::cl_ulong");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_ulong");
       }
       if (!sizeResults[9] && device_supports_fp16) {
-        FAIL(log, errorStr + "size: sycl::cl_half");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_half");
       }
       if (!sizeResults[10]) {
-        FAIL(log, errorStr + "size: sycl::cl_float");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_float");
       }
       if (!sizeResults[11] && device_supports_fp64) {
-        FAIL(log, errorStr + "size: sycl::cl_double");
+        FAIL(log, errorStr + "size: sycl::opencl::cl_double");
       }
 
       myQueue.wait_and_throw();


### PR DESCRIPTION
This improves compatibility with implementations that do not expose OpenCL interop (notably [SimSYCL](https://github.com/celerity/SimSYCL), and AFAIK also AdaptiveCpp / hipSYCL).

This change is probably incomplete, but enough to get some tests to build with SimSYCL that otherwise wouldn't. 

`group_async_work_group_copy.cpp` had `!is_same` checks between cl types and stdint types - please correct me if it's wrong to remove these checks, it appears to me as though performing the same check twice is not an issue - but maybe there's symbol clashes.