### PR TITLE
Prevent CI tests from being skipped

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -206,7 +206,7 @@ jobs:
 
   run-cts:
     needs: cts-compiles-for-all-implementations
-    if: needs.cts-compiles-for-all-implementations.result == 'success'
+    if: always() && !cancelled() && needs.cts-compiles-for-all-implementations.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -206,6 +206,7 @@ jobs:
 
   run-cts:
     needs: cts-compiles-for-all-implementations
+    # This expression ensures the job runs even when other jobs are skipped.
     if: always() && !cancelled() && needs.cts-compiles-for-all-implementations.result == 'success'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
GitHub Actions default to checking `success()` in `if` conditionals unless the expression includes another status check function. This change ensures that the `run-cts` job always runs, even when upstream jobs for building container images are skipped.