### PR TITLE
Remove non-informative "Supported optional features" section

### DIFF
--- a/conformance/submission_details_template.txt
+++ b/conformance/submission_details_template.txt
@@ -75,13 +75,6 @@ Environment requirements:
 # List of KHR extension supported by the SYCL implementation.
 # KHR extensions:
 
-# Supported optional features.
-#
-# List of optional features supported by the SYCL implementation, and the
-# backend/platform/device combninations for which they are supported.
-#
-Optional features:
-
 # Tests version.
 #
 # Commit SHA (full hash) of the commit which was used to run the tests.


### PR DESCRIPTION
The "Supported optional features" in the conformance submission template does not add any useful information that is not already covered by the rest of the document, so this patch proposes its removal.