### PR TITLE
[NFC] Use `device::has` query directly

### DIFF
--- a/tests/address_space/address_space_fp16.cpp
+++ b/tests/address_space/address_space_fp16.cpp
@@ -9,7 +9,6 @@
 #define TEST_NAME address_space_fp16
 
 #include "../common/common.h"
-#include "./../../util/extensions.h"
 #include "address_space_common.h"
 
 namespace TEST_NAMESPACE {
@@ -24,9 +23,12 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     auto queue = util::get_cts_object::queue();
 
-    using availability =
-        util::extensions::availability<util::extensions::tag::fp16>;
-    if (!availability::check(queue, log)) return;
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      WARN(
+          "Device doesn't support half precision floating point data type - "
+          "skipping the test");
+      return;
+    }
 
     test_types<sycl::half>(log);
   }

--- a/tests/address_space/address_space_fp64.cpp
+++ b/tests/address_space/address_space_fp64.cpp
@@ -9,7 +9,6 @@
 #define TEST_NAME address_space_fp64
 
 #include "../common/common.h"
-#include "./../../util/extensions.h"
 #include "address_space_common.h"
 
 namespace TEST_NAMESPACE {
@@ -24,9 +23,12 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     auto queue = util::get_cts_object::queue();
 
-    using availability =
-        util::extensions::availability<util::extensions::tag::fp64>;
-    if (!availability::check(queue, log)) return;
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      WARN(
+          "Device doesn't support double precision floating point data type - "
+          "skipping the test");
+      return;
+    }
 
     test_types<double>(log);
   }

--- a/tests/function_objects/function_objects_fp64.cpp
+++ b/tests/function_objects/function_objects_fp64.cpp
@@ -18,7 +18,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
 #include "../common/type_coverage.h"
