### PR TITLE
Split up vector_swizzle tests into smaller chunks to improve compilation times

### DIFF
--- a/tests/common/common_python_vec.py
+++ b/tests/common/common_python_vec.py
@@ -21,9 +21,9 @@
 # ************************************************************************
 
 from collections import defaultdict
-from string import Template
 from itertools import product
 from math import ceil, floor
+from string import Template
 
 class Data:
     signs = [True, False]

--- a/tests/common/vector_swizzles.template
+++ b/tests/common/vector_swizzles.template
@@ -83,7 +83,7 @@ class TEST_NAME : public util::test_base {
   }
 };
 
-util::test_proxy<TEST_NAME> proxy;
+inline util::test_proxy<TEST_NAME> proxy;
 
 } /* namespace vector_swizzles_$TYPE_NAME__ */
 $ENDIF

--- a/tests/vector_swizzles/CMakeLists.txt
+++ b/tests/vector_swizzles/CMakeLists.txt
@@ -1,6 +1,14 @@
 set(TEST_CASES_LIST "")
 
 set(TYPE_LIST "")
+
+# The vector swizzle tests can become too large if we dont split them into chunks or batches
+# and this can hurt compilation times or even cause it to fail on machines 16 GB of RAM or less.
+# Therefore, we output the tests in batches in order to instead generate a larger number of files
+# which are individually much smaller which in turn speeds up compilation when using multiple threads.
+# It also reduces the memory footprint of the tests. 
+# Some experimentation has shown 32 to be a reasonable value for the number of chunks/batches 
+# where the compilation suceeds iunder constrained space resorces  and we don't produce a huge number of files.
 set(NUM_BATCHES "32")
 get_std_type(TYPE_LIST)
 get_no_vec_alias_type(TYPE_LIST)

--- a/tests/vector_swizzles/CMakeLists.txt
+++ b/tests/vector_swizzles/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_CASES_LIST "")
 
 set(TYPE_LIST "")
+set(NUM_BATCHES "32")
 get_std_type(TYPE_LIST)
 get_no_vec_alias_type(TYPE_LIST)
 get_fixed_width_type(TYPE_LIST)
@@ -8,18 +9,20 @@ get_fixed_width_type(TYPE_LIST)
 half_double_filter(TYPE_LIST)
 
 foreach(TY IN LISTS TYPE_LIST)
-  set(OUT_FILE "vector_swizzles_${TY}.cpp")
-  STRING(REGEX REPLACE ":" "_" OUT_FILE ${OUT_FILE})
-  STRING(REGEX REPLACE " " "_" OUT_FILE ${OUT_FILE})
-  STRING(REGEX REPLACE "std__" "" OUT_FILE ${OUT_FILE})
+    foreach(BATCH_INDEX RANGE 1 ${NUM_BATCHES})
+        set(OUT_FILE "vector_swizzles_${TY}_batch_${BATCH_INDEX}.cpp")
+        STRING(REGEX REPLACE ":" "_" OUT_FILE ${OUT_FILE})
+        STRING(REGEX REPLACE " " "_" OUT_FILE ${OUT_FILE})
+        STRING(REGEX REPLACE "std__" "" OUT_FILE ${OUT_FILE})
 
-  # Invoke our generator
-  # the path to the generated cpp file will be added to TEST_CASES_LIST
-  generate_cts_test(TESTS TEST_CASES_LIST
-    GENERATOR "generate_vector_swizzles.py"
-    OUTPUT ${OUT_FILE}
-    INPUT "../common/vector_swizzles.template"
-    EXTRA_ARGS -type "${TY}")
+        # Invoke our generator
+        # the path to the generated cpp file will be added to TEST_CASES_LIST
+        generate_cts_test(TESTS TEST_CASES_LIST
+        GENERATOR "generate_vector_swizzles.py"
+        OUTPUT ${OUT_FILE}
+        INPUT "../common/vector_swizzles.template"
+        EXTRA_ARGS -type "${TY}" -num_batches ${NUM_BATCHES} -batch_index ${BATCH_INDEX})
+    endforeach()
 endforeach()
 
 add_cts_test(${TEST_CASES_LIST})

--- a/tests/vector_swizzles/CMakeLists.txt
+++ b/tests/vector_swizzles/CMakeLists.txt
@@ -3,12 +3,12 @@ set(TEST_CASES_LIST "")
 set(TYPE_LIST "")
 
 # The vector swizzle tests can become too large if we dont split them into chunks or batches
-# and this can hurt compilation times or even cause it to fail on machines 16 GB of RAM or less.
+# and this can hurt compilation times or even cause it to fail on machines with 16 GB of RAM or less.
 # Therefore, we output the tests in batches in order to instead generate a larger number of files
 # which are individually much smaller which in turn speeds up compilation when using multiple threads.
 # It also reduces the memory footprint of the tests. 
 # Some experimentation has shown 32 to be a reasonable value for the number of chunks/batches 
-# where the compilation suceeds iunder constrained space resorces  and we don't produce a huge number of files.
+# where the compilation suceeds under constrained space resorces and we don't produce a huge number of files.
 set(NUM_BATCHES "32")
 get_std_type(TYPE_LIST)
 get_no_vec_alias_type(TYPE_LIST)

--- a/tests/vector_swizzles/generate_vector_swizzles.py
+++ b/tests/vector_swizzles/generate_vector_swizzles.py
@@ -41,6 +41,18 @@ def main():
         choices=get_types(),
         help='Type to generate the test for')
     argparser.add_argument(
+        '-num_batches',
+        dest='num_batches',
+        required=True,
+        type=int,
+        help='Number of batches to split the test cases into')
+    argparser.add_argument(
+        '-batch_index',
+        dest='batch_index',
+        required=True,
+        type=int,
+        help='Batch index of the test batch to write to the output file.') 
+    argparser.add_argument(
         '-o',
         required=True,
         dest="output",
@@ -48,7 +60,7 @@ def main():
         help='CTS test output')
     args = argparser.parse_args()
 
-    make_swizzles_tests(args.ty, args.template, args.output)
+    make_swizzles_tests(args.ty, args.template, args.output, args.num_batches, args.batch_index - 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The vector swizzle tests are failing to compile on machines with 16 GB of RAM due to the huge size of some of the test .cpp files that are generated by the scripts. This PR makes the necessary changes to enforce splitting of these test files into smaller and more manageable files that can be compiled without requiring a large memory footprint. As of the time of this writing, I've chosen the number of batches aka chunks to be 32 so that each large file will be subdivided into 32 smaller files. I chose this number because with 16 chunks I was seeing flaky results where a compilation would succeed or fail depending on the state of the machine at the time of compilation. With 32 however, compilation was succeeding constantly. Nevertheless, this can easily be adjusted according to our needs.