### PR TITLE
Add missing tests for `multi_ptr` aliases for `access::address_space::generic`

### DIFF
--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -184,17 +184,6 @@ void check_pointer_aliases(const std::string &type_name) {
               sycl::multi_ptr<T, sycl::access::address_space::private_space,
                               sycl::access::decorated::no>>);
     }
-// Not yet supported
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
-    {
-      INFO("raw_generic_ptr");
-      STATIC_CHECK(
-          std::is_same_v<
-              sycl::raw_generic_ptr<T>,
-              sycl::multi_ptr<T, sycl::access::address_space::generic_space,
-                              sycl::access::decorated::no>>);
-    }
-#endif  //! SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
     {
       INFO("decorated_global_ptr");
       STATIC_CHECK(std::is_same_v<
@@ -217,7 +206,15 @@ void check_pointer_aliases(const std::string &type_name) {
               sycl::multi_ptr<T, sycl::access::address_space::private_space,
                               sycl::access::decorated::yes>>);
     }
-// Not yet supported
+  }
+}
+
+template <typename T>
+void check_generic_pointer_aliases(const std::string& type_name) {
+  SECTION(sycl_cts::section_name("Check explicit generic pointer aliases")
+              .with("T", type_name)
+              .create()) {
+    // FIXME: Enable when aliases defined in implementations.
 #if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
     {
       INFO("decorated_generic_ptr");
@@ -227,9 +224,25 @@ void check_pointer_aliases(const std::string &type_name) {
               sycl::multi_ptr<T, sycl::access::address_space::generic_space,
                               sycl::access::decorated::yes>>);
     }
-#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
+    {
+      INFO("raw_generic_ptr");
+      STATIC_CHECK(
+          std::is_same_v<
+              sycl::raw_generic_ptr<T>,
+              sycl::multi_ptr<T, sycl::access::address_space::generic_space,
+                              sycl::access::decorated::no>>);
+    }
+#endif  //! SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
   }
 }
+
+template <typename T>
+class check_generic_ptr_aliases_for_type {
+ public:
+  void operator()(const std::string& type_name) {
+    check_generic_pointer_aliases<T>(type_name);
+  }
+};
 
 template <typename T>
 class check_multi_ptr_explicit_convert_for_type {

--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -227,8 +227,8 @@ void check_pointer_aliases(const std::string &type_name) {
               sycl::multi_ptr<T, sycl::access::address_space::generic_space,
                               sycl::access::decorated::yes>>);
     }
-  }
 #endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
+  }
 }
 
 template <typename T>

--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -184,6 +184,8 @@ void check_pointer_aliases(const std::string &type_name) {
               sycl::multi_ptr<T, sycl::access::address_space::private_space,
                               sycl::access::decorated::no>>);
     }
+// Not yet supported
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
     {
       INFO("raw_generic_ptr");
       STATIC_CHECK(
@@ -192,6 +194,7 @@ void check_pointer_aliases(const std::string &type_name) {
               sycl::multi_ptr<T, sycl::access::address_space::generic_space,
                               sycl::access::decorated::no>>);
     }
+#endif  //! SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
     {
       INFO("decorated_global_ptr");
       STATIC_CHECK(std::is_same_v<
@@ -214,6 +217,8 @@ void check_pointer_aliases(const std::string &type_name) {
               sycl::multi_ptr<T, sycl::access::address_space::private_space,
                               sycl::access::decorated::yes>>);
     }
+// Not yet supported
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
     {
       INFO("decorated_generic_ptr");
       STATIC_CHECK(
@@ -223,6 +228,7 @@ void check_pointer_aliases(const std::string &type_name) {
                               sycl::access::decorated::yes>>);
     }
   }
+#endif  // !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
 }
 
 template <typename T>

--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -185,6 +185,14 @@ void check_pointer_aliases(const std::string &type_name) {
                               sycl::access::decorated::no>>);
     }
     {
+      INFO("raw_generic_ptr");
+      STATIC_CHECK(
+          std::is_same_v<
+              sycl::raw_generic_ptr<T>,
+              sycl::multi_ptr<T, sycl::access::address_space::generic_space,
+                              sycl::access::decorated::no>>);
+    }
+    {
       INFO("decorated_global_ptr");
       STATIC_CHECK(std::is_same_v<
                    sycl::decorated_global_ptr<T>,
@@ -204,6 +212,14 @@ void check_pointer_aliases(const std::string &type_name) {
           std::is_same_v<
               sycl::decorated_private_ptr<T>,
               sycl::multi_ptr<T, sycl::access::address_space::private_space,
+                              sycl::access::decorated::yes>>);
+    }
+    {
+      INFO("decorated_generic_ptr");
+      STATIC_CHECK(
+          std::is_same_v<
+              sycl::decorated_generic_ptr<T>,
+              sycl::multi_ptr<T, sycl::access::address_space::generic_space,
                               sycl::access::decorated::yes>>);
     }
   }

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_core.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_core.cpp
@@ -36,6 +36,14 @@ TEST_CASE("multi_ptr explicit conversions. Core types", "[multi_ptr]") {
   for_all_types<check_multi_ptr_explicit_convert_for_type>(composite_types);
 }
 
