### PR TITLE
Replace reserve with resize for write-back buffer

### DIFF
--- a/tests/buffer/buffer_storage_common.h
+++ b/tests/buffer/buffer_storage_common.h
@@ -70,7 +70,7 @@ class buffer_storage_test {
 
     // Case 5 - Vector data
     std::vector<T> data_vector;
-    data_vector.reserve(size);
+    data_vector.resize(size);
     auto data_final5 = data_vector.begin();
 
     check_write_back(log, r, data_final1.get());


### PR DESCRIPTION
In the buffer storage tests, the case using a vector iterator reserves size in the buffer and then expects to be able to access through the specified size. However, this is not the intention of reserve, as it does not change the end of the vector. Instead, this should use resize.