### PR TITLE
[CI][NFC] Update ccache workaround comments

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -123,7 +123,7 @@ jobs:
             version: 27ca7a05e65d24c784ba831225d0a53341719590
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
-      parallel-build-jobs: 2
+      parallel-build-jobs: 3
     container:
       image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
     steps:

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -123,7 +123,7 @@ jobs:
             version: 27ca7a05e65d24c784ba831225d0a53341719590
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
-      parallel-build-jobs: 3
+      parallel-build-jobs: 2
     container:
       image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
     steps:

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -144,13 +144,6 @@ jobs:
           key: ${{ matrix.sycl-impl }}-ccache-${{ github.sha }}
           restore-keys: |
             ${{ matrix.sycl-impl }}-ccache-
-      # Use ccache's "depend mode" to work around DPC++ issue (see https://github.com/intel/llvm/issues/5260)
-      # This requires compilation with -MD, which is enabled because we use the Ninja generator
-      # Using this mode should not have any practical disadvantages
-      - name: Set ccache environment variables
-        run: |
-          echo "CCACHE_DEPEND=1" >> "$GITHUB_ENV"
-          echo "CCACHE_DIR=${{ env.container-workspace }}/.ccache" >> "$GITHUB_ENV"
       - name: Build 'oclmath'
         working-directory: ${{ env.container-workspace }}/build
         run: cmake --build . --target oclmath

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -141,6 +141,14 @@ jobs:
           key: ${{ matrix.sycl-impl }}-ccache-${{ github.sha }}
           restore-keys: |
             ${{ matrix.sycl-impl }}-ccache-
+      # Use ccache's "depend mode" to meet the GitHub Actions timeout of 6 hours with DPC++ compiler.
+      # This is a workaround for the fact that ccache's default mode (i.e. "preprocessor mode") introduces significant overhead in case of the cache miss.
+      # This requires compilation with -MD, which is enabled because we use the Ninja generator.
+      # Using this mode should not have any practical disadvantages.
+      - name: Set ccache environment variables
+        run: |
+          echo "CCACHE_DEPEND=1" >> "$GITHUB_ENV"
+          echo "CCACHE_DIR=${{ env.container-workspace }}/.ccache" >> "$GITHUB_ENV"
       - name: Build 'oclmath'
         working-directory: ${{ env.container-workspace }}/build
         run: cmake --build . --target oclmath


### PR DESCRIPTION
DPC++ compiler fixed the problem blocking ccache functionality reported in https://github.com/intel/llvm/issues/5260.

Unfortunately, we can't remove the workaround due to the overhead added by the default "preprocessor mode". Rebuilding the cache in "preprocessor mode" on GitHub runners takes more than 6h, which is a limit for our plan.