### PR TITLE
[range_api] Fix bitwise shift rhs out-of-range

### DIFF
--- a/tests/range/range_api.cpp
+++ b/tests/range/range_api.cpp
@@ -50,6 +50,9 @@ void test_range_kernels(
   const sycl::range<dims> range_two_const(range_two);
   const sycl::range<dims> range_const(range);
 
+  sycl::range<dims> range_quarter(range / 4);
+  const sycl::range<dims> range_quarter_const(range_quarter);
+
   // friend bool operator==(const T& lhs, const T& rhs)
   INDEX_EQ_KERNEL_TEST(==, range, range_two);
 
@@ -62,8 +65,8 @@ void test_range_kernels(
   INDEX_KERNEL_TEST(*, range, range_two_const, result);
   INDEX_KERNEL_TEST(/, range, range_two_const, result);
   INDEX_KERNEL_TEST(%, range, range_two_const, result);
-  INDEX_KERNEL_TEST(<<, range, range_two_const, result);
-  INDEX_KERNEL_TEST(>>, range, range_two_const, result);
+  INDEX_KERNEL_TEST(<<, range, range_quarter_const, result);
+  INDEX_KERNEL_TEST(>>, range, range_quarter_const, result);
   INDEX_KERNEL_TEST(&, range, range_two_const, result);
   INDEX_KERNEL_TEST(|, range, range_two_const, result);
   INDEX_KERNEL_TEST(^, range, range_two_const, result);
@@ -81,8 +84,8 @@ void test_range_kernels(
   DUAL_SIZE_INDEX_KERNEL_TEST(*, range, integer, result);
   DUAL_SIZE_INDEX_KERNEL_TEST(/, range, integer, result);
   DUAL_SIZE_INDEX_KERNEL_TEST(%, range, integer, result);
-  DUAL_SIZE_INDEX_KERNEL_TEST(<<, range, integer, result);
-  DUAL_SIZE_INDEX_KERNEL_TEST(>>, range, integer, result);
+  DUAL_SIZE_INDEX_KERNEL_TEST(<<, range_quarter, integer, result);
+  DUAL_SIZE_INDEX_KERNEL_TEST(>>, range_quarter, integer, result);
   DUAL_SIZE_INDEX_KERNEL_TEST(&, range, integer, result);
   DUAL_SIZE_INDEX_KERNEL_TEST(|, range, integer, result);
   DUAL_SIZE_INDEX_KERNEL_TEST(^, range, integer, result);
@@ -99,8 +102,8 @@ void test_range_kernels(
   INDEX_ASSIGNMENT_TESTS(*=, *, range, range_two, result);
   INDEX_ASSIGNMENT_TESTS(/=, /, range, range_two, result);
   INDEX_ASSIGNMENT_TESTS(%=, %, range, range_two, result);
-  INDEX_ASSIGNMENT_TESTS(<<=, <<, range, range_two, result);
-  INDEX_ASSIGNMENT_TESTS(>>=, >>, range, range_two, result);
+  INDEX_ASSIGNMENT_TESTS(<<=, <<, range, range_quarter, result);
+  INDEX_ASSIGNMENT_TESTS(>>=, >>, range, range_quarter, result);
   INDEX_ASSIGNMENT_TESTS(&=, &, range, range_two, result);
   INDEX_ASSIGNMENT_TESTS(|=, |, range, range_two, result);
   INDEX_ASSIGNMENT_TESTS(^=, ^, range, range_two, result);
@@ -111,8 +114,8 @@ void test_range_kernels(
   INDEX_ASSIGNMENT_INTEGER_TESTS(*=, *, range, integer, result);
   INDEX_ASSIGNMENT_INTEGER_TESTS(/=, /, range, integer, result);
   INDEX_ASSIGNMENT_INTEGER_TESTS(%=, %, range, integer, result);
-  INDEX_ASSIGNMENT_INTEGER_TESTS(<<=, <<, range, integer, result);
-  INDEX_ASSIGNMENT_INTEGER_TESTS(>>=, >>, range, integer, result);
+  INDEX_ASSIGNMENT_INTEGER_TESTS(<<=, <<, range_quarter, integer, result);
+  INDEX_ASSIGNMENT_INTEGER_TESTS(>>=, >>, range_quarter, integer, result);
   INDEX_ASSIGNMENT_INTEGER_TESTS(&=, &, range, integer, result);
   INDEX_ASSIGNMENT_INTEGER_TESTS(|=, |, range, integer, result);
   INDEX_ASSIGNMENT_INTEGER_TESTS(^=, ^, range, integer, result);

--- a/tests/range/range_api.cpp
+++ b/tests/range/range_api.cpp
@@ -50,6 +50,7 @@ void test_range_kernels(
   const sycl::range<dims> range_two_const(range_two);
   const sycl::range<dims> range_const(range);
 
+  // make sure bitwise shift rhs is smaller than number of bits in size_t.
   sycl::range<dims> range_quarter(range / 4);
   const sycl::range<dims> range_quarter_const(range_quarter);
 


### PR DESCRIPTION
In function test_range_kernels, range[2] is 64 and range_two[2] is 128. It is undefined behavior to use either of them as rhs of bitwise shift operator because the rhs is not smaller than the number of bits in range value type. This PR divides rhs by 4 so that it is smaller than 64.