### PR TITLE
[CI] Switch clang-format to cpp-linter action

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -86,24 +86,21 @@ jobs:
 
   check-clang-format:
     if: github.event_name == 'pull_request'
-    runs-on: "ubuntu-22.04"
+    
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: cpp-linter/cpp-linter-action@main
+        id: linter
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          fetch-depth: 0 # Need to check out base branch as well
-      - name: Run clang-format on changed files
-        run: |
-          set -o errexit -o pipefail -o noclobber -o nounset
-          DIFF=$( git diff -U0 --no-color ${{ github.event.pull_request.base.sha }} | clang-format-diff-14 -p1 )
-          if [ ! -z "$DIFF" ]; then
-            echo 'The following changes are not formatted according to `clang-format`:' >> $GITHUB_STEP_SUMMARY
-            echo '```diff' >> $GITHUB_STEP_SUMMARY
-            echo "$DIFF" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "Not all files are formatted according to clang-format. See workflow summary for details."
-            exit 1 # Fail CI run
-          fi
+          style: file
+          tidy-checks: '-*' # Disable all clang-tidy checks for now. Enable checks as needed.
+          lines-changed-only: true
+          format-review: true
+          passive-reviews: true
 
   compile-cts:
     needs: build-image-for-sycl-impl


### PR DESCRIPTION
Today we use our own implementation of clang-format check which posts
the diff proposed by clang-format to GitHub actions summary. Switching
to cpp-linter action enables use of review suggestions, which are more
user friendly.