### PR TITLE
Add tests for platform::get_devices()

### DIFF
--- a/tests/platform/platform_api.cpp
+++ b/tests/platform/platform_api.cpp
@@ -26,6 +26,54 @@
 namespace platform_api__ {
 using namespace sycl_cts;
 
+// Compares two devices by their hash value.
+struct DeviceHashLessT {
+  bool operator()(const sycl::device& lDevice, const sycl::device& rDevice) {
+    std::hash<sycl::device> hasher;
+    return hasher(lDevice) < hasher(rDevice);
+  }
+};
+
+// Checks that all devices in a vector are unique.
+inline bool AllDevicesUnique(const std::vector<sycl::device> &devices) {
+  std::vector<sycl::device> devicesCopy = devices;
+  std::sort(devicesCopy.begin(), devicesCopy.end(), DeviceHashLessT{});
+  return std::unique(devicesCopy.begin(), devicesCopy.end()) ==
+         devicesCopy.end();
+}
+
+// Checks that all devices are in the list devices returned by the platform.
+inline bool AllDevicesAreInPlatform(const std::vector<sycl::device>& devices,
+                                    const sycl::platform& platform) {
+  std::vector<sycl::device> devicesCopy = devices;
+  std::vector<sycl::device> allDevices = platform.get_devices();
+  std::sort(devicesCopy.begin(), devicesCopy.end(), DeviceHashLessT{});
+  std::sort(allDevices.begin(), allDevices.end(), DeviceHashLessT{});
+  return std::includes(allDevices.begin(), allDevices.end(),
+                       devicesCopy.begin(), devicesCopy.end(),
+                       DeviceHashLessT{});
+}
+
+// Checks that all devices return the specified device_type when queried.
+inline bool AllDevicesHaveType(const std::vector<sycl::device>& devices,
+                               sycl::info::device_type devType) {
+  return std::all_of(
+      devices.begin(), devices.end(), [devType](const sycl::device& device) {
+        return device.get_info<sycl::info::device::device_type>() == devType;
+      });
+}
+
+// Returns the number of devices in the platform with the specified device type.
+inline size_t CountPlatformDevicesWithType(const sycl::platform& platform,
+                                           sycl::info::device_type devType) {
+  std::vector<sycl::device> allDevices = platform.get_devices();
+  return std::all_of(
+      allDevices.begin(), allDevices.end(),
+      [devType](const sycl::device& device) {
+        return device.get_info<sycl::info::device::device_type>() == devType;
+      });
+}
+
 /** tests the api for sycl::platform
  */
 class TEST_NAME : public util::test_base {
@@ -43,21 +91,69 @@ class TEST_NAME : public util::test_base {
       /** check get_devices() member function
        */
       {
+        INFO("Checking platform::get_devices()");
         auto plt = util::get_cts_object::platform(cts_selector);
         auto devs = plt.get_devices();
         check_return_type<std::vector<sycl::device>>(log, devs,
                                                      "platform::get_devices()");
+        CHECK(AllDevicesUnique(devs));
       }
 
       /** check get_devices(info::device_type::all) member function
        */
       {
+        INFO("Checking platform::get_devices(info::device_type::all)");
         auto plt = util::get_cts_object::platform(cts_selector);
         auto devs = plt.get_devices(sycl::info::device_type::all);
-        if (devs.size() != 0) {
-          check_return_type<std::vector<sycl::device>>(
-              log, devs, "platform::get_devices(info::device_type::all)");
+        check_return_type<std::vector<sycl::device>>(
+            log, devs, "platform::get_devices(info::device_type::all)");
+        CHECK(AllDevicesUnique(devs));
+      }
+
+      /** check get_devices(info::device_type::automatic) member function
+       */
+      {
+        INFO("Checking platform::get_devices(info::device_type::automatic)");
+        auto plt = util::get_cts_object::platform(cts_selector);
+        auto devs = plt.get_devices(sycl::info::device_type::automatic);
+        check_return_type<std::vector<sycl::device>>(
+            log, devs, "platform::get_devices(info::device_type::automatic)");
+        if (devs.size() == 0) {
+          CHECK(plt.get_devices().size() == 0);
+        } else {
+          CHECK(AllDevicesAreInPlatform(devs, plt));
         }
+      }
+
+      /** check get_devices(info::device_type::<cpu|gpu|accelerator|custom>)
+       * member function
+       */
+      for (sycl::info::device_type devType :
+           {sycl::info::device_type::cpu, sycl::info::device_type::gpu,
+            sycl::info::device_type::accelerator,
+            sycl::info::device_type::custom}) {
+        std::string devTypeName = [devType]() {
+          switch (devType) {
+            case sycl::info::device_type::cpu:
+              return "sycl::info::device_type::cpu";
+            case sycl::info::device_type::gpu:
+              return "sycl::info::device_type::gpu";
+            case sycl::info::device_type::accelerator:
+              return "sycl::info::device_type::accelerator";
+            case sycl::info::device_type::custom:
+              return "sycl::info::device_type::custom";
+            default:
+              assert(false && "Missing enumeration!");
+          }
+        }();
+        INFO("Checking platform::get_devices(" + devTypeName + ")");
+        auto plt = util::get_cts_object::platform(cts_selector);
+        auto devs = plt.get_devices(devType);
+        check_return_type<std::vector<sycl::device>>(
+            log, devs, "platform::get_devices("+ devTypeName + ")");
+        CHECK(AllDevicesAreInPlatform(devs, plt));
+        CHECK(AllDevicesHaveType(devs, devType));
+        CHECK(devs.size() == CountPlatformDevicesWithType(plt, devType));
       }
 
       /** check has() member function


### PR DESCRIPTION
This commit adds testing for more device_type enumerations in platform::get_devices and improves the coverage of the existing tests.

This is related to the clarifications in
https://github.com/KhronosGroup/SYCL-Docs/pull/861.

Fixes https://github.com/KhronosGroup/SYCL-CTS/issues/1123.