### PR TITLE
Template non-uniform group test cases on the group type

### DIFF
--- a/tests/extension/oneapi_non_uniform_groups/group_barrier.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_barrier.cpp
@@ -27,21 +27,10 @@ namespace non_uniform_groups::tests {
 template <int D>
 class test_fence;
 
-TEST_CASE("Non-uniform-group barriers",
-          "[oneapi_non_uniform_groups][group_func]") {
-  auto queue = once_per_unit::get_queue();
-
-  non_uniform_group_barrier<oneapi_ext::ballot_group<sycl::sub_group>>(queue);
-  non_uniform_group_barrier<oneapi_ext::fixed_size_group<1, sycl::sub_group>>(
-      queue);
-  non_uniform_group_barrier<oneapi_ext::fixed_size_group<2, sycl::sub_group>>(
-      queue);
-  non_uniform_group_barrier<oneapi_ext::fixed_size_group<4, sycl::sub_group>>(
-      queue);
-  non_uniform_group_barrier<oneapi_ext::fixed_size_group<8, sycl::sub_group>>(
-      queue);
-  non_uniform_group_barrier<oneapi_ext::tangle_group<sycl::sub_group>>(queue);
-  non_uniform_group_barrier<oneapi_ext::opportunistic_group>(queue);
+TEMPLATE_LIST_TEST_CASE("Non-uniform-group barriers",
+                        "[oneapi_non_uniform_groups][group_func]",
+                        GroupPackTypes) {
+  for_all_combinations<non_uniform_group_barrier_test>(TestType{});
 }
 
 }  // namespace non_uniform_groups::tests

--- a/tests/extension/oneapi_non_uniform_groups/group_barrier.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_barrier.h
@@ -27,190 +27,195 @@ class non_uniform_group_barrier_kernel;
 /**
  * @brief Provides test for arbitraty non-uniform group barriers
  * @tparam GroupT Type of the non-uniform group to test with
- * @tparam T Type pointed by Ptr
  */
 template <typename GroupT>
-void non_uniform_group_barrier(sycl::queue& queue) {
-  const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
+struct non_uniform_group_barrier_test {
+  void operator()() {
+    auto queue = once_per_unit::get_queue();
+    const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
-  INFO("Testing group-of predicate function for " + group_name);
-  if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
-    SKIP("Device does not support " + group_name);
-  }
-
-  std::vector<sycl::memory_scope> supported_barriers =
-      queue.get_context()
-          .get_info<sycl::info::context::atomic_fence_scope_capabilities>();
-
-  using sms = std::tuple<sycl::memory_scope, bool, bool>;
-  // indices of the tuple components
-  enum s { scope = 0, support = 1, test = 2 };
-
-  constexpr int non_uniform_group_barrier_variants = 5;
-  std::array<sms, non_uniform_group_barrier_variants>
-      non_uniform_group_barriers{{{sycl::memory_scope::sub_group, true, true},
-                                  {sycl::memory_scope::sub_group, true, true},
-                                  {sycl::memory_scope::work_group, true, true},
-                                  {sycl::memory_scope::device, true, true},
-                                  {sycl::memory_scope::system, true, true}}};
-  std::array<std::string, non_uniform_group_barrier_variants>
-      non_uniform_group_barriers_names{
-          "default", "sycl::memory_scope::sub_group",
-          "sycl::memory_scope::work_group", "sycl::memory_scope::device",
-          "sycl::memory_scope::system"};
-  for (auto& barrier : non_uniform_group_barriers) {
-    auto& sb = supported_barriers;
-    if (std::find(sb.begin(), sb.end(), std::get<s::scope>(barrier)) ==
-        sb.end()) {
-      std::get<s::support>(barrier) = false;
+    INFO("Testing group-of predicate function for " + group_name);
+    if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
+      SKIP("Device does not support " + group_name);
     }
-  }
 
-  using el_type = int32_t;
-  sycl::device device = queue.get_device();
+    std::vector<sycl::memory_scope> supported_barriers =
+        queue.get_context()
+            .get_info<sycl::info::context::atomic_fence_scope_capabilities>();
 
-  // Check the maximum number elements of type "el_type" that can be
-  // placed in the device's global and local memory. Since the test
-  // tries to allocate local and global buffers with a size equal to
-  // the work group size, the latter must be limited by the allowed
-  // buffer size.
-  uint64_t global_mem_size_in_bytes =
-      device.get_info<sycl::info::device::max_mem_alloc_size>();
-  uint64_t global_mem_size_in_elements =
-      global_mem_size_in_bytes / sizeof(el_type);
+    using sms = std::tuple<sycl::memory_scope, bool, bool>;
+    // indices of the tuple components
+    enum s { scope = 0, support = 1, test = 2 };
 
-  uint64_t local_mem_size_in_bytes =
-      device.get_info<sycl::info::device::local_mem_size>();
-  uint64_t local_mem_size_in_elements =
-      local_mem_size_in_bytes / sizeof(el_type);
+    constexpr int non_uniform_group_barrier_variants = 5;
+    std::array<sms, non_uniform_group_barrier_variants>
+        non_uniform_group_barriers{
+            {{sycl::memory_scope::sub_group, true, true},
+             {sycl::memory_scope::sub_group, true, true},
+             {sycl::memory_scope::work_group, true, true},
+             {sycl::memory_scope::device, true, true},
+             {sycl::memory_scope::system, true, true}}};
+    std::array<std::string, non_uniform_group_barrier_variants>
+        non_uniform_group_barriers_names{
+            "default", "sycl::memory_scope::sub_group",
+            "sycl::memory_scope::work_group", "sycl::memory_scope::device",
+            "sycl::memory_scope::system"};
+    for (auto& barrier : non_uniform_group_barriers) {
+      auto& sb = supported_barriers;
+      if (std::find(sb.begin(), sb.end(), std::get<s::scope>(barrier)) ==
+          sb.end()) {
+        std::get<s::support>(barrier) = false;
+      }
+    }
 
-  uint64_t work_items_limit =
-      std::min(global_mem_size_in_elements, local_mem_size_in_elements);
+    using el_type = int32_t;
+    sycl::device device = queue.get_device();
 
-  sycl::range<1> work_group_range =
-      sycl_cts::util::work_group_range<1>(queue, work_items_limit);
-  size_t work_group_size = work_group_range.size();
+    // Check the maximum number elements of type "el_type" that can be
+    // placed in the device's global and local memory. Since the test
+    // tries to allocate local and global buffers with a size equal to
+    // the work group size, the latter must be limited by the allowed
+    // buffer size.
+    uint64_t global_mem_size_in_bytes =
+        device.get_info<sycl::info::device::max_mem_alloc_size>();
+    uint64_t global_mem_size_in_elements =
+        global_mem_size_in_bytes / sizeof(el_type);
 
-  for (size_t test_case = 0;
-       test_case < NonUniformGroupHelper<GroupT>::num_test_cases; ++test_case) {
-    const std::string test_case_name =
-        NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
-    INFO("Running test case (" + std::to_string(test_case) + ") with " +
-         test_case_name);
+    uint64_t local_mem_size_in_bytes =
+        device.get_info<sycl::info::device::local_mem_size>();
+    uint64_t local_mem_size_in_elements =
+        local_mem_size_in_bytes / sizeof(el_type);
 
-    std::vector<int32_t> v(work_group_size, 0);
-    sycl::buffer<int32_t, 1> global_mem(v.data(),
-                                        sycl::range<1>(work_group_size));
+    uint64_t work_items_limit =
+        std::min(global_mem_size_in_elements, local_mem_size_in_elements);
 
-    sycl::buffer<sms, 1> non_uniform_group_barriers_buf(
-        non_uniform_group_barriers.data(),
-        sycl::range<1>(non_uniform_group_barrier_variants));
+    sycl::range<1> work_group_range =
+        sycl_cts::util::work_group_range<1>(queue, work_items_limit);
+    size_t work_group_size = work_group_range.size();
 
-    queue.submit([&](sycl::handler& cgh) {
-      sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+    for (size_t test_case = 0;
+         test_case < NonUniformGroupHelper<GroupT>::num_test_cases;
+         ++test_case) {
+      const std::string test_case_name =
+          NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
+      INFO("Running test case (" + std::to_string(test_case) + ") with " +
+           test_case_name);
 
-      auto non_uniform_group_barriers_acc =
-          non_uniform_group_barriers_buf
-              .get_access<sycl::access::mode::read_write>(cgh);
+      std::vector<int32_t> v(work_group_size, 0);
+      sycl::buffer<int32_t, 1> global_mem(v.data(),
+                                          sycl::range<1>(work_group_size));
 
-      sycl::local_accessor<int32_t, 1> local_acc(
-          sycl::range<1>(work_group_size), cgh);
-      sycl::accessor<int32_t, 1> global_acc =
-          global_mem.get_access<sycl::access::mode::read_write>(cgh);
+      sycl::buffer<sms, 1> non_uniform_group_barriers_buf(
+          non_uniform_group_barriers.data(),
+          sycl::range<1>(non_uniform_group_barrier_variants));
 
-      cgh.parallel_for<non_uniform_group_barrier_kernel<GroupT>>(
-          executionRange, [=](sycl::nd_item<1> item) {
-            sycl::sub_group sub_group = item.get_sub_group();
+      queue.submit([&](sycl::handler& cgh) {
+        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
 
-            // If this item is not participating in the group, leave early.
-            if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                   test_case))
-              return;
+        auto non_uniform_group_barriers_acc =
+            non_uniform_group_barriers_buf
+                .get_access<sycl::access::mode::read_write>(cgh);
 
-            GroupT non_uniform_group =
-                NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+        sycl::local_accessor<int32_t, 1> local_acc(
+            sycl::range<1>(work_group_size), cgh);
+        sycl::accessor<int32_t, 1> global_acc =
+            global_mem.get_access<sycl::access::mode::read_write>(cgh);
 
-            size_t llid = non_uniform_group.get_local_linear_id();
-            size_t max_id = non_uniform_group.get_local_linear_range() - 1;
+        cgh.parallel_for<non_uniform_group_barrier_kernel<GroupT>>(
+            executionRange, [=](sycl::nd_item<1> item) {
+              sycl::sub_group sub_group = item.get_sub_group();
 
-            static_assert(std::is_same_v<void, decltype(sycl::group_barrier(
-                                                   non_uniform_group))>,
-                          "Return type of group_barrier(GroupT g) is wrong\n");
-            static_assert(
-                std::is_same_v<void, decltype(sycl::group_barrier(
-                                         non_uniform_group,
-                                         non_uniform_group.fence_scope))>,
-                "Return type of group_barrier(GroupT g, "
-                "memory_scope fence_scope) is wrong\n");
+              // If this item is not participating in the group, leave early.
+              if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                                     test_case))
+                return;
 
-            // test of default barrier
-            local_acc[llid] = llid;
-            sycl::group_barrier(non_uniform_group);
+              GroupT non_uniform_group =
+                  NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
 
-            if (local_acc[max_id - llid] != max_id - llid)
-              std::get<s::test>(non_uniform_group_barriers_acc[0]) = false;
-            sycl::group_barrier(non_uniform_group);
+              size_t llid = non_uniform_group.get_local_linear_id();
+              size_t max_id = non_uniform_group.get_local_linear_range() - 1;
 
-            local_acc[llid] = 1;
-            sycl::group_barrier(non_uniform_group);
+              static_assert(
+                  std::is_same_v<void, decltype(sycl::group_barrier(
+                                           non_uniform_group))>,
+                  "Return type of group_barrier(GroupT g) is wrong\n");
+              static_assert(
+                  std::is_same_v<void, decltype(sycl::group_barrier(
+                                           non_uniform_group,
+                                           non_uniform_group.fence_scope))>,
+                  "Return type of group_barrier(GroupT g, "
+                  "memory_scope fence_scope) is wrong\n");
 
-            if (local_acc[max_id - llid] != 1)
-              std::get<s::test>(non_uniform_group_barriers_acc[0]) = false;
-            sycl::group_barrier(non_uniform_group);
+              // test of default barrier
+              local_acc[llid] = llid;
+              sycl::group_barrier(non_uniform_group);
 
-            // tests for other barriers
-            for (int i = 1; i < non_uniform_group_barrier_variants; ++i) {
-              auto& barrier = non_uniform_group_barriers_acc[i];
+              if (local_acc[max_id - llid] != max_id - llid)
+                std::get<s::test>(non_uniform_group_barriers_acc[0]) = false;
+              sycl::group_barrier(non_uniform_group);
 
-              if ((sub_group.get_group_linear_id() == 0) &&
-                  (non_uniform_group.get_group_linear_id() ==
-                   NonUniformGroupHelper<
-                       GroupT>::preferred_single_worker_group_id(test_case)) &&
-                  std::get<s::support>(barrier)) {
-                local_acc[llid] = llid;
-                global_acc[llid] = llid;
-                sycl::group_barrier(non_uniform_group);
+              local_acc[llid] = 1;
+              sycl::group_barrier(non_uniform_group);
 
-                if (local_acc[max_id - llid] != max_id - llid ||
-                    global_acc[max_id - llid] != max_id - llid)
-                  std::get<s::test>(barrier) = false;
-                sycl::group_barrier(non_uniform_group);
+              if (local_acc[max_id - llid] != 1)
+                std::get<s::test>(non_uniform_group_barriers_acc[0]) = false;
+              sycl::group_barrier(non_uniform_group);
 
-                switch (std::get<s::scope>(barrier)) {
-                  case sycl::memory_scope::sub_group:
-                  case sycl::memory_scope::work_group:
-                    local_acc[llid] = 1;
-                    sycl::group_barrier(non_uniform_group,
-                                        std::get<s::scope>(barrier));
+              // tests for other barriers
+              for (int i = 1; i < non_uniform_group_barrier_variants; ++i) {
+                auto& barrier = non_uniform_group_barriers_acc[i];
 
-                    if (local_acc[max_id - llid] != 1)
-                      std::get<s::test>(barrier) = false;
-                    sycl::group_barrier(non_uniform_group);
+                if ((sub_group.get_group_linear_id() == 0) &&
+                    (non_uniform_group.get_group_linear_id() ==
+                     NonUniformGroupHelper<GroupT>::
+                         preferred_single_worker_group_id(test_case)) &&
+                    std::get<s::support>(barrier)) {
+                  local_acc[llid] = llid;
+                  global_acc[llid] = llid;
+                  sycl::group_barrier(non_uniform_group);
 
-                    [[fallthrough]];
-                  default:
-                    global_acc[llid] = 1;
-                    sycl::group_barrier(non_uniform_group,
-                                        std::get<s::scope>(barrier));
+                  if (local_acc[max_id - llid] != max_id - llid ||
+                      global_acc[max_id - llid] != max_id - llid)
+                    std::get<s::test>(barrier) = false;
+                  sycl::group_barrier(non_uniform_group);
 
-                    if (global_acc[max_id - llid] != 1)
-                      std::get<s::test>(barrier) = false;
-                    sycl::group_barrier(non_uniform_group);
+                  switch (std::get<s::scope>(barrier)) {
+                    case sycl::memory_scope::sub_group:
+                    case sycl::memory_scope::work_group:
+                      local_acc[llid] = 1;
+                      sycl::group_barrier(non_uniform_group,
+                                          std::get<s::scope>(barrier));
+
+                      if (local_acc[max_id - llid] != 1)
+                        std::get<s::test>(barrier) = false;
+                      sycl::group_barrier(non_uniform_group);
+
+                      [[fallthrough]];
+                    default:
+                      global_acc[llid] = 1;
+                      sycl::group_barrier(non_uniform_group,
+                                          std::get<s::scope>(barrier));
+
+                      if (global_acc[max_id - llid] != 1)
+                        std::get<s::test>(barrier) = false;
+                      sycl::group_barrier(non_uniform_group);
+                  }
                 }
               }
-            }
-          });
-    });
+            });
+      });
 
-    for (int i = 0; i < non_uniform_group_barrier_variants; ++i) {
-      bool result = std::get<s::test>(non_uniform_group_barriers[i]);
-      std::string work_group =
-          sycl_cts::util::work_group_print(work_group_range);
-      CAPTURE(group_name, work_group);
-      INFO("Result of group_barrier invocation for sub-group and "
-           << non_uniform_group_barriers_names[i] << " memory scope is "
-           << (result ? "right" : "wrong"));
-      CHECK(result);
+      for (int i = 0; i < non_uniform_group_barrier_variants; ++i) {
+        bool result = std::get<s::test>(non_uniform_group_barriers[i]);
+        std::string work_group =
+            sycl_cts::util::work_group_print(work_group_range);
+        CAPTURE(group_name, work_group);
+        INFO("Result of group_barrier invocation for sub-group and "
+             << non_uniform_group_barriers_names[i] << " memory scope is "
+             << (result ? "right" : "wrong"));
+        CHECK(result);
+      }
     }
   }
-}
+};

