### PR TITLE
Build test_conformance instead of test_all in CI

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -157,7 +157,7 @@ jobs:
         working-directory: ${{ env.container-workspace }}/build
         run: |
           TS_BEFORE=$(date +%s)
-          cmake --build . --target test_all --parallel ${{ env.parallel-build-jobs }}
+          cmake --build . --target test_conformance --parallel ${{ env.parallel-build-jobs }}
           TS_AFTER=$(date +%s)
           ELAPSED=$(($TS_AFTER - $TS_BEFORE))
           sort --numeric-sort --reverse --output=build_times.log build_times.log


### PR DESCRIPTION
In our CI testing, the system is running out of disk space while building the `test_all` executable. That said, the resulting executable is reundant, as it is a combined executable of all the other test category executables produced. This commit changes the target built by CI to `test_conformance` which only builds the test category executables.