### PR TITLE
Remove fpga-specific `implement_in_csr` and `init_mode` properties

### DIFF
--- a/test_plans/oneapi/compile-time-property_list.asciidoc
+++ b/test_plans/oneapi/compile-time-property_list.asciidoc
@@ -28,34 +28,34 @@ because of it test should be skipped if `SYCL_EXT_ONEAPI_DEVICE_GLOBAL` is not d
 
 Get prop_values from prop_lists:
 
-`property_list props1{device_image_scope_v};`
+`property_list props1{device_image_scope};`
 
-`auto prop_value1 = props.get_property<device_image_scope>();`
+`auto prop_value1 = props.get_property<device_image_scope_key>();`
 
-`property_list props2{host_access_v<A>};`
-where `A = host_access::access::read, host_access::access::write, host_access::access::read_write, host_access::access::none`
+`property_list props2{host_access<A>};`
+where `A = host_access_enum::read, host_access_enum::write, host_access_enum::read_write, host_access_enum::none`
 
-`auto prop_value_A = props.get_property<host_access>();`
+`auto prop_value_A = props.get_property<host_access_key>();`
 
 Check that for `prop_value1` members `value` and `value_t` are not available.
 
-Check that for every `A` `prop_value_A` member `value` is `A` and member `value_t` is `host_access::access`.
+Check that for every `A` `prop_value_A` member `value` is `A` and member `value_t` is `host_access_enum`.
 
 === Tests for equality and inequality operators for properties
 
 Get prop_values from prop_lists:
 
-`property_list props1{device_image_scope_v};`
+`property_list props1{device_image_scope};`
 
-`auto prop_value_device_image_scope = props.get_property<device_image_scope>();`
+`auto prop_value_device_image_scope = props.get_property<device_image_scope_key>();`
 
-`property_list props2{implement_in_csr_v<true>};`
+`property_list props2{host_access<host_access_enum::read>};`
 
-`auto prop_value_implement_in_csr_true = props.get_property<implement_in_csr_v>();`
+`auto prop_value_host_access_read = props2.get_property<host_access_key>();`
 
-`property_list props3{implement_in_csr_v<false>};`
+`property_list props3{host_access<host_access_enum::write>};`
 
-`auto prop_value_implement_in_csr_false = props.get_property<implement_in_csr_v>();`
+`auto prop_value_host_access_write = props3.get_property<host_access_key>();`
 
 Check constexpr correctness if required and result for operators:
 
