### PR TITLE
Avoid non-uniform group contesting access to memory in group_of tests

### DIFF
--- a/tests/extension/oneapi_non_uniform_groups/group_of.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_of.h
@@ -82,9 +82,14 @@ void joint_of_group(sycl::queue& queue) {
               sycl::sub_group sub_group = item.get_sub_group();
 
               // If this item is not participating in the group, leave early.
-              if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                     test_case))
+              if (!NonUniformGroupHelper<GroupT>::should_participate(
+                      sub_group, test_case)) {
+                // If an item is not participating, its results are trivially
+                // correct.
+                for (unsigned i = 0; i < test_matrix * test_cases; ++i)
+                  res_acc[gid][i] = true;
                 return;
+              }
 
               GroupT non_uniform_group =
                   NonUniformGroupHelper<GroupT>::create(sub_group, test_case);

--- a/tests/extension/oneapi_non_uniform_groups/group_of.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_of.h
@@ -64,102 +64,103 @@ void joint_of_group(sycl::queue& queue) {
       std::vector<T> v(size);
       std::iota(v.begin(), v.end(), 1);
 
-      // array to return results:
-      bool res[test_matrix * test_cases] = {false};
+      sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
+
+      sycl::buffer<bool, 2> res_sycl(
+          sycl::range<2>(work_group_size, test_matrix * test_cases));
+
+      queue.submit([&](sycl::handler& cgh) {
+        auto v_acc =
+            v_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+
+        cgh.parallel_for<joint_of_group_kernel<GroupT, T>>(
+            executionRange, [=](sycl::nd_item<1> item) {
+              size_t gid = item.get_global_linear_id();
+              sycl::sub_group sub_group = item.get_sub_group();
+
+              // If this item is not participating in the group, leave early.
+              if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                                     test_case))
+                return;
+
+              GroupT non_uniform_group =
+                  NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+
+              T* v_begin = v_acc.get_pointer();
+              T* v_end = v_begin + v_acc.size();
+
+              // predicates
+              auto none_true = [&](T i) { return i == 0; };
+              auto one_true = [&](T i) { return i == 1; };
+              auto some_true = [&](T i) { return i > size / 2; };
+              auto all_true = [&](T i) { return i <= size; };
+
+              static_assert(
+                  std::is_same_v<bool, decltype(sycl::joint_any_of(
+                                           non_uniform_group, v_begin, v_end,
+                                           none_true))>,
+                  "Return type of joint_any_of(GroupT g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[gid][0] = !sycl::joint_any_of(non_uniform_group, v_begin,
+                                                    v_end, none_true);
+              res_acc[gid][1] = sycl::joint_any_of(non_uniform_group, v_begin,
+                                                   v_end, one_true);
+              res_acc[gid][2] = sycl::joint_any_of(non_uniform_group, v_begin,
+                                                   v_end, some_true);
+              res_acc[gid][3] = sycl::joint_any_of(non_uniform_group, v_begin,
+                                                   v_end, all_true);
+
+              static_assert(
+                  std::is_same_v<bool, decltype(sycl::joint_all_of(
+                                           non_uniform_group, v_begin, v_end,
+                                           none_true))>,
+                  "Return type of joint_all_of(GroupT g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[gid][4] = !sycl::joint_all_of(non_uniform_group, v_begin,
+                                                    v_end, none_true);
+              res_acc[gid][5] = !sycl::joint_all_of(non_uniform_group, v_begin,
+                                                    v_end, one_true);
+              res_acc[gid][6] = !sycl::joint_all_of(non_uniform_group, v_begin,
+                                                    v_end, some_true);
+              res_acc[gid][7] = sycl::joint_all_of(non_uniform_group, v_begin,
+                                                   v_end, all_true);
+
+              static_assert(
+                  std::is_same_v<bool, decltype(sycl::joint_none_of(
+                                           non_uniform_group, v_begin, v_end,
+                                           none_true))>,
+                  "Return type of joint_none_of(GroupT g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[gid][8] = sycl::joint_none_of(non_uniform_group, v_begin,
+                                                    v_end, none_true);
+              res_acc[gid][9] = !sycl::joint_none_of(non_uniform_group, v_begin,
+                                                     v_end, one_true);
+              res_acc[gid][10] = !sycl::joint_none_of(
+                  non_uniform_group, v_begin, v_end, some_true);
+              res_acc[gid][11] = !sycl::joint_none_of(non_uniform_group,
+                                                      v_begin, v_end, all_true);
+            });
+      });
       {
-        sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
-
-        sycl::buffer<bool, 1> res_sycl(
-            res, sycl::range<1>(test_matrix * test_cases));
-
-        queue.submit([&](sycl::handler& cgh) {
-          auto v_acc =
-              v_sycl.template get_access<sycl::access::mode::read_write>(cgh);
-          auto res_acc =
-              res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
-          sycl::nd_range<1> executionRange(work_group_range, work_group_range);
-
-          cgh.parallel_for<joint_of_group_kernel<
-              GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
-            sycl::sub_group sub_group = item.get_sub_group();
-
-            // If this item is not participating in the group, leave early.
-            if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                   test_case))
-              return;
-
-            GroupT non_uniform_group =
-                NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
-
-            T* v_begin = v_acc.get_pointer();
-            T* v_end = v_begin + v_acc.size();
-
-            // predicates
-            auto none_true = [&](T i) { return i == 0; };
-            auto one_true = [&](T i) { return i == 1; };
-            auto some_true = [&](T i) { return i > size / 2; };
-            auto all_true = [&](T i) { return i <= size; };
-
-            static_assert(
-                std::is_same_v<bool, decltype(sycl::joint_any_of(
-                                         non_uniform_group, v_begin, v_end,
-                                         none_true))>,
-                "Return type of joint_any_of(GroupT g, Ptr first, Ptr last, "
-                "Predicate pred) is wrong\n");
-            res_acc[0] = !sycl::joint_any_of(non_uniform_group, v_begin, v_end,
-                                             none_true);
-            res_acc[1] =
-                sycl::joint_any_of(non_uniform_group, v_begin, v_end, one_true);
-            res_acc[2] = sycl::joint_any_of(non_uniform_group, v_begin, v_end,
-                                            some_true);
-            res_acc[3] =
-                sycl::joint_any_of(non_uniform_group, v_begin, v_end, all_true);
-
-            static_assert(
-                std::is_same_v<bool, decltype(sycl::joint_all_of(
-                                         non_uniform_group, v_begin, v_end,
-                                         none_true))>,
-                "Return type of joint_all_of(GroupT g, Ptr first, Ptr last, "
-                "Predicate pred) is wrong\n");
-            res_acc[4] = !sycl::joint_all_of(non_uniform_group, v_begin, v_end,
-                                             none_true);
-            res_acc[5] = !sycl::joint_all_of(non_uniform_group, v_begin, v_end,
-                                             one_true);
-            res_acc[6] = !sycl::joint_all_of(non_uniform_group, v_begin, v_end,
-                                             some_true);
-            res_acc[7] =
-                sycl::joint_all_of(non_uniform_group, v_begin, v_end, all_true);
-
-            static_assert(
-                std::is_same_v<bool, decltype(sycl::joint_none_of(
-                                         non_uniform_group, v_begin, v_end,
-                                         none_true))>,
-                "Return type of joint_none_of(GroupT g, Ptr first, Ptr last, "
-                "Predicate pred) is wrong\n");
-            res_acc[8] = sycl::joint_none_of(non_uniform_group, v_begin, v_end,
-                                             none_true);
-            res_acc[9] = !sycl::joint_none_of(non_uniform_group, v_begin, v_end,
-                                              one_true);
-            res_acc[10] = !sycl::joint_none_of(non_uniform_group, v_begin,
-                                               v_end, some_true);
-            res_acc[11] = !sycl::joint_none_of(non_uniform_group, v_begin,
-                                               v_end, all_true);
-          });
-        });
-      }
-      int index = 0;
-      for (int i = 0; i < test_matrix; ++i)
-        for (int j = 0; j < test_cases; ++j) {
-          std::string work_group =
-              sycl_cts::util::work_group_print(work_group_range);
-          CAPTURE(group_name, work_group);
-          INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                           << " predicate"
-                              " is "
-                           << (res[index] ? "right" : "wrong"));
-          CHECK(res[index++]);
+        sycl::host_accessor res_host{res_sycl};
+        for (size_t gid = 0; gid < work_group_size; ++gid) {
+          int index = 0;
+          for (int i = 0; i < test_matrix; ++i)
+            for (int j = 0; j < test_cases; ++j) {
+              std::string work_group =
+                  sycl_cts::util::work_group_print(work_group_range);
+              CAPTURE(group_name, work_group);
+              INFO("Value of " << test_names[i] << " with "
+                               << test_cases_names[j] << " for item " << gid
+                               << " predicate is "
+                               << (res_host[gid][index] ? "right" : "wrong"));
+              CHECK(res_host[gid][index++]);
+            }
         }
