### PR TITLE
Add test for value_type alias in vector_api

### DIFF
--- a/tests/vector_api/generate_vector_api.py
+++ b/tests/vector_api/generate_vector_api.py
@@ -34,6 +34,7 @@ TEST_NAME = 'API'
 vector_element_type_template = Template("""
     CHECK(std::is_same_v<typename sycl::vec<${type}, ${size}>::element_type, ${type}>);
     sycl::vec<${type}, ${size}> vec;
+    CHECK(std::is_same_v<typename sycl::vec<${type}, ${size}>::value_type, ${type}>);
     CHECK(std::is_same_v<typename decltype(
         vec.template swizzle<${swizIndexes}>())::element_type, ${type}>);
 """)


### PR DESCRIPTION
This PR adds testing logic to verify that the type described by the vec::value_type alias is the same as the underlying type of the vector. 