### PR TITLE
Fix accessor using unsuitable property

### DIFF
--- a/tests/accessor_legacy/accessor_constructors_buffer_utility.h
+++ b/tests/accessor_legacy/accessor_constructors_buffer_utility.h
@@ -170,8 +170,7 @@ public:
       using verifier = check_accessor_constructor_buffer<accTag, property_list>;
 
       auto context = util::get_cts_object::context();
-      property_list properties {
-          sycl::property::buffer::context_bound(context)};
+      property_list properties;
 
       {
         const auto constructorName = usesHander ?

--- a/tests/accessor_legacy/accessor_constructors_image_utility.h
+++ b/tests/accessor_legacy/accessor_constructors_image_utility.h
@@ -90,8 +90,7 @@ public:
       using verifier = check_accessor_constructor_image<accTag, property_list>;
 
       auto context = util::get_cts_object::context();
-      property_list properties {
-          sycl::property::buffer::context_bound(context)};
+      property_list properties;
 
       const auto constructorName = usesHander ?
           "constructor(image, handler, property_list)" :


### PR DESCRIPTION
Accessor shouldn't use buffer::property.
It looks like there is no real need for `properties` to contain any property, as the test just checks all possible constructors.