### PR TITLE
Fix `operator[]` call in `accessor_requisite_entire_buffer.cpp`

### DIFF
--- a/tests/accessor_basic/accessor_requisite_entire_buffer.cpp
+++ b/tests/accessor_basic/accessor_requisite_entire_buffer.cpp
@@ -73,7 +73,7 @@ TEST_CASE("requisite for the entire underlying buffer for sycl::accessor ",
           data_buf, cgh, sycl::range<1>(1), sycl::id<1>(offset_size));
       cgh.single_task<class kernel_check>([=] {
         *check_data = accessor_tests_common::changed_val;
-        auto v = acc[offset_size];
+        auto v = acc[0];
       });
     });
     q.wait_and_throw();


### PR DESCRIPTION
This test case creates a ranged accessor with an offset of 7. The `operator[]` member function for ranged accessors adds the offset to the index parameter. Calling the operator with an index of 7 exceeds the accessor's range and the buffer size. This PR changes the index to 0 so that the reference is to the buffer's 8th element.