### PR TITLE
Avoid bleeding async exceptions between cases in event tests

### DIFF
--- a/tests/event/event.cpp
+++ b/tests/event/event.cpp
@@ -231,6 +231,9 @@ TEST_CASE("event::wait does not report asynchronous errors", "[event]") {
   }
 
   CHECK(teh.count() == 0);
+
+  // Consume all unconsumed exceptions to avoid them bleeding into other cases.
+  e.wait_and_throw();
 }
 
 TEST_CASE("event::wait_and_throw reports asynchronous errors", "[event]") {


### PR DESCRIPTION
This commit adds a event::wait_and_throw to the case checking that event::wait() does not consume asynchronous exceptions. This is to avoid the unconsumed exception from bleeding into other test cases in implementations that consume such exceptions when consuming other unconsumed exceptions.