### PR TITLE
Remove `vec::vector_t` tests

### DIFF
--- a/tests/vector_constructors/generate_vector_constructors.py
+++ b/tests/vector_constructors/generate_vector_constructors.py
@@ -165,16 +165,6 @@ def generate_mixed(type_str, size):
                             + ', ' + str(size) + '>', test_string)
 
 
-def generate_opencl(type_str, size):
-    """Generates test for vec(vector_t openclVector)"""
-    test_string = opencl_constructor_vec_template.substitute(
-        type=type_str, size=size)
-    return '#ifdef __SYCL_DEVICE_ONLY__\n' + wrap_with_kernel(
-        type_str, 'VEC_OPENCL_CONSTRUCTOR_KERNEL_' + type_str + str(size),
-        'vec(vector_t openclVector), sycl::vec<' + type_str + ', ' +
-        str(size) + '>', test_string) + '#endif  // __SYCL_DEVICE_ONLY__\n'
-
-
 def generate_constructor_tests(type_str, input_file, output_file):
     """Generates a string for each constructor type containing each combination of test
     Constructor types: default, explicit, vec, opencl
@@ -192,7 +182,6 @@ def generate_constructor_tests(type_str, input_file, output_file):
         test_str += generate_explicit(type_str, size)
         test_str += generate_vec(type_str, size)
         test_str += generate_mixed(type_str, size)
-        test_str += generate_opencl(type_str, size)
         test_func_str += wrap_with_test_func(TEST_NAME, type_str,
                                              test_str, str(size))
         test_str = ''

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -1259,23 +1259,6 @@ subscript_operator_test_template = Template("""
   }
 """)
 
-vector_t_operator_test_template = Template("""
-#ifdef __SYCL_DEVICE_ONLY__
-  // check operator vector_t() const
-  {
-    ${type} val = ${val};
-    const sycl::vec<${type}, 1> testVec(val);
-    sycl::vec<${type}, ${size}>::vector_t data = testVec;
-
-    const sycl::vec<${type}, 1> testVec2(data);
-
-    if (!(testVec == testVec2)) {
-      resAcc[0] = false;
-    }
-  }
-#endif  // __SYCL_DEVICE_ONLY__
-""")
-
 dataT_operator_test_template = Template("""
   // check operator DataT() const
   {
@@ -1325,11 +1308,6 @@ def generate_all_type_test(type_str, size):
     if size == 1:
         test_string += dataT_operator_test_template.substitute(
           type=type_str,
-          swizzle=get_swizzle(size),
-          val=Data.value_default_dict[type_str])
-        test_string += vector_t_operator_test_template.substitute(
-          type=type_str,
-          size=str(size),
           swizzle=get_swizzle(size),
           val=Data.value_default_dict[type_str])
     test_string += assign_dataT_operator_test_template.substitute(


### PR DESCRIPTION
Following the specification change in https://github.com/KhronosGroup/SYCL-Docs/pull/676.