--- a/tests/extension/oneapi_non_uniform_groups/group_broadcast.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_broadcast.cpp
@@ -22,25 +22,13 @@
 
 namespace non_uniform_groups::tests {
 
-using BroadcastTypes = CustomTypes;
-
 TEMPLATE_LIST_TEST_CASE("Non-uniform group broadcast and select",
                         "[oneapi_non_uniform_groups][group_func][type_list]",
-                        BroadcastTypes) {
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
-  broadcast_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>,
-                              TestType>(queue);
-  broadcast_non_uniform_group<oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-                              TestType>(queue);
-  broadcast_non_uniform_group<oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-                              TestType>(queue);
-  broadcast_non_uniform_group<oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-                              TestType>(queue);
-  broadcast_non_uniform_group<oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-                              TestType>(queue);
-  broadcast_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>,
-                              TestType>(queue);
-  broadcast_non_uniform_group<oneapi_ext::opportunistic_group, TestType>(queue);
+
+  for_all_combinations<broadcast_non_uniform_group_test>(
+      TestType{}, CustomTypePack{}, queue);
 }
 
 }  // namespace non_uniform_groups::tests

--- a/tests/extension/oneapi_non_uniform_groups/group_broadcast.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_broadcast.h
@@ -30,170 +30,177 @@ class broadcast_non_uniform_group_kernel;
  * @tparam T Type pointed by Ptr
  */
 template <typename GroupT, typename T>
-void broadcast_non_uniform_group(sycl::queue& queue) {
-  const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
+struct broadcast_non_uniform_group_test {
+  void operator()(sycl::queue &queue) {
+    const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
-  INFO("Testing broadcast and select for " + group_name);
-  if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
-    SKIP("Device does not support " + group_name);
-  }
+    INFO("Testing broadcast and select for " + group_name);
+    if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
+      SKIP("Device does not support " + group_name);
+    }
 
-  // 4 functions
-  constexpr int test_matrix = 4;
-  const std::string test_names[test_matrix] = {
-      "T group_broadcast(GroupT g, T x)",
-      "T group_broadcast(GroupT g, T x, GroupT::linear_id_type "
-      "local_linear_id)",
-      "T group_broadcast(GroupT g, T x, GroupT::id_type local_id)",
-      "T select_from_group(GroupT g, T x, GroupT::id_type local_id)"};
+    // 4 functions
+    constexpr int test_matrix = 4;
+    const std::string test_names[test_matrix] = {
+        "T group_broadcast(GroupT g, T x)",
+        "T group_broadcast(GroupT g, T x, GroupT::linear_id_type "
+        "local_linear_id)",
+        "T group_broadcast(GroupT g, T x, GroupT::id_type local_id)",
+        "T select_from_group(GroupT g, T x, GroupT::id_type local_id)"};
 
-  sycl::range<1> work_group_range = sycl_cts::util::work_group_range<1>(queue);
+    sycl::range<1> work_group_range =
+        sycl_cts::util::work_group_range<1>(queue);
 
-  for (size_t test_case = 0;
-       test_case < NonUniformGroupHelper<GroupT>::num_test_cases; ++test_case) {
-    const std::string test_case_name =
-        NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
-    INFO("Running test case (" + std::to_string(test_case) + ") with " +
-         test_case_name);
-    // array to return results
-    T origin_values[test_matrix] = {splat_init<T>(0)};
-    T broadcasted_values[test_matrix] = {splat_init<T>(0)};
-    {
-      sycl::buffer<T, 1> origin_values_buf(origin_values,
-                                           sycl::range<1>(test_matrix));
-      sycl::buffer<T, 1> broadcasted_values_buf(broadcasted_values,
-                                                sycl::range<1>(test_matrix));
+    for (size_t test_case = 0;
+         test_case < NonUniformGroupHelper<GroupT>::num_test_cases;
+         ++test_case) {
+      const std::string test_case_name =
+          NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
+      INFO("Running test case (" + std::to_string(test_case) + ") with " +
+           test_case_name);
+      // array to return results
+      T origin_values[test_matrix] = {splat_init<T>(0)};
+      T broadcasted_values[test_matrix] = {splat_init<T>(0)};
+      {
+        sycl::buffer<T, 1> origin_values_buf(origin_values,
+                                             sycl::range<1>(test_matrix));
+        sycl::buffer<T, 1> broadcasted_values_buf(broadcasted_values,
+                                                  sycl::range<1>(test_matrix));
 
-      queue.submit([&](sycl::handler& cgh) {
-        auto origin_values_acc =
-            origin_values_buf
-                .template get_access<sycl::access::mode::read_write>(cgh);
-        auto broadcasted_values_acc =
-            broadcasted_values_buf
-                .template get_access<sycl::access::mode::read_write>(cgh);
+        queue.submit([&](sycl::handler& cgh) {
+          auto origin_values_acc =
+              origin_values_buf
+                  .template get_access<sycl::access::mode::read_write>(cgh);
+          auto broadcasted_values_acc =
+              broadcasted_values_buf
+                  .template get_access<sycl::access::mode::read_write>(cgh);
 
-        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
-        // Values computed in a kernel depend on global linear id. We need to
-        // make sure that there are no overflows
-        REQUIRE(executionRange.get_global_range().size() <
-                std::numeric_limits<size_t>::max() / 100);
+          sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+          // Values computed in a kernel depend on global linear id. We need to
+          // make sure that there are no overflows
+          REQUIRE(executionRange.get_global_range().size() <
+                  std::numeric_limits<size_t>::max() / 100);
 
-        cgh.parallel_for<broadcast_non_uniform_group_kernel<
-            GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
-          sycl::sub_group sub_group = item.get_sub_group();
+          cgh.parallel_for<broadcast_non_uniform_group_kernel<
+              GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
+            sycl::sub_group sub_group = item.get_sub_group();
 
-          // If this item is not participating in the group, leave early.
-          if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                 test_case))
-            return;
+            // If this item is not participating in the group, leave early.
+            if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                                   test_case))
+              return;
 
-          GroupT non_uniform_group =
-              NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+            GroupT non_uniform_group =
+                NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
 
-          // Each work-item computes a unique value
-          T value_to_broadcast(splat_init<T>(
-              static_cast<size_t>(item.get_global_linear_id() * 100 +
-                                  non_uniform_group.get_local_id())));
+            // Each work-item computes a unique value
+            T value_to_broadcast(splat_init<T>(
+                static_cast<size_t>(item.get_global_linear_id() * 100 +
+                                    non_uniform_group.get_local_id())));
 
-          // To simplify the test, we are only checking the first group in
-          // the first sub-group.
-          size_t preferred_group_id =
-              NonUniformGroupHelper<GroupT>::preferred_single_worker_group_id(
-                  test_case);
-          if (item.get_sub_group().get_group_id()[0] == 0 &&
-              non_uniform_group.get_group_id()[0] == preferred_group_id) {
-            // Find local id of first, last and some third sub-group item in
-            // between. Will be used to check different combinations of
-            // broadcasting and receiving work-items
-            sycl::id<1> first_id = 0;
-            sycl::id<1> mid_id = non_uniform_group.get_local_range() / 2;
-            sycl::id<1> last_id = non_uniform_group.get_local_range() - 1;
+            // To simplify the test, we are only checking the first group in
+            // the first sub-group.
+            size_t preferred_group_id =
+                NonUniformGroupHelper<GroupT>::preferred_single_worker_group_id(
+                    test_case);
+            if (item.get_sub_group().get_group_id()[0] == 0 &&
+                non_uniform_group.get_group_id()[0] == preferred_group_id) {
+              // Find local id of first, last and some third sub-group item in
+              // between. Will be used to check different combinations of
+              // broadcasting and receiving work-items
+              sycl::id<1> first_id = 0;
+              sycl::id<1> mid_id = non_uniform_group.get_local_range() / 2;
+              sycl::id<1> last_id = non_uniform_group.get_local_range() - 1;
 
-            // Broadcast from the first work-item
-            static_assert(
-                std::is_same_v<T, decltype(sycl::group_broadcast(
-                                      non_uniform_group, value_to_broadcast))>,
-                "Return type of group_broadcast(GroupT g, T x) is wrong\n");
+              // Broadcast from the first work-item
+              static_assert(
+                  std::is_same_v<T,
+                                 decltype(sycl::group_broadcast(
+                                     non_uniform_group, value_to_broadcast))>,
+                  "Return type of group_broadcast(GroupT g, T x) is wrong\n");
 
-            if (non_uniform_group.leader()) {
-              // Work-item which does the broadcast stores value to
-              // broadcast to use it later as a reference
-              origin_values_acc[0] = value_to_broadcast;
+              if (non_uniform_group.leader()) {
+                // Work-item which does the broadcast stores value to
+                // broadcast to use it later as a reference
+                origin_values_acc[0] = value_to_broadcast;
+              }
+              auto broadcasted_value =
+                  sycl::group_broadcast(non_uniform_group, value_to_broadcast);
+              // We read broadcasted value in another work-item
+              if (non_uniform_group.get_local_id() == last_id)
+                broadcasted_values_acc[0] = broadcasted_value;
+
+              // Broadcast from the last work-item
+              static_assert(
+                  std::is_same_v<T, decltype(sycl::group_broadcast(
+                                        non_uniform_group, value_to_broadcast,
+                                        last_id))>,
+                  "Return type of group_broadcast(GroupT g, T x, "
+                  "GroupT::linear_id_type local_linear_id) is wrong\n");
+
+              if (non_uniform_group.get_local_id() == last_id) {
+                // Work-item which does the broadcast stores value to
+                // broadcast to use it later as a reference
+                origin_values_acc[1] = value_to_broadcast;
+              }
+
+              broadcasted_value = sycl::group_broadcast(
+                  non_uniform_group, value_to_broadcast,
+                  non_uniform_group.get_local_linear_range() - 1);
+              // We read broadcasted value in another work-item
+              if (non_uniform_group.get_local_id() == mid_id)
+                broadcasted_values_acc[1] = broadcasted_value;
+
+              // Broadcast from a mid work-item
+              static_assert(std::is_same_v<T, decltype(sycl::group_broadcast(
+                                                  non_uniform_group,
+                                                  value_to_broadcast, mid_id))>,
+                            "Return type of group_broadcast(GroupT g, T x, "
+                            "GroupT::id_type local_id) is wrong\n");
+
+              if (non_uniform_group.get_local_id() == mid_id) {
+                // Work-item which does the broadcast stores value to
+                // broadcast to use it later as a reference
+                origin_values_acc[2] = value_to_broadcast;
+              }
+              broadcasted_value = sycl::group_broadcast(
+                  non_uniform_group, value_to_broadcast, mid_id);
+              // We read broadcasted value in another work-item
+              if (non_uniform_group.get_local_id() == first_id)
+                broadcasted_values_acc[2] = broadcasted_value;
+
+              // Select from the first work-item
+              static_assert(
+                  std::is_same_v<T, decltype(sycl::select_from_group(
+                                        non_uniform_group, value_to_broadcast,
+                                        first_id))>,
+                  "Return type of select_from_group(GroupT g, T x, "
+                  "GroupT::id_type local_id) is wrong\n");
+
+              if (non_uniform_group.get_local_id() == first_id) {
+                // Work-item which does the broadcast stores value to
+                // broadcast to use it later as a reference
+                origin_values_acc[3] = value_to_broadcast;
+              }
+              broadcasted_value = sycl::select_from_group(
+                  non_uniform_group, value_to_broadcast, first_id);
+              // We read broadcasted value in another work-item
+              if (non_uniform_group.get_local_id() == mid_id)
+                broadcasted_values_acc[3] = broadcasted_value;
             }
-            auto broadcasted_value =
-                sycl::group_broadcast(non_uniform_group, value_to_broadcast);
-            // We read broadcasted value in another work-item
-            if (non_uniform_group.get_local_id() == last_id)
-              broadcasted_values_acc[0] = broadcasted_value;
-
-            // Broadcast from the last work-item
-            static_assert(std::is_same_v<T, decltype(sycl::group_broadcast(
-                                                non_uniform_group,
-                                                value_to_broadcast, last_id))>,
-                          "Return type of group_broadcast(GroupT g, T x, "
-                          "GroupT::linear_id_type local_linear_id) is wrong\n");
-
-            if (non_uniform_group.get_local_id() == last_id) {
-              // Work-item which does the broadcast stores value to
-              // broadcast to use it later as a reference
-              origin_values_acc[1] = value_to_broadcast;
-            }
-
-            broadcasted_value = sycl::group_broadcast(
-                non_uniform_group, value_to_broadcast,
-                non_uniform_group.get_local_linear_range() - 1);
-            // We read broadcasted value in another work-item
-            if (non_uniform_group.get_local_id() == mid_id)
-              broadcasted_values_acc[1] = broadcasted_value;
-
-            // Broadcast from a mid work-item
-            static_assert(std::is_same_v<T, decltype(sycl::group_broadcast(
-                                                non_uniform_group,
-                                                value_to_broadcast, mid_id))>,
-                          "Return type of group_broadcast(GroupT g, T x, "
-                          "GroupT::id_type local_id) is wrong\n");
-
-            if (non_uniform_group.get_local_id() == mid_id) {
-              // Work-item which does the broadcast stores value to
-              // broadcast to use it later as a reference
-              origin_values_acc[2] = value_to_broadcast;
-            }
-            broadcasted_value = sycl::group_broadcast(
-                non_uniform_group, value_to_broadcast, mid_id);
-            // We read broadcasted value in another work-item
-            if (non_uniform_group.get_local_id() == first_id)
-              broadcasted_values_acc[2] = broadcasted_value;
-
-            // Select from the first work-item
-            static_assert(std::is_same_v<T, decltype(sycl::select_from_group(
-                                                non_uniform_group,
-                                                value_to_broadcast, first_id))>,
-                          "Return type of select_from_group(GroupT g, T x, "
-                          "GroupT::id_type local_id) is wrong\n");
-
-            if (non_uniform_group.get_local_id() == first_id) {
-              // Work-item which does the broadcast stores value to
-              // broadcast to use it later as a reference
-              origin_values_acc[3] = value_to_broadcast;
-            }
-            broadcasted_value = sycl::select_from_group(
-                non_uniform_group, value_to_broadcast, first_id);
-            // We read broadcasted value in another work-item
-            if (non_uniform_group.get_local_id() == mid_id)
-              broadcasted_values_acc[3] = broadcasted_value;
-          }
+          });
         });
-      });
-    }
-    for (int i = 0; i < test_matrix; ++i) {
-      std::string work_group =
-          sycl_cts::util::work_group_print(work_group_range);
-      CAPTURE(group_name, work_group);
-      INFO("Return value of "
-           << test_names[i] << " with T = " << type_name<T>() << " is "
-           << (equal(broadcasted_values[i], origin_values[i]) ? "right"
-                                                              : "wrong"));
-      CHECK(equal(broadcasted_values[i], origin_values[i]));
+      }
+      for (int i = 0; i < test_matrix; ++i) {
+        std::string work_group =
+            sycl_cts::util::work_group_print(work_group_range);
+        CAPTURE(group_name, work_group);
+        INFO("Return value of "
+             << test_names[i] << " with T = " << type_name<T>() << " is "
+             << (equal(broadcasted_values[i], origin_values[i]) ? "right"
+                                                                : "wrong"));
+        CHECK(equal(broadcasted_values[i], origin_values[i]));
+      }
     }
   }
