### PR TITLE
Align marray ctor checking with comments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "algorithm": "cpp"
+  }
+}

--- a/tests/marray/marray_constructor.h
+++ b/tests/marray/marray_constructor.h
@@ -145,7 +145,6 @@ class run_marray_constructor_test {
             })
             .wait_and_throw();
       }
-      run_checks(check_results);
       for (size_t i = 0; i < num_test_cases; ++i) {
         INFO(check_names[i]);
         CHECK(check_results[i]);


### PR DESCRIPTION
Remove redundant `run_checks` in marray_operators.h