+      }
     }
   }
 }
@@ -201,119 +202,119 @@ void predicate_function_of_non_uniform_group(sycl::queue& queue) {
     INFO("Running test case (" + std::to_string(test_case) + ") with " +
          test_case_name);
 
-    // array to return results: 4 predicates * 3 functions
+    // test cases: 4 predicates * 3 functions
     constexpr int total_case_count = test_matrix * test_cases;
-    bool res[total_case_count];
-    // Initially fill the results array with 'true'. Each non-uniform group test
-    // 'ands' with this to ensure every non-uniform group in the work-group
-    // returns the correct result.
-    std::fill(res, res + total_case_count, true);
-    {
-      sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(total_case_count));
+    sycl::buffer<bool, 2> res_sycl(
+        sycl::range<2>(work_group_range.size(), total_case_count));
 
-      queue.submit([&](sycl::handler& cgh) {
-        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
 
-        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+      sycl::nd_range<1> executionRange(work_group_range, work_group_range);
 
-        cgh.parallel_for<predicate_function_of_non_uniform_group_kernel<
-            GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
-          sycl::sub_group sub_group = item.get_sub_group();
+      cgh.parallel_for<predicate_function_of_non_uniform_group_kernel<
+          GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
+        size_t gid = item.get_global_linear_id();
+        sycl::sub_group sub_group = item.get_sub_group();
 
-          // If this item is not participating in the group, leave early.
-          if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                 test_case))
-            return;
+        // If this item is not participating in the group, leave early.
+        if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                               test_case))
+          return;
 
