### PR TITLE
Fix check for composite devices not being root devices

### DIFF
--- a/tests/extension/oneapi_composite_device/enumerating_composite_devices.cpp
+++ b/tests/extension/oneapi_composite_device/enumerating_composite_devices.cpp
@@ -158,7 +158,7 @@ TEST_CASE(
   for (auto composite_device : composite_devices) {
     REQUIRE(std::none_of(root_devices.begin(), root_devices.end(),
                          [&](sycl::device& root_device) {
-                           return composite_device != root_device;
+                           return composite_device == root_device;
                          }));
   }
 #endif


### PR DESCRIPTION
The logic in the test for checking that composite devices are not root devices as it checks that "none of the root devices *are not* the same as any composite device" instead of "none of the root devices *are* the same as any composite device." This commit fixes this check.