### PR TITLE
Gather linker flags to prevent /link break linking stage

### DIFF
--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -72,8 +72,8 @@ set_target_properties(DPCPP::Runtime PROPERTIES
 
 set(CMAKE_CXX_COMPILER ${DPCPP_CXX_EXECUTABLE})
 # Use DPC++ compiler instead of default linker for building SYCL application
-set(CMAKE_CXX_LINK_EXECUTABLE "${DPCPP_CXX_EXECUTABLE} <FLAGS> \
-    <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+set(CMAKE_CXX_LINK_EXECUTABLE "${DPCPP_CXX_EXECUTABLE} <FLAGS> <OBJECTS> -o <TARGET> \
+    <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <LINK_LIBRARIES>")
 
 function(add_sycl_to_target)
     set(options)


### PR DESCRIPTION
`-DCMAKE_EXE_LINKER_FLAGS="/link /stack:2097152"` will break linking stage on Windows because all options following "/link" are passed to linker. And "-o" passed to linker can't be recognized by linker and trigger an error