### PR TITLE
Add `SYCL_CTS_ENABLE_EXT_ONEAPI_ROOT_GROUP_TESTS` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,10 @@ add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_COMPOSITE_DEVICE_TESTS
     "Enable extension oneAPI composite_device tests" OFF
     FORCE_ON ${SYCL_CTS_ENABLE_EXT_ONEAPI_TESTS})
 
+add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_ROOT_GROUP_TESTS
+    "Enable extension oneAPI root group tests" OFF
+    FORCE_ON ${SYCL_CTS_ENABLE_EXT_ONEAPI_TESTS})
+
 # TODO: Deprecated - remove
 add_cts_option(SYCL_CTS_ENABLE_VERBOSE_LOG
     "Enable debug-level logs (deprecated)" OFF)


### PR DESCRIPTION
Add a CTS option for enabling root group tests and enable it when `SYCL_CTS_ENABLE_EXT_ONEAPI_TESTS` is on. We forgot this when merging #799.