### PR TITLE
Remove `[[noreturn]]` attribute from functions that return

### DIFF
--- a/tests/sycl_external/sycl_external.cpp
+++ b/tests/sycl_external/sycl_external.cpp
@@ -87,11 +87,11 @@ class kernel_before_aspect {
 };
 
 template <sycl::aspect aspect>
-[[sycl::device_has(aspect)]] SYCL_EXTERNAL [[noreturn]] void
-between_aspects_device(const accT& acc);
+[[sycl::device_has(aspect)]] SYCL_EXTERNAL void between_aspects_device(
+    const accT& acc);
 template <sycl::aspect aspect>
-[[sycl::device_has(aspect)]] SYCL_EXTERNAL [[noreturn]] void
-between_aspects_host(hostAccT& acc);
+[[sycl::device_has(aspect)]] SYCL_EXTERNAL void between_aspects_host(
+    hostAccT& acc);
 template <int TestCase, sycl::aspect aspect>
 class kernel_between_aspects {
   accT acc;


### PR DESCRIPTION
This commit removes the `[[noreturn]]` attribute from the `SYCL_EXTERNAL` function declarations to avoid undefined behavior since the function definitions return.