### PR TITLE
Add missing include of map in non-uniform group tests

### DIFF
--- a/tests/extension/oneapi_non_uniform_groups/group_reduce.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_reduce.h
@@ -18,6 +18,8 @@
 //
 *******************************************************************************/
 
+#include <map>
+
 #include "../../group_functions/group_functions_common.h"
 #include "non_uniform_group_common.h"
 

--- a/tests/extension/oneapi_non_uniform_groups/group_scan.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_scan.h
@@ -18,6 +18,7 @@
 //
 *******************************************************************************/
 
+#include <map>
 #include <valarray>
 
 #include "../../group_functions/group_functions_common.h"


### PR DESCRIPTION
The recently merged tests for the oneAPI non-uniform groups extension are failing on Windows due to missing includes of the map header. This commit fixes this issue.