-          GroupT non_uniform_group =
-              NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+        GroupT non_uniform_group =
+            NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
 
-          size_t size = non_uniform_group.get_local_linear_range();
+        size_t size = non_uniform_group.get_local_linear_range();
 
-          // Use the non-uniform group local ID (plus 1) as a variable against
-          // which to test our predicates. Note that this has a well-defined set
-          // of values [1,2,...,N] where N is the non-uniform group size. Note
-          // that the non-uniform group could also just be of size 1.
-          T local_var(non_uniform_group.get_local_linear_id() + 1);
+        // Use the non-uniform group local ID (plus 1) as a variable against
+        // which to test our predicates. Note that this has a well-defined set
+        // of values [1,2,...,N] where N is the non-uniform group size. Note
+        // that the non-uniform group could also just be of size 1.
+        T local_var(non_uniform_group.get_local_linear_id() + 1);
 
-          // predicates
-          // The variable is never 1 for any member of the non-uniform group
-          auto none_true = [&](T i) { return i == 0; };
-          // Exactly one member of the non-uniform group has value 1 (the first)
-          auto one_true = [&](T i) { return i == 1; };
-          // Some (or all, for non-uniform groups of size 1) members of the
-          // non-uniform group have this value
-          auto some_true = [&](T i) { return i > size / 2; };
-          // The variable is less than or equal to the non-uniform group size
-          // for all members of the non-uniform group.
-          auto all_true = [&](T i) { return i <= size; };
+        // predicates
+        // The variable is never 1 for any member of the non-uniform group
+        auto none_true = [&](T i) { return i == 0; };
+        // Exactly one member of the non-uniform group has value 1 (the first)
+        auto one_true = [&](T i) { return i == 1; };
+        // Some (or all, for non-uniform groups of size 1) members of the
+        // non-uniform group have this value
+        auto some_true = [&](T i) { return i > size / 2; };
+        // The variable is less than or equal to the non-uniform group size
+        // for all members of the non-uniform group.
+        auto all_true = [&](T i) { return i <= size; };
 
