### PR TITLE
Fix for `sycl_link_different_device_for_sycl_link` test

### DIFF
--- a/tests/kernel_bundle/sycl_link_different_device_for_sycl_link.cpp
+++ b/tests/kernel_bundle/sycl_link_different_device_for_sycl_link.cpp
@@ -41,10 +41,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
     sycl::queue q{devices[0]};
 
-    const auto first_simple_kernel_id =
+        const auto first_simple_kernel_id =
         sycl::get_kernel_id<first_simple_kernel>();
     auto kernel_bundle = sycl::get_kernel_bundle<sycl::bundle_state::object>(
-        q.get_context(), {first_simple_kernel_id});
+        q.get_context(), {q.get_device()}, {first_simple_kernel_id});
     vector_with_object_bundles vector_with_kb{kernel_bundle};
 
     expect_throws<sycl::errc::invalid>(

--- a/tests/kernel_bundle/sycl_link_different_device_for_sycl_link.cpp
+++ b/tests/kernel_bundle/sycl_link_different_device_for_sycl_link.cpp
@@ -41,7 +41,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
     sycl::queue q{devices[0]};
 
-        const auto first_simple_kernel_id =
+    const auto first_simple_kernel_id =
         sycl::get_kernel_id<first_simple_kernel>();
     auto kernel_bundle = sycl::get_kernel_bundle<sycl::bundle_state::object>(
         q.get_context(), {q.get_device()}, {first_simple_kernel_id});


### PR DESCRIPTION
This patch addresses issue of test assuming that devices from `get_devices` that are not in the set of associated devices for kernel bundle.  However in some scenarios when only 2 devices are available of same type test will fail because `q.get_context()` includes both devices and test doesn't issue exception with `errc::invalid` which was expected.