### PR TITLE
Fix invalid reqd_work_group_size in kernel_features_reqd_work_group_size.cpp

### DIFF
--- a/tests/optional_kernel_features/CMakeLists.txt
+++ b/tests/optional_kernel_features/CMakeLists.txt
@@ -1,5 +1,3 @@
 file(GLOB test_cases_list *.cpp)
 
-add_compile_options(-Wno-implicitly-unsigned-literal)
-
 add_cts_test(${test_cases_list})

--- a/tests/optional_kernel_features/CMakeLists.txt
+++ b/tests/optional_kernel_features/CMakeLists.txt
@@ -1,3 +1,5 @@
 file(GLOB test_cases_list *.cpp)
 
+add_compile_options(-Wno-implicitly-unsigned-literal)
+
 add_cts_test(${test_cases_list})

--- a/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
+++ b/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
@@ -31,32 +31,34 @@ namespace kernel_features_reqd_work_group_size {
 using namespace sycl_cts;
 using namespace kernel_features_common;
 
-template <size_t N, int Dimensions>
+template <size_t N0, size_t N1, size_t N2, int Dimensions>
 class Functor {
  public:
-  [[sycl::reqd_work_group_size(N)]] void operator()(sycl::nd_item<1>) const {}
-  [[sycl::reqd_work_group_size(N)]] void operator()(sycl::group<1>) const {}
+  [[sycl::reqd_work_group_size(N0)]] void operator()(sycl::nd_item<1>) const {}
+  [[sycl::reqd_work_group_size(N0)]] void operator()(sycl::group<1>) const {}
 
-  [[sycl::reqd_work_group_size(N, N)]] void operator()(sycl::nd_item<2>) const {
-  }
-  [[sycl::reqd_work_group_size(N, N)]] void operator()(sycl::group<2>) const {}
+  [[sycl::reqd_work_group_size(N0, N1)]] void operator()(
+      sycl::nd_item<2>) const {}
+  [[sycl::reqd_work_group_size(N0, N1)]] void operator()(
+      sycl::group<2>) const {}
 
-  [[sycl::reqd_work_group_size(N, N, N)]] void operator()(
+  [[sycl::reqd_work_group_size(N0, N1, N2)]] void operator()(
       sycl::nd_item<3>) const {}
-  [[sycl::reqd_work_group_size(N, N, N)]] void operator()(
+  [[sycl::reqd_work_group_size(N0, N1, N2)]] void operator()(
       sycl::group<3>) const {}
 };
 
-template <size_t N, int Dimensions>
+template <size_t N0, size_t N1, size_t N2, int Dimensions>
 class kernel_reqd_wg_size;
 
 // FIXME: re-enable when max_work_item_sizes is implemented in adaptivecpp and
 // computcpp
 #if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
-template <size_t N, int Dimensions>
+template <size_t N0, size_t N1, size_t N2, int Dimensions>
 void test_size() {
-  INFO("N = " + std::to_string(N));
-  using kname = kernel_reqd_wg_size<N, Dimensions>;
+  INFO("N0 = " + std::to_string(N0) + ", N1 = " + std::to_string(N1) +
+       ", N2 = " + std::to_string(N2));
+  using kname = kernel_reqd_wg_size<N0, N1, N2, Dimensions>;
   auto queue = util::get_cts_object::queue();
   auto max_wg_size =
       queue.get_device().get_info<sycl::info::device::max_work_group_size>();
@@ -64,10 +66,12 @@ void test_size() {
       queue.get_device()
           .get_info<sycl::info::device::max_work_item_sizes<Dimensions>>();
 
-  bool is_exception_expected = (std::pow(N, Dimensions) > max_wg_size);
+  const size_t sizes[3] = {N0, N1, N2};
+
+  bool is_exception_expected = (N0 * N1 * N2 > max_wg_size);
 
   for (int i = 0; i < Dimensions; i++)
-    if (max_work_item_sizes[i] < N) is_exception_expected |= true;
+    if (max_work_item_sizes[i] < sizes[i]) is_exception_expected |= true;
 
   // Set expected error code
   constexpr sycl::errc expected_errc = sycl::errc::kernel_not_supported;
@@ -75,47 +79,47 @@ void test_size() {
   {
     if constexpr (Dimensions == 1) {
       const auto lambda_nd_item_arg_1D =
-          [](sycl::nd_item<1>) [[sycl::reqd_work_group_size(N)]] {};
+          [](sycl::nd_item<1>) [[sycl::reqd_work_group_size(N0)]] {};
       const auto lambda_group_arg_1D = [](sycl::group<1>)
-                                           [[sycl::reqd_work_group_size(N)]] {};
-      run_separate_lambda_nd_range<kname, N, Dimensions>(
+                                           [[sycl::reqd_work_group_size(N0)]] {};
+      run_separate_lambda_nd_range<kname, N0, Dimensions>(
           is_exception_expected, expected_errc, queue, lambda_nd_item_arg_1D,
           lambda_group_arg_1D);
     } else if constexpr (Dimensions == 2) {
       const auto lambda_nd_item_arg_2D =
-          [](sycl::nd_item<2>) [[sycl::reqd_work_group_size(N, N)]] {};
+          [](sycl::nd_item<2>) [[sycl::reqd_work_group_size(N0, N1)]] {};
       const auto lambda_group_arg_2D =
-          [](sycl::group<2>) [[sycl::reqd_work_group_size(N, N)]] {};
-      run_separate_lambda_nd_range<kname, N, Dimensions>(
+          [](sycl::group<2>) [[sycl::reqd_work_group_size(N0, N1)]] {};
+      run_separate_lambda_nd_range<kname, N0, Dimensions>(
           is_exception_expected, expected_errc, queue, lambda_nd_item_arg_2D,
           lambda_group_arg_2D);
     } else {
       const auto lambda_nd_item_arg_3D =
-          [](sycl::nd_item<3>) [[sycl::reqd_work_group_size(N, N, N)]] {};
+          [](sycl::nd_item<3>) [[sycl::reqd_work_group_size(N0, N1, N2)]] {};
       const auto lambda_group_arg_3D =
-          [](sycl::group<3>) [[sycl::reqd_work_group_size(N, N, N)]] {};
-      run_separate_lambda_nd_range<kname, N, Dimensions>(
+          [](sycl::group<3>) [[sycl::reqd_work_group_size(N0, N1, N2)]] {};
+      run_separate_lambda_nd_range<kname, N0, Dimensions>(
           is_exception_expected, expected_errc, queue, lambda_nd_item_arg_3D,
           lambda_group_arg_3D);
     }
   }
   {
-    run_functor_nd_range<Functor<N, Dimensions>, N, Dimensions>(
+    run_functor_nd_range<Functor<N0, N1, N2, Dimensions>, N0, Dimensions>(
         is_exception_expected, expected_errc, queue);
   }
   {
     if constexpr (Dimensions == 1) {
       RUN_SUBMISSION_CALL_ND_RANGE(
-          N, Dimensions, is_exception_expected, expected_errc, queue,
-          [[sycl::reqd_work_group_size(N)]], kname, NO_KERNEL_BODY);
+          N0, Dimensions, is_exception_expected, expected_errc, queue,
+          [[sycl::reqd_work_group_size(N0)]], kname, NO_KERNEL_BODY);
     } else if constexpr (Dimensions == 2) {
       RUN_SUBMISSION_CALL_ND_RANGE(
-          N, Dimensions, is_exception_expected, expected_errc, queue,
-          [[sycl::reqd_work_group_size(N, N)]], kname, NO_KERNEL_BODY);
+          N0, Dimensions, is_exception_expected, expected_errc, queue,
+          [[sycl::reqd_work_group_size(N0, N1)]], kname, NO_KERNEL_BODY);
     } else {
       RUN_SUBMISSION_CALL_ND_RANGE(
-          N, Dimensions, is_exception_expected, expected_errc, queue,
-          [[sycl::reqd_work_group_size(N, N, N)]], kname, NO_KERNEL_BODY);
+          N0, Dimensions, is_exception_expected, expected_errc, queue,
+          [[sycl::reqd_work_group_size(N0, N1, N2)]], kname, NO_KERNEL_BODY);
     }
   }
 }
@@ -124,8 +128,10 @@ void test_size() {
 DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
 ("Exceptions thrown by [[reqd_work_group_size(N)]] with unsupported size",
  "[kernel_features]", ((int Dimensions), Dimensions), 1, 2, 3)({
-  test_size<4, Dimensions>();
-  test_size<4294967295, Dimensions>();
+  test_size<4, 4, 4, Dimensions>();
+  // Product of reqd_work_group_size elements should fit in range::size() return
+  // type size_t.
+  test_size<4294967295, 1, 1, Dimensions>();
 });
 
 }  // namespace kernel_features_reqd_work_group_size

--- a/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
+++ b/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
@@ -72,7 +72,9 @@ void test_size() {
 
   const size_t sizes[3] = {N0, N1, N2};
 
-  bool is_exception_expected = (N0 * N1 * N2 > max_wg_size);
+  bool is_exception_expected =
+      std::accumulate(sizes, sizes + Dimensions, (size_t)1,
+                      std::multiplies<size_t>()) > max_wg_size;
 
   for (int i = 0; i < Dimensions; i++)
     if (max_work_item_sizes[i] < sizes[i]) is_exception_expected |= true;

--- a/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
+++ b/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
@@ -26,6 +26,7 @@
 #include "catch2/catch_template_test_macros.hpp"
 #include "kernel_features_common.h"
 #include <cmath>
+#include <limits>
 
 namespace kernel_features_reqd_work_group_size {
 using namespace sycl_cts;
@@ -131,7 +132,7 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
   test_size<4, 4, 4, Dimensions>();
   // Product of reqd_work_group_size elements should fit in range::size() return
   // type size_t.
-  test_size<4294967295, 1, 1, Dimensions>();
+  test_size<std::numeric_limits<std::size_t>::max(), 1, 1, Dimensions>();
 });
 
 }  // namespace kernel_features_reqd_work_group_size

--- a/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
+++ b/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
@@ -57,6 +57,9 @@ class kernel_reqd_wg_size;
 #if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP
 template <size_t N0, size_t N1, size_t N2, int Dimensions>
 void test_size() {
+  // Product of reqd_work_group_size elements must fit in size_t.
+  static_assert(N0 <= std::numeric_limits<size_t>::max() / (N1 * N2),
+                "N0 * N1 * N2 must not overflow size_t");
   INFO("N0 = " + std::to_string(N0) + ", N1 = " + std::to_string(N1) +
        ", N2 = " + std::to_string(N2));
   using kname = kernel_reqd_wg_size<N0, N1, N2, Dimensions>;
@@ -131,8 +134,11 @@ DISABLED_FOR_TEMPLATE_TEST_CASE_SIG(AdaptiveCpp)
  "[kernel_features]", ((int Dimensions), Dimensions), 1, 2, 3)({
   test_size<4, 4, 4, Dimensions>();
   // Product of reqd_work_group_size elements should fit in range::size() return
-  // type size_t.
-  test_size<std::numeric_limits<std::size_t>::max(), 1, 1, Dimensions>();
+  // type size_t. Avoid large n0 in case backend takes long time to run.
+  constexpr size_t n0 = sizeof(size_t) == 8
+                            ? size_t{4294967296ull}
+                            : std::numeric_limits<size_t>::max();
+  test_size<n0, 1, 1, Dimensions>();
 });
 
 }  // namespace kernel_features_reqd_work_group_size

--- a/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
+++ b/tests/optional_kernel_features/kernel_features_reqd_work_group_size.cpp
@@ -39,8 +39,8 @@ class Functor {
 
   [[sycl::reqd_work_group_size(N0, N1)]] void operator()(
       sycl::nd_item<2>) const {}
-  [[sycl::reqd_work_group_size(N0, N1)]] void operator()(
-      sycl::group<2>) const {}
+  [[sycl::reqd_work_group_size(N0, N1)]] void operator()(sycl::group<2>) const {
+  }
 
   [[sycl::reqd_work_group_size(N0, N1, N2)]] void operator()(
       sycl::nd_item<3>) const {}
@@ -80,8 +80,8 @@ void test_size() {
     if constexpr (Dimensions == 1) {
       const auto lambda_nd_item_arg_1D =
           [](sycl::nd_item<1>) [[sycl::reqd_work_group_size(N0)]] {};
-      const auto lambda_group_arg_1D = [](sycl::group<1>)
-                                           [[sycl::reqd_work_group_size(N0)]] {};
+      const auto lambda_group_arg_1D =
+          [](sycl::group<1>) [[sycl::reqd_work_group_size(N0)]] {};
       run_separate_lambda_nd_range<kname, N0, Dimensions>(
           is_exception_expected, expected_errc, queue, lambda_nd_item_arg_1D,
           lambda_group_arg_1D);


### PR DESCRIPTION
Recently https://github.com/llvm/llvm-project/commit/6794e31e894d adds LLVM IR verification that product of reqd_work_group_size elements should not exceed uint64 max. The new rule make sense because SYCL 2020 spec (Secion 4.9.1.1, Table 79) defines range::size() as product of its dimensions and return type is size_t.

This PR fixes out-of-range reqd_work_group_size values in the test.