### PR TITLE
Uplift GitHub Action upload-artifact version.

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -163,7 +163,7 @@ jobs:
           sort --numeric-sort --reverse --output=build_times.log build_times.log
           echo "Total time: $( date --date=@$ELAPSED --utc '+%-Hh %-Mm %-Ss' )" >> build_times.log
       - name: Upload build times artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-times-${{ matrix.sycl-impl }}
           path: ${{ env.container-workspace }}/build/build_times.log


### PR DESCRIPTION
The CI jobs fail with the error:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Moving to version 4 to fix the error.