### PR TITLE
Skip kernel bundle tests when `online_compiler` not available

### DIFF
--- a/tests/kernel_bundle/kernel_bundle_spec_const.cpp
+++ b/tests/kernel_bundle/kernel_bundle_spec_const.cpp
@@ -47,6 +47,10 @@ TEST_CASE(
   sycl::queue queue = sycl_cts::util::get_cts_object::queue();
   sycl::context ctx = queue.get_context();
 
+  if (!device.has(sycl::aspect::online_compiler)) {
+    SKIP("Device does not support online compilation");
+  }
+
   using KernelName = class simple_kernel;
 
   queue.submit([&](sycl::handler& cgh) {

--- a/tests/kernel_bundle/sycl_build_verify_prop_list_existence.cpp
+++ b/tests/kernel_bundle/sycl_build_verify_prop_list_existence.cpp
@@ -32,6 +32,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     auto q = util::get_cts_object::queue();
 
+    if (!q.get_device().has(sycl::aspect::online_compiler)) {
+      SKIP("Device does not support online compilation");
+    }
+
     using kernel = simple_kernel_descriptor::type;
     const auto first_simple_kernel_id = sycl::get_kernel_id<kernel>();
 

--- a/tests/kernel_bundle/sycl_build_zero_device.cpp
+++ b/tests/kernel_bundle/sycl_build_zero_device.cpp
@@ -36,6 +36,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     auto q = util::get_cts_object::queue();
 
+    if (!q.get_device().has(sycl::aspect::online_compiler)) {
+      SKIP("Device does not support online compilation");
+    }
+
     std::vector<sycl::device> zero_device;
     const auto first_simple_kernel_id =
         sycl::get_kernel_id<first_simple_kernel>();

--- a/tests/kernel_bundle/sycl_join_kernel_bundle_with_empty_one.cpp
+++ b/tests/kernel_bundle/sycl_join_kernel_bundle_with_empty_one.cpp
@@ -76,8 +76,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger &log) override {
     // Execute tests for all sycl::bundle_states
-    run_verification<sycl::bundle_state::input>(log);
-    run_verification<sycl::bundle_state::object>(log);
+    if (util::get_cts_object::device().has(sycl::aspect::online_compiler))
+      run_verification<sycl::bundle_state::input>(log);
+    if (util::get_cts_object::device().has(sycl::aspect::online_linker))
+      run_verification<sycl::bundle_state::object>(log);
     run_verification<sycl::bundle_state::executable>(log);
   }
 };

--- a/tests/kernel_bundle/sycl_join_single_kernel_bundle.cpp
+++ b/tests/kernel_bundle/sycl_join_single_kernel_bundle.cpp
@@ -69,8 +69,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
    */
   void run(util::logger &log) override {
     // Execute tests for all sycl::bundle_states
-    run_verification<sycl::bundle_state::input>(log);
-    run_verification<sycl::bundle_state::object>(log);
+    if (util::get_cts_object::device().has(sycl::aspect::online_compiler))
+      run_verification<sycl::bundle_state::input>(log);
+    if (util::get_cts_object::device().has(sycl::aspect::online_linker))
+      run_verification<sycl::bundle_state::object>(log);
     run_verification<sycl::bundle_state::executable>(log);
   }
 };

--- a/tests/kernel_bundle/sycl_link_verify_prop_list_existence.cpp
+++ b/tests/kernel_bundle/sycl_link_verify_prop_list_existence.cpp
@@ -33,6 +33,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     auto q = util::get_cts_object::queue();
 
+    if (!q.get_device().has(sycl::aspect::online_linker)) {
+      SKIP("Device does not support online linker aspect");
+    }
+
     const auto first_simple_kernel_id =
         sycl::get_kernel_id<first_simple_kernel>();
 

--- a/tests/kernel_bundle/sycl_link_zero_device.cpp
+++ b/tests/kernel_bundle/sycl_link_zero_device.cpp
@@ -36,6 +36,10 @@ class TEST_NAME : public sycl_cts::util::test_base {
   void run(util::logger &log) override {
     auto q = util::get_cts_object::queue();
 
+    if (!q.get_device().has(sycl::aspect::online_linker)) {
+      SKIP("Device does not support online linker aspect");
+    }
+
     const auto first_simple_kernel_id =
         sycl::get_kernel_id<first_simple_kernel>();
 

--- a/tests/kernel_bundle/use_kernel_bundle_verify_that_kernel_was_invoked.cpp
+++ b/tests/kernel_bundle/use_kernel_bundle_verify_that_kernel_was_invoked.cpp
@@ -40,6 +40,10 @@ void invoke_kernel_and_verify_invocation(util::logger& log,
   sycl::queue queue(ctx, ctx.get_devices()[0]);
   bool flags[] = {false, false};
 
+  if (!queue.get_device().has(sycl::aspect::online_compiler)) {
+    SKIP("Device does not support online compiler aspect");
+  }
+
   {
     sycl::buffer<bool> flag_buffer{flags, sycl::range<1>{2}};
     queue.submit([&](sycl::handler& cgh) {


### PR DESCRIPTION
According to section 4.11.7 of the SYCL 2020 specification, certain calls to `get_kernel_bundle` throw `errc::invalid` when a device does not have `aspect::online_compiler` or `aspect::online_linker`. This change updates certain kernel bundle tests to skip if the device does not have the required aspects.