### PR TITLE
test_oneapi_device_global_unique...: use the device filter

### DIFF
--- a/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
+++ b/tests/extension/oneapi_device_global/device_global_functional_unique_for_every_device.cpp
@@ -11,6 +11,7 @@
 *******************************************************************************/
 
 #include "../../common/common.h"
+#include "../../common/cts_selector.h"
 #include "../../common/type_coverage.h"
 #include "device_global_common.h"
 #include "type_pack.h"
@@ -134,6 +135,8 @@ void run_test(util::logger& log, const std::string& type_name) {
   for (auto& platform : platforms) {
     auto cur_platform_devices = platform.get_devices();
     for (const auto& device : cur_platform_devices) {
+      // Respect the device filter
+      if (cts_selector(device) < 0) continue;
       // Try to partition device into subdevices
       auto subdevices = try_to_get_sub_devices(device);
       if (subdevices.size() > 1) {


### PR DESCRIPTION
device_global_functional_unique_for_every_device has its own logic to select (2) devices, but it does not apply the regex filtering used by other tests (`--device` command line option). This PR adds the filtering to the test, by calling `cts_selector` and checking for a negative return value before considering to use a device.