### PR TITLE
Make math_builtin_api tests splittable into smaller chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+build*/
 .idea
 log.txt
 *.pyc

--- a/tests/math_builtin_api/CMakeLists.txt
+++ b/tests/math_builtin_api/CMakeLists.txt
@@ -18,33 +18,44 @@ set(math_builtin_depends
   "modules/test_generator.py"
 )
 
+set(SYCL_CTS_MATH_BUILTIN_N_SPLITS 16 CACHE STRING 
+    "The number of times to divide each math_builtin_api test")
+
 foreach(cat ${MATH_CAT_WITH_VARIANT})
   foreach(var ${MATH_VARIANT})
-    if ("${cat}" STREQUAL geometric AND "${var}" STREQUAL half)
-      continue()
-    endif()
-    # Invoke our generator
-    # the path to the generated cpp file will be added to TEST_CASES_LIST
-    generate_cts_test(TESTS TEST_CASES_LIST
-      GENERATOR "generate_math_builtin.py"
-      OUTPUT "math_builtin_${cat}_${var}.cpp"
-      INPUT "math_builtin.template"
-      EXTRA_ARGS -test ${cat} -variante ${var} -marray true
-      DEPENDS ${math_builtin_depends}
-    )
+    foreach(split_index RANGE 1 ${SYCL_CTS_MATH_BUILTIN_N_SPLITS})
+      if ("${cat}" STREQUAL geometric AND "${var}" STREQUAL half)
+        continue()
+      endif()
+      # Invoke our generator
+      # the path to the generated cpp file will be added to TEST_CASES_LIST
+      math(EXPR split_index_0 "${split_index} - 1")
+      generate_cts_test(TESTS TEST_CASES_LIST
+        GENERATOR "generate_math_builtin.py"
+        OUTPUT "math_builtin_${cat}_${var}_${split_index}_${SYCL_CTS_MATH_BUILTIN_N_SPLITS}.cpp"
+        INPUT "math_builtin.template"
+        EXTRA_ARGS -test ${cat} -variante ${var} -marray true 
+                   -i ${split_index_0} -n ${SYCL_CTS_MATH_BUILTIN_N_SPLITS}
+        DEPENDS ${math_builtin_depends}
+      )
+    endforeach()
   endforeach()
 endforeach()
 
 foreach(cat ${MATH_CAT})
-  # Invoke our generator
-  # the path to the generated cpp file will be added to TEST_CASES_LIST
-  generate_cts_test(TESTS TEST_CASES_LIST
-    GENERATOR "generate_math_builtin.py"
-    OUTPUT "math_builtin_${cat}.cpp"
-    INPUT "math_builtin.template"
-    EXTRA_ARGS -test ${cat} -marray true
-    DEPENDS ${math_builtin_depends}
-  )
+  foreach(split_index RANGE 1 ${SYCL_CTS_MATH_BUILTIN_N_SPLITS})
+    # Invoke our generator
+    # the path to the generated cpp file will be added to TEST_CASES_LIST
+    math(EXPR split_index_0 "${split_index} - 1")
+    generate_cts_test(TESTS TEST_CASES_LIST
+      GENERATOR "generate_math_builtin.py"
+      OUTPUT "math_builtin_${cat}_${split_index}_${SYCL_CTS_MATH_BUILTIN_N_SPLITS}.cpp"
+      INPUT "math_builtin.template"
+      EXTRA_ARGS -test ${cat} -marray true 
+                 -i ${split_index_0} -n ${SYCL_CTS_MATH_BUILTIN_N_SPLITS}
+      DEPENDS ${math_builtin_depends}
+    )
+  endforeach()
 endforeach()
 
 add_cts_test(${TEST_CASES_LIST})

--- a/tests/math_builtin_api/modules/test_generator.py
+++ b/tests/math_builtin_api/modules/test_generator.py
@@ -347,31 +347,31 @@ def generate_test_case(test_id, types, sig, memory, check, decorated = ""):
 
 def generate_test_cases(test_id, types, sig_list, check):
     random.seed(0)
