### PR TITLE
Remove test_all target

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Finally, start the compilation:
 `cmake --build ./build`
 
 After the compilation has finished, test executables for each category will be
-placed in the `build/bin` directory. The `test_all` executable contains tests
-for all categories.
+placed in the `build/bin` directory.
 
 ### CMake Configuration Options
 
@@ -98,7 +97,7 @@ Additionally, the following SYCL implementation-specific options can be used:
 
 Each of the executables produced in the `build/bin` directory acts as a
 standalone test runner that can be used to launch tests for a particular test
-category (or all tests in the case of `build/bin/test_all`).
+category.
 
 The ``--device`` argument is used to specify which device to run the tests on.
 Selection is based on substring matching of the device name. ECMAScript regular

--- a/ci/generate_exclude_filter.py
+++ b/ci/generate_exclude_filter.py
@@ -88,7 +88,7 @@ def query_cmake_targets(build_dir: str):
     cmake_targets = []
     for rt in raw_targets:
         m = target_pattern.match(rt)
-        if m and m.group(1) != 'test_all':
+        if m:
             cmake_targets.append(m.group(1))
 
     return cmake_targets

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -230,7 +230,7 @@ This adds a test case with the description `"a simple test case"` and the _tag_ 
 Both can later be used to narrow down the set of test cases that will be executed during runtime.
 
 When configuring CMake, the new test category will automatically be detected and a target with the name `test_simple` is added.
-You can run the test case by either executing `./bin/test_simple` directly, or alternatively as part of `./bin/test_all`.
+You can run the test case by executing `./bin/test_simple`.
 
 IMPORTANT: For historic reasons, the CTS currently contains many test cases that are written in a different style.
 Please see <<New-style vs Legacy Test Cases>> for more information.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,12 +138,7 @@ function(generate_cts_test)
   add_dependencies(generate_test_sources ${GEN_TEST_FILE_NAME}_gen)
 endfunction()
 
-# create a target to group all tests together into one test executable
-add_executable(test_all)
-
-# create a target to encapsulate all test categories, excluding test_all. This
-# is intended for conformance testing to avoid redundant testing and excessive
-# resource use from building and running test_all.
+# create a target to encapsulate all test categories.
 add_custom_target(test_conformance)
 
 # create test executable targets for each test project using the build_sycl function
@@ -187,8 +182,6 @@ function(add_cts_test_helper)
                PROPERTY FOLDER "Tests/${test_exe_name}")
   set_property(TARGET ${test_exe_name}_objects
                PROPERTY FOLDER "Tests/${test_exe_name}")
-
-  target_sources(test_all PRIVATE $<TARGET_OBJECTS:${test_exe_name}_objects>)
 
   add_dependencies(test_conformance ${test_exe_name})
 endfunction()
@@ -234,7 +227,3 @@ foreach(dir ${test_category_dirs})
     add_subdirectory(${dir})
   endif()
 endforeach()
-
-target_link_libraries(test_all PRIVATE CTS::util CTS::main_function oclmath)
-target_link_libraries(test_all PRIVATE Catch2::Catch2 Threads::Threads)
-add_sycl_to_target(TARGET test_all)


### PR DESCRIPTION
After the conformance submission discourages the use of test_all and the CI has moved away from using test_all, all the benefit of it becomes convenience when wanting to run all tests. However, as it is an overall target and with the size of it increasing with the test suite, to general users it will just be an inconvenience, as it results in longer compilation times and higher resource requirements. Given this, this commit removes the test_all target.