@@ -32,9 +31,7 @@ DISABLED_FOR_TEST_CASE(AdaptiveCpp)
 ("function objects void specializations scalar fp64",
  "[function_objects][fp64]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
-  using availability = sycl_cts::util::extensions::availability<
-      sycl_cts::util::extensions::tag::fp64>;
-  if (!availability::check(queue)) {
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
     SKIP("Device does not support double precision floating point operations.");
   }
 
@@ -54,9 +51,7 @@ DISABLED_FOR_TEST_CASE(AdaptiveCpp)
 ("function objects void specializations vector fp64",
  "[function_objects][fp64]")({
   auto queue = sycl_cts::util::get_cts_object::queue();
-  using availability = sycl_cts::util::extensions::availability<
-      sycl_cts::util::extensions::tag::fp64>;
-  if (!availability::check(queue)) {
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
     SKIP("Device does not support double precision floating point operations.");
   }
 

--- a/tests/marray_basic/marray_alias.cpp
+++ b/tests/marray_basic/marray_alias.cpp
@@ -18,7 +18,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "marray_common.h"
 
 namespace marray_alignment {
@@ -57,9 +56,7 @@ TEST_CASE("marray_alignment", "[marray]") {
   auto queue = util::get_cts_object::queue();
 
 #if SYCL_CTS_ENABLE_HALF_TESTS
-  using availability_fp16 =
-      util::extensions::availability<util::extensions::tag::fp16>;
-  if (!availability_fp16::check(queue)) {
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
     WARN(
         "Device does not support half precision floating point operations."
         "Skipping the test case.");
@@ -69,9 +66,7 @@ TEST_CASE("marray_alignment", "[marray]") {
 #endif  // SYCL_CTS_ENABLE_HALF_TESTS
 
 #if SYCL_CTS_ENABLE_DOUBLE_TESTS
-  using availability_fp64 =
-      util::extensions::availability<util::extensions::tag::fp64>;
-  if (!availability_fp64::check(queue)) {
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
     WARN(
         "Device does not support double precision floating point operations."
         "Skipping the test case.");

--- a/tests/multi_ptr/multi_ptr_accessor_constructor_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_accessor_constructor_fp16.cpp
@@ -6,7 +6,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "../common/type_coverage.h"
 #include "multi_ptr_accessor_constructor.h"
@@ -33,10 +32,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
 
     auto queue = util::get_cts_object::queue();
 
-    using avaliability =
-        util::extensions::availability<util::extensions::tag::fp16>;
-    if (!avaliability::check(queue, log)) {
-      SKIP("Device does not support half precision floating point operations");
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      SKIP(
+          "Device does not support half precision floating point operations - "
+          "skipping the test");
     }
 
     check_multi_ptr_accessor_constructor_for_type<sycl::half>{}(log,

--- a/tests/multi_ptr/multi_ptr_accessor_constructor_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_accessor_constructor_fp64.cpp
@@ -6,7 +6,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "../common/type_coverage.h"
 #include "multi_ptr_accessor_constructor.h"
@@ -32,11 +31,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using namespace multi_ptr_accessor_constructors;
 
     auto queue = util::get_cts_object::queue();
-    using avaliability =
-        util::extensions::availability<util::extensions::tag::fp64>;
-    if (!avaliability::check(queue, log)) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
       WARN(
-          "Device does not support double precision floating point operations");
+          "Device does not support double precision floating point operations "
+          "- skipping the test");
       return;
     }
 

--- a/tests/multi_ptr/multi_ptr_common_constructors_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_common_constructors_fp16.cpp
@@ -6,7 +6,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "../common/type_coverage.h"
 
@@ -33,10 +32,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using namespace multi_ptr_common_constructors;
 
     auto queue = util::get_cts_object::queue();
-    using avaliability =
-        util::extensions::availability<util::extensions::tag::fp16>;
-    if (!avaliability::check(queue, log)) {
-      WARN("Device does not support half precision floating point operations");
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      WARN(
+          "Device does not support half precision floating point operations - "
+          "skipping the test");
       return;
     }
 

--- a/tests/multi_ptr/multi_ptr_common_constructors_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_common_constructors_fp64.cpp
@@ -6,7 +6,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "../common/type_coverage.h"
 
@@ -33,11 +32,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
     using namespace multi_ptr_common_constructors;
 
     auto queue = util::get_cts_object::queue();
-    using avaliability =
-        util::extensions::availability<util::extensions::tag::fp64>;
-    if (!avaliability::check(queue, log)) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
       WARN(
-          "Device does not support double precision floating point operations");
+          "Device does not support double precision floating point operations "
+          "- skipping the test");
       return;
     }
 

--- a/tests/multi_ptr/multi_ptr_members_fp16.cpp
+++ b/tests/multi_ptr/multi_ptr_members_fp16.cpp
@@ -6,7 +6,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "multi_ptr_members.h"
 
@@ -30,10 +29,10 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     auto queue = util::get_cts_object::queue();
-    using avaliability =
-        util::extensions::availability<util::extensions::tag::fp16>;
-    if (!avaliability::check(queue, log)) {
-      WARN("Device does not support half precision floating point operations");
+    if (!queue.get_device().has(sycl::aspect::fp16)) {
+      WARN(
+          "Device does not support half precision floating point operations - "
+          "skipping the test");
       return;
     }
 

--- a/tests/multi_ptr/multi_ptr_members_fp64.cpp
+++ b/tests/multi_ptr/multi_ptr_members_fp64.cpp
@@ -6,7 +6,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "multi_ptr_members.h"
 
@@ -30,11 +29,10 @@ class TEST_NAME : public util::test_base {
    */
   void run(util::logger &log) override {
     auto queue = util::get_cts_object::queue();
-    using avaliability =
-        util::extensions::availability<util::extensions::tag::fp64>;
-    if (!avaliability::check(queue, log)) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
       WARN(
-          "Device does not support double precision floating point operations");
+          "Device does not support double precision floating point operations "
+          "- skipping the test");
       return;
     }
 

--- a/tests/queue/queue_shortcuts_explicit_fp16.cpp
+++ b/tests/queue/queue_shortcuts_explicit_fp16.cpp
@@ -18,7 +18,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "queue_shortcuts_explicit.h"
 
@@ -29,13 +28,10 @@ using namespace queue_shortcuts_explict;
 
 TEST_CASE("queue shortcuts explicit copy fp16", "[queue]") {
   auto queue = util::get_cts_object::queue();
-  using availability =
-      util::extensions::availability<util::extensions::tag::fp16>;
-  if (!availability::check(queue)) {
-    WARN(
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    SKIP(
         "Device does not support half precision floating point operations"
         "Skipping the test case.");
-    return;
   }
 
   check_queue_shortcuts_explicit_for_type<sycl::half>{}(queue, "sycl::half");

--- a/tests/queue/queue_shortcuts_explicit_fp64.cpp
+++ b/tests/queue/queue_shortcuts_explicit_fp64.cpp
@@ -18,7 +18,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "queue_shortcuts_explicit.h"
 
@@ -29,13 +28,10 @@ using namespace queue_shortcuts_explict;
 
 TEST_CASE("queue shortcuts explicit copy fp64", "[queue]") {
   auto queue = util::get_cts_object::queue();
-  using availability =
-      util::extensions::availability<util::extensions::tag::fp64>;
-  if (!availability::check(queue)) {
-    WARN(
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
         "Device does not support double precision floating point operations"
         "Skipping the test case.");
-    return;
   }
 
   check_queue_shortcuts_explicit_for_type<double>{}(queue, "double");

--- a/tests/queue/queue_shortcuts_kernel_fp16.cpp
+++ b/tests/queue/queue_shortcuts_kernel_fp16.cpp
@@ -18,7 +18,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "queue_shortcuts_kernel.h"
 
@@ -29,13 +28,10 @@ using namespace queue_shortcuts_kernel;
 
 TEST_CASE("queue shortcuts kernel function fp16", "[queue]") {
   auto queue = util::get_cts_object::queue();
-  using availability =
-      util::extensions::availability<util::extensions::tag::fp16>;
-  if (!availability::check(queue)) {
-    WARN(
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    SKIP(
         "Device does not support half precision floating point operations"
         "Skipping the test case.");
-    return;
   }
 
   check_queue_shortcuts_kernel_for_type<sycl::half>{}(queue, "sycl::half");

--- a/tests/queue/queue_shortcuts_kernel_fp64.cpp
+++ b/tests/queue/queue_shortcuts_kernel_fp64.cpp
@@ -18,7 +18,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "queue_shortcuts_kernel.h"
 
@@ -29,13 +28,10 @@ using namespace queue_shortcuts_kernel;
 
 TEST_CASE("queue shortcuts kernel function fp64", "[queue]") {
   auto queue = util::get_cts_object::queue();
-  using availability =
-      util::extensions::availability<util::extensions::tag::fp64>;
-  if (!availability::check(queue)) {
-    WARN(
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
         "Device does not support double precision floating point operations"
         "Skipping the test case.");
-    return;
   }
 
   check_queue_shortcuts_kernel_for_type<double>{}(queue, "double");

--- a/tests/queue/queue_shortcuts_usm_fp16.cpp
+++ b/tests/queue/queue_shortcuts_usm_fp16.cpp
@@ -18,7 +18,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "queue_shortcuts_usm.h"
 
@@ -29,13 +28,10 @@ using namespace queue_shortcuts_usm;
 
 TEST_CASE("queue shortcuts unified shared memory fp16", "[queue]") {
   auto queue = util::get_cts_object::queue();
-  using availability =
-      util::extensions::availability<util::extensions::tag::fp16>;
-  if (!availability::check(queue)) {
-    WARN(
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
+    SKIP(
         "Device does not support half precision floating point operations"
         "Skipping the test case.");
-    return;
   }
 
   check_queue_shortcuts_usm_for_type<sycl::half>{}(queue, "sycl::half");

--- a/tests/queue/queue_shortcuts_usm_fp64.cpp
+++ b/tests/queue/queue_shortcuts_usm_fp64.cpp
@@ -18,7 +18,6 @@
 //
 *******************************************************************************/
 
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "queue_shortcuts_usm.h"
 
@@ -29,13 +28,10 @@ using namespace queue_shortcuts_usm;
 
 TEST_CASE("queue shortcuts unified shared memory fp64", "[queue]") {
   auto queue = util::get_cts_object::queue();
-  using availability =
-      util::extensions::availability<util::extensions::tag::fp64>;
-  if (!availability::check(queue)) {
-    WARN(
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
+    SKIP(
         "Device does not support double precision floating point operations"
         "Skipping the test case.");
-    return;
   }
 
   check_queue_shortcuts_usm_for_type<double>{}(queue, "double");

--- a/tests/reduction/reducer_api_fp16.cpp
+++ b/tests/reduction/reducer_api_fp16.cpp
@@ -17,7 +17,6 @@
 //  limitations under the License.
 //
 *******************************************************************************/
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
 // FIXME: re-enable when sycl::reduction is implemented in AdaptiveCpp
@@ -30,9 +29,7 @@
 DISABLED_FOR_TEST_CASE(AdaptiveCpp)
 ("reducer api fp16", "[reducer][fp16]")({
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
-  using avaliability = sycl_cts::util::extensions::availability<
-      sycl_cts::util::extensions::tag::fp16>;
-  if (!avaliability::check(queue)) {
+  if (!queue.get_device().has(sycl::aspect::fp16)) {
     SKIP("Device does not support half precision floating point operations.");
   }
 

--- a/tests/reduction/reducer_api_fp64.cpp
+++ b/tests/reduction/reducer_api_fp64.cpp
@@ -17,7 +17,6 @@
 //  limitations under the License.
 //
 *******************************************************************************/
-#include "../../util/extensions.h"
 #include "../common/common.h"
 #include "../common/disabled_for_test_case.h"
 // FIXME: re-enable when sycl::reduction is implemented in AdaptiveCpp
@@ -30,9 +29,7 @@
 DISABLED_FOR_TEST_CASE(AdaptiveCpp)
 ("reducer api fp64", "[reducer][fp64]")({
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
-  using avaliability = sycl_cts::util::extensions::availability<
-      sycl_cts::util::extensions::tag::fp64>;
-  if (!avaliability::check(queue)) {
+  if (!queue.get_device().has(sycl::aspect::fp64)) {
     SKIP("Device does not support double precision floating point operations.");
   }
 


### PR DESCRIPTION
This patch is done with the intent to eventually drop `util/extension.h` helper file. It probably had a reason to be there in SYCL 1.2.1 to avoid hardcoding OpenCL extension names everywhere. However, it is very easy to check for support for an optional feature in SYCL 2020 so there is less value in having this verbose helper.

Note that this commit does not remove all uses of `util/extension.h` - some of those uses are more complex than others and therefore their removal is left to another PR.