-    test_source = ""
+    test_cases = []
     decorated_yes = "sycl::access::decorated::yes"
     decorated_no = "sycl::access::decorated::no"
     for sig in sig_list:
         if sig.pntr_indx:#If the signature contains a pointer argument.
-            test_source += generate_test_case(test_id, types, sig, "private", check, decorated_no)
+            test_cases.append(generate_test_case(test_id, types, sig, "private", check, decorated_no))
             test_id += 1
-            test_source += generate_test_case(test_id, types, sig, "private", check, decorated_yes)
+            test_cases.append(generate_test_case(test_id, types, sig, "private", check, decorated_yes))
             test_id += 1
-            test_source += generate_test_case(test_id, types, sig, "local", check, decorated_no)
+            test_cases.append(generate_test_case(test_id, types, sig, "local", check, decorated_no))
             test_id += 1
-            test_source += generate_test_case(test_id, types, sig, "local", check, decorated_yes)
+            test_cases.append(generate_test_case(test_id, types, sig, "local", check, decorated_yes))
             test_id += 1
-            test_source += generate_test_case(test_id, types, sig, "global", check, decorated_no)
+            test_cases.append(generate_test_case(test_id, types, sig, "global", check, decorated_no))
             test_id += 1
-            test_source += generate_test_case(test_id, types, sig, "global", check, decorated_yes)
+            test_cases.append(generate_test_case(test_id, types, sig, "global", check, decorated_yes))
             test_id += 1
         else:
             if check:
-                test_source += generate_test_case(test_id, types, sig, "no_ptr", check)
+                test_cases.append(generate_test_case(test_id, types, sig, "no_ptr", check))
                 test_id += 1
             else:
-                test_source += generate_test_case(test_id, types, sig, "private", check)
+                test_cases.append(generate_test_case(test_id, types, sig, "private", check))
                 test_id += 1
-    return test_source
+    return test_cases
 
 # Lists of the types with equal sizes
 chars = ["char", "signed char", "unsigned char"]


### PR DESCRIPTION
Currently, the some of the generated `math_builtin_api` tests are huge. These are the current line counts:

```
   72405 tests/math_builtin_api/math_builtin_integer.cpp
   27088 tests/math_builtin_api/math_builtin_float_half.cpp
   27088 tests/math_builtin_api/math_builtin_float_double.cpp
   27079 tests/math_builtin_api/math_builtin_float_base.cpp
   17218 tests/math_builtin_api/math_builtin_relational_base.cpp
    4599 tests/math_builtin_api/math_builtin_relational_half.cpp
    4599 tests/math_builtin_api/math_builtin_relational_double.cpp
    4307 tests/math_builtin_api/math_builtin_common_half.cpp
    4307 tests/math_builtin_api/math_builtin_common_double.cpp
    4298 tests/math_builtin_api/math_builtin_common_base.cpp
    3689 tests/math_builtin_api/math_builtin_native.cpp
    3689 tests/math_builtin_api/math_builtin_half.cpp
    1163 tests/math_builtin_api/math_builtin_geometric_base.cpp
     832 tests/math_builtin_api/math_builtin_geometric_double.cpp
```

When building on release mode, `-O3` optimization will be used, which aside from making compilation taking much longer, will make building `math_builtin_integer.cpp` use an unreasonable amount of RAM for the average person (64GB+). 

This PR adds a functionality to split these tests into smaller chunks, which allows for each chunk to be compiled with a reasonable amount of RAM, and leads to a much faster compilation time. 

Each of the original generated files listed above are all split into a test-wide configurable amount `SYCL_CTS_MATH_BUILTIN_N_SPLITS`, which is 16 initially. This makes each of the chunks of the biggest test `math_builtin_integer.cpp` under 5k LOC.