-}
+};

--- a/tests/extension/oneapi_non_uniform_groups/group_broadcast.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_broadcast.h
@@ -31,7 +31,7 @@ class broadcast_non_uniform_group_kernel;
  */
 template <typename GroupT, typename T>
 struct broadcast_non_uniform_group_test {
-  void operator()(sycl::queue &queue) {
+  void operator()(sycl::queue& queue) {
     const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
     INFO("Testing broadcast and select for " + group_name);

--- a/tests/extension/oneapi_non_uniform_groups/group_broadcast_fp16.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_broadcast_fp16.cpp
@@ -22,24 +22,14 @@
 
 namespace non_uniform_groups::tests {
 
-TEST_CASE("Non-uniform group broadcast and select",
-          "[oneapi_non_uniform_groups][group_func][fp16]") {
+TEMPLATE_LIST_TEST_CASE("Non-uniform group broadcast and select",
+                        "[oneapi_non_uniform_groups][group_func][fp16]",
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
+
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    broadcast_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>,
-                                sycl::half>(queue);
-    broadcast_non_uniform_group<
-        oneapi_ext::fixed_size_group<1, sycl::sub_group>, sycl::half>(queue);
-    broadcast_non_uniform_group<
-        oneapi_ext::fixed_size_group<2, sycl::sub_group>, sycl::half>(queue);
-    broadcast_non_uniform_group<
-        oneapi_ext::fixed_size_group<4, sycl::sub_group>, sycl::half>(queue);
-    broadcast_non_uniform_group<
-        oneapi_ext::fixed_size_group<8, sycl::sub_group>, sycl::half>(queue);
-    broadcast_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>,
-                                sycl::half>(queue);
-    broadcast_non_uniform_group<oneapi_ext::opportunistic_group, sycl::half>(
-        queue);
+    for_all_combinations<broadcast_non_uniform_group_test>(
+        TestType{}, unnamed_type_pack<sycl::half>{}, queue);
   } else {
     WARN("Device does not support half precision floating point operations.");
   }

--- a/tests/extension/oneapi_non_uniform_groups/group_broadcast_fp64.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_broadcast_fp64.cpp
@@ -22,22 +22,13 @@
 
 namespace non_uniform_groups::tests {
 
-TEST_CASE("Non-uniform group broadcast and select", "[group_func][fp64]") {
+TEMPLATE_LIST_TEST_CASE("Non-uniform group broadcast and select",
+                        "[group_func][fp64]", GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
+
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    broadcast_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>,
-                                double>(queue);
-    broadcast_non_uniform_group<
-        oneapi_ext::fixed_size_group<1, sycl::sub_group>, double>(queue);
-    broadcast_non_uniform_group<
-        oneapi_ext::fixed_size_group<2, sycl::sub_group>, double>(queue);
-    broadcast_non_uniform_group<
-        oneapi_ext::fixed_size_group<4, sycl::sub_group>, double>(queue);
-    broadcast_non_uniform_group<
-        oneapi_ext::fixed_size_group<8, sycl::sub_group>, double>(queue);
-    broadcast_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>,
-                                double>(queue);
-    broadcast_non_uniform_group<oneapi_ext::opportunistic_group, double>(queue);
+    for_all_combinations<broadcast_non_uniform_group_test>(
+        TestType{}, unnamed_type_pack<double>{}, queue);
   } else {
     WARN("Device does not support double precision floating point operations.");
   }

--- a/tests/extension/oneapi_non_uniform_groups/group_joint_reduce.cpp.in
+++ b/tests/extension/oneapi_non_uniform_groups/group_joint_reduce.cpp.in
@@ -28,19 +28,12 @@ namespace non_uniform_groups::tests {
 // clang-format on
 using ReduceTypes = Types;
 
-TEST_CASE(CTS_TYPE_NAME + " non-uniform group joint reduce functions",
-          "[oneapi_non_uniform_groups][group_func][type_list]") {
+TEMPLATE_LIST_TEST_CASE(CTS_TYPE_NAME + " non-uniform group joint reduce functions",
+          "[oneapi_non_uniform_groups][group_func][type_list]", GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
   const auto Operators = get_op_types<CTS_TYPE>();
   const auto RetType = unnamed_type_pack<CTS_TYPE>();
-  const auto GroupTypes = unnamed_type_pack<
-      oneapi_ext::ballot_group<sycl::sub_group>,
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-      oneapi_ext::tangle_group<sycl::sub_group>,
-      oneapi_ext::opportunistic_group>();
+  const auto GroupTypes = TestType{};
 
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
@@ -60,20 +53,13 @@ TEST_CASE(CTS_TYPE_NAME + " non-uniform group joint reduce functions",
 
 TEMPLATE_LIST_TEST_CASE(
     CTS_TYPE_NAME + " non-uniform group joint reduce functions with init",
-    "[oneapi_non_uniform_groups][group_func][type_list]", ReduceTypes) {
+    "[oneapi_non_uniform_groups][group_func][type_list]", GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
 
   const auto Operators = get_op_types<CTS_TYPE>();
   const auto RetType = unnamed_type_pack<CTS_TYPE>();
-  const auto ReducedType = unnamed_type_pack<TestType>();
-  const auto GroupTypes = unnamed_type_pack<
-      oneapi_ext::ballot_group<sycl::sub_group>,
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-      oneapi_ext::tangle_group<sycl::sub_group>,
-      oneapi_ext::opportunistic_group>();
+  const auto ReducedType = Types{};
+  const auto GroupTypes = TestType{};
 
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))

--- a/tests/extension/oneapi_non_uniform_groups/group_joint_scan.cpp.in
+++ b/tests/extension/oneapi_non_uniform_groups/group_joint_scan.cpp.in
@@ -28,21 +28,14 @@
 
 namespace non_uniform_groups::tests {
 
-using TestType = unnamed_type_pack<CTS_TYPE>;
+using CurrentType = unnamed_type_pack<CTS_TYPE>;
 using ScanTypes = Types;
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL
 
-TEST_CASE(CTS_TYPE_NAME + " non-uniform group joint scan functions",
-          "[oneapi_non_uniform_groups][group_func][type_list]"){
+TEMPLATE_LIST_TEST_CASE(
+          CTS_TYPE_NAME + " non-uniform group joint scan functions",
+          "[oneapi_non_uniform_groups][group_func][type_list]", GroupPackTypes){
   auto queue = once_per_unit::get_queue();
-  const auto GroupTypes = unnamed_type_pack<
-      oneapi_ext::ballot_group<sycl::sub_group>,
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-      oneapi_ext::tangle_group<sycl::sub_group>,
-      oneapi_ext::opportunistic_group>();
 
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
@@ -56,21 +49,14 @@ TEST_CASE(CTS_TYPE_NAME + " non-uniform group joint scan functions",
           "operations.");
   }
 
-  for_all_combinations<invoke_joint_scan_group>(GroupTypes, TestType{},
+  for_all_combinations<invoke_joint_scan_group>(TestType{}, CurrentType{},
                                                 ScanTypes{}, queue);
 };
 
-TEST_CASE(CTS_TYPE_NAME + " non-uniform group joint scan functions with init",
-          "[oneapi_non_uniform_groups][group_func][type_list]"){
+TEMPLATE_LIST_TEST_CASE(
+          CTS_TYPE_NAME + " non-uniform group joint scan functions with init",
+          "[oneapi_non_uniform_groups][group_func][type_list]", GroupPackTypes){
   auto queue = once_per_unit::get_queue();
-  const auto GroupTypes = unnamed_type_pack<
-      oneapi_ext::ballot_group<sycl::sub_group>,
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-      oneapi_ext::tangle_group<sycl::sub_group>,
-      oneapi_ext::opportunistic_group>();
 
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
@@ -85,7 +71,7 @@ TEST_CASE(CTS_TYPE_NAME + " non-uniform group joint scan functions with init",
   }
 
   for_all_combinations<invoke_init_joint_scan_group>(
-      GroupTypes, TestType{}, ScanTypes{}, ScanTypes{}, queue);
+      TestType{}, CurrentType{}, ScanTypes{}, ScanTypes{}, queue);
 };
 
 }  // namespace non_uniform_groups::tests

--- a/tests/extension/oneapi_non_uniform_groups/group_of.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_of.cpp
@@ -23,61 +23,27 @@
 namespace non_uniform_groups::tests {
 
 // use wide types to exclude truncation of init values
-using WideTypes = std::tuple<int32_t, uint32_t, int64_t, uint64_t, float>;
+static const auto wide_types =
+    named_type_pack<int32_t, uint32_t, int64_t, uint64_t, float>::generate(
+        "int32_t", "uint32_t", "int64_t", "uint64_t", "float");
 
 TEMPLATE_LIST_TEST_CASE("Non-uniform group joint of bool functions",
                         "[oneapi_non_uniform_groups][group_func][type_list]",
-                        WideTypes) {
-  auto queue = once_per_unit::get_queue();
-  joint_of_group<oneapi_ext::ballot_group<sycl::sub_group>, TestType>(queue);
-  joint_of_group<oneapi_ext::fixed_size_group<1, sycl::sub_group>, TestType>(
-      queue);
-  joint_of_group<oneapi_ext::fixed_size_group<2, sycl::sub_group>, TestType>(
-      queue);
-  joint_of_group<oneapi_ext::fixed_size_group<4, sycl::sub_group>, TestType>(
-      queue);
-  joint_of_group<oneapi_ext::fixed_size_group<8, sycl::sub_group>, TestType>(
-      queue);
-  joint_of_group<oneapi_ext::tangle_group<sycl::sub_group>, TestType>(queue);
-  joint_of_group<oneapi_ext::opportunistic_group, TestType>(queue);
+                        GroupPackTypes) {
+  for_all_combinations<joint_of_group_test>(TestType{}, wide_types);
 }
 
 TEMPLATE_LIST_TEST_CASE(
     "Non-uniform group of bool functions with predicate functions",
-    "[oneapi_non_uniform_groups][group_func][type_list]", WideTypes) {
-  auto queue = once_per_unit::get_queue();
-  predicate_function_of_non_uniform_group<
-      oneapi_ext::ballot_group<sycl::sub_group>, TestType>(queue);
-  predicate_function_of_non_uniform_group<
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>, TestType>(queue);
-  predicate_function_of_non_uniform_group<
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>, TestType>(queue);
-  predicate_function_of_non_uniform_group<
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>, TestType>(queue);
-  predicate_function_of_non_uniform_group<
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>, TestType>(queue);
-  predicate_function_of_non_uniform_group<
-      oneapi_ext::tangle_group<sycl::sub_group>, TestType>(queue);
-  predicate_function_of_non_uniform_group<oneapi_ext::opportunistic_group,
-                                          TestType>(queue);
+    "[oneapi_non_uniform_groups][group_func][type_list]", GroupPackTypes) {
+  for_all_combinations<predicate_function_of_non_uniform_group_test>(
+      TestType{}, wide_types);
 }
 
-TEST_CASE("Non-uniform group of bool functions",
-          "[oneapi_non_uniform_groups][group_func]") {
-  auto queue = once_per_unit::get_queue();
-  bool_function_of_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>>(
-      queue);
-  bool_function_of_non_uniform_group<
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>>(queue);
-  bool_function_of_non_uniform_group<
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>>(queue);
-  bool_function_of_non_uniform_group<
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>>(queue);
-  bool_function_of_non_uniform_group<
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>>(queue);
-  bool_function_of_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>>(
-      queue);
-  bool_function_of_non_uniform_group<oneapi_ext::opportunistic_group>(queue);
+TEMPLATE_LIST_TEST_CASE("Non-uniform group of bool functions",
+                        "[oneapi_non_uniform_groups][group_func]",
+                        GroupPackTypes) {
+  for_all_combinations<bool_function_of_non_uniform_group_test>(TestType{});
 }
 
 }  // namespace non_uniform_groups::tests

--- a/tests/extension/oneapi_non_uniform_groups/group_of.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_of.h
@@ -31,138 +31,145 @@ class joint_of_group_kernel;
  * @tparam T Type pointed by Ptr
  */
 template <typename GroupT, typename T>
-void joint_of_group(sycl::queue& queue) {
-  const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
+struct joint_of_group_test {
+  void operator()(const std::string& type_name) {
+    auto queue = once_per_unit::get_queue();
 
-  INFO("Testing group-of predicate function for " + group_name);
-  if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
-    SKIP("Device does not support " + group_name);
-  }
+    const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
-  // 3 functions * 4 predicates
-  constexpr int test_matrix = 3;
-  const std::string test_names[test_matrix] = {
-      "bool joint_any_of(GroupT g, Ptr first, Ptr last, Predicate pred)",
-      "bool joint_all_of(GroupT g, Ptr first, Ptr last, Predicate pred)",
-      "bool joint_none_of(GroupT g, Ptr first, Ptr last, Predicate pred)"};
-  constexpr int test_cases = 4;
-  const std::string test_cases_names[test_cases] = {"none true", "one true",
-                                                    "some true", "all true"};
+    INFO("Testing group-of predicate function for " + group_name);
+    if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
+      SKIP("Device does not support " + group_name);
+    }
 
-  sycl::range<1> work_group_range = sycl_cts::util::work_group_range<1>(queue);
-  size_t work_group_size = work_group_range.size();
+    // 3 functions * 4 predicates
+    constexpr int test_matrix = 3;
+    const std::string test_names[test_matrix] = {
+        "bool joint_any_of(GroupT g, Ptr first, Ptr last, Predicate pred)",
+        "bool joint_all_of(GroupT g, Ptr first, Ptr last, Predicate pred)",
+        "bool joint_none_of(GroupT g, Ptr first, Ptr last, Predicate pred)"};
+    constexpr int test_cases = 4;
+    const std::string test_cases_names[test_cases] = {"none true", "one true",
+                                                      "some true", "all true"};
 
-  const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
-  for (size_t test_case = 0;
-       test_case < NonUniformGroupHelper<GroupT>::num_test_cases; ++test_case) {
-    const std::string test_case_name =
-        NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
-    INFO("Running test case (" + std::to_string(test_case) + ") with " +
-         test_case_name);
+    sycl::range<1> work_group_range =
+        sycl_cts::util::work_group_range<1>(queue);
+    size_t work_group_size = work_group_range.size();
 
-    for (size_t size : sizes) {
-      std::vector<T> v(size);
-      std::iota(v.begin(), v.end(), 1);
+    const size_t sizes[3] = {5, work_group_size / 2, 3 * work_group_size};
+    for (size_t test_case = 0;
+         test_case < NonUniformGroupHelper<GroupT>::num_test_cases;
+         ++test_case) {
+      const std::string test_case_name =
+          NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
+      INFO("Running test case (" + std::to_string(test_case) + ") with " +
+           test_case_name);
 
-      // array to return results:
-      bool res[test_matrix * test_cases] = {false};
-      {
-        sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
+      for (size_t size : sizes) {
+        std::vector<T> v(size);
+        std::iota(v.begin(), v.end(), 1);
 
-        sycl::buffer<bool, 1> res_sycl(
-            res, sycl::range<1>(test_matrix * test_cases));
+        // array to return results:
+        bool res[test_matrix * test_cases] = {false};
+        {
+          sycl::buffer<T, 1> v_sycl(v.data(), sycl::range<1>(size));
 
-        queue.submit([&](sycl::handler& cgh) {
-          auto v_acc =
-              v_sycl.template get_access<sycl::access::mode::read_write>(cgh);
-          auto res_acc =
-              res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+          sycl::buffer<bool, 1> res_sycl(
+              res, sycl::range<1>(test_matrix * test_cases));
 
-          sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+          queue.submit([&](sycl::handler& cgh) {
+            auto v_acc =
+                v_sycl.template get_access<sycl::access::mode::read_write>(cgh);
+            auto res_acc =
+                res_sycl.get_access<sycl::access::mode::read_write>(cgh);
 
-          cgh.parallel_for<joint_of_group_kernel<
-              GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
-            sycl::sub_group sub_group = item.get_sub_group();
+            sycl::nd_range<1> executionRange(work_group_range,
+                                             work_group_range);
 
-            // If this item is not participating in the group, leave early.
-            if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                   test_case))
-              return;
+            cgh.parallel_for<joint_of_group_kernel<
+                GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
+              sycl::sub_group sub_group = item.get_sub_group();
 
-            GroupT non_uniform_group =
-                NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+              // If this item is not participating in the group, leave early.
+              if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                                     test_case))
+                return;
 
-            T* v_begin = v_acc.get_pointer();
-            T* v_end = v_begin + v_acc.size();
+              GroupT non_uniform_group =
+                  NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
 
-            // predicates
-            auto none_true = [&](T i) { return i == 0; };
-            auto one_true = [&](T i) { return i == 1; };
-            auto some_true = [&](T i) { return i > size / 2; };
-            auto all_true = [&](T i) { return i <= size; };
+              T* v_begin = v_acc.get_pointer();
+              T* v_end = v_begin + v_acc.size();
 
-            static_assert(
-                std::is_same_v<bool, decltype(sycl::joint_any_of(
-                                         non_uniform_group, v_begin, v_end,
-                                         none_true))>,
-                "Return type of joint_any_of(GroupT g, Ptr first, Ptr last, "
-                "Predicate pred) is wrong\n");
-            res_acc[0] = !sycl::joint_any_of(non_uniform_group, v_begin, v_end,
-                                             none_true);
-            res_acc[1] =
-                sycl::joint_any_of(non_uniform_group, v_begin, v_end, one_true);
-            res_acc[2] = sycl::joint_any_of(non_uniform_group, v_begin, v_end,
-                                            some_true);
-            res_acc[3] =
-                sycl::joint_any_of(non_uniform_group, v_begin, v_end, all_true);
+              // predicates
+              auto none_true = [&](T i) { return i == 0; };
+              auto one_true = [&](T i) { return i == 1; };
+              auto some_true = [&](T i) { return i > size / 2; };
+              auto all_true = [&](T i) { return i <= size; };
 
-            static_assert(
-                std::is_same_v<bool, decltype(sycl::joint_all_of(
-                                         non_uniform_group, v_begin, v_end,
-                                         none_true))>,
-                "Return type of joint_all_of(GroupT g, Ptr first, Ptr last, "
-                "Predicate pred) is wrong\n");
-            res_acc[4] = !sycl::joint_all_of(non_uniform_group, v_begin, v_end,
-                                             none_true);
-            res_acc[5] = !sycl::joint_all_of(non_uniform_group, v_begin, v_end,
-                                             one_true);
-            res_acc[6] = !sycl::joint_all_of(non_uniform_group, v_begin, v_end,
-                                             some_true);
-            res_acc[7] =
-                sycl::joint_all_of(non_uniform_group, v_begin, v_end, all_true);
-
-            static_assert(
-                std::is_same_v<bool, decltype(sycl::joint_none_of(
-                                         non_uniform_group, v_begin, v_end,
-                                         none_true))>,
-                "Return type of joint_none_of(GroupT g, Ptr first, Ptr last, "
-                "Predicate pred) is wrong\n");
-            res_acc[8] = sycl::joint_none_of(non_uniform_group, v_begin, v_end,
-                                             none_true);
-            res_acc[9] = !sycl::joint_none_of(non_uniform_group, v_begin, v_end,
+              static_assert(
+                  std::is_same_v<bool, decltype(sycl::joint_any_of(
+                                           non_uniform_group, v_begin, v_end,
+                                           none_true))>,
+                  "Return type of joint_any_of(GroupT g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[0] = !sycl::joint_any_of(non_uniform_group, v_begin,
+                                               v_end, none_true);
+              res_acc[1] = sycl::joint_any_of(non_uniform_group, v_begin, v_end,
                                               one_true);
-            res_acc[10] = !sycl::joint_none_of(non_uniform_group, v_begin,
+              res_acc[2] = sycl::joint_any_of(non_uniform_group, v_begin, v_end,
+                                              some_true);
+              res_acc[3] = sycl::joint_any_of(non_uniform_group, v_begin, v_end,
+                                              all_true);
+
+              static_assert(
+                  std::is_same_v<bool, decltype(sycl::joint_all_of(
+                                           non_uniform_group, v_begin, v_end,
+                                           none_true))>,
+                  "Return type of joint_all_of(GroupT g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[4] = !sycl::joint_all_of(non_uniform_group, v_begin,
+                                               v_end, none_true);
+              res_acc[5] = !sycl::joint_all_of(non_uniform_group, v_begin,
+                                               v_end, one_true);
+              res_acc[6] = !sycl::joint_all_of(non_uniform_group, v_begin,
                                                v_end, some_true);
-            res_acc[11] = !sycl::joint_none_of(non_uniform_group, v_begin,
-                                               v_end, all_true);
+              res_acc[7] = sycl::joint_all_of(non_uniform_group, v_begin, v_end,
+                                              all_true);
+
+              static_assert(
+                  std::is_same_v<bool, decltype(sycl::joint_none_of(
+                                           non_uniform_group, v_begin, v_end,
+                                           none_true))>,
+                  "Return type of joint_none_of(GroupT g, Ptr first, Ptr last, "
+                  "Predicate pred) is wrong\n");
+              res_acc[8] = sycl::joint_none_of(non_uniform_group, v_begin,
+                                               v_end, none_true);
+              res_acc[9] = !sycl::joint_none_of(non_uniform_group, v_begin,
+                                                v_end, one_true);
+              res_acc[10] = !sycl::joint_none_of(non_uniform_group, v_begin,
+                                                 v_end, some_true);
+              res_acc[11] = !sycl::joint_none_of(non_uniform_group, v_begin,
+                                                 v_end, all_true);
+            });
           });
-        });
-      }
-      int index = 0;
-      for (int i = 0; i < test_matrix; ++i)
-        for (int j = 0; j < test_cases; ++j) {
-          std::string work_group =
-              sycl_cts::util::work_group_print(work_group_range);
-          CAPTURE(group_name, work_group);
-          INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                           << " predicate"
-                              " is "
-                           << (res[index] ? "right" : "wrong"));
-          CHECK(res[index++]);
         }
+        int index = 0;
+        for (int i = 0; i < test_matrix; ++i)
+          for (int j = 0; j < test_cases; ++j) {
+            std::string work_group =
+                sycl_cts::util::work_group_print(work_group_range);
+            CAPTURE(group_name, work_group);
+            INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                             << " predicate"
+                                " is "
+                             << (res[index] ? "right" : "wrong"));
+            CHECK(res[index++]);
+          }
+      }
     }
   }
-}
+};
 
 template <typename GroupT, typename T>
 class predicate_function_of_non_uniform_group_kernel;
@@ -174,148 +181,156 @@ class predicate_function_of_non_uniform_group_kernel;
  * @tparam T Type pointed by Ptr
  */
 template <typename GroupT, typename T>
-void predicate_function_of_non_uniform_group(sycl::queue& queue) {
-  const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
+struct predicate_function_of_non_uniform_group_test {
+  void operator()(const std::string& type_name) {
+    auto queue = once_per_unit::get_queue();
 
-  INFO("Testing group-of predicate function for " + group_name);
-  if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
-    SKIP("Device does not support " + group_name);
-  }
+    const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
-  // 3 functions * 4 predicates
-  constexpr int test_matrix = 3;
-  const std::string test_names[test_matrix] = {
-      "bool any_of_group(GroupT g, T x, Predicate pred)",
-      "bool all_of_group(GroupT g, T x, Predicate pred)",
-      "bool none_of_group(GroupT g, T x, Predicate pred)"};
-  constexpr int test_cases = 4;
-  const std::string test_cases_names[test_cases] = {"none true", "one true",
-                                                    "some true", "all true"};
-
-  sycl::range<1> work_group_range = sycl_cts::util::work_group_range<1>(queue);
-
-  for (size_t test_case = 0;
-       test_case < NonUniformGroupHelper<GroupT>::num_test_cases; ++test_case) {
-    const std::string test_case_name =
-        NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
-    INFO("Running test case (" + std::to_string(test_case) + ") with " +
-         test_case_name);
-
-    // array to return results: 4 predicates * 3 functions
-    constexpr int total_case_count = test_matrix * test_cases;
-    bool res[total_case_count];
-    // Initially fill the results array with 'true'. Each non-uniform group test
-    // 'ands' with this to ensure every non-uniform group in the work-group
-    // returns the correct result.
-    std::fill(res, res + total_case_count, true);
-    {
-      sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(total_case_count));
-
-      queue.submit([&](sycl::handler& cgh) {
-        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
-        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
-
-        cgh.parallel_for<predicate_function_of_non_uniform_group_kernel<
-            GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
-          sycl::sub_group sub_group = item.get_sub_group();
-
-          // If this item is not participating in the group, leave early.
-          if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                 test_case))
-            return;
-
-          GroupT non_uniform_group =
-              NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
-
-          size_t size = non_uniform_group.get_local_linear_range();
-
-          // Use the non-uniform group local ID (plus 1) as a variable against
-          // which to test our predicates. Note that this has a well-defined set
-          // of values [1,2,...,N] where N is the non-uniform group size. Note
-          // that the non-uniform group could also just be of size 1.
-          T local_var(non_uniform_group.get_local_linear_id() + 1);
-
-          // predicates
-          // The variable is never 1 for any member of the non-uniform group
-          auto none_true = [&](T i) { return i == 0; };
-          // Exactly one member of the non-uniform group has value 1 (the first)
-          auto one_true = [&](T i) { return i == 1; };
-          // Some (or all, for non-uniform groups of size 1) members of the
-          // non-uniform group have this value
-          auto some_true = [&](T i) { return i > size / 2; };
-          // The variable is less than or equal to the non-uniform group size
-          // for all members of the non-uniform group.
-          auto all_true = [&](T i) { return i <= size; };
-
-          {
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::any_of_group(
-                                   non_uniform_group, local_var, none_true))>,
-                "Return type of any_of_group(GroupT g, bool pred) is wrong\n");
-            res_acc[0] &=
-                !sycl::any_of_group(non_uniform_group, local_var, none_true);
-            res_acc[1] &=
-                sycl::any_of_group(non_uniform_group, local_var, one_true);
-            res_acc[2] &=
-                sycl::any_of_group(non_uniform_group, local_var, some_true);
-            res_acc[3] &=
-                sycl::any_of_group(non_uniform_group, local_var, all_true);
-
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::all_of_group(
-                                   non_uniform_group, local_var, none_true))>,
-                "Return type of all_of_group(GroupT g, bool pred) is wrong\n");
-            res_acc[4] &=
-                !sycl::all_of_group(non_uniform_group, local_var, none_true);
-            // Note that 'one_true' returns true for the first item. Thus in the
-            // case that the non-uniform group size is 1, check that all items
-            // match; otherwise check that not all items match.
-            res_acc[5] &=
-                sycl::all_of_group(non_uniform_group, local_var, one_true) ^
-                (size != 1);
-            // Note that 'some_true' returns true for the first item if the
-            // non-uniform group size is 1. In that case, check that all items
-            // match; otherwise check that not all items match.
-            res_acc[6] &=
-                sycl::all_of_group(non_uniform_group, local_var, some_true) ^
-                (size != 1);
-            res_acc[7] &=
-                sycl::all_of_group(non_uniform_group, local_var, all_true);
-
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::none_of_group(
-                                   non_uniform_group, local_var, none_true))>,
-                "Return type of none_of_group(GroupT g, bool pred) is "
-                "wrong\n");
-            res_acc[8] &=
-                sycl::none_of_group(non_uniform_group, local_var, none_true);
-            res_acc[9] &=
-                !sycl::none_of_group(non_uniform_group, local_var, one_true);
-            res_acc[10] &=
-                !sycl::none_of_group(non_uniform_group, local_var, some_true);
-            res_acc[11] &=
-                !sycl::none_of_group(non_uniform_group, local_var, all_true);
-          }
-        });
-      });
+    INFO("Testing group-of predicate function for " + group_name);
+    if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
+      SKIP("Device does not support " + group_name);
     }
