### PR TITLE
Move `CMAKE_CXX_STANDARD` to implementation CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(sycl_cts LANGUAGES CXX)
 
-if(SYCL_IMPLEMENTATION STREQUAL SimSYCL)
-    set(CMAKE_CXX_STANDARD 20)
-elseif(SYCL_IMPLEMENTATION STREQUAL ProtoSYCL)
-    set(CMAKE_CXX_STANDARD 23)
-else()
-    set(CMAKE_CXX_STANDARD 17)
-endif()
-
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON) # Required for hex floats in C++11 mode on gcc 6+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 

--- a/cmake/AdaptAdaptiveCpp.cmake
+++ b/cmake/AdaptAdaptiveCpp.cmake
@@ -1,3 +1,4 @@
+set(SYCL_IMPLEMENTATION_CXX_STANDARD 17)
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SYCL::SYCL INTERFACE AdaptiveCpp::acpp-rt)
 # add_sycl_executable_implementation function

--- a/cmake/AdaptAdaptiveCpp.cmake
+++ b/cmake/AdaptAdaptiveCpp.cmake
@@ -1,4 +1,4 @@
-set(SYCL_IMPLEMENTATION_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SYCL::SYCL INTERFACE AdaptiveCpp::acpp-rt)
 # add_sycl_executable_implementation function

--- a/cmake/AdaptDPCPP.cmake
+++ b/cmake/AdaptDPCPP.cmake
@@ -1,3 +1,4 @@
+set(SYCL_IMPLEMENTATION_CXX_STANDARD 17)
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SYCL::SYCL INTERFACE DPCPP::Runtime)
 # add_sycl_executable_implementation function

--- a/cmake/AdaptDPCPP.cmake
+++ b/cmake/AdaptDPCPP.cmake
@@ -1,4 +1,4 @@
-set(SYCL_IMPLEMENTATION_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SYCL::SYCL INTERFACE DPCPP::Runtime)
 # add_sycl_executable_implementation function

--- a/cmake/AdaptProtoSYCL.cmake
+++ b/cmake/AdaptProtoSYCL.cmake
@@ -1,4 +1,4 @@
-set(SYCL_IMPLEMENTATION_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 23)
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SYCL::SYCL INTERFACE ProtoSYCL)
 # add_sycl_executable_implementation function

--- a/cmake/AdaptProtoSYCL.cmake
+++ b/cmake/AdaptProtoSYCL.cmake
@@ -1,3 +1,4 @@
+set(SYCL_IMPLEMENTATION_CXX_STANDARD 23)
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SYCL::SYCL INTERFACE ProtoSYCL)
 # add_sycl_executable_implementation function

--- a/cmake/AdaptSimSYCL.cmake
+++ b/cmake/AdaptSimSYCL.cmake
@@ -1,3 +1,4 @@
+set(SYCL_IMPLEMENTATION_CXX_STANDARD 20)
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SYCL::SYCL INTERFACE SimSYCL::simsycl)
 # add_sycl_executable_implementation function

--- a/cmake/AdaptSimSYCL.cmake
+++ b/cmake/AdaptSimSYCL.cmake
@@ -1,4 +1,4 @@
-set(SYCL_IMPLEMENTATION_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 20)
 add_library(SYCL::SYCL INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SYCL::SYCL INTERFACE SimSYCL::simsycl)
 # add_sycl_executable_implementation function

--- a/cmake/AddSYCLExecutable.cmake
+++ b/cmake/AddSYCLExecutable.cmake
@@ -20,7 +20,19 @@ find_file(SYCL_IMPLEMENTATION_ADAPTER
   Adapt${SYCL_IMPLEMENTATION}.cmake
   PATHS ${CMAKE_MODULE_PATH}
 )
+set(SYCL_IMPLEMENTATION_CXX_STANDARD "" CACHE INTERNAL "")
 include("${SYCL_IMPLEMENTATION_ADAPTER}")
+
+if (NOT SYCL_IMPLEMENTATION_CXX_STANDARD MATCHES "^[0-9]+$")
+    message(FATAL_ERROR
+        "The SYCL CTS requires the SYCL implementation to set the C++ standard "
+        "to be used for compiling SYCL code. The CMake variable "
+        "SYCL_IMPLEMENTATION_CXX_STANDARD should be set to a valid CMake "
+        "CXX_STANDARD value (e.g. 17, 20, etc.)"
+    )
+endif()
+set(CMAKE_CXX_STANDARD ${SYCL_IMPLEMENTATION_CXX_STANDARD})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT TARGET SYCL::SYCL)
     message(FATAL_ERROR

--- a/cmake/AddSYCLExecutable.cmake
+++ b/cmake/AddSYCLExecutable.cmake
@@ -20,18 +20,12 @@ find_file(SYCL_IMPLEMENTATION_ADAPTER
   Adapt${SYCL_IMPLEMENTATION}.cmake
   PATHS ${CMAKE_MODULE_PATH}
 )
-set(SYCL_IMPLEMENTATION_CXX_STANDARD "" CACHE INTERNAL "")
 include("${SYCL_IMPLEMENTATION_ADAPTER}")
 
-if (NOT SYCL_IMPLEMENTATION_CXX_STANDARD MATCHES "^[0-9]+$")
-    message(FATAL_ERROR
-        "The SYCL CTS requires the SYCL implementation to set the C++ standard "
-        "to be used for compiling SYCL code. The CMake variable "
-        "SYCL_IMPLEMENTATION_CXX_STANDARD should be set to a valid CMake "
-        "CXX_STANDARD value (e.g. 17, 20, etc.)"
-    )
+# Default to C++17 if the SYCL implementation does not specify a C++ standard version.
+if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
 endif()
-set(CMAKE_CXX_STANDARD ${SYCL_IMPLEMENTATION_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT TARGET SYCL::SYCL)


### PR DESCRIPTION
This changes upates the CMake files to enable each SYCL implementation to choose a required C++ standard.