### PR TITLE
Disambiguate `nextafter`

### DIFF
--- a/util/math_reference.cpp
+++ b/util/math_reference.cpp
@@ -519,7 +519,8 @@ sycl::half fdim(sycl::half a, sycl::half b) {
     double resd = static_cast<double>(a) - static_cast<double>(b);
     sycl::half res = static_cast<sycl::half>(resd);
     double diff = resd - static_cast<double>(res);
-    sycl::half next = nextafter(res, static_cast<sycl::half>(DBL_MAX * diff));
+    sycl::half next =
+        reference::nextafter(res, static_cast<sycl::half>(DBL_MAX * diff));
     if (static_cast<double>(next) - resd == diff) {
       int16_t rep;
       type_punn(next, rep);
@@ -532,7 +533,8 @@ sycl::half fdim(sycl::half a, sycl::half b) {
 
 sycl::half fract(sycl::half a, sycl::half* b) {
   *b = std::floor(a);
-  return std::fmin(a - *b, nextafter(sycl::half(1.0), sycl::half(0.0)));
+  return std::fmin(a - *b,
+                   reference::nextafter(sycl::half(1.0), sycl::half(0.0)));
 }
 
 sycl::half nan(unsigned short a) { return nan(unsigned(a)); }


### PR DESCRIPTION
Argument-dependent lookup makes the call ambiguous since the `sycl::half` argument is defined in the `sycl` namespace. This PR changes the reference definitions to call the other reference definitions.