### PR TITLE
Change `#ifdef` to `#if` in `address_space_core.cpp`

### DIFF
--- a/tests/address_space/address_space_core.cpp
+++ b/tests/address_space/address_space_core.cpp
@@ -65,7 +65,7 @@ class TEST_NAME : public sycl_cts::util::test_base {
     test_types<std::uint64_t>(log);
 #endif
 
-#ifdef SYCL_CTS_SYCL_NEXT_TESTS
+#if SYCL_CTS_SYCL_NEXT_TESTS
 #if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP && \
     !SYCL_CTS_COMPILING_WITH_SIMSYCL && !SYCL_CTS_COMPILING_WITH_DPCPP
     // Tests are disabled because none of the implementations support them yet.


### PR DESCRIPTION
Use `#if` instead `#ifdef` to check the `SYCL_CTS_SYCL_NEXT_TESTS` CTS option. This change ensures the condition has the intended meaning when the macro is defined as 0. It also matches how we check other CTS options like `SYCL_CTS_ENABLE_FULL_CONFORMANCE`.