### PR TITLE
Use `std::remove_reference_t` in reducer tests

### DIFF
--- a/tests/reduction/reducer_api.h
+++ b/tests/reduction/reducer_api.h
@@ -179,9 +179,9 @@ struct check_reducer_subscript {
                 // OperatorT is sycl::plus, so checking the result of += member
                 // function
                 auto& res_plus = reducer[0] += val;
-                acc_results[i++] =
-                    std::is_same_v<std::remove_reference_t<decltype(res_plus)>,
-                                   std::remove_reference_t<decltype(reducer[0])>>;
+                acc_results[i++] = std::is_same_v<
+                    std::remove_reference_t<decltype(res_plus)>,
+                    std::remove_reference_t<decltype(reducer[0])>>;
               }
 
               assert(i == result_count);


### PR DESCRIPTION
The return type of `reducer::operator[]` is unspecified in SYCL. This commit updates the test so that it passes in cases where the implementation returns a reference type.