### PR TITLE
[NFC] Transfer host variable to sycl kernel to avoid using unsupported memory capabilities.

### DIFF
--- a/tests/atomic_fence/atomic_fence.cpp
+++ b/tests/atomic_fence/atomic_fence.cpp
@@ -194,7 +194,7 @@ class run_atomic_fence {
                                    " and test_type = " + test_type_name)
                 .create()) {
       auto queue = once_per_unit::get_queue();
-      // Early return for unsupported memory order abd memory scope.
+      // Early return for unsupported memory order or memory scope.
       if (!check_memory_order_scope_capabilities(queue, MemoryOrder,
                                                  MemoryScope, memory_order_name,
                                                  memory_scope_name)) {


### PR DESCRIPTION
Test checks if memory capabilities are supported in the host code, and then early return in the final run time for unsupported capabilities. When use const host variable MemoryScope in the sycl kernel directly, aot compile will fail in the compile time if MemoryScope is not supported. So this patch transfers host variable to sycl kernel to avoid using unsupported memory capabilities.