### PR TITLE
Remove work_item scope from atomic_ref conformance

### DIFF
--- a/tests/atomic_ref/atomic_ref_common.h
+++ b/tests/atomic_ref/atomic_ref_common.h
@@ -217,11 +217,13 @@ inline auto get_memory_orders() {
 /**
  * @brief Factory function for getting type_pack with memory_scope values
  */
+// Note: sycl::memory_scope::work_item is intentionally excluded — the SYCL
+// working group clarified that using it with any sycl::atomic_ref operation
+// is undefined behaviour.
 inline auto get_memory_scopes() {
   static const auto memory_scopes =
-      value_pack<sycl::memory_scope, sycl::memory_scope::work_item,
-                 sycl::memory_scope::sub_group, sycl::memory_scope::work_group,
-                 sycl::memory_scope::device,
+      value_pack<sycl::memory_scope, sycl::memory_scope::sub_group,
+                 sycl::memory_scope::work_group, sycl::memory_scope::device,
                  sycl::memory_scope::system>::generate_named();
   return memory_scopes;
 }

--- a/tests/atomic_ref/atomic_ref_test_base.h
+++ b/tests/atomic_ref/atomic_ref_test_base.h
@@ -34,10 +34,12 @@ class atomic_ref_test {
   static constexpr sycl::memory_order memory_orders[] = {
       sycl::memory_order::relaxed, sycl::memory_order::acq_rel,
       sycl::memory_order::seq_cst};
+  // Note: sycl::memory_scope::work_item is intentionally excluded — the SYCL
+  // working group clarified that using it with any sycl::atomic_ref
+  // operation is undefined behaviour.
   static constexpr sycl::memory_scope memory_scopes[] = {
-      sycl::memory_scope::work_item, sycl::memory_scope::sub_group,
-      sycl::memory_scope::work_group, sycl::memory_scope::device,
-      sycl::memory_scope::system};
+      sycl::memory_scope::sub_group, sycl::memory_scope::work_group,
+      sycl::memory_scope::device, sycl::memory_scope::system};
   static constexpr sycl::memory_order memory_order_for_atomic_ref_obj =
       MemoryOrderT::value;
   static constexpr sycl::memory_scope memory_scope_for_atomic_ref_obj =


### PR DESCRIPTION
Per SYCL working group clarification, calling any atomic_ref operation with memory_scope::work_item is undefined behaviour. Drop work_item from the shared scope lists in atomic_ref_common.h and
atomic_ref_test_base.h so no atomic_ref subtest exercises this UB.