### PR TITLE
Update checks for `sycl::info::device::preferred_interop_user_sync` and  `sycl::info::device::profile` in `device_info` test

### DIFF
--- a/tests/common/common.h
+++ b/tests/common/common.h
@@ -36,6 +36,7 @@
 #include "get_cts_object.h"
 #include "macros.h"
 #include "string_makers.h"
+#include "sycl/backend_types.hpp"
 #include "value_operations.h"
 
 #include <algorithm>
@@ -157,6 +158,22 @@ void check_get_info_param(const ObjectT& object) {
   // Check get_info return type
   auto returnValue = object.template get_info<InfoDesc>();
   check_return_type<ReturnT>(returnValue, "object::get_info()");
+}
+/**
+ * @brief Helper function to check an info parameter for specific backend.
+ */
+template <typename InfoDesc, typename ReturnT, sycl::backend Backend,
+          typename ObjectT>
+void check_get_info_param_backend_specific(const ObjectT& object) {
+  try {
+    check_get_info_param<InfoDesc, ReturnT>(object);
+    CHECK(object.get_backend() == Backend);
+  } catch (const sycl::exception& e) {
+    CHECK(e.code() == sycl::make_error_code(sycl::errc::invalid));
+    CHECK(object.get_backend() != Backend);
+  } catch (...) {
+    FAIL("Unexpected exception");
+  }
 }
 
 /**

--- a/tests/device/device_info.cpp
+++ b/tests/device/device_info.cpp
@@ -220,7 +220,9 @@ TEST_CASE("device info", "[device]") {
     check_get_info_param<sycl::info::device::name, std::string>(dev);
     check_get_info_param<sycl::info::device::vendor, std::string>(dev);
     check_get_info_param<sycl::info::device::driver_version, std::string>(dev);
-    check_get_info_param<sycl::info::device::profile, std::string>(dev);
+    check_get_info_param_backend_specific<sycl::info::device::profile,
+                                          std::string, sycl::backend::opencl>(
+        dev);
     check_get_info_param<sycl::info::device::version, std::string>(dev);
     check_get_info_param<sycl::info::device::backend_version, std::string>(dev);
 
@@ -230,8 +232,9 @@ TEST_CASE("device info", "[device]") {
     check_get_info_param<sycl::info::device::extensions,
                          std::vector<std::string>>(dev);
     check_get_info_param<sycl::info::device::printf_buffer_size, size_t>(dev);
-    check_get_info_param<sycl::info::device::preferred_interop_user_sync, bool>(
-        dev);
+    check_get_info_param_backend_specific<
+        sycl::info::device::preferred_interop_user_sync, bool,
+        sycl::backend::opencl>(dev);
     auto SupportedProperties =
         dev.get_info<sycl::info::device::partition_properties>();
     if (std::find(SupportedProperties.begin(), SupportedProperties.end(),


### PR DESCRIPTION
Based on specification https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_device_information_descriptors 
 `sycl::info::device::preferred_interop_user_sync` and ``sycl::info::device::profile` info descriptors are supposed to throw an exception when the backend is not OpenCL. 