### PR TITLE
Update test_accessor according to the spec change

### DIFF
--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -1047,7 +1047,8 @@ void test_accessor_ptr_device(AccT& accessor, T& expected_data, AccRes& res_acc,
 
   auto acc_pointer = accessor.get_pointer();
   res_acc[res_i++] =
-      std::is_same_v<decltype(acc_pointer), sycl::global_ptr<AccT::value_type>>;
+      std::is_same_v<decltype(acc_pointer),
+                     sycl::global_ptr<typename AccT::value_type>>;
   res_acc[res_i++] = value_operations::are_equal(*acc_pointer, expected_data);
 }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL

--- a/tests/accessor/accessor_common.h
+++ b/tests/accessor/accessor_common.h
@@ -1046,7 +1046,8 @@ void test_accessor_ptr_device(AccT& accessor, T& expected_data, AccRes& res_acc,
                                                  expected_data);
 
   auto acc_pointer = accessor.get_pointer();
-  res_acc[res_i++] = std::is_same_v<decltype(acc_pointer), sycl::global_ptr<T>>;
+  res_acc[res_i++] =
+      std::is_same_v<decltype(acc_pointer), sycl::global_ptr<AccT::value_type>>;
   res_acc[res_i++] = value_operations::are_equal(*acc_pointer, expected_data);
 }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL


### PR DESCRIPTION
accessor::get_pointer() should return global_pointer<value_type>, but not global_pointer<DataT>
Spec: https://github.com/KhronosGroup/SYCL-Docs/pull/549