### PR TITLE
Remove testing of removed info::platform::profile.

### DIFF
--- a/tests/platform/platform_info.cpp
+++ b/tests/platform/platform_info.cpp
@@ -46,8 +46,6 @@ class TEST_NAME : public util::test_base {
        */
       {
         auto plt = util::get_cts_object::platform(cts_selector);
-        check_get_info_param<sycl::info::platform::profile, std::string>(log,
-                                                                         plt);
         check_get_info_param<sycl::info::platform::version, std::string>(log,
                                                                          plt);
         check_get_info_param<sycl::info::platform::name, std::string>(log, plt);


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SYCL-CTS/issues/929.
Corresponding spec change: https://github.com/KhronosGroup/SYCL-Docs/pull/608