-          {
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::any_of_group(
-                                   non_uniform_group, local_var, none_true))>,
-                "Return type of any_of_group(GroupT g, bool pred) is wrong\n");
-            res_acc[0] &=
-                !sycl::any_of_group(non_uniform_group, local_var, none_true);
-            res_acc[1] &=
-                sycl::any_of_group(non_uniform_group, local_var, one_true);
-            res_acc[2] &=
-                sycl::any_of_group(non_uniform_group, local_var, some_true);
-            res_acc[3] &=
-                sycl::any_of_group(non_uniform_group, local_var, all_true);
+        {
+          static_assert(
+              std::is_same_v<bool,
+                             decltype(sycl::any_of_group(
+                                 non_uniform_group, local_var, none_true))>,
+              "Return type of any_of_group(GroupT g, bool pred) is wrong\n");
+          res_acc[gid][0] =
+              !sycl::any_of_group(non_uniform_group, local_var, none_true);
+          res_acc[gid][1] =
+              sycl::any_of_group(non_uniform_group, local_var, one_true);
+          res_acc[gid][2] =
+              sycl::any_of_group(non_uniform_group, local_var, some_true);
+          res_acc[gid][3] =
+              sycl::any_of_group(non_uniform_group, local_var, all_true);
 
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::all_of_group(
-                                   non_uniform_group, local_var, none_true))>,
-                "Return type of all_of_group(GroupT g, bool pred) is wrong\n");
-            res_acc[4] &=
-                !sycl::all_of_group(non_uniform_group, local_var, none_true);
-            // Note that 'one_true' returns true for the first item. Thus in the
-            // case that the non-uniform group size is 1, check that all items
-            // match; otherwise check that not all items match.
-            res_acc[5] &=
-                sycl::all_of_group(non_uniform_group, local_var, one_true) ^
-                (size != 1);
-            // Note that 'some_true' returns true for the first item if the
-            // non-uniform group size is 1. In that case, check that all items
-            // match; otherwise check that not all items match.
-            res_acc[6] &=
-                sycl::all_of_group(non_uniform_group, local_var, some_true) ^
-                (size != 1);
-            res_acc[7] &=
-                sycl::all_of_group(non_uniform_group, local_var, all_true);
+          static_assert(
+              std::is_same_v<bool,
+                             decltype(sycl::all_of_group(
+                                 non_uniform_group, local_var, none_true))>,
+              "Return type of all_of_group(GroupT g, bool pred) is wrong\n");
+          res_acc[gid][4] =
+              !sycl::all_of_group(non_uniform_group, local_var, none_true);
+          // Note that 'one_true' returns true for the first item. Thus in the
+          // case that the non-uniform group size is 1, check that all items
+          // match; otherwise check that not all items match.
+          res_acc[gid][5] =
+              sycl::all_of_group(non_uniform_group, local_var, one_true) ^
+              (size != 1);
+          // Note that 'some_true' returns true for the first item if the
+          // non-uniform group size is 1. In that case, check that all items
+          // match; otherwise check that not all items match.
+          res_acc[gid][6] =
+              sycl::all_of_group(non_uniform_group, local_var, some_true) ^
+              (size != 1);
+          res_acc[gid][7] =
+              sycl::all_of_group(non_uniform_group, local_var, all_true);
 
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::none_of_group(
-                                   non_uniform_group, local_var, none_true))>,
-                "Return type of none_of_group(GroupT g, bool pred) is "
-                "wrong\n");
-            res_acc[8] &=
-                sycl::none_of_group(non_uniform_group, local_var, none_true);
-            res_acc[9] &=
-                !sycl::none_of_group(non_uniform_group, local_var, one_true);
-            res_acc[10] &=
-                !sycl::none_of_group(non_uniform_group, local_var, some_true);
-            res_acc[11] &=
-                !sycl::none_of_group(non_uniform_group, local_var, all_true);
-          }
-        });
+          static_assert(std::is_same_v<bool, decltype(sycl::none_of_group(
+                                                 non_uniform_group, local_var,
+                                                 none_true))>,
+                        "Return type of none_of_group(GroupT g, bool pred) is "
+                        "wrong\n");
+          res_acc[gid][8] =
+              sycl::none_of_group(non_uniform_group, local_var, none_true);
+          res_acc[gid][9] =
+              !sycl::none_of_group(non_uniform_group, local_var, one_true);
+          res_acc[gid][10] =
+              !sycl::none_of_group(non_uniform_group, local_var, some_true);
+          res_acc[gid][11] =
+              !sycl::none_of_group(non_uniform_group, local_var, all_true);
+        }
       });
