### PR TITLE
ci: Update docker + artefac actions

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -32,14 +32,14 @@ jobs:
         with:
           submodules: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build common base image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: docker/common
           push: true
@@ -67,14 +67,14 @@ jobs:
         with:
           submodules: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build SYCL container image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: docker/${{ matrix.sycl-impl }}
           push: true
@@ -174,7 +174,7 @@ jobs:
           sort --numeric-sort --reverse --output=build_times.log build_times.log
           echo "Total time: $( date --date=@$ELAPSED --utc '+%-Hh %-Mm %-Ss' )" >> build_times.log
       - name: Upload build times artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-times-${{ matrix.sycl-impl }}
           path: ${{ env.container-workspace }}/build/build_times.log
@@ -217,7 +217,7 @@ jobs:
       image: khronosgroup/sycl-cts-ci:${{ matrix.sycl-impl }}-${{ matrix.version }}
     steps:
       - name: Download test binaries artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: test-binaries-${{ matrix.sycl-impl }}
           path: ${{ env.container-workspace }}/bin


### PR DESCRIPTION
Bump both uses from v4 to v7 to silence the deprecation warning for the older action version's Node runtime.