### PR TITLE
Value-initialize marray to avoid undefined behavior.

### DIFF
--- a/tests/marray_basic/marray_constructor.h
+++ b/tests/marray_basic/marray_constructor.h
@@ -48,7 +48,7 @@ class run_marray_constructor_test {
   static void run_checks(IteratorT results) {
     // default constructor
     {
-      marray_t ma;
+      marray_t ma{};
       *(results++) = value_operations::are_equal(ma, DataT{});
     }
 


### PR DESCRIPTION
sycl::marray default constructor check has undefined behavior.
marray is default-initialized, which means that elements of marray is
also default-initialized. For element data type like `int`
default-initialized value with automatic storage produces indeterminate
value. The check compares marray elements with value-initialized object
(i.e. with `0` for `int` data type). Using indetermiate values in
compare operation causes undefined behavior.

The issue is exposed by recent change in DPC++ implementation, which
switched marray elements initialization in default constructor from
value-initialization to default-initialization.
https://github.com/intel/llvm/commit/ba4f090bff414537ee4f7c91ed15fcc70ba12739

See
https://en.cppreference.com/w/cpp/language/default_initialization.html
for more details.