### PR TITLE
Placeholder should be used for link executable

### DIFF
--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -89,7 +89,9 @@ set_target_properties(DPCPP::Runtime PROPERTIES
 
 set(CMAKE_CXX_COMPILER ${DPCPP_CXX_EXECUTABLE})
 # Use DPC++ compiler instead of default linker for building SYCL application
-set(CMAKE_CXX_LINK_EXECUTABLE "${DPCPP_CXX_EXECUTABLE} <FLAGS> <OBJECTS> -o <TARGET> \
+# Using the placeholder syntax as otherwise cmake won't expand this as a placeholder.
+# Which in the case of cross-compilation would bypass setting --target or --sysroot.
+set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <FLAGS> <OBJECTS> -o <TARGET> \
     <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <LINK_LIBRARIES>")
 
 function(add_sycl_to_target)


### PR DESCRIPTION
When setting the dpcpp executable directly it bypasses any additional flags which cmake would set. For example, this currently prevents cmake from setting `--target=` when cross-compiling the SYCL-CTS. Since `CMAKE_CXX_COMPILER` is already set to `DPCPP_CXX_EXECUTABLE` this will have the same desired effect.