### PR TITLE
OpenCL Interop: Use matching context when constructing queue

### DIFF
--- a/tests/opencl_interop/opencl_interop_constructors.cpp
+++ b/tests/opencl_interop/opencl_interop_constructors.cpp
@@ -127,8 +127,10 @@ class TEST_NAME :
       /** check make_queue (cl_command_queue, const context&)
        */
       {
+        sycl::context context =
+            sycl::make_context<sycl::backend::opencl>(m_cl_context);
         sycl::queue queue = sycl::make_queue<sycl::backend::opencl>(
-            m_cl_command_queue, ctsContext);
+            m_cl_command_queue, context);
 
         cl_command_queue interopQueue =
             sycl::get_native<sycl::backend::opencl>(queue);
@@ -148,9 +150,11 @@ class TEST_NAME :
       /** check make_queue (cl_command_queue, const context&, async_handler)
        */
       {
+        sycl::context context =
+            sycl::make_context<sycl::backend::opencl>(m_cl_context);
         cts_async_handler asyncHandler;
         sycl::queue queue = sycl::make_queue<sycl::backend::opencl>(
-            m_cl_command_queue, ctsContext, asyncHandler);
+            m_cl_command_queue, context, asyncHandler);
 
         cl_command_queue interopQueue =
             sycl::get_native<sycl::backend::opencl>(queue);


### PR DESCRIPTION
`make_queue` accepts both a native handle and a context. While the spec
doesn't explictly say so, it's my understanding that the "internal"
native handle of the provided context must match the context of the
provided handle.

This fixes the `opencl_interop_constructors` test, which was incorrectly
trying to construct a sycl::queue from a native handle created from a
different context.