-    int index = 0;
-    for (int i = 0; i < test_matrix; ++i)
-      for (int j = 0; j < test_cases; ++j) {
-        std::string work_group =
-            sycl_cts::util::work_group_print(work_group_range);
-        CAPTURE(group_name, work_group);
-        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                         << " predicate is "
-                         << (res[index] ? "right" : "wrong"));
-        CHECK(res[index++]);
+
+    // 3 functions * 4 predicates
+    constexpr int test_matrix = 3;
+    const std::string test_names[test_matrix] = {
+        "bool any_of_group(GroupT g, T x, Predicate pred)",
+        "bool all_of_group(GroupT g, T x, Predicate pred)",
+        "bool none_of_group(GroupT g, T x, Predicate pred)"};
+    constexpr int test_cases = 4;
+    const std::string test_cases_names[test_cases] = {"none true", "one true",
+                                                      "some true", "all true"};
+
+    sycl::range<1> work_group_range =
+        sycl_cts::util::work_group_range<1>(queue);
+
+    for (size_t test_case = 0;
+         test_case < NonUniformGroupHelper<GroupT>::num_test_cases;
+         ++test_case) {
+      const std::string test_case_name =
+          NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
+      INFO("Running test case (" + std::to_string(test_case) + ") with " +
+           test_case_name);
+
+      // array to return results: 4 predicates * 3 functions
+      constexpr int total_case_count = test_matrix * test_cases;
+      bool res[total_case_count];
+      // Initially fill the results array with 'true'. Each non-uniform group
+      // test 'ands' with this to ensure every non-uniform group in the
+      // work-group returns the correct result.
+      std::fill(res, res + total_case_count, true);
+      {
+        sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(total_case_count));
+
+        queue.submit([&](sycl::handler& cgh) {
+          auto res_acc =
+              res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+          sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+
+          cgh.parallel_for<predicate_function_of_non_uniform_group_kernel<
+              GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
+            sycl::sub_group sub_group = item.get_sub_group();
+
+            // If this item is not participating in the group, leave early.
+            if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                                   test_case))
+              return;
+
+            GroupT non_uniform_group =
+                NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+
+            size_t size = non_uniform_group.get_local_linear_range();
+
+            // Use the non-uniform group local ID (plus 1) as a variable against
+            // which to test our predicates. Note that this has a well-defined
+            // set of values [1,2,...,N] where N is the non-uniform group size.
+            // Note that the non-uniform group could also just be of size 1.
+            T local_var(non_uniform_group.get_local_linear_id() + 1);
+
+            // predicates
+            // The variable is never 1 for any member of the non-uniform group
+            auto none_true = [&](T i) { return i == 0; };
+            // Exactly one member of the non-uniform group has value 1 (the
+            // first)
+            auto one_true = [&](T i) { return i == 1; };
+            // Some (or all, for non-uniform groups of size 1) members of the
+            // non-uniform group have this value
+            auto some_true = [&](T i) { return i > size / 2; };
+            // The variable is less than or equal to the non-uniform group size
+            // for all members of the non-uniform group.
+            auto all_true = [&](T i) { return i <= size; };
+
+            {
+              static_assert(std::is_same_v<bool, decltype(sycl::any_of_group(
+                                                     non_uniform_group,
+                                                     local_var, none_true))>,
+                            "Return type of any_of_group(GroupT g, bool pred) "
+                            "is wrong\n");
+              res_acc[0] &=
+                  !sycl::any_of_group(non_uniform_group, local_var, none_true);
+              res_acc[1] &=
+                  sycl::any_of_group(non_uniform_group, local_var, one_true);
+              res_acc[2] &=
+                  sycl::any_of_group(non_uniform_group, local_var, some_true);
+              res_acc[3] &=
+                  sycl::any_of_group(non_uniform_group, local_var, all_true);
+
+              static_assert(std::is_same_v<bool, decltype(sycl::all_of_group(
+                                                     non_uniform_group,
+                                                     local_var, none_true))>,
+                            "Return type of all_of_group(GroupT g, bool pred) "
+                            "is wrong\n");
+              res_acc[4] &=
+                  !sycl::all_of_group(non_uniform_group, local_var, none_true);
+              // Note that 'one_true' returns true for the first item. Thus in
+              // the case that the non-uniform group size is 1, check that all
+              // items match; otherwise check that not all items match.
+              res_acc[5] &=
+                  sycl::all_of_group(non_uniform_group, local_var, one_true) ^
+                  (size != 1);
+              // Note that 'some_true' returns true for the first item if the
+              // non-uniform group size is 1. In that case, check that all items
+              // match; otherwise check that not all items match.
+              res_acc[6] &=
+                  sycl::all_of_group(non_uniform_group, local_var, some_true) ^
+                  (size != 1);
+              res_acc[7] &=
+                  sycl::all_of_group(non_uniform_group, local_var, all_true);
+
+              static_assert(
+                  std::is_same_v<bool,
+                                 decltype(sycl::none_of_group(
+                                     non_uniform_group, local_var, none_true))>,
+                  "Return type of none_of_group(GroupT g, bool pred) is "
+                  "wrong\n");
+              res_acc[8] &=
+                  sycl::none_of_group(non_uniform_group, local_var, none_true);
+              res_acc[9] &=
+                  !sycl::none_of_group(non_uniform_group, local_var, one_true);
+              res_acc[10] &=
+                  !sycl::none_of_group(non_uniform_group, local_var, some_true);
+              res_acc[11] &=
+                  !sycl::none_of_group(non_uniform_group, local_var, all_true);
+            }
+          });
+        });
       }
