### PR TITLE
Fix branch name in CI workflow and links to test plans.

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       # Run on our default base branch to prime ccache for faster CI runs in PRs.
-      - SYCL-2020
+      - main
 
 jobs:
   # Pushing container images requires DockerHub credentials, provided as GitHub secrets.

--- a/test_plans/kernel.asciidoc
+++ b/test_plans/kernel.asciidoc
@@ -7,7 +7,7 @@ This is a test plan cover sycl::kernel functionality that is not covered by curr
 
 == Testing scope
 
-Tests intend to cover functions from 4.11.13. The kernel class that are not covered in https://github.com/KhronosGroup/SYCL-CTS/tree/SYCL-2020/tests/kernel
+Tests intend to cover functions from 4.11.13. The kernel class that are not covered in https://github.com/KhronosGroup/SYCL-CTS/tree/main/tests/kernel
 
 === Device coverage
 

--- a/test_plans/kernel_bundle.asciidoc
+++ b/test_plans/kernel_bundle.asciidoc
@@ -7,7 +7,7 @@ This is a test plan cover kernel_bundle functionality that is not covered by cur
 
 == Testing scope
 
-Tests intend to cover functions from 4.11. Kernel bundles that are not covered in https://github.com/KhronosGroup/SYCL-CTS/tree/SYCL-2020/tests/kernel_bundle
+Tests intend to cover functions from 4.11. Kernel bundles that are not covered in https://github.com/KhronosGroup/SYCL-CTS/tree/main/tests/kernel_bundle
 
 === Device coverage
 
@@ -116,7 +116,7 @@ Check that result of `get_kernel_ids`:
 
 === Tests for working with specialization constants
 
-Partially tested in https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/tests/specialization_constants/specialization_constants_via_kernel_bundle.h
+Partially tested in https://github.com/KhronosGroup/SYCL-CTS/blob/main/tests/spec_constants/spec_constants_via_kernel_bundle.h
 
 There are two spec constant defined: `SpecName` and `OtherSpecName`.
 kernel_handler::get_specialization_constant<OtherSpecName>() shouldn't be used in any kernel in the application.

--- a/test_plans/queue_constructors.asciidoc
+++ b/test_plans/queue_constructors.asciidoc
@@ -7,7 +7,7 @@ This is a test plan for the for new constructors of class `sycl::queue` describe
 
 == Testing scope
 
-Tests intend to cover not covered constructors from 4.6.5.1. Queue interface that are not covered in https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/tests/queue/queue_constructors.cpp
+Tests intend to cover not covered constructors from 4.6.5.1. Queue interface that are not covered in https://github.com/KhronosGroup/SYCL-CTS/blob/main/tests/queue/queue_constructors.cpp
 
 === Device coverage
 

--- a/tests/invoke/parallel_for_simplifications.cpp
+++ b/tests/invoke/parallel_for_simplifications.cpp
@@ -21,8 +21,8 @@
 //  parallel_for({N}, some_kernel)
 //  parallel_for({N1, N2}, some_kernel)
 //  parallel_for({N1, N2, N3}, some_kernel)
-//  Test plan:
-https://github.com/KhronosGroup/SYCL-CTS/blob/SYCL-2020/test_plans/parallel_for_simplifications.asciidoc
+//
+//  Test plan: /test_plans/parallel_for_simplifications.asciidoc
 //
 *******************************************************************************/
 


### PR DESCRIPTION
The default branch has been renamed from `SYCL-2020` to `main`. There are places in the source code where we still use old name.