### PR TITLE
[NFC] Drop unnecessary `sycl.hpp` includes

### DIFF
--- a/tests/common/disabled_for_test_case.h
+++ b/tests/common/disabled_for_test_case.h
@@ -13,7 +13,6 @@
 #include "macro_utils.h"
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <sycl/sycl.hpp>
 
 // TODO: Add other Catch2 test case variants, as needed
 

--- a/tests/common/macros.h
+++ b/tests/common/macros.h
@@ -22,8 +22,6 @@
 #ifndef __SYCLCTS_TESTS_COMMON_MACROS_H
 #define __SYCLCTS_TESTS_COMMON_MACROS_H
 
-#include <sycl/sycl.hpp>
-
 #include <catch2/catch_test_macros.hpp>
 #undef FAIL  // We define our own FAIL macro
 


### PR DESCRIPTION
Those files only define macro and those macro don't even use anything SYCL-specific.