+      int index = 0;
+      for (int i = 0; i < test_matrix; ++i)
+        for (int j = 0; j < test_cases; ++j) {
+          std::string work_group =
+              sycl_cts::util::work_group_print(work_group_range);
+          CAPTURE(group_name, work_group);
+          INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                           << " predicate is "
+                           << (res[index] ? "right" : "wrong"));
+          CHECK(res[index++]);
+        }
+    }
   }
-}
+};
 
 template <typename GroupT>
 class predicate_function_of_non_uniform_group_bool_kernel;
@@ -325,147 +340,154 @@ class predicate_function_of_non_uniform_group_bool_kernel;
  * @tparam GroupT Type of the non-uniform group to test with
  */
 template <typename GroupT>
-void bool_function_of_non_uniform_group(sycl::queue& queue) {
-  const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
+struct bool_function_of_non_uniform_group_test {
+  void operator()() {
+    auto queue = once_per_unit::get_queue();
+    const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
-  INFO("Testing group-of bool function for " + group_name);
-  if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
-    SKIP("Device does not support " + group_name);
-  }
-
-  // 3 functions * 4 predicates
-  constexpr int test_matrix = 3;
-  const std::string test_names[test_matrix] = {
-      "bool any_of_group(GroupT g, bool pred)",
-      "bool all_of_group(GroupT g, bool pred)",
-      "bool none_of_group(GroupT g, bool pred)"};
-  constexpr int test_cases = 4;
-  const std::string test_cases_names[test_cases] = {"none true", "one true",
-                                                    "some true", "all true"};
-
-  using T = size_t;
-
-  sycl::range<1> work_group_range = sycl_cts::util::work_group_range<1>(queue);
-
-  for (size_t test_case = 0;
-       test_case < NonUniformGroupHelper<GroupT>::num_test_cases; ++test_case) {
-    const std::string test_case_name =
-        NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
-    INFO("Running test case (" + std::to_string(test_case) + ") with " +
-         test_case_name);
-
-    // array to return results: 4 predicates * 3 functions
-    constexpr int total_case_count = test_matrix * test_cases;
-    bool res[total_case_count];
-    // Initially fill the results array with 'true'. Each non-uniform group test
-    // 'ands' with this to ensure every non-uniform group in the work-group
-    // returns the correct result.
-    std::fill(res, res + total_case_count, true);
-    {
-      sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(total_case_count));
-
-      queue.submit([&](sycl::handler& cgh) {
-        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
-        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
-
-        cgh.parallel_for<predicate_function_of_non_uniform_group_bool_kernel<
-            GroupT>>(executionRange, [=](sycl::nd_item<1> item) {
-          sycl::sub_group sub_group = item.get_sub_group();
-
-          // If this item is not participating in the group, leave early.
-          if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
-                                                                 test_case))
-            return;
-
-          GroupT non_uniform_group =
-              NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
-
-          size_t size = non_uniform_group.get_local_linear_range();
-
-          // Use the non-uniform group local ID (plus 1) as a variable against
-          // which to test our predicates. Note that this has a well-defined set
-          // of values [1,2,...,N] where N is the non-uniform group size. Note
-          // that the non-uniform group could also just be of size 1.
-          T local_var(non_uniform_group.get_local_linear_id() + 1);
-
-          // predicates
-          // The variable is never 1 for any member of the non-uniform group
-          auto none_true = [&](T i) { return i == 0; };
-          // Exactly one member of the non-uniform group has value 1 (the first)
-          auto one_true = [&](T i) { return i == 1; };
-          // Some (or all, for non-uniform groups of size 1) members of the
-          // non-uniform group have this value
-          auto some_true = [&](T i) { return i > size / 2; };
-          // The variable is less than or equal to the non-uniform group size
-          // for all members of the non-uniform group.
-          auto all_true = [&](T i) { return i <= size; };
-
-          {
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::any_of_group(
-                                   non_uniform_group, none_true(local_var)))>,
-                "Return type of any_of_group(GroupT g, bool pred) is wrong\n");
-            res_acc[0] &=
-                !sycl::any_of_group(non_uniform_group, none_true(local_var));
-            res_acc[1] &=
-                sycl::any_of_group(non_uniform_group, one_true(local_var));
-            res_acc[2] &=
-                sycl::any_of_group(non_uniform_group, some_true(local_var));
-            res_acc[3] &=
-                sycl::any_of_group(non_uniform_group, all_true(local_var));
-
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::all_of_group(
-                                   non_uniform_group, none_true(local_var)))>,
-                "Return type of all_of_group(GroupT g, bool pred) is wrong\n");
-            res_acc[4] =
-                !sycl::all_of_group(non_uniform_group, none_true(local_var));
-            // Note that 'one_true' returns true for the first item. Thus in the
-            // case that the non-uniform group size is 1, check that all items
-            // match; otherwise check that not all items match.
-            res_acc[5] &=
-                sycl::all_of_group(non_uniform_group, one_true(local_var)) ^
-                (size != 1);
-            // Note that 'some_true' returns true for the first item if the
-            // non-uniform group size is 1. In that case, check that all items
-            // match; otherwise check that not all items match.
-            res_acc[6] &=
-                sycl::all_of_group(non_uniform_group, some_true(local_var)) ^
-                (size != 1);
-            res_acc[7] &=
-                sycl::all_of_group(non_uniform_group, all_true(local_var));
-
-            static_assert(
-                std::is_same_v<bool,
-                               decltype(sycl::none_of_group(
-                                   non_uniform_group, none_true(local_var)))>,
-                "Return type of none_of_group(GroupT g, bool pred) is "
-                "wrong\n");
-            res_acc[8] &=
-                sycl::none_of_group(non_uniform_group, none_true(local_var));
-            res_acc[9] &=
-                !sycl::none_of_group(non_uniform_group, one_true(local_var));
-            res_acc[10] &=
-                !sycl::none_of_group(non_uniform_group, some_true(local_var));
-            res_acc[11] &=
-                !sycl::none_of_group(non_uniform_group, all_true(local_var));
-          }
-        });
-      });
+    INFO("Testing group-of bool function for " + group_name);
+    if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
+      SKIP("Device does not support " + group_name);
     }
