### PR TITLE
Restore relational/logical operators tests for `sycl::vec`

### DIFF
--- a/tests/common/common_vec.h
+++ b/tests/common/common_vec.h
@@ -44,6 +44,15 @@
 
 namespace {
 
+template <typename T>
+using rel_log_ret_t = std::conditional_t<
+    sizeof(T) == 1, std::int8_t,
+    std::conditional_t<
+        sizeof(T) == 2, std::int16_t,
+        std::conditional_t<sizeof(T) == 4, std::int32_t,
+                           std::conditional_t<sizeof(T) == 8, std::int64_t,
+                                              void /*Not expected*/>>>>;
+
 /**
  * @brief Helper function to check the size of a vector is correct.
  */

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -431,6 +431,9 @@ all_type_test_template = Template("""
 """)
 
 specific_return_type_test_template = Template("""
+#if SYCL_CTS_COMPILING_WITH_SIMSYCL
+  FAIL_CHECK("SimSYCL has incorrect return types for logical/relational operators.");
+#else
   /** Tests each logical and relational operator available to vector types
    */
   auto testVec1 = sycl::vec<${type}, ${size}>(static_cast<${type}>(${test_value_1}));
@@ -732,6 +735,7 @@ specific_return_type_test_template = Template("""
   if (!check_vector_values(resVec, resArr)) {
     resAcc[0] = false;
   }
+#endif
 """)
 
 non_fp_bitwise_test_template = Template("""

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -1355,7 +1355,7 @@ def generate_all_types_specific_return_type_test(type_str, size):
         type=type_str,
         size=str(size),
         swizzle=get_swizzle(size),
-        ret_type='rel_log_ret_t<{}>'.format(type_str),
+        ret_type=f'rel_log_ret_t<{type_str}>',
         test_value_1=1,
         test_value_2=2)
     return wrap_with_kernel(

--- a/tests/vector_operators/generate_vector_operators.py
+++ b/tests/vector_operators/generate_vector_operators.py
@@ -1355,7 +1355,7 @@ def generate_all_types_specific_return_type_test(type_str, size):
         type=type_str,
         size=str(size),
         swizzle=get_swizzle(size),
-        ret_type=Data.opencl_sized_return_type_dict[type_str],
+        ret_type='rel_log_ret_t<{}>'.format(type_str),
         test_value_1=1,
         test_value_2=2)
     return wrap_with_kernel(
@@ -1419,6 +1419,15 @@ def generate_operator_tests(type_str, input_file, output_file):
                                              type_str, test_str, str(size))
         func_calls += make_func_call(TEST_NAME + '_ALL_TYPES', type_str,
                                      str(size))
+
+        test_str = generate_all_types_specific_return_type_test(
+            type_str, size)
+        test_func_str += wrap_with_test_func(
+            TEST_NAME + '_SPECIFIC_RETURN_TYPES', type_str, test_str,
+            str(size))
+        func_calls += make_func_call(TEST_NAME + '_SPECIFIC_RETURN_TYPES',
+                                        type_str, str(size))
+
         if not type_str in [
                 'float', 'double', 'sycl::half'
         ]:


### PR DESCRIPTION
Seems to have been removed accidentally in https://github.com/KhronosGroup/SYCL-CTS/pull/130.
https://github.com/KhronosGroup/SYCL-Docs/pull/675 might be considered somewhat related.