### PR TITLE
Fix check for exceptions with a `what_arg`

### DIFF
--- a/tests/exception_handling/synchronous_exceptions.cpp
+++ b/tests/exception_handling/synchronous_exceptions.cpp
@@ -66,7 +66,8 @@ void check_exception_api(util::logger &log) {
   } catch (const custom_exception &e) {
     log_exception(log, e);
 
-    if (e.what() != custom_exception::reference::what()) {
+    if (std::string{e.what()}.find(custom_exception::reference::what()) ==
+        std::string::npos) {
       FAIL(log, "invalid value for what()");
     }
     if (e.code() != custom_exception::reference::code()) {


### PR DESCRIPTION
The SYCL specification requires the string returned by `what()` contain the `what_arg` as a substring. This commit updates the test to check the same condition. 