@@ -73,33 +73,33 @@ constexpr bool operator==(property_value<Prop, A...> V1, property_value<Prop, B.
 | `true`
 
 |`template <class Prop, class...A, class...B>
+constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
+|`prop_value_device_image_scope`
+|`prop_value_device_image_scope`
+| `false`
+
+|`template <class Prop, class...A, class...B>
 constexpr bool operator==(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
-|`prop_value_implement_in_csr_true`
-|`prop_value_implement_in_csr_true`
+|`prop_value_host_access_read`
+|`prop_value_host_access_read`
 | `true`
 
 |`template <class Prop, class...A, class...B>
+constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
+|`prop_value_host_access_read`
+|`prop_value_host_access_read`
+| `false`
+
+|`template <class Prop, class...A, class...B>
 constexpr bool operator==(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
-|`prop_value_implement_in_csr_true`
-|`prop_value_implement_in_csr_false`
+|`prop_value_host_access_read`
+|`prop_value_host_access_write`
 | `false`
 
 |`template <class Prop, class...A, class...B>
 constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
-|`prop_value_device_image_scope`
-|`prop_value_device_image_scope`
-| `false`
-
-|`template <class Prop, class...A, class...B>
-constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
-|`prop_value_implement_in_csr_false`
-|`prop_value_implement_in_csr_false`
-| `false`
-
-|`template <class Prop, class...A, class...B>
-constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B...> V2)`
-|`prop_value_implement_in_csr_true`
-|`prop_value_implement_in_csr_false`
+|`prop_value_host_access_read`
+|`prop_value_host_access_write`
 | `true`
 
 |===
@@ -108,17 +108,15 @@ constexpr bool operator!=(property_value<Prop, A...> V1, property_value<Prop, B.
 
 ==== has_property
 
-Create property_list with `property_list P1{device_image_scope_v, implement_in_csr_v<true>, host_access_v<access:read>}`
+Create property_list with `property_list P1{device_image_scope}`
 and check P1.has_property<T> returns:
 
-* `true` for `T = device_image_scope`
-* `true` for `T = implement_in_csr`
-* `true` for `T = host_access`
-* `false` for `T = init_mode`
+* `true` for `T = device_image_scope_key`
+* `false` for `T = host_access_key`
 
 === Tests for is_property_list
 
-* Create property_list with `property_list props{device_image_scope_v, implement_in_csr_v<true>}`
+* Create property_list with `property_list props{device_image_scope, host_access<host_access_enum::read_write>}`
 * Check that `is_property_list<decltype(props)>` is `std::true_type`
 * Check that `is_property_list_v<decltype(props)>` is `true`
 
@@ -128,30 +126,24 @@ and check P1.has_property<T> returns:
 
 === Different order
 
-* Call property_list constructor `property_list P1{implement_in_csr_v<true>, device_image_scope_v}`
-* Call property_list constructor `property_list P2{device_image_scope_v, implement_in_csr_v<true>}`
+* Call property_list constructor `property_list P1{host_access<host_access_enum::read_write>, device_image_scope}`
+* Call property_list constructor `property_list P2{device_image_scope, host_access<host_access_enum::read_write>}`
 * Check that `std::is_same_v<decltype(P1), decltype(P2)>` is `true`.
 
 === is_property
 
 * Check that `is_property<device_image_scope>` is `std::true_type`
 * Check that `is_property<host_access>` is `std::true_type`
-* Check that `is_property<init_mode>` is `std::true_type`
-* Check that `is_property<device_image_scope>` is `std::true_type`
 
 === is_device_copyable
 
 ==== is_device_copyable for compile-time-constant properties
 
 * Check that `is_device_copyable<device_image_scope::value_t>` is `std::true_type`
-* Check that `is_device_copyable<host_access::value_t<access::read>>` is `std::true_type`
-* Check that `is_device_copyable<host_access::value_t<access::write>>` is `std::true_type`
-* Check that `is_device_copyable<host_access::value_t<access::read_write>>` is `std::true_type`
-* Check that `is_device_copyable<host_access::value_t<access::none>>` is `std::true_type`
-* Check that `is_device_copyable<init_mode::value_t<trigger::reprogram>>` is `std::true_type`
-* Check that `is_device_copyable<init_mode::value_t<trigger::reset>>` is `std::true_type`
-* Check that `is_device_copyable<implement_in_csr::value_t<true>>` is `std::true_type`
-* Check that `is_device_copyable<implement_in_csr::value_t<false>>` is `std::true_type`
+* Check that `is_device_copyable<host_access::value_t<host_access_enum::read>>` is `std::true_type`
+* Check that `is_device_copyable<host_access::value_t<host_access_enum::write>>` is `std::true_type`
+* Check that `is_device_copyable<host_access::value_t<host_access_enum::read_write>>` is `std::true_type`
+* Check that `is_device_copyable<host_access::value_t<host_access_enum::none>>` is `std::true_type`
 
 ==== is_device_copyable for empty property_list
 
@@ -160,5 +152,5 @@ and check P1.has_property<T> returns:
 
 ==== is_device_copyable for property_list with only compile-time-constant properties
 
-* Create property_list `property_list P2{implement_in_csr_v<true>, device_image_scope_v}`
+* Create property_list `property_list P2{host_access<host_access_enum::read_write>, device_image_scope}`
 * Check that `is_device_copyable<decltype(P2)>` is `std::true_type`

--- a/test_plans/oneapi/device_global.asciidoc
+++ b/test_plans/oneapi/device_global.asciidoc
@@ -116,10 +116,6 @@ This check is run for `device_global` with following properites:
 * `host_access(write)`
 * `host_access(read_write)`
 * `host_access(none)`
-* `init_mode(reprogram)`
-* `init_mode(reset)`
-* `implement_in_csr(true)`
-* `implement_in_csr(false)`
 
 Steps:
 

--- a/tests/extension/oneapi_device_global/device_global_api_basic.cpp
+++ b/tests/extension/oneapi_device_global/device_global_api_basic.cpp
@@ -416,8 +416,7 @@ void run_tests(sycl_cts::util::logger& log, const std::string& type_name) {
   {
     using prop_key = host_access_key;
     using prop_value = host_access_key::value_t<host_access_enum::read>;
-    using other_props =
-        type_pack<device_image_scope_key, init_mode_key, implement_in_csr_key>;
+    using other_props = type_pack<device_image_scope_key>;
 
     has_property_method::run_test<T, prop_key, prop_value, other_props>(
         log, type_name);
@@ -425,26 +424,7 @@ void run_tests(sycl_cts::util::logger& log, const std::string& type_name) {
   {
     using prop_key = device_image_scope_key;
     using prop_value = device_image_scope_key::value_t;
-    using other_props =
-        type_pack<host_access_key, init_mode_key, implement_in_csr_key>;
-
-    has_property_method::run_test<T, prop_key, prop_value, other_props>(
-        log, type_name);
-  }
-  {
-    using prop_key = init_mode_key;
-    using prop_value = init_mode_key::value_t<init_mode_enum::reprogram>;
-    using other_props = type_pack<host_access_key, device_image_scope_key,
-                                  implement_in_csr_key>;
-
-    has_property_method::run_test<T, prop_key, prop_value, other_props>(
-        log, type_name);
-  }
-  {
-    using prop_key = implement_in_csr_key;
-    using prop_value = implement_in_csr_key::value_t<true>;
-    using other_props =
-        type_pack<host_access_key, device_image_scope_key, init_mode_key>;
+    using other_props = type_pack<host_access_key>;
 
     has_property_method::run_test<T, prop_key, prop_value, other_props>(
         log, type_name);
@@ -458,13 +438,8 @@ void run_tests(sycl_cts::util::logger& log, const std::string& type_name) {
     get_property_method::run_test<T, prop_key, prop_value>(log, type_name);
   }
   {
-    using prop_key = init_mode_key;
-    using prop_value = init_mode_key::value_t<init_mode_enum::reprogram>;
-    get_property_method::run_test<T, prop_key, prop_value>(log, type_name);
-  }
-  {
-    using prop_key = implement_in_csr_key;
-    using prop_value = implement_in_csr_key::value_t<true>;
+    using prop_key = device_image_scope_key;
+    using prop_value = device_image_scope_key::value_t;
     get_property_method::run_test<T, prop_key, prop_value>(log, type_name);
   }
 

--- a/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_one_kernel.cpp
@@ -179,31 +179,6 @@ void run_tests_with_properties(sycl_cts::util::logger& log,
                  host_access<host_access_enum::none>}),
              property_tag::host_access_none>(log, type_name);
   }
-
-  {
-    using oneapi::experimental::init_mode;
-    using oneapi::experimental::init_mode_enum;
-    // Run with different init_mode properies
-    run_test<T,
-             decltype(oneapi::experimental::properties{
-                 init_mode<init_mode_enum::reprogram>}),
-             property_tag::init_mode_trig_reprogram>(log, type_name);
-    run_test<T,
-             decltype(oneapi::experimental::properties{
-                 init_mode<init_mode_enum::reset>}),
-             property_tag::init_mode_trig_reset>(log, type_name);
-  }
-
-  {
-    using oneapi::experimental::implement_in_csr;
-    // Run with different implement_in_csr properies
-    run_test<T,
-             decltype(oneapi::experimental::properties{implement_in_csr<true>}),
-             property_tag::impl_in_csr_true>(log, type_name);
-    run_test<
-        T, decltype(oneapi::experimental::properties{implement_in_csr<false>}),
-        property_tag::impl_in_csr_false>(log, type_name);
-  }
 }
 
 }  // namespace one_kernel_multiple_times

--- a/tests/extension/oneapi_properties/properties_different_order.cpp
+++ b/tests/extension/oneapi_properties/properties_different_order.cpp
@@ -35,8 +35,10 @@ class TEST_NAME : public util::test_base {
 #else
     {
       using namespace sycl::ext::oneapi::experimental;
-      properties P1{implement_in_csr<true>, device_image_scope};
-      properties P2{device_image_scope, implement_in_csr<true>};
+      properties P1{host_access<host_access_enum::read_write>,
+                    device_image_scope};
+      properties P2{device_image_scope,
+                    host_access<host_access_enum::read_write>};
       if (!std::is_same_v<decltype(P1), decltype(P2)>)
         FAIL(log,
              "property lists initialized with different order are not the same "

--- a/tests/extension/oneapi_properties/properties_has_property.cpp
+++ b/tests/extension/oneapi_properties/properties_has_property.cpp
@@ -34,18 +34,12 @@ class TEST_NAME : public util::test_base {
 #else
     {
       using namespace sycl::ext::oneapi::experimental;
-      properties prop_list{device_image_scope, implement_in_csr<true>,
-                           host_access<host_access_enum::read>};
+      properties prop_list{device_image_scope};
 
       if (!prop_list.has_property<device_image_scope_key>())
         FAIL(log, "properties should have device_image_scope property");
-      if (!prop_list.has_property<implement_in_csr_key>())
-        FAIL(log, "properties should have implement_in_csr property");
-      if (!prop_list.has_property<host_access_key>())
-        FAIL(log, "properties should have host_access property");
-
-      if (prop_list.has_property<init_mode_key>())
-        FAIL(log, "properties shouldn't have init_mode property");
+      if (prop_list.has_property<host_access_key>())
+        FAIL(log, "properties shouldn't have host_access property");
     }
 #endif
   }

--- a/tests/extension/oneapi_properties/properties_is_device_copyable.cpp
+++ b/tests/extension/oneapi_properties/properties_is_device_copyable.cpp
@@ -60,23 +60,6 @@ class TEST_NAME : public util::test_base {
         FAIL(log,
              "is_device_copyable_v for host_access<host_access_enum::none> is "
              "not true");
-      if (!sycl::is_device_copyable_v<decltype(
-              init_mode<init_mode_enum::reprogram>)>)
-        FAIL(log,
-             "is_device_copyable_v for init_mode<init_mode_enum::reprogram is "
-             "not "
-             "true");
-      if (!sycl::is_device_copyable_v<decltype(
-              init_mode<init_mode_enum::reset>)>)
-        FAIL(log,
-             "is_device_copyable_v for init_mode<init_mode_enum::reset is not "
-             "true");
-      if (!sycl::is_device_copyable_v<decltype(implement_in_csr<true>)>)
-        FAIL(log,
-             "is_device_copyable_v for implement_in_csr<true> is not true");
-      if (!sycl::is_device_copyable_v<decltype(implement_in_csr<false>)>)
-        FAIL(log,
-             "is_device_copyable_v for implement_in_csr<false> is not true");
 
       // is_device_copyable for empty properties
       properties prop_list1{};
@@ -85,7 +68,8 @@ class TEST_NAME : public util::test_base {
 
       // is_device_copyable for properties with only compile-time-constant
       // properties
-      properties prop_list2{implement_in_csr<true>, device_image_scope};
+      properties prop_list2{host_access<host_access_enum::read_write>,
+                            device_image_scope};
       if (!sycl::is_device_copyable_v<decltype(prop_list2)>)
         FAIL(log,
              "is_device_copyable_v for properties with only "

--- a/tests/extension/oneapi_properties/properties_is_property_list.cpp
+++ b/tests/extension/oneapi_properties/properties_is_property_list.cpp
@@ -36,7 +36,8 @@ class TEST_NAME : public util::test_base {
 #else
     {
       using namespace sycl::ext::oneapi::experimental;
-      properties prop_list{device_image_scope, implement_in_csr<true>};
+      properties prop_list{device_image_scope,
+                           host_access<host_access_enum::read_write>};
 
       if (!std::is_base_of_v<std::true_type,
                              is_property_list<decltype(prop_list)>>)

--- a/tests/extension/oneapi_properties/properties_prop_eq_op.cpp
+++ b/tests/extension/oneapi_properties/properties_prop_eq_op.cpp
@@ -38,27 +38,23 @@ class TEST_NAME : public util::test_base {
       constexpr auto prop_value_device_image_scope =
           props.get_property<device_image_scope_key>();
 
-      properties props2{implement_in_csr<true>};
-      constexpr auto prop_value_implement_in_csr_true =
-          props2.get_property<implement_in_csr_key>();
+      properties props2{host_access<host_access_enum::read>};
+      constexpr auto prop_value_host_access_read =
+          props2.get_property<host_access_key>();
 
-      properties props3{implement_in_csr<false>};
-      constexpr auto prop_value_implement_in_csr_false =
-          props3.get_property<implement_in_csr_key>();
+      properties props3{host_access<host_access_enum::write>};
+      constexpr auto prop_value_host_access_write =
+          props3.get_property<host_access_key>();
 
       CHECK(prop_value_device_image_scope == prop_value_device_image_scope);
       CHECK_FALSE(prop_value_device_image_scope !=
                   prop_value_device_image_scope);
 
-      CHECK(prop_value_implement_in_csr_true ==
-            prop_value_implement_in_csr_true);
-      CHECK_FALSE(prop_value_implement_in_csr_true !=
-                  prop_value_implement_in_csr_true);
+      CHECK(prop_value_host_access_read == prop_value_host_access_read);
+      CHECK_FALSE(prop_value_host_access_read != prop_value_host_access_read);
 
-      CHECK_FALSE(prop_value_implement_in_csr_true ==
-                  prop_value_implement_in_csr_false);
-      CHECK(prop_value_implement_in_csr_true !=
-            prop_value_implement_in_csr_false);
+      CHECK_FALSE(prop_value_host_access_read == prop_value_host_access_write);
+      CHECK(prop_value_host_access_read != prop_value_host_access_write);
     }
 #endif
   }


### PR DESCRIPTION
FPGA features including these two fpga-specific properties have been removed from DPCPP, see https://github.com/intel/llvm/issues/16929

In some tests replaced `implement_in_csr_v` usages with `host_access` property to keep the coverage (where it doesn't matter which property to use).

Updated test plan documentation as well, with some minor renamings which were supposed to be done in scope of ca1898f11488987b6480e131a3345b33a1822eb2