### PR TITLE
Don't call `accessor::get_pointer()` from outside command when not allowed

### DIFF
--- a/tests/accessor_legacy/accessor_api_local_common.h
+++ b/tests/accessor_legacy/accessor_api_local_common.h
@@ -93,9 +93,7 @@ class check_local_accessor_api_methods {
           }
         }
         check_get_range(log, acc, range, typeName, is_zero_dim<dims>{});
-        if constexpr (target == sycl::access::target::constant_buffer ||
-                      target == sycl::access::target::local ||
-                      target == sycl::access::target::host_buffer) {
+        if constexpr (target == sycl::access::target::host_buffer) {
           /** check get_pointer() method for deprecated accessor targets
            */
           auto pointer = acc.get_pointer();


### PR DESCRIPTION
Both `target::constant_buffer` and `target::local` have the restriction that `get_pointer()` may only be called from within a command.