### PR TITLE
Don't use interop host task for event tests

### DIFF
--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -217,7 +217,7 @@ static sycl::event make_throwing_host_event(
     for (auto& dep : dependencies) {
       cgh.depends_on(dep);
     }
-    cgh.host_task([name](auto) { throw test_exception{name}; });
+    cgh.host_task([name] { throw test_exception{name}; });
   });
 }
 


### PR DESCRIPTION
There's two variants of the host task, one that does interop and one that doesn't.

The only difference between the two is that the one that does interop takes an `interop_handle`.

In this event test using `(auto)` for the host task lambda will be interpreted as taking an `interop_handle` which means the interop version of the host task will be used.

This test doesn't do or check any interop so this is unnecessary, and I suspect it also wasn't intended when the test was written.