### PR TITLE
Enable generic pointer aliases tests in DPCPP

### DIFF
--- a/tests/multi_ptr/multi_ptr_explicit_conversions.h
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions.h
@@ -215,7 +215,7 @@ void check_generic_pointer_aliases(const std::string& type_name) {
               .with("T", type_name)
               .create()) {
     // FIXME: Enable when aliases defined in implementations.
-#if !SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_HIPSYCL
     {
       INFO("decorated_generic_ptr");
       STATIC_CHECK(
@@ -232,7 +232,7 @@ void check_generic_pointer_aliases(const std::string& type_name) {
               sycl::multi_ptr<T, sycl::access::address_space::generic_space,
                               sycl::access::decorated::no>>);
     }
-#endif  //! SYCL_CTS_COMPILING_WITH_HIPSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
+#endif  //! SYCL_CTS_COMPILING_WITH_HIPSYCL
   }
 }
 

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_core.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_core.cpp
@@ -37,7 +37,7 @@ TEST_CASE("multi_ptr explicit conversions. Core types", "[multi_ptr]") {
   for_all_types<check_multi_ptr_explicit_convert_for_type>(composite_types);
 }
 
-DISABLED_FOR_TEST_CASE(DPCPP, hipSYCL)
+DISABLED_FOR_TEST_CASE(hipSYCL)
 ("generic_ptr alias. Core types", "[multi_ptr]")({
   using namespace multi_ptr_explicit_conversions;
   auto types = multi_ptr_common::get_types();

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_fp16.cpp
@@ -41,7 +41,7 @@ TEST_CASE("multi_ptr explicit conversions. fp16 type", "[multi_ptr]") {
   check_multi_ptr_explicit_convert_for_type<sycl::half>{}("sycl::half");
 }
 
-DISABLED_FOR_TEST_CASE(DPCPP, hipSYCL)
+DISABLED_FOR_TEST_CASE(hipSYCL)
 ("generic_ptr alias. fp16 type", "[multi_ptr]")({
   using namespace multi_ptr_explicit_conversions;
   check_generic_ptr_aliases_for_type<sycl::half>{}("sycl::half");

--- a/tests/multi_ptr/multi_ptr_explicit_conversions_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_explicit_conversions_fp64.cpp
@@ -41,7 +41,7 @@ TEST_CASE("multi_ptr explicit conversions. fp64 type", "[multi_ptr]") {
   check_multi_ptr_explicit_convert_for_type<double>{}("double");
 }
 
-DISABLED_FOR_TEST_CASE(DPCPP, hipSYCL)
+DISABLED_FOR_TEST_CASE(hipSYCL)
 ("generic_ptr alias. fp64 type", "[multi_ptr]")({
   using namespace multi_ptr_explicit_conversions;
   check_generic_ptr_aliases_for_type<double>{}("double");


### PR DESCRIPTION
Enable generic pointer aliases tests in DPCPP as they were added in 82d874f49293d342eb2e2ffe2eb8174778d4ceab.