-    }
-    int index = 0;
-    for (int i = 0; i < test_matrix; ++i)
-      for (int j = 0; j < test_cases; ++j) {
-        std::string work_group =
-            sycl_cts::util::work_group_print(work_group_range);
-        CAPTURE(group_name, work_group);
-        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                         << " predicate is "
-                         << (res[index] ? "right" : "wrong"));
-        CHECK(res[index++]);
+    });
+
+    {
+      sycl::host_accessor res_host{res_sycl};
+      for (size_t gid = 0; gid < work_group_range.size(); ++gid) {
+        int index = 0;
+        for (int i = 0; i < test_matrix; ++i)
+          for (int j = 0; j < test_cases; ++j) {
+            std::string work_group =
+                sycl_cts::util::work_group_print(work_group_range);
+            CAPTURE(group_name, work_group);
+            INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                             << " for item " << gid << " predicate is "
+                             << (res_host[gid][index] ? "right" : "wrong"));
+            CHECK(res_host[gid][index++]);
+          }
       }
+    }
   }
 }
 
@@ -354,118 +355,118 @@ void bool_function_of_non_uniform_group(sycl::queue& queue) {
     INFO("Running test case (" + std::to_string(test_case) + ") with " +
          test_case_name);
 
-    // array to return results: 4 predicates * 3 functions
+    // test cases: 4 predicates * 3 functions
     constexpr int total_case_count = test_matrix * test_cases;
-    bool res[total_case_count];
-    // Initially fill the results array with 'true'. Each non-uniform group test
-    // 'ands' with this to ensure every non-uniform group in the work-group
-    // returns the correct result.
-    std::fill(res, res + total_case_count, true);
-    {
-      sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(total_case_count));
+    sycl::buffer<bool, 2> res_sycl(
+        sycl::range<2>(work_group_range.size(), total_case_count));
 
-      queue.submit([&](sycl::handler& cgh) {
-        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
 
-        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+      sycl::nd_range<1> executionRange(work_group_range, work_group_range);
 
-        cgh.parallel_for<predicate_function_of_non_uniform_group_bool_kernel<
-            GroupT>>(executionRange, [=](sycl::nd_item<1> item) {
-          sycl::sub_group sub_group = item.get_sub_group();
+      cgh.parallel_for<predicate_function_of_non_uniform_group_bool_kernel<
+          GroupT>>(executionRange, [=](sycl::nd_item<1> item) {
+        size_t gid = item.get_global_linear_id();
+        sycl::sub_group sub_group = item.get_sub_group();
 
-          // If this item is not participating in the group, leave early.
-          if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                 test_case))
-            return;
+        // If this item is not participating in the group, leave early.
+        if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                               test_case))
+          return;
 
-          GroupT non_uniform_group =
-              NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+        GroupT non_uniform_group =
+            NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
 
-          size_t size = non_uniform_group.get_local_linear_range();
+        size_t size = non_uniform_group.get_local_linear_range();
 
-          // Use the non-uniform group local ID (plus 1) as a variable against
-          // which to test our predicates. Note that this has a well-defined set
-          // of values [1,2,...,N] where N is the non-uniform group size. Note
-          // that the non-uniform group could also just be of size 1.
-          T local_var(non_uniform_group.get_local_linear_id() + 1);
+        // Use the non-uniform group local ID (plus 1) as a variable against
+        // which to test our predicates. Note that this has a well-defined set
+        // of values [1,2,...,N] where N is the non-uniform group size. Note
+        // that the non-uniform group could also just be of size 1.
+        T local_var(non_uniform_group.get_local_linear_id() + 1);
 
-          // predicates
-          // The variable is never 1 for any member of the non-uniform group
-          auto none_true = [&](T i) { return i == 0; };
-          // Exactly one member of the non-uniform group has value 1 (the first)
-          auto one_true = [&](T i) { return i == 1; };
-          // Some (or all, for non-uniform groups of size 1) members of the
-          // non-uniform group have this value
-          auto some_true = [&](T i) { return i > size / 2; };
-          // The variable is less than or equal to the non-uniform group size
-          // for all members of the non-uniform group.
-          auto all_true = [&](T i) { return i <= size; };
+        // predicates
+        // The variable is never 1 for any member of the non-uniform group
+        auto none_true = [&](T i) { return i == 0; };
+        // Exactly one member of the non-uniform group has value 1 (the first)
+        auto one_true = [&](T i) { return i == 1; };
+        // Some (or all, for non-uniform groups of size 1) members of the
+        // non-uniform group have this value
+        auto some_true = [&](T i) { return i > size / 2; };
+        // The variable is less than or equal to the non-uniform group size
+        // for all members of the non-uniform group.
+        auto all_true = [&](T i) { return i <= size; };
 
-          {
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::any_of_group(
-                                   non_uniform_group, none_true(local_var)))>,
-                "Return type of any_of_group(GroupT g, bool pred) is wrong\n");
-            res_acc[0] &=
-                !sycl::any_of_group(non_uniform_group, none_true(local_var));
-            res_acc[1] &=
-                sycl::any_of_group(non_uniform_group, one_true(local_var));
-            res_acc[2] &=
-                sycl::any_of_group(non_uniform_group, some_true(local_var));
-            res_acc[3] &=
-                sycl::any_of_group(non_uniform_group, all_true(local_var));
+        {
+          static_assert(
+              std::is_same_v<bool,
+                             decltype(sycl::any_of_group(
+                                 non_uniform_group, none_true(local_var)))>,
+              "Return type of any_of_group(GroupT g, bool pred) is wrong\n");
+          res_acc[gid][0] =
+              !sycl::any_of_group(non_uniform_group, none_true(local_var));
+          res_acc[gid][1] =
+              sycl::any_of_group(non_uniform_group, one_true(local_var));
+          res_acc[gid][2] =
+              sycl::any_of_group(non_uniform_group, some_true(local_var));
+          res_acc[gid][3] =
+              sycl::any_of_group(non_uniform_group, all_true(local_var));
 
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::all_of_group(
-                                   non_uniform_group, none_true(local_var)))>,
-                "Return type of all_of_group(GroupT g, bool pred) is wrong\n");
-            res_acc[4] =
-                !sycl::all_of_group(non_uniform_group, none_true(local_var));
-            // Note that 'one_true' returns true for the first item. Thus in the
-            // case that the non-uniform group size is 1, check that all items
-            // match; otherwise check that not all items match.
-            res_acc[5] &=
-                sycl::all_of_group(non_uniform_group, one_true(local_var)) ^
-                (size != 1);
-            // Note that 'some_true' returns true for the first item if the
-            // non-uniform group size is 1. In that case, check that all items
-            // match; otherwise check that not all items match.
-            res_acc[6] &=
-                sycl::all_of_group(non_uniform_group, some_true(local_var)) ^
-                (size != 1);
-            res_acc[7] &=
-                sycl::all_of_group(non_uniform_group, all_true(local_var));
+          static_assert(
+              std::is_same_v<bool,
+                             decltype(sycl::all_of_group(
+                                 non_uniform_group, none_true(local_var)))>,
+              "Return type of all_of_group(GroupT g, bool pred) is wrong\n");
+          res_acc[gid][4] =
+              !sycl::all_of_group(non_uniform_group, none_true(local_var));
+          // Note that 'one_true' returns true for the first item. Thus in the
+          // case that the non-uniform group size is 1, check that all items
+          // match; otherwise check that not all items match.
+          res_acc[gid][5] =
+              sycl::all_of_group(non_uniform_group, one_true(local_var)) ^
+              (size != 1);
+          // Note that 'some_true' returns true for the first item if the
+          // non-uniform group size is 1. In that case, check that all items
+          // match; otherwise check that not all items match.
+          res_acc[gid][6] =
+              sycl::all_of_group(non_uniform_group, some_true(local_var)) ^
+              (size != 1);
+          res_acc[gid][7] =
+              sycl::all_of_group(non_uniform_group, all_true(local_var));
 
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::none_of_group(
-                                   non_uniform_group, none_true(local_var)))>,
-                "Return type of none_of_group(GroupT g, bool pred) is "
-                "wrong\n");
-            res_acc[8] &=
-                sycl::none_of_group(non_uniform_group, none_true(local_var));
-            res_acc[9] &=
-                !sycl::none_of_group(non_uniform_group, one_true(local_var));
-            res_acc[10] &=
-                !sycl::none_of_group(non_uniform_group, some_true(local_var));
-            res_acc[11] &=
-                !sycl::none_of_group(non_uniform_group, all_true(local_var));
-          }
-        });
+          static_assert(std::is_same_v<bool, decltype(sycl::none_of_group(
+                                                 non_uniform_group,
+                                                 none_true(local_var)))>,
+                        "Return type of none_of_group(GroupT g, bool pred) is "
+                        "wrong\n");
+          res_acc[gid][8] =
+              sycl::none_of_group(non_uniform_group, none_true(local_var));
+          res_acc[gid][9] =
+              !sycl::none_of_group(non_uniform_group, one_true(local_var));
+          res_acc[gid][10] =
+              !sycl::none_of_group(non_uniform_group, some_true(local_var));
+          res_acc[gid][11] =
+              !sycl::none_of_group(non_uniform_group, all_true(local_var));
+        }
       });