-    int index = 0;
-    for (int i = 0; i < test_matrix; ++i)
-      for (int j = 0; j < test_cases; ++j) {
-        std::string work_group =
-            sycl_cts::util::work_group_print(work_group_range);
-        CAPTURE(group_name, work_group);
-        INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
-                         << " predicate is "
-                         << (res[index] ? "right" : "wrong"));
-        CHECK(res[index++]);
+
+    // 3 functions * 4 predicates
+    constexpr int test_matrix = 3;
+    const std::string test_names[test_matrix] = {
+        "bool any_of_group(GroupT g, bool pred)",
+        "bool all_of_group(GroupT g, bool pred)",
+        "bool none_of_group(GroupT g, bool pred)"};
+    constexpr int test_cases = 4;
+    const std::string test_cases_names[test_cases] = {"none true", "one true",
+                                                      "some true", "all true"};
+
+    using T = size_t;
+
+    sycl::range<1> work_group_range =
+        sycl_cts::util::work_group_range<1>(queue);
+
+    for (size_t test_case = 0;
+         test_case < NonUniformGroupHelper<GroupT>::num_test_cases;
+         ++test_case) {
+      const std::string test_case_name =
+          NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
+      INFO("Running test case (" + std::to_string(test_case) + ") with " +
+           test_case_name);
+
+      // array to return results: 4 predicates * 3 functions
+      constexpr int total_case_count = test_matrix * test_cases;
+      bool res[total_case_count];
+      // Initially fill the results array with 'true'. Each non-uniform group
+      // test 'ands' with this to ensure every non-uniform group in the
+      // work-group returns the correct result.
+      std::fill(res, res + total_case_count, true);
+      {
+        sycl::buffer<bool, 1> res_sycl(res, sycl::range<1>(total_case_count));
+
+        queue.submit([&](sycl::handler& cgh) {
+          auto res_acc =
+              res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+          sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+
+          cgh.parallel_for<predicate_function_of_non_uniform_group_bool_kernel<
+              GroupT>>(executionRange, [=](sycl::nd_item<1> item) {
+            sycl::sub_group sub_group = item.get_sub_group();
+
+            // If this item is not participating in the group, leave early.
+            if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                                   test_case))
+              return;
+
+            GroupT non_uniform_group =
+                NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+
+            size_t size = non_uniform_group.get_local_linear_range();
+
+            // Use the non-uniform group local ID (plus 1) as a variable against
+            // which to test our predicates. Note that this has a well-defined
+            // set of values [1,2,...,N] where N is the non-uniform group size.
+            // Note that the non-uniform group could also just be of size 1.
+            T local_var(non_uniform_group.get_local_linear_id() + 1);
+
+            // predicates
+            // The variable is never 1 for any member of the non-uniform group
+            auto none_true = [&](T i) { return i == 0; };
+            // Exactly one member of the non-uniform group has value 1 (the
+            // first)
+            auto one_true = [&](T i) { return i == 1; };
+            // Some (or all, for non-uniform groups of size 1) members of the
+            // non-uniform group have this value
+            auto some_true = [&](T i) { return i > size / 2; };
+            // The variable is less than or equal to the non-uniform group size
+            // for all members of the non-uniform group.
+            auto all_true = [&](T i) { return i <= size; };
+
+            {
+              static_assert(std::is_same_v<bool, decltype(sycl::any_of_group(
+                                                     non_uniform_group,
+                                                     none_true(local_var)))>,
+                            "Return type of any_of_group(GroupT g, bool pred) "
+                            "is wrong\n");
+              res_acc[0] &=
+                  !sycl::any_of_group(non_uniform_group, none_true(local_var));
+              res_acc[1] &=
+                  sycl::any_of_group(non_uniform_group, one_true(local_var));
+              res_acc[2] &=
+                  sycl::any_of_group(non_uniform_group, some_true(local_var));
+              res_acc[3] &=
+                  sycl::any_of_group(non_uniform_group, all_true(local_var));
+
+              static_assert(std::is_same_v<bool, decltype(sycl::all_of_group(
+                                                     non_uniform_group,
+                                                     none_true(local_var)))>,
+                            "Return type of all_of_group(GroupT g, bool pred) "
+                            "is wrong\n");
+              res_acc[4] =
+                  !sycl::all_of_group(non_uniform_group, none_true(local_var));
+              // Note that 'one_true' returns true for the first item. Thus in
+              // the case that the non-uniform group size is 1, check that all
+              // items match; otherwise check that not all items match.
+              res_acc[5] &=
+                  sycl::all_of_group(non_uniform_group, one_true(local_var)) ^
+                  (size != 1);
+              // Note that 'some_true' returns true for the first item if the
+              // non-uniform group size is 1. In that case, check that all items
+              // match; otherwise check that not all items match.
+              res_acc[6] &=
+                  sycl::all_of_group(non_uniform_group, some_true(local_var)) ^
+                  (size != 1);
+              res_acc[7] &=
+                  sycl::all_of_group(non_uniform_group, all_true(local_var));
+
+              static_assert(
+                  std::is_same_v<bool,
+                                 decltype(sycl::none_of_group(
+                                     non_uniform_group, none_true(local_var)))>,
+                  "Return type of none_of_group(GroupT g, bool pred) is "
+                  "wrong\n");
+              res_acc[8] &=
+                  sycl::none_of_group(non_uniform_group, none_true(local_var));
+              res_acc[9] &=
+                  !sycl::none_of_group(non_uniform_group, one_true(local_var));
+              res_acc[10] &=
+                  !sycl::none_of_group(non_uniform_group, some_true(local_var));
+              res_acc[11] &=
+                  !sycl::none_of_group(non_uniform_group, all_true(local_var));
+            }
+          });
+        });
       }
+      int index = 0;
+      for (int i = 0; i < test_matrix; ++i)
+        for (int j = 0; j < test_cases; ++j) {
+          std::string work_group =
+              sycl_cts::util::work_group_print(work_group_range);
+          CAPTURE(group_name, work_group);
+          INFO("Value of " << test_names[i] << " with " << test_cases_names[j]
+                           << " predicate is "
+                           << (res[index] ? "right" : "wrong"));
+          CHECK(res[index++]);
+        }
+    }
   }
-}
+};

--- a/tests/extension/oneapi_non_uniform_groups/group_permute.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_permute.cpp
@@ -25,22 +25,11 @@ namespace non_uniform_groups::tests {
 // hipSYCL does not permute right 8-bit types inside groups
 TEMPLATE_LIST_TEST_CASE("Non-uniform-group permute",
                         "[oneapi_non_uniform_groups][group_func][type_list]",
-                        CustomTypes) {
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
 
-  permute_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>,
-                            TestType>(queue);
-  permute_non_uniform_group<oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-                            TestType>(queue);
-  permute_non_uniform_group<oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-                            TestType>(queue);
-  permute_non_uniform_group<oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-                            TestType>(queue);
-  permute_non_uniform_group<oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-                            TestType>(queue);
-  permute_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>,
-                            TestType>(queue);
-  permute_non_uniform_group<oneapi_ext::opportunistic_group, TestType>(queue);
+  for_all_combinations<permute_non_uniform_group_test>(TestType{},
+                                                       CustomTypePack{}, queue);
 }
 
 }  // namespace non_uniform_groups::tests

