### PR TITLE
Replace deprecated id -> range conversion

### DIFF
--- a/tests/hierarchical/hierarchical_non_uniform_local_range.cpp
+++ b/tests/hierarchical/hierarchical_non_uniform_local_range.cpp
@@ -92,9 +92,13 @@ template <int dim> void check_dim(util::logger &log) {
                 local_range_total>(local_range, local_range);
         cgh.parallel_for_work_group<kernel<dim>>(
             groupRange, localRange, [=](sycl::group<dim> group_pid) {
+              sycl::range<dim> r;
+              auto group_id = group_pid.get_group_id();
+              for (int i = 0; i < dim; ++i)
+                r[i] = group_id[i];
+
               group_pid.parallel_for_work_item(
-                  sycl::range<dim>(group_pid.get_id()),
-                  [&](sycl::h_item<dim> item_id) {
+                r, [&](sycl::h_item<dim> item_id) {
                     unsigned physical_local_d1 =
                         item_id.get_physical_local()[0];
                     unsigned physical_local_d2 =

--- a/tests/hierarchical/hierarchical_non_uniform_local_range.cpp
+++ b/tests/hierarchical/hierarchical_non_uniform_local_range.cpp
@@ -94,11 +94,10 @@ template <int dim> void check_dim(util::logger &log) {
             groupRange, localRange, [=](sycl::group<dim> group_pid) {
               sycl::range<dim> r;
               auto group_id = group_pid.get_group_id();
-              for (int i = 0; i < dim; ++i)
-                r[i] = group_id[i];
+              for (int i = 0; i < dim; ++i) r[i] = group_id[i];
 
               group_pid.parallel_for_work_item(
-                r, [&](sycl::h_item<dim> item_id) {
+                  r, [&](sycl::h_item<dim> item_id) {
                     unsigned physical_local_d1 =
                         item_id.get_physical_local()[0];
                     unsigned physical_local_d2 =


### PR DESCRIPTION
As I understand - this API was never part of the specification.
Found out this test fails to compile after https://github.com/intel/llvm/commit/f98e99c9e858984b19633825c31d8379d25a806b.