### PR TITLE
[KHR] Tests for max_num_work_groups extension

### DIFF
--- a/tests/extension/khr_max_num_work_groups/CMakeLists.txt
+++ b/tests/extension/khr_max_num_work_groups/CMakeLists.txt
@@ -1,0 +1,5 @@
+if(SYCL_CTS_ENABLE_MAX_NUM_WORK_GROUPS)
+    file(GLOB test_cases_list *.cpp)
+
+    add_cts_test(${test_cases_list})
+endif()

--- a/tests/extension/khr_max_num_work_groups/max_num_work_groups_macro.cpp
+++ b/tests/extension/khr_max_num_work_groups/max_num_work_groups_macro.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2025 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+
+namespace max_num_work_groups_macro::tests {
+    TEST_CASE(
+        "the max_num_work_groups extension defines the "
+        "SYCL_KHR_MAX_NUM_WORK_GROUPS macro",
+        "[khr_max_num_work_groups]") {
+    #ifndef SYCL_KHR_MAX_NUM_WORK_GROUPS
+    static_assert(false, "SYCL_KHR_MAX_NUM_WORK_GROUPS is not defined");
+    #endif
+    }
+}  // namespace max_num_work_groups_macro::tests

--- a/tests/extension/khr_max_num_work_groups/max_num_work_groups_min.cpp
+++ b/tests/extension/khr_max_num_work_groups/max_num_work_groups_min.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2025 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+
+namespace max_num_work_groups::tests {
+
+TEST_CASE("if the device is not info::device_type::custom, the minimal",
+          "size in each dimension is (1,1,1)",
+          "[khr_max_num_work_groups]") {
+  sycl::queue q;
+  sycl::device dev = q.get_device();
+
+  if (dev.get_info<sycl::info::device::device_type>() !=
+      sycl::info::device_type::custom) {
+    auto max_work_groups =
+        dev.get_info<khr::info::device::max_num_work_groups<3>>();
+    CHECK(max_work_groups[0] >= 1);
+    CHECK(max_work_groups[1] >= 1);
+    CHECK(max_work_groups[2] >= 1);
+  }
+}
+
+}  // namespace max_num_work_groups::tests

--- a/tests/extension/khr_max_num_work_groups/max_num_work_groups_submission.cpp
+++ b/tests/extension/khr_max_num_work_groups/max_num_work_groups_submission.cpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+//
+//  SYCL 2020 Conformance Test Suite
+//
+//  Copyright (c) 2025 The Khronos Group Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+*******************************************************************************/
+
+#include "../../common/common.h"
+
+namespace max_num_work_groups::tests {
+
+TEST_CASE("max_num_work_groups submission at numeric_limits int max in ",
+          "dimension 1 [khr_max_num_work_groups]") {
+  sycl::queue q;
+  sycl::device dev = q.get_device();
+
+  auto max_work_groups_nd =
+      dev.get_info<khr::info::device::max_num_work_groups<3>>();
+
+  if (max_work_groups_nd[0] >= std::numeric_limits<int>::max()) {
+    int* result = sycl::malloc_shared<int>(1, q);
+    *result = 0;
+
+    sycl::nd_range<3> ndra({std::numeric_limits<int>::max(), 1, 1}, {1, 1, 1});
+
+        q.submit([&](sycl::handler& h) {
+           h.parallel_for(ndra, [=](sycl::nd_item<3> item) {
+             if (item.get_global_id(0) == std::numeric_limits<int>::max() - 1)
+               *result = 42;
+           });
+         }).wait();
+
+    CHECK(*result == 42);
+    sycl::free(result, q);
+  }
+}
+
+}  // namespace max_num_work_groups::tests


### PR DESCRIPTION
The CTS for the khr [extension proposal](https://github.com/KhronosGroup/SYCL-Docs/pull/712) for the device descriptor `max_num_work_groups`.

There is a [PR](https://github.com/AdaptiveCpp/AdaptiveCpp/pull/1736) for an implementation in AdaptiveCpp.