### PR TITLE
[CI] Fix DPCPP container creation

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - sycl-impl: dpcpp
-            version: df9fba6d524b59459b1a98eea1339f0c1e492bc9
+            version: 2025-01-14
           - sycl-impl: adaptivecpp
             version: 061e2d6ffe1084021d99f22ac1f16e28c6dab899
     steps:
@@ -114,7 +114,7 @@ jobs:
       matrix:
         include:
           - sycl-impl: dpcpp
-            version: df9fba6d524b59459b1a98eea1339f0c1e492bc9
+            version: 2025-01-14
           - sycl-impl: adaptivecpp
             version: 061e2d6ffe1084021d99f22ac1f16e28c6dab899
     env:

--- a/docker/dpcpp/Dockerfile
+++ b/docker/dpcpp/Dockerfile
@@ -1,17 +1,28 @@
-# DPC++ build version (git revision) to install
-# Go to https://github.com/intel/llvm/pkgs/container/llvm%2Fsycl_ubuntu2204_nightly to see avilable docker image tags
-ARG IMPL_VERSION
+FROM ubuntu:22.04
 
-FROM ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers-$IMPL_VERSION
+# DPC++ nightly to install
+# Go to https://github.com/intel/llvm/releases to see avilable nightly builds.
+ARG IMPL_VERSION
 
 # Make sure that apt is executed with root previlegies
 USER root
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt update && \
-    apt install -y --no-install-recommends \
-      ccache && \
+    apt install -y --no-install-recommends wget ca-certificates build-essential \
+      cmake ninja-build ccache git python3 python3-psutil python-is-python3 python3-pip \
+      zstd ocl-icd-opencl-dev vim libffi-dev libva-dev libtool wget sudo zstd zip \
+      unzip jq curl libhwloc-dev libzstd-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists*
+
+RUN mkdir -p /opt/sycl && \
+    cd /opt/sycl && \
+    wget https://github.com/intel/llvm/releases/download/nightly-${IMPL_VERSION}/sycl_linux.tar.gz && \
+    tar xf sycl_linux.tar.gz && \
+    rm sycl_linux.tar.gz
+
+ENV PATH="/opt/sycl/bin:$PATH"
+ENV LD_LIBRARY_PATH="/opt/sycl/lib:$LD_LIBRARY_PATH"
 
 COPY configure.sh /scripts/


### PR DESCRIPTION
Intel has restricted access to Docker containers with pre-installed DPC++ compiler.
Let's build the containers here using pre-built DPC++ binaries still available on GitHub.