### PR TITLE
Fix kernel_bundle tests for multi-device systems

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -857,7 +857,7 @@ inline sycl::id<3> unlinearize(sycl::range<3> range, size_t id) {
  *  @param rhs std::vector with sycl::device
  */
 inline bool have_same_devices(std::vector<sycl::device> lhs,
-                       std::vector<sycl::device> rhs) {
+                              std::vector<sycl::device> rhs) {
   auto device_order_f = [](const sycl::device& d1,
                            const sycl::device& d2) -> bool {
     std::hash<sycl::device> h{};

--- a/tests/kernel_bundle/sycl_build_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
+++ b/tests/kernel_bundle/sycl_build_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
@@ -59,7 +59,7 @@ void verify_results(
   if (kernel_bundle.get_context() != ctx) {
     FAIL(log, "Kernel bundle's context does not equal to provided context");
   }
-  if (kernel_bundle.get_devices() != dev_vector) {
+  if (!have_same_devices(kernel_bundle.get_devices(), dev_vector)) {
     FAIL(log, "Devices from kernel bundle not equal to provided devices");
   }
 }
@@ -118,7 +118,7 @@ struct verify_that_bundles_are_same {
  */
 void run_verification(util::logger &log, sycl::queue &q) {
   auto ctx = q.get_context();
-  std::vector<sycl::device> dev_vector{ctx.get_devices()[0]};
+  std::vector<sycl::device> dev_vector{ctx.get_devices()};
 
   const auto first_simple_kernel_id =
       sycl::get_kernel_id<first_simple_kernel>();

--- a/tests/kernel_bundle/sycl_join_kernel_bundle_with_empty_one.cpp
+++ b/tests/kernel_bundle/sycl_join_kernel_bundle_with_empty_one.cpp
@@ -35,8 +35,7 @@ void run_verification(util::logger &log) {
 
   // Selector that always returns false. Used to get empty kernel_bundle
   auto false_selector = [](const sycl::device_image<State> &) { return false; };
-  auto empty_kb =
-      sycl::get_kernel_bundle<State>(ctx, ctx.get_devices(), false_selector);
+  auto empty_kb = sycl::get_kernel_bundle<State>(ctx, false_selector);
 
   // Check joined bundles in such order: (kernel_bundle, empty_kernel_bundle)
   {

--- a/tests/kernel_bundle/sycl_join_kernel_bundle_with_empty_one.cpp
+++ b/tests/kernel_bundle/sycl_join_kernel_bundle_with_empty_one.cpp
@@ -30,13 +30,13 @@ template <sycl::bundle_state State>
 void run_verification(util::logger &log) {
   auto queue = util::get_cts_object::queue();
   const auto ctx = queue.get_context();
-  const auto dev = queue.get_device();
 
   auto kb = sycl::get_kernel_bundle<State>(ctx);
 
   // Selector that always returns false. Used to get empty kernel_bundle
   auto false_selector = [](const sycl::device_image<State> &) { return false; };
-  auto empty_kb = sycl::get_kernel_bundle<State>(ctx, {dev}, false_selector);
+  auto empty_kb =
+      sycl::get_kernel_bundle<State>(ctx, ctx.get_devices(), false_selector);
 
   // Check joined bundles in such order: (kernel_bundle, empty_kernel_bundle)
   {

--- a/tests/kernel_bundle/sycl_link_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
+++ b/tests/kernel_bundle/sycl_link_verify_kernel_invoked_and_kernel_in_result_bundle.cpp
@@ -71,7 +71,7 @@ void verify_results(
   if (kernel_bundle.get_context() != ctx) {
     FAIL(log, "Kernel bundle's context does not equal to provided context");
   }
-  if (kernel_bundle.get_devices() != dev_vector) {
+  if (!have_same_devices(kernel_bundle.get_devices(), dev_vector)) {
     FAIL(log, "Devices from kernel bundle not equal to provided devices");
   }
 }
@@ -117,7 +117,7 @@ void run_verification(util::logger &log, sycl::queue &queue) {
       kb_with_first_simple_kernel_from_input, kb_with_second_simple_kernel};
 
   std::vector<sycl::device> dev_vector{ctx.get_devices()};
-  std::vector<sycl::device> current_dev_vector{util::get_cts_object::device()};
+  std::vector<sycl::device> current_dev_vector{queue.get_device()};
 
   log.note("Verify link(vector<kernel_bundle<>>, vector<device>) overload");
   verify_results(log, current_dev_vector, ctx,


### PR DESCRIPTION
Some of the kernel_bundle tests make faulty assumptions about the set of devices used in the kernel bundles. This commit fixes these assumptions.