### PR TITLE
Update DPC++ version used in CI to 2026-08-27

### DIFF
--- a/.github/workflows/cts_ci.yml
+++ b/.github/workflows/cts_ci.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - sycl-impl: dpcpp
-            version: 2026-04-22
+            version: 2026-08-27
           - sycl-impl: adaptivecpp
             version: fcd26a61b600cd4b653724e59e72d4f7d1da259c
           - sycl-impl: protosycl
@@ -116,7 +116,7 @@ jobs:
       matrix:
         include:
           - sycl-impl: dpcpp
-            version: 2026-04-22
+            version: 2026-08-27
           - sycl-impl: adaptivecpp
             version: fcd26a61b600cd4b653724e59e72d4f7d1da259c
           - sycl-impl: protosycl


### PR DESCRIPTION
Bump the pinned DPC++ nightly from `2026-04-22` to `2026-08-27` in both the `build-image-for-sycl-impl` and `compile-cts` matrices of `.github/workflows/cts_ci.yml` to pass tests added in https://github.com/KhronosGroup/SYCL-CTS/pull/1231

The corresponding nightly release exists at https://github.com/intel/llvm/releases/tag/nightly-2026-08-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)