--- a/tests/extension/oneapi_non_uniform_groups/group_permute.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_permute.h
@@ -28,7 +28,7 @@ class permute_non_uniform_group_kernel;
 
 template <typename GroupT, typename T>
 struct permute_non_uniform_group_test {
-  void operator()(sycl::queue &queue) {
+  void operator()(sycl::queue& queue) {
     const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
     INFO("Testing permute for " + group_name);

--- a/tests/extension/oneapi_non_uniform_groups/group_permute.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_permute.h
@@ -27,84 +27,92 @@ template <typename GroupT, typename T>
 class permute_non_uniform_group_kernel;
 
 template <typename GroupT, typename T>
-void permute_non_uniform_group(sycl::queue& queue) {
-  const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
+struct permute_non_uniform_group_test {
+  void operator()(sycl::queue &queue) {
+    const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
-  INFO("Testing permute for " + group_name);
-  if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
-    SKIP("Device does not support " + group_name);
-  }
-
-  const std::string test_name =
-      "T permute_group_by_xor(GroupT g, T x, GroupT::linear_id_type mask)";
-
-  sycl::range<1> work_group_range = sycl_cts::util::work_group_range<1>(queue);
-  size_t work_group_size = work_group_range.size();
-
-  for (size_t test_case = 0;
-       test_case < NonUniformGroupHelper<GroupT>::num_test_cases; ++test_case) {
-    const std::string test_case_name =
-        NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
-    INFO("Running test case (" + std::to_string(test_case) + ") with " +
-         test_case_name);
-
-    // array to return results:
-    std::valarray<bool> res(false, work_group_size);
-    {
-      sycl::buffer<bool, 1> res_sycl(std::begin(res),
-                                     sycl::range<1>(work_group_size));
-
-      queue.submit([&](sycl::handler& cgh) {
-        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
-        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
-
-        cgh.parallel_for<permute_non_uniform_group_kernel<GroupT, T>>(
-            executionRange, [=](sycl::nd_item<1> item) {
-              sycl::sub_group sub_group = item.get_sub_group();
-
-              // If this item is not participating in the group, they fill their
-              // elements in the result with true and leave early.
-              if (!NonUniformGroupHelper<GroupT>::should_participate(
-                      sub_group, test_case)) {
-                res_acc[item.get_local_linear_id()] = true;
-                return;
-              }
-
-              GroupT non_uniform_group =
-                  NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
-
-              using lin_id_type = typename GroupT::linear_id_type;
-              const lin_id_type llid = non_uniform_group.get_local_linear_id();
-
-              T local_var(splat_init<T>(llid + 1));
-              T permuted_var(splat_init<T>(llid + 1));
-
-              static_assert(
-                  std::is_same_v<T, decltype(sycl::permute_group_by_xor(
-                                        non_uniform_group, local_var, 0))>,
-                  "Return type of permute_group_by_xor(GroupT g, T x, "
-                  "GroupT::linear_id_type mask) is wrong\n");
-
-              bool res = true;
-              for (lin_id_type mask = 1u; mask > 0; mask <<= 1) {
-                permuted_var = sycl::permute_group_by_xor(non_uniform_group,
-                                                          local_var, mask);
-                res &= equal(permuted_var, splat_init<T>((llid ^ mask) + 1)) ||
-                       ((llid ^ mask) >=
-                        non_uniform_group.get_local_linear_range());
-              }
-              res_acc[item.get_local_linear_id()] = res;
-            });
-      });
+    INFO("Testing permute for " + group_name);
+    if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
+      SKIP("Device does not support " + group_name);
     }
-    bool result = res[0];
-    for (size_t j = 1; j < work_group_size; ++j) result &= res[j];
 
-    std::string work_group = sycl_cts::util::work_group_print(work_group_range);
-    CAPTURE(group_name, work_group);
-    INFO("Value of " << test_name << " with T = " << type_name<T>() << " is "
-                     << (result ? "right" : "wrong"));
-    CHECK(result);
+    const std::string test_name =
+        "T permute_group_by_xor(GroupT g, T x, GroupT::linear_id_type mask)";
+
+    sycl::range<1> work_group_range =
+        sycl_cts::util::work_group_range<1>(queue);
+    size_t work_group_size = work_group_range.size();
+
+    for (size_t test_case = 0;
+         test_case < NonUniformGroupHelper<GroupT>::num_test_cases;
+         ++test_case) {
+      const std::string test_case_name =
+          NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
+      INFO("Running test case (" + std::to_string(test_case) + ") with " +
+           test_case_name);
+
+      // array to return results:
+      std::valarray<bool> res(false, work_group_size);
+      {
+        sycl::buffer<bool, 1> res_sycl(std::begin(res),
+                                       sycl::range<1>(work_group_size));
+
+        queue.submit([&](sycl::handler& cgh) {
+          auto res_acc =
+              res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+          sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+
+          cgh.parallel_for<permute_non_uniform_group_kernel<GroupT, T>>(
+              executionRange, [=](sycl::nd_item<1> item) {
+                sycl::sub_group sub_group = item.get_sub_group();
+
+                // If this item is not participating in the group, they fill
+                // their elements in the result with true and leave early.
+                if (!NonUniformGroupHelper<GroupT>::should_participate(
+                        sub_group, test_case)) {
+                  res_acc[item.get_local_linear_id()] = true;
+                  return;
+                }
+
+                GroupT non_uniform_group =
+                    NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+
+                using lin_id_type = typename GroupT::linear_id_type;
+                const lin_id_type llid =
+                    non_uniform_group.get_local_linear_id();
+
+                T local_var(splat_init<T>(llid + 1));
+                T permuted_var(splat_init<T>(llid + 1));
+
+                static_assert(
+                    std::is_same_v<T, decltype(sycl::permute_group_by_xor(
+                                          non_uniform_group, local_var, 0))>,
+                    "Return type of permute_group_by_xor(GroupT g, T x, "
+                    "GroupT::linear_id_type mask) is wrong\n");
+
+                bool res = true;
+                for (lin_id_type mask = 1u; mask > 0; mask <<= 1) {
+                  permuted_var = sycl::permute_group_by_xor(non_uniform_group,
+                                                            local_var, mask);
+                  res &=
+                      equal(permuted_var, splat_init<T>((llid ^ mask) + 1)) ||
+                      ((llid ^ mask) >=
+                       non_uniform_group.get_local_linear_range());
+                }
+                res_acc[item.get_local_linear_id()] = res;
+              });
+        });
+      }
+      bool result = res[0];
+      for (size_t j = 1; j < work_group_size; ++j) result &= res[j];
+
+      std::string work_group =
+          sycl_cts::util::work_group_print(work_group_range);
+      CAPTURE(group_name, work_group);
+      INFO("Value of " << test_name << " with T = " << type_name<T>() << " is "
+                       << (result ? "right" : "wrong"));
+      CHECK(result);
+    }
   }
-}
+};

--- a/tests/extension/oneapi_non_uniform_groups/group_permute_fp16.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_permute_fp16.cpp
@@ -22,25 +22,14 @@
 
 namespace non_uniform_groups::tests {
 
-TEST_CASE("Non-uniform-group permute",
-          "[oneapi_non_uniform_groups][group_func][fp16]") {
+TEMPLATE_LIST_TEST_CASE("Non-uniform-group permute",
+                        "[oneapi_non_uniform_groups][group_func][fp16]",
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
 
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    permute_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>,
-                              sycl::half>(queue);
-    permute_non_uniform_group<oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-                              sycl::half>(queue);
-    permute_non_uniform_group<oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-                              sycl::half>(queue);
-    permute_non_uniform_group<oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-                              sycl::half>(queue);
-    permute_non_uniform_group<oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-                              sycl::half>(queue);
-    permute_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>,
-                              sycl::half>(queue);
-    permute_non_uniform_group<oneapi_ext::opportunistic_group, sycl::half>(
-        queue);
+    for_all_combinations<permute_non_uniform_group_test>(
+        TestType{}, unnamed_type_pack<sycl::half>{}, queue);
   } else {
     WARN("Device does not support half precision floating point operations.");
   }

--- a/tests/extension/oneapi_non_uniform_groups/group_permute_fp64.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_permute_fp64.cpp
@@ -22,24 +22,14 @@
 
 namespace non_uniform_groups::tests {
 
-TEST_CASE("Non-uniform-group permute",
-          "[oneapi_non_uniform_groups][group_func][fp64]") {
+TEMPLATE_LIST_TEST_CASE("Non-uniform-group permute",
+                        "[oneapi_non_uniform_groups][group_func][fp64]",
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
 
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    permute_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>,
-                              double>(queue);
-    permute_non_uniform_group<oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-                              double>(queue);
-    permute_non_uniform_group<oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-                              double>(queue);
-    permute_non_uniform_group<oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-                              double>(queue);
-    permute_non_uniform_group<oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-                              double>(queue);
-    permute_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>,
-                              double>(queue);
-    permute_non_uniform_group<oneapi_ext::opportunistic_group, double>(queue);
+    for_all_combinations<permute_non_uniform_group_test>(
+        TestType{}, unnamed_type_pack<double>{}, queue);
   } else {
     WARN("Device does not support double precision floating point operations.");
   }

--- a/tests/extension/oneapi_non_uniform_groups/group_reduce_over_group.cpp.in
+++ b/tests/extension/oneapi_non_uniform_groups/group_reduce_over_group.cpp.in
@@ -28,20 +28,14 @@ namespace non_uniform_groups::tests {
 // clang-format on
 using ReduceTypes = Types;
 
-TEST_CASE(CTS_TYPE_NAME + " non-uniform group reduce functions",
-          "[oneapi_non_uniform_groups][group_func][type_list]") {
+TEMPLATE_LIST_TEST_CASE(CTS_TYPE_NAME + " non-uniform group reduce functions",
+                        "[oneapi_non_uniform_groups][group_func][type_list]",
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
   // Get binary operators from TestType
   const auto Operators = get_op_types<CTS_TYPE>();
   const auto RetType = unnamed_type_pack<CTS_TYPE>();
-  const auto GroupTypes = unnamed_type_pack<
-      oneapi_ext::ballot_group<sycl::sub_group>,
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-      oneapi_ext::tangle_group<sycl::sub_group>,
-      oneapi_ext::opportunistic_group>();
+  const auto GroupTypes = TestType{};
 
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
@@ -62,21 +56,14 @@ TEST_CASE(CTS_TYPE_NAME + " non-uniform group reduce functions",
 TEMPLATE_LIST_TEST_CASE(CTS_TYPE_NAME +
                             " non-uniform group reduce functions with init",
                         "[oneapi_non_uniform_groups][group_func][type_list]",
-                        ReduceTypes) {
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
 
   // Get binary operators from T
   const auto Operators = get_op_types<CTS_TYPE>();
   const auto RetType = unnamed_type_pack<CTS_TYPE>();
-  const auto ReducedType = unnamed_type_pack<TestType>();
-  const auto GroupTypes = unnamed_type_pack<
-      oneapi_ext::ballot_group<sycl::sub_group>,
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-      oneapi_ext::tangle_group<sycl::sub_group>,
-      oneapi_ext::opportunistic_group>();
+  const auto ReducedType = ReduceTypes{};
+  const auto GroupTypes = TestType{};
 
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))

--- a/tests/extension/oneapi_non_uniform_groups/group_scan_over_group.cpp.in
+++ b/tests/extension/oneapi_non_uniform_groups/group_scan_over_group.cpp.in
@@ -27,20 +27,13 @@
 
 namespace non_uniform_groups::tests {
 
-using TestType = unnamed_type_pack<CTS_TYPE>;
+using CurrentType = unnamed_type_pack<CTS_TYPE>;
 using ScanTypes = Types;
 
-TEST_CASE(CTS_TYPE_NAME + " non-uniform group scan functions",
-          "[oneapi_non_uniform_groups][group_func][type_list]"){
+TEMPLATE_LIST_TEST_CASE(CTS_TYPE_NAME + " non-uniform group scan functions",
+                        "[oneapi_non_uniform_groups][group_func][type_list]",
+                        GroupPackTypes){
   auto queue = once_per_unit::get_queue();
-  const auto GroupTypes = unnamed_type_pack<
-      oneapi_ext::ballot_group<sycl::sub_group>,
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-      oneapi_ext::tangle_group<sycl::sub_group>,
-      oneapi_ext::opportunistic_group>();
 
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
@@ -53,20 +46,14 @@ TEST_CASE(CTS_TYPE_NAME + " non-uniform group scan functions",
           "Device does not support double precision floating point "
           "operations.");
   }
-  for_all_combinations<invoke_scan_over_group>(GroupTypes, TestType{}, queue);
+  for_all_combinations<invoke_scan_over_group>(TestType{}, CurrentType{}, queue);
 };
 
-TEST_CASE(CTS_TYPE_NAME + " non-uniform group scan functions with init",
-          "[oneapi_non_uniform_groups][group_func][type_list]"){
+TEMPLATE_LIST_TEST_CASE(
+          CTS_TYPE_NAME + " non-uniform group scan functions with init",
+          "[oneapi_non_uniform_groups][group_func][type_list]",
+          GroupPackTypes){
   auto queue = once_per_unit::get_queue();
-  const auto GroupTypes = unnamed_type_pack<
-      oneapi_ext::ballot_group<sycl::sub_group>,
-      oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-      oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-      oneapi_ext::tangle_group<sycl::sub_group>,
-      oneapi_ext::opportunistic_group>();
 
   if constexpr (std::is_same_v<std::remove_cv_t<CTS_TYPE>, sycl::half>) {
     if (!queue.get_device().has(sycl::aspect::fp16))
@@ -79,7 +66,7 @@ TEST_CASE(CTS_TYPE_NAME + " non-uniform group scan functions with init",
           "Device does not support double precision floating point "
           "operations.");
   }
-  for_all_combinations<invoke_init_scan_over_group>(GroupTypes, TestType{},
+  for_all_combinations<invoke_init_scan_over_group>(TestType{}, CurrentType{},
                                                     ScanTypes{}, queue);
 };
 

--- a/tests/extension/oneapi_non_uniform_groups/group_shift.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_shift.cpp
@@ -25,22 +25,11 @@ namespace non_uniform_groups::tests {
 // errors in hipSYCL with bool and 8-bit types - only in group shifts
 TEMPLATE_LIST_TEST_CASE("Non-uniform-group shift",
                         "[oneapi_non_uniform_groups][group_func][type_list]",
-                        CustomTypes) {
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
 
-  shift_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>, TestType>(
-      queue);
-  shift_non_uniform_group<oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-                          TestType>(queue);
-  shift_non_uniform_group<oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-                          TestType>(queue);
-  shift_non_uniform_group<oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-                          TestType>(queue);
-  shift_non_uniform_group<oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-                          TestType>(queue);
-  shift_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>, TestType>(
-      queue);
-  shift_non_uniform_group<oneapi_ext::opportunistic_group, TestType>(queue);
+  for_all_combinations<shift_non_uniform_group_test>(TestType{},
+                                                     CustomTypePack{}, queue);
 }
 
 }  // namespace non_uniform_groups::tests

--- a/tests/extension/oneapi_non_uniform_groups/group_shift.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_shift.h
@@ -28,7 +28,7 @@ class shift_non_uniform_group_kernel;
 
 template <typename GroupT, typename T>
 struct shift_non_uniform_group_test {
-  void operator()(sycl::queue &queue) {
+  void operator()(sycl::queue& queue) {
     const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
     INFO("Testing permute for " + group_name);

--- a/tests/extension/oneapi_non_uniform_groups/group_shift.h
+++ b/tests/extension/oneapi_non_uniform_groups/group_shift.h
@@ -27,127 +27,126 @@ template <typename GroupT, typename T>
 class shift_non_uniform_group_kernel;
 
 template <typename GroupT, typename T>
-void shift_non_uniform_group(sycl::queue& queue) {
-  const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
+struct shift_non_uniform_group_test {
+  void operator()(sycl::queue &queue) {
+    const std::string group_name = NonUniformGroupHelper<GroupT>::get_name();
 
-  INFO("Testing permute for " + group_name);
-  if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
-    SKIP("Device does not support " + group_name);
-  }
-
-  // 4 functions
-  constexpr int test_matrix = 4;
-  const std::string test_names[test_matrix] = {
-      "T shift_group_left(GroupT g, T x)",
-      "T shift_group_left(GroupT g, T x, GroupT::linear_id_type delta)",
-      "T shift_group_right(GroupT g, T x)",
-      "T shift_group_right(GroupT g, T x, GroupT::linear_id_type delta)"};
-
-  sycl::range<1> work_group_range = sycl_cts::util::work_group_range<1>(queue);
-  size_t work_group_size = work_group_range.size();
-
-  for (size_t test_case = 0;
-       test_case < NonUniformGroupHelper<GroupT>::num_test_cases; ++test_case) {
-    const std::string test_case_name =
-        NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
-    INFO("Running test case (" + std::to_string(test_case) + ") with " +
-         test_case_name);
-
-    // array to return results:
-    std::valarray<bool> res(false, test_matrix * work_group_size);
-    {
-      sycl::buffer<bool, 1> res_sycl(
-          std::begin(res), sycl::range<1>(test_matrix * work_group_size));
-
-      queue.submit([&](sycl::handler& cgh) {
-        auto res_acc = res_sycl.get_access<sycl::access::mode::read_write>(cgh);
-
-        sycl::nd_range<1> executionRange(work_group_range, work_group_range);
-
-        cgh.parallel_for<shift_non_uniform_group_kernel<GroupT, T>>(
-            executionRange, [=](sycl::nd_item<1> item) {
-              sycl::sub_group sub_group = item.get_sub_group();
-
-              // If this item is not participating in the group, they fill their
-              // elements in the result with true and leave early.
-              if (!NonUniformGroupHelper<GroupT>::should_participate(
-                      sub_group, test_case)) {
-                res_acc[0 * work_group_size + item.get_local_linear_id()] =
-                    true;
-                res_acc[1 * work_group_size + item.get_local_linear_id()] =
-                    true;
-                res_acc[2 * work_group_size + item.get_local_linear_id()] =
-                    true;
-                res_acc[3 * work_group_size + item.get_local_linear_id()] =
-                    true;
-                return;
-              }
-
-              GroupT non_uniform_group =
-                  NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
-              const typename GroupT::linear_id_type llid =
-                  non_uniform_group.get_local_linear_id();
-
-              T local_var(splat_init<T>(llid + 1));
-              T shifted_var(splat_init<T>(llid + 1));
-
-              static_assert(
-                  std::is_same_v<T, decltype(sycl::shift_group_left(
-                                        non_uniform_group, local_var))>,
-                  "Return type of shift_group_left(GroupT g, T x) is wrong\n");
-
-              shifted_var =
-                  sycl::shift_group_left(non_uniform_group, local_var);
-              res_acc[0 * work_group_size + item.get_local_linear_id()] =
-                  equal(shifted_var, splat_init<T>(llid + 2)) ||
-                  (llid + 1 >= non_uniform_group.get_local_linear_range());
-
-              static_assert(
-                  std::is_same_v<T, decltype(sycl::shift_group_left(
-                                        non_uniform_group, local_var, 3))>,
-                  "Return type of shift_group_left(GroupT g, T x, "
-                  "GroupT::linear_id_type delta) is wrong\n");
-
-              shifted_var =
-                  sycl::shift_group_left(non_uniform_group, local_var, 3);
-              res_acc[1 * work_group_size + item.get_local_linear_id()] =
-                  equal(shifted_var, splat_init<T>(llid + 4)) ||
-                  (llid + 3 >= non_uniform_group.get_local_linear_range());
-
-              static_assert(
-                  std::is_same_v<T, decltype(sycl::shift_group_right(
-                                        non_uniform_group, local_var))>,
-                  "Return type of shift_group_right(GroupT g, T x) is wrong\n");
-
-              shifted_var =
-                  sycl::shift_group_right(non_uniform_group, local_var);
-              res_acc[2 * work_group_size + item.get_local_linear_id()] =
-                  equal(shifted_var, splat_init<T>(llid)) || (llid < 1);
-
-              static_assert(
-                  std::is_same_v<T, decltype(sycl::shift_group_right(
-                                        non_uniform_group, local_var, 2))>,
-                  "Return type of shift_group_right(GroupT g, T x, "
-                  "GroupT::linear_id_type delta) is wrong\n");
-
-              shifted_var =
-                  sycl::shift_group_right(non_uniform_group, local_var, 2);
-              res_acc[3 * work_group_size + item.get_local_linear_id()] =
-                  equal(shifted_var, splat_init<T>(llid - 1)) || (llid < 2);
-            });
-      });
+    INFO("Testing permute for " + group_name);
+    if (!NonUniformGroupHelper<GroupT>::is_supported(queue.get_device())) {
+      SKIP("Device does not support " + group_name);
     }
-    for (int i = 0; i < test_matrix; ++i) {
-      bool result = res[i * work_group_size];
-      for (size_t j = 1; j < work_group_size; ++j)
-        result &= res[i * work_group_size + j];
 
-      std::string work_group =
-          sycl_cts::util::work_group_print(work_group_range);
-      CAPTURE(group_name, work_group);
-      INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
-                       << " is " << (result ? "right" : "wrong"));
-      CHECK(result);
+    // 4 functions
+    constexpr int test_matrix = 4;
+    const std::string test_names[test_matrix] = {
+        "T shift_group_left(GroupT g, T x)",
+        "T shift_group_left(GroupT g, T x, GroupT::linear_id_type delta)",
+        "T shift_group_right(GroupT g, T x)",
+        "T shift_group_right(GroupT g, T x, GroupT::linear_id_type delta)"};
+
+    sycl::range<1> work_group_range =
+        sycl_cts::util::work_group_range<1>(queue);
+    size_t work_group_size = work_group_range.size();
+
+    for (size_t test_case = 0;
+         test_case < NonUniformGroupHelper<GroupT>::num_test_cases;
+         ++test_case) {
+      const std::string test_case_name =
+          NonUniformGroupHelper<GroupT>::get_test_case_name(test_case);
+      INFO("Running test case (" + std::to_string(test_case) + ") with " +
+           test_case_name);
+
+      // array to return results:
+      std::valarray<bool> res(false, test_matrix * work_group_size);
+      {
+        sycl::buffer<bool, 1> res_sycl(
+            std::begin(res), sycl::range<1>(test_matrix * work_group_size));
+
+        queue.submit([&](sycl::handler& cgh) {
+          auto res_acc =
+              res_sycl.get_access<sycl::access::mode::read_write>(cgh);
+
+          sycl::nd_range<1> executionRange(work_group_range, work_group_range);
+
+          cgh.parallel_for<shift_non_uniform_group_kernel<
+              GroupT, T>>(executionRange, [=](sycl::nd_item<1> item) {
+            sycl::sub_group sub_group = item.get_sub_group();
+
+            // If this item is not participating in the group, they fill their
+            // elements in the result with true and leave early.
+            if (!NonUniformGroupHelper<GroupT>::should_participate(sub_group,
+                                                                   test_case)) {
+              res_acc[0 * work_group_size + item.get_local_linear_id()] = true;
+              res_acc[1 * work_group_size + item.get_local_linear_id()] = true;
+              res_acc[2 * work_group_size + item.get_local_linear_id()] = true;
+              res_acc[3 * work_group_size + item.get_local_linear_id()] = true;
+              return;
+            }
+
+            GroupT non_uniform_group =
+                NonUniformGroupHelper<GroupT>::create(sub_group, test_case);
+            const typename GroupT::linear_id_type llid =
+                non_uniform_group.get_local_linear_id();
+
+            T local_var(splat_init<T>(llid + 1));
+            T shifted_var(splat_init<T>(llid + 1));
+
+            static_assert(
+                std::is_same_v<T, decltype(sycl::shift_group_left(
+                                      non_uniform_group, local_var))>,
+                "Return type of shift_group_left(GroupT g, T x) is wrong\n");
+
+            shifted_var = sycl::shift_group_left(non_uniform_group, local_var);
+            res_acc[0 * work_group_size + item.get_local_linear_id()] =
+                equal(shifted_var, splat_init<T>(llid + 2)) ||
+                (llid + 1 >= non_uniform_group.get_local_linear_range());
+
+            static_assert(
+                std::is_same_v<T, decltype(sycl::shift_group_left(
+                                      non_uniform_group, local_var, 3))>,
+                "Return type of shift_group_left(GroupT g, T x, "
+                "GroupT::linear_id_type delta) is wrong\n");
+
+            shifted_var =
+                sycl::shift_group_left(non_uniform_group, local_var, 3);
+            res_acc[1 * work_group_size + item.get_local_linear_id()] =
+                equal(shifted_var, splat_init<T>(llid + 4)) ||
+                (llid + 3 >= non_uniform_group.get_local_linear_range());
+
+            static_assert(
+                std::is_same_v<T, decltype(sycl::shift_group_right(
+                                      non_uniform_group, local_var))>,
+                "Return type of shift_group_right(GroupT g, T x) is wrong\n");
+
+            shifted_var = sycl::shift_group_right(non_uniform_group, local_var);
+            res_acc[2 * work_group_size + item.get_local_linear_id()] =
+                equal(shifted_var, splat_init<T>(llid)) || (llid < 1);
+
+            static_assert(
+                std::is_same_v<T, decltype(sycl::shift_group_right(
+                                      non_uniform_group, local_var, 2))>,
+                "Return type of shift_group_right(GroupT g, T x, "
+                "GroupT::linear_id_type delta) is wrong\n");
+
+            shifted_var =
+                sycl::shift_group_right(non_uniform_group, local_var, 2);
+            res_acc[3 * work_group_size + item.get_local_linear_id()] =
+                equal(shifted_var, splat_init<T>(llid - 1)) || (llid < 2);
+          });
+        });
+      }
+      for (int i = 0; i < test_matrix; ++i) {
+        bool result = res[i * work_group_size];
+        for (size_t j = 1; j < work_group_size; ++j)
+          result &= res[i * work_group_size + j];
+
+        std::string work_group =
+            sycl_cts::util::work_group_print(work_group_range);
+        CAPTURE(group_name, work_group);
+        INFO("Value of " << test_names[i] << " with T = " << type_name<T>()
+                         << " is " << (result ? "right" : "wrong"));
+        CHECK(result);
+      }
     }
   }
-}
+};

--- a/tests/extension/oneapi_non_uniform_groups/group_shift_fp16.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_shift_fp16.cpp
@@ -22,24 +22,14 @@
 
 namespace non_uniform_groups::tests {
 
-TEST_CASE("Non-uniform-group shift",
-          "[oneapi_non_uniform_groups][group_func][fp16]") {
+TEMPLATE_LIST_TEST_CASE("Non-uniform-group shift",
+                        "[oneapi_non_uniform_groups][group_func][fp16]",
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
 
   if (queue.get_device().has(sycl::aspect::fp16)) {
-    shift_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>,
-                            sycl::half>(queue);
-    shift_non_uniform_group<oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-                            sycl::half>(queue);
-    shift_non_uniform_group<oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-                            sycl::half>(queue);
-    shift_non_uniform_group<oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-                            sycl::half>(queue);
-    shift_non_uniform_group<oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-                            sycl::half>(queue);
-    shift_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>,
-                            sycl::half>(queue);
-    shift_non_uniform_group<oneapi_ext::opportunistic_group, sycl::half>(queue);
+    for_all_combinations<shift_non_uniform_group_test>(
+        TestType{}, unnamed_type_pack<sycl::half>{}, queue);
   } else {
     WARN("Device does not support half precision floating point operations.");
   }

--- a/tests/extension/oneapi_non_uniform_groups/group_shift_fp64.cpp
+++ b/tests/extension/oneapi_non_uniform_groups/group_shift_fp64.cpp
@@ -22,24 +22,14 @@
 
 namespace non_uniform_groups::tests {
 
-TEST_CASE("Non-uniform-group shift",
-          "[oneapi_non_uniform_groups][group_func][fp64]") {
+TEMPLATE_LIST_TEST_CASE("Non-uniform-group shift",
+                        "[oneapi_non_uniform_groups][group_func][fp64]",
+                        GroupPackTypes) {
   auto queue = once_per_unit::get_queue();
 
   if (queue.get_device().has(sycl::aspect::fp64)) {
-    shift_non_uniform_group<oneapi_ext::ballot_group<sycl::sub_group>, double>(
-        queue);
-    shift_non_uniform_group<oneapi_ext::fixed_size_group<1, sycl::sub_group>,
-                            double>(queue);
-    shift_non_uniform_group<oneapi_ext::fixed_size_group<2, sycl::sub_group>,
-                            double>(queue);
-    shift_non_uniform_group<oneapi_ext::fixed_size_group<4, sycl::sub_group>,
-                            double>(queue);
-    shift_non_uniform_group<oneapi_ext::fixed_size_group<8, sycl::sub_group>,
-                            double>(queue);
-    shift_non_uniform_group<oneapi_ext::tangle_group<sycl::sub_group>, double>(
-        queue);
-    shift_non_uniform_group<oneapi_ext::opportunistic_group, double>(queue);
+    for_all_combinations<shift_non_uniform_group_test>(
+        TestType{}, unnamed_type_pack<double>{}, queue);
   } else {
     WARN("Device does not support double precision floating point operations.");
   }

--- a/tests/extension/oneapi_non_uniform_groups/non_uniform_group_common.h
+++ b/tests/extension/oneapi_non_uniform_groups/non_uniform_group_common.h
@@ -22,6 +22,16 @@
 
 namespace oneapi_ext = sycl::ext::oneapi::experimental;
 
+// Group packs to test for.
+using GroupPackTypes = std::tuple<
+    unnamed_type_pack<oneapi_ext::ballot_group<sycl::sub_group>>,
+    unnamed_type_pack<oneapi_ext::fixed_size_group<1, sycl::sub_group>,
+                      oneapi_ext::fixed_size_group<2, sycl::sub_group>,
+                      oneapi_ext::fixed_size_group<4, sycl::sub_group>,
+                      oneapi_ext::fixed_size_group<8, sycl::sub_group>>,
+    unnamed_type_pack<oneapi_ext::tangle_group<sycl::sub_group>>,
+    unnamed_type_pack<oneapi_ext::opportunistic_group>>;
+
 // Helper class for working with non-uniform group of type GroupT. If the
 // result is empty the work-item does not participate in the execution.
 template <typename GroupT>

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -234,14 +234,23 @@ using ExtendedTypes =
     concatenation<FundamentalTypes,
                   std::tuple<bool, sycl::vec<unsigned int, 4>,
                              sycl::vec<long long int, 2>>>::type;
+using ExtendedTypePack = concatenation<
+    Types, unnamed_type_pack<
+               bool, sycl::vec<unsigned int, 4>, sycl::vec<long long int, 2>,
+               sycl::marray<float, 5>, sycl::marray<short int, 7>>>::type;
 #else
 using ExtendedTypes = concatenation<
     FundamentalTypes,
     std::tuple<bool, sycl::vec<unsigned int, 4>, sycl::vec<long long int, 2>,
                sycl::marray<float, 5>, sycl::marray<short int, 7>>>::type;
+using ExtendedTypePack = concatenation<
+    Types, unnamed_type_pack<
+               bool, sycl::vec<unsigned int, 4>, sycl::vec<long long int, 2>,
+               sycl::marray<float, 5>, sycl::marray<short int, 7>>>::type;
 #endif
 
 using CustomTypes = concatenation<ExtendedTypes, util::custom_type>::type;
+using CustomTypePack = concatenation<ExtendedTypePack, util::custom_type>::type;
 
 template <typename T>
 inline auto get_op_types() {

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -234,9 +234,10 @@ using ExtendedTypes =
     concatenation<FundamentalTypes,
                   std::tuple<bool, sycl::vec<unsigned int, 4>,
                              sycl::vec<long long int, 2>>>::type;
-using ExtendedTypePack concatenation<
-    FundamentalTypes, unnamed_type_pack<bool, sycl::vec<unsigned int, 4>,
-                                        sycl::vec<long long int, 2>>>::type;
+using ExtendedTypePack =
+    concatenation<FundamentalTypes,
+                  unnamed_type_pack<bool, sycl::vec<unsigned int, 4>,
+                                    sycl::vec<long long int, 2>>>::type;
 #else
 using ExtendedTypes = concatenation<
     FundamentalTypes,

--- a/tests/group_functions/group_functions_common.h
+++ b/tests/group_functions/group_functions_common.h
@@ -234,10 +234,9 @@ using ExtendedTypes =
     concatenation<FundamentalTypes,
                   std::tuple<bool, sycl::vec<unsigned int, 4>,
                              sycl::vec<long long int, 2>>>::type;
-using ExtendedTypePack = concatenation<
-    Types, unnamed_type_pack<
-               bool, sycl::vec<unsigned int, 4>, sycl::vec<long long int, 2>,
-               sycl::marray<float, 5>, sycl::marray<short int, 7>>>::type;
+using ExtendedTypePack concatenation<
+    FundamentalTypes, unnamed_type_pack<bool, sycl::vec<unsigned int, 4>,
+                                        sycl::vec<long long int, 2>>>::type;
 #else
 using ExtendedTypes = concatenation<
     FundamentalTypes,


### PR DESCRIPTION
To avoid case where tests are skipped for supported non-uniform groups because of a skip in the cases for unsupported non-uniform groups, this commit changes all the test cases to be templated on packs of these group types, based on their aspect groupings.