### PR TITLE
Use `parallel_for` in test with local accessors

### DIFF
--- a/tests/vector_load_store/generate_vector_load_store.py
+++ b/tests/vector_load_store/generate_vector_load_store.py
@@ -170,7 +170,7 @@ private_multi_ptr_load_store_test_template = Template(
             sycl::local_accessor<${type}> swizzleInLocalPtr${type_as_str}${size}(${size}, cgh);
             sycl::local_accessor<${type}> swizzleOutLocalPtr${type_as_str}${size}(${size}, cgh);
 
-            cgh.single_task<class ${kernelName}>([=]() {
+            cgh.parallel_for<class ${kernelName}>(sycl::nd_range<1>(sycl::range<1>(1), sycl::range<1>(1)), [=](sycl::nd_item<1>) {
               ${type} inPrivatePtr${type_as_str}${size}[${size}];
               ${type} outPrivatePtr${type_as_str}${size}[${size}];
 


### PR DESCRIPTION
Local accessors must not be used with kernels invoked using `single_task`. This commit changes the vector test generator to use `parallel_for` with an ND-range parameter instead.