-    }
-    int index = 0;
-    for (int i = 0; i < test_matrix; ++i)
-      for (int j = 0; j < test_cases; ++j) {
-        std::string work_group =
-            sycl_cts::util::work_group_print(work_group_range);
-        CAPTURE(group_name, work_group);
-        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                         << " predicate is "
-                         << (res[index] ? "right" : "wrong"));
-        CHECK(res[index++]);
+    });
+
+    {
+      sycl::host_accessor res_host{res_sycl};
+      for (size_t gid = 0; gid < work_group_range.size(); ++gid) {
+        int index = 0;
+        for (int i = 0; i < test_matrix; ++i)
+          for (int j = 0; j < test_cases; ++j) {
+            std::string work_group =
+                sycl_cts::util::work_group_print(work_group_range);
+            CAPTURE(group_name, work_group);
+            INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                             << " for item " << gid << " predicate is "
+                             << (res_host[gid][index] ? "right" : "wrong"));
+            CHECK(res_host[gid][index++]);
+          }
       }
+    }
   }
 }


### PR DESCRIPTION
The group_of tests have all active items trying to write to the same index in the memory. For non-uniform groups this can be problematic as not all the results are the same, which means optimizations like vectorization may stumble. This commit splits the results into separate values that are in turn validated. This also allows more precise identification of error origin.