### PR TITLE
Add new macro for SYCL Next CTS tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_TESTS
 add_cts_option(SYCL_CTS_ENABLE_KHR_TESTS
     "Enable all extension Khronos tests" OFF)
 
+add_cts_option(SYCL_CTS_SYCL_NEXT_TESTS
+    "Enable all SYCL Next tests" OFF)
+
 add_cts_option(SYCL_CTS_ENABLE_EXT_ONEAPI_PROPERTIES_TESTS
     "Enable extension oneAPI compile-time property list tests" OFF
     FORCE_ON ${SYCL_CTS_ENABLE_EXT_ONEAPI_TESTS})


### PR DESCRIPTION
New macro for `SYCL Next` to be able to differentiate between SYCL 2020 and SYCL Next CTS tests.
https://github.com/KhronosGroup/SYCL-CTS/issues/952