### PR TITLE
Pass real filename to catch in legacy tests

### DIFF
--- a/util/proxy.h
+++ b/util/proxy.h
@@ -40,16 +40,16 @@ template <typename T>
 class test_proxy {
  public:
   test_proxy() {
-    test_base::info info;
-    T{}.get_info_legacy(info);
+    T{}.get_info_legacy(m_info);
 
     Catch::AutoReg(
-        Catch::makeTestInvoker<T>(&T::run_legacy), {__FILE__, __LINE__},
+        Catch::makeTestInvoker<T>(&T::run_legacy), {m_info.m_file.c_str(), /*.line=*/0},
         "__SYCL_CTS_LEGACY_TEST__" + std::to_string(next_legacy_test_id++),
-        {info.m_name, "[legacy]"});
+        {m_info.m_name, "[legacy]"});
   }
 
  private:
+  test_base::info m_info;
   inline static size_t next_legacy_test_id = 0;
 };
 


### PR DESCRIPTION
Catch2 has the ability to allow execution of tests from a specific file using the `-# [#<filename>]` command line arguments. This already works well for the tests directly using Catch2 macros, but not for the legacy tests which are registered through the `test_proxy` class.

Instead of passing `__FILE__` which always resolves to the proxy header `util/proxy.h`, take the filename we already stash into the `test_base::info` struct and pass that to Catch2. This allows to run legacy tests per-file using the `-# [#<filename>]` syntax as well.

To ensure the lifetime of the `test_base::info` struct is long enough, store it as a member variable of the `test_proxy` class, the instances of which are global and thus live until program termination.