### PR TITLE
Fix MSVC build.

### DIFF
--- a/oclmath/rounding_mode.cpp
+++ b/oclmath/rounding_mode.cpp
@@ -130,8 +130,6 @@ RoundingMode set_round(RoundingMode r, Type outType) {
 
   int err = _controlfp_s(&oldRound, 0, 0);  // get rounding mode into oldRound
   if (err) {
-    vlog_error("\t\tERROR: -- cannot get rounding mode in %s:%d\n", __FILE__,
-               __LINE__);
     return kDefaultRoundingMode;  // what else never happens
   }
 

--- a/oclmath/rounding_mode.h
+++ b/oclmath/rounding_mode.h
@@ -18,11 +18,6 @@
 
 #include "compat.h"
 
-#if (defined(_WIN32) && defined(_MSC_VER))
-#include "errorHelpers.h"
-#include "testHarness.h"
-#endif
-
 typedef enum {
   kDefaultRoundingMode = 0,
   kRoundToNearestEven,


### PR DESCRIPTION
In commit 33be1b17, I updated rounding_mode.* to their current OpenCL-CTS versions without noticing that the old versions had an intentional deviation from OpenCL-CTS: a call to vlog_error had been commented out, and the headers that were needed only for that were also left out. This commit reapplies those changes.