### PR TITLE
Add option to save commit hash in report

### DIFF
--- a/run_conformance_tests.py
+++ b/run_conformance_tests.py
@@ -83,8 +83,13 @@ def handle_args(argv):
                         help='Test the reduced feature set instead of the full feature set.',
                         required=False,
                         action='store_true')
+    parser.add_argument('--commit-hash',
+                        help='Original SYCL-CTS commit hash used for the run',
+                        type=str,
+                        required=False)
     args = parser.parse_args(argv)
 
+    commit_hash = args.commit_hash if args.commit_hash else 'Not specified'
     full_conformance = 'OFF' if args.fast else 'ON'
     test_deprecated_features = 'OFF' if args.disable_deprecated_features else 'ON'
     full_feature_set = 'OFF' if args.reduced_feature_set else 'ON'
@@ -92,7 +97,7 @@ def handle_args(argv):
     return (args.cmake_exe, args.build_system_name, args.build_system_call,
             full_conformance, test_deprecated_features, args.exclude_categories,
             args.implementation_name, args.additional_cmake_args, args.device,
-            args.additional_ctest_args, args.build_only,
+            args.additional_ctest_args, args.build_only, commit_hash,
             full_feature_set)
 
 
@@ -232,7 +237,7 @@ def get_xml_test_results():
 def update_xml_attribs(info_json, implementation_name, test_xml_root,
                        full_conformance, cmake_call, build_system_name,
                        build_system_call, ctest_call, test_deprecated_features,
-                       full_feature_set):
+                       commit_hash, full_feature_set):
     """
     Adds attributes to the root of the xml trees json required by the
     conformance report.
@@ -259,6 +264,7 @@ def update_xml_attribs(info_json, implementation_name, test_xml_root,
     test_xml_root.attrib["DeviceFP64"] = info_json['device-fp64']
 
     # Set Build Information attribs
+    test_xml_root.attrib["CommitHash"] = commit_hash
     test_xml_root.attrib["FullConformanceMode"] = full_conformance
     test_xml_root.attrib["CMakeInput"] = ' '.join(cmake_call)
     test_xml_root.attrib["BuildSystemGenerator"] = build_system_name
@@ -276,7 +282,7 @@ def main(argv=sys.argv[1:]):
     (cmake_exe, build_system_name, build_system_call, full_conformance,
      test_deprecated_features, exclude_categories, implementation_name,
      additional_cmake_args, device, additional_ctest_args,
-     build_only, full_feature_set) = handle_args(argv)
+     build_only, commit_hash, full_feature_set) = handle_args(argv)
 
     # Generate a cmake call in a form accepted by subprocess.call()
     cmake_call = generate_cmake_call(cmake_exe, build_system_name,
@@ -311,6 +317,7 @@ def main(argv=sys.argv[1:]):
                                          cmake_call, build_system_name,
                                          build_system_call, ctest_call,
                                          test_deprecated_features,
+                                         commit_hash,
                                          full_feature_set)
 
     # Get the xml report stylesheet and add it to the results.

--- a/tools/stylesheet.xml
+++ b/tools/stylesheet.xml
@@ -102,6 +102,7 @@
         <tr><td>Half Precision Floating Point</td><td><xsl:value-of select="./@DeviceFP16" /></td></tr>
         <tr><td>Double Precision Floating Point</td><td><xsl:value-of select="./@DeviceFP64" /></td></tr>
         <tr><td class="site-header" colspan="2">Build Information</td></tr>
+        <tr><td>SYCL-CTS commit hash</td><td><xsl:value-of select="./@CommitHash"/></td></tr>
         <tr><td>Full Conformance Mode</td><td><xsl:value-of select="./@FullConformanceMode" /></td></tr>
         <tr><td>CMake Input</td><td><xsl:value-of select="./@CMakeInput" /></td></tr>
         <tr><td>Build System Generator</td><td><xsl:value-of select="./@BuildSystemGenerator" /></td></tr>


### PR DESCRIPTION
This patch adds a command line option for run_conformance_report.py to
save the SYCL-CTS commit hash in the conformance_report.xml.

This option is optional and serves to help to determine the version of
the suite.