### PR TITLE
Split conformant product fields in submission template

### DIFF
--- a/conformance/submission_details_template.txt
+++ b/conformance/submission_details_template.txt
@@ -58,10 +58,12 @@ Target SYCL device:
 # and device combinations.
 #
 SYCL implementation version(s):
+Device(s):
+Platform:
+Backend:
 Host architecture(s):
 Host operating system(s) and version(s):
 Host toolchains(s) and version(s):
-SYCL backend/platform/device combinations(s):
 
 # Environment requirements.
 #

--- a/conformance/submission_details_template.txt
+++ b/conformance/submission_details_template.txt
@@ -59,8 +59,8 @@ Target SYCL device:
 #
 SYCL implementation version(s):
 Device(s):
-Platform:
-Backend:
+Platform(s):
+Backend(s):
 Host architecture(s):
 Host operating system(s) and version(s):
 Host toolchains(s) and version(s):

--- a/conformance/submission_details_template.txt
+++ b/conformance/submission_details_template.txt
@@ -59,8 +59,7 @@ Target SYCL device:
 #
 SYCL implementation version(s):
 Device(s):
-Platform(s):
-Backend(s):
+Backend / platform(s):
 Host architecture(s):
 Host operating system(s) and version(s):
 Host toolchains(s) and version(s):

--- a/conformance/submission_details_template.txt
+++ b/conformance/submission_details_template.txt
@@ -42,12 +42,11 @@ SYCL Version:
 # backend, platform and device.
 #
 SYCL implementation and version:
+Device:
+Backend / platform:
 Host architecture:
 Host operating system and version:
 Host toolchain and version:
-Target SYCL backend:
-Target SYCL platform:
-Target SYCL device:
 
 # Conformant products.
 #


### PR DESCRIPTION
This commit splits one of the fields in the "Conformant Product"  and "Conformance submission details" sections of the submission_details_template file. This brings the fields closer in line with the conformant products page.