### PR TITLE
Replace legacy cl_half4

### DIFF
--- a/tests/accessor_legacy/accessor_types_image_fp16.h
+++ b/tests/accessor_legacy/accessor_types_image_fp16.h
@@ -44,7 +44,8 @@ public:
     if (!availability::check(queue, log))
       return;
 
-    check_type<sycl::cl_half4>()(log, queue, "sycl::opencl::cl_half");
+    check_type<sycl::vec<sycl::opencl::cl_half, 4>>()(log, queue,
+                                                      "sycl::opencl::cl_half");
 
     queue.wait_and_throw();
   }


### PR DESCRIPTION
This type is not part of SYCL 2020.