### PR TITLE
Add tests for nd_range default constructor

### DIFF
--- a/tests/nd_range/nd_range_constructors.cpp
+++ b/tests/nd_range/nd_range_constructors.cpp
@@ -18,6 +18,8 @@ enum class op_codes : size_t {
   ctor_move = 2,
   assign_copy = 3,
   assign_move = 4,
+  ctor_default = 5,
+  assign_to_default = 6,
   code_count
 };
 
@@ -31,6 +33,8 @@ static const std::array<std::string, error_count> error_strings{
     "nd_range with nd_range was not move constructed correctly",
     "nd_range with nd_range was not copy assigned correctly",
     "nd_range with nd_range was not move assigned correctly",
+    "nd_range was not default constructed correctly",
+    "default constructed nd_range was not assigned correctly",
 };
 
 template <op_codes Code, typename ResultArray>
@@ -89,10 +93,55 @@ sycl::nd_range<dim> get_nd_range(sycl::range<dim>& ls, sycl::range<dim>& gs) {
 template <int dim, bool with_offset, typename ResultArray>
 void check_by_value_semantics(ResultArray& result, sycl::range<dim>& ls,
                               sycl::range<dim>& gs) {
+  static_assert(std::is_default_constructible_v<sycl::nd_range<dim>>,
+                "nd_range must be default constructible");
+
   sycl::id<dim> offset = sycl_cts::util::get_cts_object::id<dim>::get(0, 0, 0);
   if constexpr (with_offset) {
     offset = get_offset<dim>();
   }
+
+  // A default constructed nd_range has the value 0 for each component of its
+  // global range, local range and offset. Note that get_group_range() is
+  // deliberately not queried, it would divide the global range by a local
+  // range of zeros.
+  const sycl::range<dim> zero_range =
+      sycl_cts::util::get_cts_object::range<dim>::get(0, 0, 0);
+  sycl::nd_range<dim> default_constructed;
+  for (int i = 0; i < dim; i++) {
+    set_success_operation<op_codes::ctor_default>(
+        result, default_constructed.get_global_range()[i] == 0);
+    set_success_operation<op_codes::ctor_default>(
+        result, default_constructed.get_local_range()[i] == 0);
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+    set_success_operation<op_codes::ctor_default>(
+        result, default_constructed.get_offset()[i] == 0);
+#endif
+  }
+  set_success_operation<op_codes::ctor_default>(
+      result,
+      default_constructed == sycl::nd_range<dim>(zero_range, zero_range));
+  set_success_operation<op_codes::ctor_default>(
+      result, default_constructed != sycl::nd_range<dim>(gs, ls));
+
+  // The default constructor allows an nd_range to be declared before the
+  // global and local ranges are known, so it has to be possible to assign a
+  // fully specified nd_range to a default constructed one afterwards.
+  sycl::nd_range<dim> assigned_to_default;
+  assigned_to_default = get_nd_range<dim, with_offset>(ls, gs);
+  for (int i = 0; i < dim; i++) {
+    set_success_operation<op_codes::assign_to_default>(
+        result, assigned_to_default.get_global_range()[i] == gs[i]);
+    set_success_operation<op_codes::assign_to_default>(
+        result, assigned_to_default.get_local_range()[i] == ls[i]);
+#if SYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS
+    set_success_operation<op_codes::assign_to_default>(
+        result, assigned_to_default.get_offset()[i] == offset[i]);
+#endif
+    set_success_operation<op_codes::assign_to_default>(
+        result, assigned_to_default.get_group_range()[i] == gs[i] / ls[i]);
+  }
+
   sycl::nd_range<dim> nd_range = get_nd_range<dim, with_offset>(ls, gs);
   for (int i = 0; i < dim; i++) {
     set_success_operation<op_codes::ctor_range>(

--- a/tests/nd_range/nd_range_constructors.cpp
+++ b/tests/nd_range/nd_range_constructors.cpp
@@ -93,13 +93,14 @@ sycl::nd_range<dim> get_nd_range(sycl::range<dim>& ls, sycl::range<dim>& gs) {
 template <int dim, bool with_offset, typename ResultArray>
 void check_by_value_semantics(ResultArray& result, sycl::range<dim>& ls,
                               sycl::range<dim>& gs) {
-  static_assert(std::is_default_constructible_v<sycl::nd_range<dim>>,
-                "nd_range must be default constructible");
-
   sycl::id<dim> offset = sycl_cts::util::get_cts_object::id<dim>::get(0, 0, 0);
   if constexpr (with_offset) {
     offset = get_offset<dim>();
   }
+
+#if !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP && !SYCL_CTS_COMPILING_WITH_PROTOSYCL
+  static_assert(std::is_default_constructible_v<sycl::nd_range<dim>>,
+                "nd_range must be default constructible");
 
   // A default constructed nd_range has the value 0 for each component of its
   // global range, local range and offset. Note that get_group_range() is
@@ -141,6 +142,8 @@ void check_by_value_semantics(ResultArray& result, sycl::range<dim>& ls,
     set_success_operation<op_codes::assign_to_default>(
         result, assigned_to_default.get_group_range()[i] == gs[i] / ls[i]);
   }
+#endif  // !SYCL_CTS_COMPILING_WITH_ADAPTIVECPP &&
+        // !SYCL_CTS_COMPILING_WITH_PROTOSYCL
 
   sycl::nd_range<dim> nd_range = get_nd_range<dim, with_offset>(ls, gs);
   for (int i = 0; i < dim; i++) {


### PR DESCRIPTION
KhronosGroup/SYCL-Docs#1043 adds a default constructor to nd_range, so that an nd_range can be declared before its global and local ranges are known, matching range and id which are already default constructible.

Extend the existing by-value semantics checks with:
 - a static_assert that nd_range is default constructible,
 - verification that every component of the global range, local range and offset of a default constructed nd_range is 0, and that it compares equal to an nd_range built from zero ranges,
 - verification that a fully specified nd_range can be assigned to a default constructed one.

get_group_range() is deliberately not queried on a default constructed nd_range, as that would divide the global range by a local range of zeros.