+DISABLED_FOR_TEST_CASE(DPCPP, hipSYCL)
+("generic_ptr alias. Core types", "[multi_ptr]")({
+  using namespace multi_ptr_explicit_conversions;
+  auto types = multi_ptr_common::get_types();
+  auto composite_types = multi_ptr_common::get_composite_types();
+  for_all_types<check_generic_ptr_aliases_for_type>(types);
+  for_all_types<check_generic_ptr_aliases_for_type>(composite_types);
+});
 }  // namespace multi_ptr_explicit_conversions_core
 
 #endif  // SYCL_CTS_ENABLE_FEATURE_SET_FULL

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_core.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_core.cpp
@@ -22,6 +22,7 @@
 
 #if SYCL_CTS_ENABLE_FEATURE_SET_FULL
 
+#include "../common/disabled_for_test_case.h"
 #include "../common/type_coverage.h"
 #include "multi_ptr_common.h"
 #include "multi_ptr_explicit_conversions.h"

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_fp16.cpp
@@ -24,6 +24,8 @@
 
 #include "multi_ptr_explicit_conversions.h"
 
+#include "../common/disabled_for_test_case.h"
+
 namespace multi_ptr_explicit_conversions_fp16 {
 
 TEST_CASE("multi_ptr explicit conversions. fp16 type", "[multi_ptr]") {

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_fp16.cpp
@@ -39,6 +39,11 @@ TEST_CASE("multi_ptr explicit conversions. fp16 type", "[multi_ptr]") {
   check_multi_ptr_explicit_convert_for_type<sycl::half>{}("sycl::half");
 }
 
+DISABLED_FOR_TEST_CASE(DPCPP, hipSYCL)
+("generic_ptr alias. fp16 type", "[multi_ptr]")({
+  using namespace multi_ptr_explicit_conversions;
+  check_generic_ptr_aliases_for_type<sycl::half>{}("sycl::half");
+});
 }  // namespace multi_ptr_explicit_conversions_fp16
 
 #endif  // SYCL_CTS_ENABLE_FEATURE_SET_FULL

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_fp64.cpp
@@ -24,6 +24,8 @@
 
 #include "multi_ptr_explicit_conversions.h"
 
+#include "../common/disabled_for_test_case.h"
+
 namespace multi_ptr_explicit_conversions_fp64 {
 
 TEST_CASE("multi_ptr explicit conversions. fp64 type", "[multi_ptr]") {
@@ -38,6 +40,12 @@ TEST_CASE("multi_ptr explicit conversions. fp64 type", "[multi_ptr]") {
   }
   check_multi_ptr_explicit_convert_for_type<double>{}("double");
 }
+
+DISABLED_FOR_TEST_CASE(DPCPP, hipSYCL)
+("generic_ptr alias. fp64 type", "[multi_ptr]")({
+  using namespace multi_ptr_explicit_conversions;
+  check_generic_ptr_aliases_for_type<double>{}("double");
+});
 
 }  // namespace multi_ptr_explicit_conversions_fp64
 


### PR DESCRIPTION
Add `(decorated_|raw_)generic_ptr` aliases definitions.

These aliases were previously referenced in the SYCL specification, but not defined and not tested in the CTS.