### PR TITLE
kernel_attributes_wg: don't call get_cts_object::device() before main()

### DIFF
--- a/tests/kernel/kernel_attributes_wg_hint.cpp
+++ b/tests/kernel/kernel_attributes_wg_hint.cpp
@@ -27,7 +27,7 @@ using namespace kernel_attributes;
 static constexpr int size = 4;
 static auto test_max_wg_size = pow(size * 2, 3);
 
-bool device_supports_test_max_wg_size() {
+static bool device_supports_test_max_wg_size() {
   static bool result =
       sycl_cts::util::get_cts_object::device()
           .get_info<sycl::info::device::max_work_group_size>() >=


### PR DESCRIPTION
The code in kernel_attributes_wg_hint.cpp was calling `get_cts_object::device()` to initialize a static variable. Static initalization happens unconditionally when the executable is loaded before `main()` is called.

This is problematic because of two reasons:
1. It unconditionally initializes the SYCL runtime even no test is going to be run (e.g. we are simply invoking `--help`,`--list-tests` etc). It might be desirable to run these commands without having a SYCL runtime installed, e.g. during build time on a machine without GPU drivers, to export the list of tests.
2. Because the device filter regex is set by `main()` the tests might run on a different device than the one used to initialize the static variable, potentially skipping part of the test or trying to run it on an unsupported device.

Fix by initializing a static variable in a function scope and return that. The initialization is guaranteed to happen once during the first call to the function.
Additionally rename the variables and the function and slightly refactor to make the code more readable.