### PR TITLE
Add tests for the new shorthand aliases of address spaces

### DIFF
--- a/tests/address_space/address_space_core.cpp
+++ b/tests/address_space/address_space_core.cpp
@@ -66,8 +66,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #endif
 
 #ifdef SYCL_CTS_SYCL_NEXT_TESTS
-#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
+#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP && !SYCL_CTS_COMPILING_WITH_SIMSYCL
+    static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
     static_assert(
         std::is_same_v<sycl::addrspace::global_space, sycl::addrspace_global>);
     static_assert(
@@ -76,7 +76,7 @@ static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
                                  sycl::addrspace_private>);
     static_assert(std::is_same_v<sycl::addrspace::generic_space,
                                  sycl::addrspace_generic>);
-#endif  // SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+#endif
 #endif
   }
 };

--- a/tests/address_space/address_space_core.cpp
+++ b/tests/address_space/address_space_core.cpp
@@ -66,7 +66,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #endif
 
 #ifdef SYCL_CTS_SYCL_NEXT_TESTS
-#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP && !SYCL_CTS_COMPILING_WITH_SIMSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
+#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP && \
+    !SYCL_CTS_COMPILING_WITH_SIMSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
     static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
     static_assert(
         std::is_same_v<sycl::addrspace::global_space, sycl::addrspace_global>);

--- a/tests/address_space/address_space_core.cpp
+++ b/tests/address_space/address_space_core.cpp
@@ -66,7 +66,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #endif
 
 #ifdef SYCL_CTS_SYCL_NEXT_TESTS
-    static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
+#ifndef SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
+static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
     static_assert(
         std::is_same_v<sycl::addrspace::global_space, sycl::addrspace_global>);
     static_assert(
@@ -75,6 +76,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
                                  sycl::addrspace_private>);
     static_assert(std::is_same_v<sycl::addrspace::generic_space,
                                  sycl::addrspace_generic>);
+#endif  // SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 #endif
   }
 };

--- a/tests/address_space/address_space_core.cpp
+++ b/tests/address_space/address_space_core.cpp
@@ -64,7 +64,16 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #ifdef UINT64_MAX
     test_types<std::uint64_t>(log);
 #endif
-  }
+
+#ifdef SYCL_CTS_SYCL_NEXT_TESTS 
+    static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
+    static_assert(std::is_same_v<sycl::addrspace::global_space, sycl::addrspace_global>);
+    static_assert(std::is_same_v<sycl::addrspace::local_space, sycl::addrspace_local>);
+    static_assert(std::is_same_v<sycl::addrspace::private_space,sycl::addrspace_private>);
+    static_assert(std::is_same_v<sycl::addrspace::generic_space, sycl::addrspace_generic>);
+#endif
+  
+}
 };
 
 util::test_proxy<TEST_NAME> proxy;

--- a/tests/address_space/address_space_core.cpp
+++ b/tests/address_space/address_space_core.cpp
@@ -65,15 +65,18 @@ class TEST_NAME : public sycl_cts::util::test_base {
     test_types<std::uint64_t>(log);
 #endif
 
-#ifdef SYCL_CTS_SYCL_NEXT_TESTS 
+#ifdef SYCL_CTS_SYCL_NEXT_TESTS
     static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
-    static_assert(std::is_same_v<sycl::addrspace::global_space, sycl::addrspace_global>);
-    static_assert(std::is_same_v<sycl::addrspace::local_space, sycl::addrspace_local>);
-    static_assert(std::is_same_v<sycl::addrspace::private_space,sycl::addrspace_private>);
-    static_assert(std::is_same_v<sycl::addrspace::generic_space, sycl::addrspace_generic>);
+    static_assert(
+        std::is_same_v<sycl::addrspace::global_space, sycl::addrspace_global>);
+    static_assert(
+        std::is_same_v<sycl::addrspace::local_space, sycl::addrspace_local>);
+    static_assert(std::is_same_v<sycl::addrspace::private_space,
+                                 sycl::addrspace_private>);
+    static_assert(std::is_same_v<sycl::addrspace::generic_space,
+                                 sycl::addrspace_generic>);
 #endif
-  
-}
+  }
 };
 
 util::test_proxy<TEST_NAME> proxy;

--- a/tests/address_space/address_space_core.cpp
+++ b/tests/address_space/address_space_core.cpp
@@ -66,7 +66,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #endif
 
 #ifdef SYCL_CTS_SYCL_NEXT_TESTS
-#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP && !SYCL_CTS_COMPILING_WITH_SIMSYCL
+#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP && !SYCL_CTS_COMPILING_WITH_SIMSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
     static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
     static_assert(
         std::is_same_v<sycl::addrspace::global_space, sycl::addrspace_global>);

--- a/tests/address_space/address_space_core.cpp
+++ b/tests/address_space/address_space_core.cpp
@@ -68,6 +68,8 @@ class TEST_NAME : public sycl_cts::util::test_base {
 #ifdef SYCL_CTS_SYCL_NEXT_TESTS
 #if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP && \
     !SYCL_CTS_COMPILING_WITH_SIMSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
+    // Tests are disabled because none of the implementations support them yet.
+    // FIXME: re-enable tests once the implementations support them.
     static_assert(std::is_same_v<sycl::access::address_space, sycl::addrspace>);
     static_assert(
         std::is_same_v<sycl::addrspace::global_space, sycl::addrspace_global>);


### PR DESCRIPTION
This PR purpose is to add tests for the new shorthand aliases of address spaces. 
https://github.com/KhronosGroup/SYCL-CTS/issues/952

Changes depend on macro proposed in https://github.com/KhronosGroup/SYCL-CTS/pull/1049